### PR TITLE
fix(ci): unblock main after workspace-creation-redesign merge

### DIFF
--- a/apps/atlas-cli/src/commands/chat.ts
+++ b/apps/atlas-cli/src/commands/chat.ts
@@ -74,11 +74,7 @@ function formatRelativeTime(iso: string): string {
 /**
  * Handle list chats command (no ID provided).
  */
-async function handleListChats(
-  workspaceId: string,
-  human: boolean,
-  limit: number,
-): Promise<void> {
+async function handleListChats(workspaceId: string, human: boolean, limit: number): Promise<void> {
   const daemonUrl = getAtlasDaemonUrl();
   const response = await fetch(
     `${daemonUrl}/api/workspaces/${encodeURIComponent(workspaceId)}/chat?limit=${limit}`,

--- a/apps/atlasd/routes/mcp-registry.ts
+++ b/apps/atlasd/routes/mcp-registry.ts
@@ -576,7 +576,7 @@ export const mcpRegistryRouter = daemonFactory
         const remoteTime = Date.parse(remoteUpdatedAt);
         const storedTime = Date.parse(storedUpdatedAt);
 
-        if (isNaN(remoteTime) || isNaN(storedTime)) {
+        if (Number.isNaN(remoteTime) || Number.isNaN(storedTime)) {
           return c.json({ hasUpdate: false, reason: "Unable to compare version timestamps." }, 200);
         }
 

--- a/apps/atlasd/routes/workspaces/config.ts
+++ b/apps/atlasd/routes/workspaces/config.ts
@@ -43,8 +43,8 @@ import {
   saveAndRecompileBlueprint,
   withBlueprintMutation,
 } from "./blueprint-recompile.ts";
-import { injectBundledAgentRefs } from "./index.ts";
 import { applyDraftAwareMutation, getEditableConfig } from "./draft-helpers.ts";
+import { injectBundledAgentRefs } from "./index.ts";
 import { mapMutationError } from "./mutation-errors.ts";
 
 /**
@@ -351,10 +351,7 @@ async function handleUpdateCredential(
     // Load editable config (draft if exists, live otherwise) for credential lookup
     const editableResult = await getEditableConfig(workspace.path);
     if (!editableResult.ok) {
-      return c.json(
-        { success: false, error: "internal", message: editableResult.error },
-        500,
-      );
+      return c.json({ success: false, error: "internal", message: editableResult.error }, 500);
     }
 
     const credentials = extractCredentials(editableResult.value);

--- a/apps/atlasd/routes/workspaces/draft-helpers.ts
+++ b/apps/atlasd/routes/workspaces/draft-helpers.ts
@@ -23,8 +23,8 @@ import { z } from "zod";
 
 const logger = createLogger({ component: "draft-helpers" });
 
-export const DRAFT_FILE_NAME = "workspace.yml.draft" as const;
-export const LIVE_FILE_NAME = "workspace.yml" as const;
+const DRAFT_FILE_NAME = "workspace.yml.draft" as const;
+const LIVE_FILE_NAME = "workspace.yml" as const;
 
 export type DraftResult<T> = { ok: true; value: T } | { ok: false; error: string };
 

--- a/apps/atlasd/routes/workspaces/draft-helpers.ts
+++ b/apps/atlasd/routes/workspaces/draft-helpers.ts
@@ -5,15 +5,15 @@ import {
   JobSpecificationSchema,
   type Registry,
   type ValidationReport,
-  type WorkspaceConfig,
+  validateWorkspace,
   WorkspaceAgentConfigSchema,
+  type WorkspaceConfig,
   WorkspaceConfigSchema,
   WorkspaceSignalConfigSchema,
-  validateWorkspace,
 } from "@atlas/config";
 import {
-  applyMutation,
   type ApplyMutationOptions,
+  applyMutation,
   type MutationResult,
 } from "@atlas/config/mutations";
 import { createLogger } from "@atlas/logger";
@@ -127,9 +127,7 @@ export async function readDraft(workspacePath: string): Promise<DraftResult<Work
 /**
  * Read the current live config file as parsed YAML.
  */
-export async function readLiveConfig(
-  workspacePath: string,
-): Promise<DraftResult<WorkspaceConfig>> {
+export async function readLiveConfig(workspacePath: string): Promise<DraftResult<WorkspaceConfig>> {
   try {
     const livePath = await resolveLiveConfigPath(workspacePath);
     const content = await readFile(livePath, "utf-8");
@@ -209,10 +207,7 @@ export async function applyDraftAwareMutation(
     const writeResult = await writeDraft(workspacePath, validation.data);
     if (!writeResult.ok) {
       return {
-        result: {
-          ok: false,
-          error: { type: "write", message: writeResult.error },
-        },
+        result: { ok: false, error: { type: "write", message: writeResult.error } },
         wroteToDraft: true,
       };
     }
@@ -322,8 +317,8 @@ function computeFlatDiff(
 
   for (const key of allKeys) {
     const fullKey = prefix ? `${prefix}.${key}` : key;
-    const hasOld = Object.prototype.hasOwnProperty.call(oldObj, key);
-    const hasNew = Object.prototype.hasOwnProperty.call(newObj, key);
+    const hasOld = Object.hasOwn(oldObj, key);
+    const hasNew = Object.hasOwn(newObj, key);
     const oldVal = oldObj[key];
     const newVal = newObj[key];
 
@@ -333,12 +328,8 @@ function computeFlatDiff(
       diff[fullKey] = { from: oldVal };
     } else if (!valuesEqual(oldVal, newVal)) {
       if (Array.isArray(oldVal) && Array.isArray(newVal)) {
-        const removed = oldVal.filter(
-          (x) => !newVal.some((y) => valuesEqual(x, y)),
-        );
-        const added = newVal.filter(
-          (x) => !oldVal.some((y) => valuesEqual(x, y)),
-        );
+        const removed = oldVal.filter((x) => !newVal.some((y) => valuesEqual(x, y)));
+        const added = newVal.filter((x) => !oldVal.some((y) => valuesEqual(x, y)));
         if (removed.length > 0 || added.length > 0) {
           diff[fullKey] = { added, removed };
         }
@@ -418,23 +409,14 @@ export async function upsertDraftItem(
   const schema = entitySchemaForKind(kind);
   const parseResult = schema.safeParse(config);
   if (!parseResult.success) {
-    return {
-      ok: false,
-      error: `Invalid ${kind} config: ${parseResult.error.message}`,
-    };
+    return { ok: false, error: `Invalid ${kind} config: ${parseResult.error.message}` };
   }
 
   const key = configKeyForKind(kind);
   const oldCollection = (readResult.value[key] as Record<string, unknown> | undefined) ?? {};
   const oldValue = (oldCollection[id] as Record<string, unknown> | undefined) ?? {};
 
-  const updated = {
-    ...readResult.value,
-    [key]: {
-      ...oldCollection,
-      [id]: parseResult.data,
-    },
-  };
+  const updated = { ...readResult.value, [key]: { ...oldCollection, [id]: parseResult.data } };
 
   const validation = WorkspaceConfigSchema.safeParse(updated);
   if (!validation.success) {
@@ -452,15 +434,9 @@ export async function upsertDraftItem(
   const report = validateWorkspace(validation.data);
   const structuralIssues = report.status === "error" ? report.errors : null;
 
-  const diff = computeFlatDiff(
-    oldValue,
-    parseResult.data as Record<string, unknown>,
-  );
+  const diff = computeFlatDiff(oldValue, parseResult.data as Record<string, unknown>);
 
-  return {
-    ok: true,
-    value: { ok: true, diff, structuralIssues },
-  };
+  return { ok: true, value: { ok: true, diff, structuralIssues } };
 }
 
 /**
@@ -483,23 +459,14 @@ export async function upsertLiveItem(
   const schema = entitySchemaForKind(kind);
   const parseResult = schema.safeParse(config);
   if (!parseResult.success) {
-    return {
-      ok: false,
-      error: `Invalid ${kind} config: ${parseResult.error.message}`,
-    };
+    return { ok: false, error: `Invalid ${kind} config: ${parseResult.error.message}` };
   }
 
   const key = configKeyForKind(kind);
   const oldCollection = (readResult.value[key] as Record<string, unknown> | undefined) ?? {};
   const oldValue = (oldCollection[id] as Record<string, unknown> | undefined) ?? {};
 
-  const updated = {
-    ...readResult.value,
-    [key]: {
-      ...oldCollection,
-      [id]: parseResult.data,
-    },
-  };
+  const updated = { ...readResult.value, [key]: { ...oldCollection, [id]: parseResult.data } };
 
   const validation = WorkspaceConfigSchema.safeParse(updated);
   if (!validation.success) {
@@ -511,14 +478,8 @@ export async function upsertLiveItem(
 
   const report = validateWorkspace(validation.data);
   if (report.status === "error") {
-    const diff = computeFlatDiff(
-      oldValue,
-      parseResult.data as Record<string, unknown>,
-    );
-    return {
-      ok: true,
-      value: { ok: false, diff, structuralIssues: report.errors },
-    };
+    const diff = computeFlatDiff(oldValue, parseResult.data as Record<string, unknown>);
+    return { ok: true, value: { ok: false, diff, structuralIssues: report.errors } };
   }
 
   const writeResult = await writeLiveConfig(workspacePath, validation.data);
@@ -526,15 +487,9 @@ export async function upsertLiveItem(
     return { ok: false, error: writeResult.error };
   }
 
-  const diff = computeFlatDiff(
-    oldValue,
-    parseResult.data as Record<string, unknown>,
-  );
+  const diff = computeFlatDiff(oldValue, parseResult.data as Record<string, unknown>);
 
-  return {
-    ok: true,
-    value: { ok: true, diff, structuralIssues: null },
-  };
+  return { ok: true, value: { ok: true, diff, structuralIssues: null } };
 }
 
 /**
@@ -586,14 +541,9 @@ export async function deleteDraftItem(
 // REFERENCE HELPERS
 // ==============================================================================
 
-const FSMStateSchema = z.object({
-  entry: z.array(z.unknown()).optional(),
-});
+const FSMStateSchema = z.object({ entry: z.array(z.unknown()).optional() });
 
-const FSMAgentActionSchema = z.object({
-  type: z.literal("agent"),
-  agentId: z.string(),
-});
+const FSMAgentActionSchema = z.object({ type: z.literal("agent"), agentId: z.string() });
 
 function findDependents(config: WorkspaceConfig, kind: DraftItemKind, id: string): string[] {
   const dependents: string[] = [];
@@ -626,7 +576,12 @@ function findDependents(config: WorkspaceConfig, kind: DraftItemKind, id: string
           let agentId: string | undefined;
           if (typeof spec === "string") {
             agentId = spec;
-          } else if (typeof spec === "object" && spec !== null && "id" in spec && typeof spec.id === "string") {
+          } else if (
+            typeof spec === "object" &&
+            spec !== null &&
+            "id" in spec &&
+            typeof spec.id === "string"
+          ) {
             agentId = spec.id;
           }
           if (agentId === id && !dependents.includes(jobId)) {

--- a/apps/atlasd/routes/workspaces/draft.test.ts
+++ b/apps/atlasd/routes/workspaces/draft.test.ts
@@ -12,8 +12,8 @@ import type { WorkspaceConfig } from "@atlas/config";
 import type { WorkspaceManager } from "@atlas/workspace";
 import { stringify } from "@std/yaml";
 import { Hono } from "hono";
-import { z } from "zod";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { z } from "zod";
 import type { AppContext, AppVariables } from "../../src/factory.ts";
 import { workspacesRoutes } from "./index.ts";
 
@@ -62,10 +62,9 @@ function createApp(opts: { workspaceDir: string; workspaceId: string }) {
         status: "idle",
         metadata: {},
       }),
-    getWorkspaceConfig: vi.fn().mockImplementation(async () => {
-      // Return a mock merged config
-      return { atlas: null, workspace: createMinimalConfig() };
-    }),
+    getWorkspaceConfig: vi
+      .fn()
+      .mockResolvedValue({ atlas: null, workspace: createMinimalConfig() }),
   } as unknown as WorkspaceManager;
 
   const mockContext: AppContext = {
@@ -398,11 +397,7 @@ describe("Draft file flow", () => {
     const agentConfig = {
       type: "llm",
       description: "Test agent",
-      config: {
-        provider: "anthropic",
-        model: "claude-sonnet-4-6",
-        prompt: "You are a test agent",
-      },
+      config: { provider: "anthropic", model: "claude-sonnet-4-6", prompt: "You are a test agent" },
     };
 
     const res = await app.request(`/workspaces/${workspaceId}/draft/items/agent`, {
@@ -412,11 +407,13 @@ describe("Draft file flow", () => {
     });
     expect(res.status).toBe(200);
 
-    const body = z.object({
-      ok: z.boolean(),
-      diff: z.record(z.string(), z.unknown()),
-      structural_issues: z.null(),
-    }).parse(await res.json());
+    const body = z
+      .object({
+        ok: z.boolean(),
+        diff: z.record(z.string(), z.unknown()),
+        structural_issues: z.null(),
+      })
+      .parse(await res.json());
     expect(body).toMatchObject({ ok: true });
     expect(body.diff).toHaveProperty("type");
     expect(body.diff["type"]).toEqual({ to: "llm" });
@@ -444,11 +441,13 @@ describe("Draft file flow", () => {
     });
     expect(res.status).toBe(200);
 
-    const body = z.object({
-      ok: z.boolean(),
-      diff: z.record(z.string(), z.unknown()),
-      structural_issues: z.null(),
-    }).parse(await res.json());
+    const body = z
+      .object({
+        ok: z.boolean(),
+        diff: z.record(z.string(), z.unknown()),
+        structural_issues: z.null(),
+      })
+      .parse(await res.json());
     expect(body).toMatchObject({ ok: true });
     expect(body.diff).toHaveProperty("provider");
 
@@ -465,9 +464,7 @@ describe("Draft file flow", () => {
     const jobConfig = {
       description: "Test job",
       triggers: [{ signal: "webhook" }],
-      execution: {
-        agents: ["test-agent"],
-      },
+      execution: { agents: ["test-agent"] },
     };
 
     const res = await app.request(`/workspaces/${workspaceId}/draft/items/job`, {
@@ -477,11 +474,13 @@ describe("Draft file flow", () => {
     });
     expect(res.status).toBe(200);
 
-    const body = z.object({
-      ok: z.boolean(),
-      diff: z.record(z.string(), z.unknown()),
-      structural_issues: z.null(),
-    }).parse(await res.json());
+    const body = z
+      .object({
+        ok: z.boolean(),
+        diff: z.record(z.string(), z.unknown()),
+        structural_issues: z.null(),
+      })
+      .parse(await res.json());
     expect(body).toMatchObject({ ok: true });
 
     const draft = await readFile(join(tempDir, "workspace.yml.draft"), "utf-8");
@@ -512,11 +511,7 @@ describe("Draft file flow", () => {
     const agentConfig = {
       type: "llm",
       description: "Live agent",
-      config: {
-        provider: "anthropic",
-        model: "claude-sonnet-4-6",
-        prompt: "You are a live agent",
-      },
+      config: { provider: "anthropic", model: "claude-sonnet-4-6", prompt: "You are a live agent" },
     };
 
     const res = await app.request(`/workspaces/${workspaceId}/items/agent`, {
@@ -526,12 +521,14 @@ describe("Draft file flow", () => {
     });
     expect(res.status).toBe(200);
 
-    const body = z.object({
-      ok: z.boolean(),
-      diff: z.record(z.string(), z.unknown()),
-      structural_issues: z.null(),
-      runtimeReloaded: z.boolean(),
-    }).parse(await res.json());
+    const body = z
+      .object({
+        ok: z.boolean(),
+        diff: z.record(z.string(), z.unknown()),
+        structural_issues: z.null(),
+        runtimeReloaded: z.boolean(),
+      })
+      .parse(await res.json());
     expect(body).toMatchObject({ ok: true, runtimeReloaded: true });
 
     const liveContent = await readFile(join(tempDir, "workspace.yml"), "utf-8");
@@ -548,11 +545,7 @@ describe("Draft file flow", () => {
       fsm: {
         id: "broken-fsm",
         initial: "step_0",
-        states: {
-          step_0: {
-            entry: [{ type: "agent", agentId: "nonexistent-agent" }],
-          },
-        },
+        states: { step_0: { entry: [{ type: "agent", agentId: "nonexistent-agent" }] } },
       },
     };
     const res = await app.request(`/workspaces/${workspaceId}/items/job`, {
@@ -562,11 +555,13 @@ describe("Draft file flow", () => {
     });
     expect(res.status).toBe(422);
 
-    const body = z.object({
-      ok: z.boolean(),
-      diff: z.record(z.string(), z.unknown()),
-      structural_issues: z.array(z.object({ code: z.string() })),
-    }).parse(await res.json());
+    const body = z
+      .object({
+        ok: z.boolean(),
+        diff: z.record(z.string(), z.unknown()),
+        structural_issues: z.array(z.object({ code: z.string() })),
+      })
+      .parse(await res.json());
     expect(body).toMatchObject({ ok: false });
     expect(body.structural_issues.length).toBeGreaterThan(0);
     expect(body.structural_issues[0]?.code).toBe("unknown_agent_id");
@@ -584,11 +579,7 @@ describe("Draft file flow", () => {
     const agentConfig = {
       type: "llm",
       description: "Original agent",
-      config: {
-        provider: "anthropic",
-        model: "claude-sonnet-4-6",
-        prompt: "Original prompt",
-      },
+      config: { provider: "anthropic", model: "claude-sonnet-4-6", prompt: "Original prompt" },
     };
     await app.request(`/workspaces/${workspaceId}/draft/items/agent`, {
       method: "POST",
@@ -599,11 +590,7 @@ describe("Draft file flow", () => {
     const updatedConfig = {
       type: "llm",
       description: "Updated agent",
-      config: {
-        provider: "anthropic",
-        model: "claude-sonnet-4-6",
-        prompt: "Updated prompt",
-      },
+      config: { provider: "anthropic", model: "claude-sonnet-4-6", prompt: "Updated prompt" },
     };
     const res = await app.request(`/workspaces/${workspaceId}/draft/items/agent`, {
       method: "POST",
@@ -612,11 +599,13 @@ describe("Draft file flow", () => {
     });
     expect(res.status).toBe(200);
 
-    const body = z.object({
-      ok: z.boolean(),
-      diff: z.record(z.string(), z.unknown()),
-      structural_issues: z.null(),
-    }).parse(await res.json());
+    const body = z
+      .object({
+        ok: z.boolean(),
+        diff: z.record(z.string(), z.unknown()),
+        structural_issues: z.null(),
+      })
+      .parse(await res.json());
     expect(body).toMatchObject({ ok: true });
     expect(body.diff).toHaveProperty("description");
     expect(body.diff["description"]).toEqual({ from: "Original agent", to: "Updated agent" });
@@ -632,11 +621,7 @@ describe("Draft file flow", () => {
     const agentConfig = {
       type: "llm",
       description: "Test agent",
-      config: {
-        provider: "anthropic",
-        model: "claude-sonnet-4-6",
-        prompt: "You are a test agent",
-      },
+      config: { provider: "anthropic", model: "claude-sonnet-4-6", prompt: "You are a test agent" },
     };
 
     await app.request(`/workspaces/${workspaceId}/draft/items/agent`, {
@@ -650,13 +635,13 @@ describe("Draft file flow", () => {
     });
     expect(res.status).toBe(200);
 
-    const body = z.object({
-      ok: z.boolean(),
-      diff: z.object({
-        removed: z.array(z.object({ path: z.string() })),
-      }),
-      structural_issues: z.null(),
-    }).parse(await res.json());
+    const body = z
+      .object({
+        ok: z.boolean(),
+        diff: z.object({ removed: z.array(z.object({ path: z.string() })) }),
+        structural_issues: z.null(),
+      })
+      .parse(await res.json());
     expect(body).toMatchObject({ ok: true });
     expect(body.diff.removed).toHaveLength(1);
     expect(body.diff.removed[0]?.path).toBe("agents.delete-me");
@@ -690,11 +675,7 @@ describe("Draft file flow", () => {
     const agentConfig = {
       type: "llm",
       description: "Test agent",
-      config: {
-        provider: "anthropic",
-        model: "claude-sonnet-4-6",
-        prompt: "You are a test agent",
-      },
+      config: { provider: "anthropic", model: "claude-sonnet-4-6", prompt: "You are a test agent" },
     };
     await app.request(`/workspaces/${workspaceId}/draft/items/agent`, {
       method: "POST",
@@ -708,11 +689,7 @@ describe("Draft file flow", () => {
       fsm: {
         id: "test-fsm",
         initial: "step_0",
-        states: {
-          step_0: {
-            entry: [{ type: "agent", agentId: "test-agent" }],
-          },
-        },
+        states: { step_0: { entry: [{ type: "agent", agentId: "test-agent" }] } },
       },
     };
     await app.request(`/workspaces/${workspaceId}/draft/items/job`, {
@@ -727,13 +704,13 @@ describe("Draft file flow", () => {
     });
     expect(res.status).toBe(200);
 
-    const body = z.object({
-      ok: z.boolean(),
-      diff: z.object({
-        removed: z.array(z.object({ path: z.string() })),
-      }),
-      structural_issues: z.array(z.object({ code: z.string() })),
-    }).parse(await res.json());
+    const body = z
+      .object({
+        ok: z.boolean(),
+        diff: z.object({ removed: z.array(z.object({ path: z.string() })) }),
+        structural_issues: z.array(z.object({ code: z.string() })),
+      })
+      .parse(await res.json());
     expect(body).toMatchObject({ ok: true });
     expect(body.diff.removed).toHaveLength(1);
     expect(body.diff.removed[0]?.path).toBe("agents.test-agent");
@@ -751,7 +728,10 @@ describe("Draft file flow", () => {
     expect(res.status).toBe(200);
 
     const body = await res.json();
-    expect(body).toMatchObject({ success: true, report: { status: "ok", errors: [], warnings: [] } });
+    expect(body).toMatchObject({
+      success: true,
+      report: { status: "ok", errors: [], warnings: [] },
+    });
   });
 
   test("validate draft returns 409 when no draft exists", async () => {
@@ -793,7 +773,9 @@ describe("Draft file flow", () => {
     const { app } = createApp({ workspaceDir: tempDir, workspaceId });
 
     // 1. Begin draft
-    const beginRes = await app.request(`/workspaces/${workspaceId}/draft/begin`, { method: "POST" });
+    const beginRes = await app.request(`/workspaces/${workspaceId}/draft/begin`, {
+      method: "POST",
+    });
     expect(beginRes.status).toBe(200);
 
     // 2. Upsert agent
@@ -851,13 +833,17 @@ describe("Draft file flow", () => {
     expect(signalRes.status).toBe(200);
 
     // 5. Validate draft
-    const validateRes = await app.request(`/workspaces/${workspaceId}/draft/validate`, { method: "POST" });
+    const validateRes = await app.request(`/workspaces/${workspaceId}/draft/validate`, {
+      method: "POST",
+    });
     expect(validateRes.status).toBe(200);
     const validateBody = await validateRes.json();
     expect(validateBody).toMatchObject({ success: true, report: { status: "ok" } });
 
     // 6. Publish
-    const publishRes = await app.request(`/workspaces/${workspaceId}/draft/publish`, { method: "POST" });
+    const publishRes = await app.request(`/workspaces/${workspaceId}/draft/publish`, {
+      method: "POST",
+    });
     expect(publishRes.status).toBe(200);
     const publishBody = await publishRes.json();
     expect(publishBody).toMatchObject({ success: true, runtimeReloaded: true });
@@ -875,7 +861,9 @@ describe("Draft file flow", () => {
   test("all draft endpoints return 404 for missing workspace", async () => {
     const mockManager = {
       find: vi.fn().mockResolvedValue(null),
-      getWorkspaceConfig: vi.fn().mockResolvedValue({ atlas: null, workspace: createMinimalConfig() }),
+      getWorkspaceConfig: vi
+        .fn()
+        .mockResolvedValue({ atlas: null, workspace: createMinimalConfig() }),
     } as unknown as WorkspaceManager;
 
     const mockContext: AppContext = {

--- a/apps/atlasd/routes/workspaces/index.ts
+++ b/apps/atlasd/routes/workspaces/index.ts
@@ -41,12 +41,12 @@ import {
   resolveCredentialsByProvider,
   resolveSlackAppByWorkspace,
 } from "@atlas/core/mcp-registry/credential-resolver";
+import { mcpServersRegistry } from "@atlas/core/mcp-registry/registry-consolidated";
 import { createDefaultResolvers } from "@atlas/core/mcp-registry/resolvers";
 import { getMCPRegistryAdapter } from "@atlas/core/mcp-registry/storage";
-import { mcpServersRegistry } from "@atlas/core/mcp-registry/registry-consolidated";
 import type { ResourceMetadata, ResourceVersion } from "@atlas/ledger";
-import { createMCPTools } from "@atlas/mcp";
 import { createLogger, logger } from "@atlas/logger";
+import { createMCPTools } from "@atlas/mcp";
 import { createLedgerClient } from "@atlas/resources";
 import { resolveVisibleSkills, SkillStorage } from "@atlas/skills";
 import { FilesystemWorkspaceCreationAdapter } from "@atlas/storage";
@@ -75,6 +75,7 @@ import {
 import { DEFAULT_WORKSPACE_MEMORY } from "./default-workspace-config.ts";
 import {
   beginDraft,
+  type DraftItemKind,
   deleteDraftItem,
   discardDraft,
   publishDraft,
@@ -83,7 +84,6 @@ import {
   upsertDraftItem,
   upsertLiveItem,
   validateDraft,
-  type DraftItemKind,
 } from "./draft-helpers.ts";
 import { injectBundledAgentRefs } from "./inject-bundled-agents.ts";
 import { mapMutationError } from "./mutation-errors.ts";
@@ -157,9 +157,7 @@ function buildValidationContext(app: AppContext): ValidationContext {
  * prefixed tools still pass via the static serverPrefixes fallback, but bare
  * tool names for those servers will not resolve.
  */
-async function buildMcpToolRegistry(
-  config: WorkspaceConfig,
-): Promise<Registry> {
+async function buildMcpToolRegistry(config: WorkspaceConfig): Promise<Registry> {
   const declaredServers = Object.keys(config.tools?.mcp?.servers ?? {});
   if (declaredServers.length === 0) return {};
 
@@ -175,11 +173,9 @@ async function buildMcpToolRegistry(
       }
       if (!server) continue;
 
-      const result = await createMCPTools(
-        { [serverId]: server.configTemplate },
-        logger,
-        { signal: AbortSignal.timeout(5000) },
-      );
+      const result = await createMCPTools({ [serverId]: server.configTemplate }, logger, {
+        signal: AbortSignal.timeout(5000),
+      });
       mcpTools[serverId] = Object.keys(result.tools);
       await result.dispose();
     } catch (error) {
@@ -2529,14 +2525,17 @@ const workspacesRoutes = daemonFactory
   // Refuses the write if structural validation errors exist.
   .post(
     "/:workspaceId/items/:kind",
-    zValidator("param", z.object({
-      workspaceId: z.string().min(1),
-      kind: z.enum(["agent", "signal", "job"] as const),
-    })),
-    zValidator("json", z.object({
-      id: z.string().min(1),
-      config: z.record(z.string(), z.unknown()),
-    })),
+    zValidator(
+      "param",
+      z.object({
+        workspaceId: z.string().min(1),
+        kind: z.enum(["agent", "signal", "job"] as const),
+      }),
+    ),
+    zValidator(
+      "json",
+      z.object({ id: z.string().min(1), config: z.record(z.string(), z.unknown()) }),
+    ),
     async (c) => {
       const { workspaceId, kind } = c.req.valid("param");
       const { id, config } = c.req.valid("json");
@@ -2577,11 +2576,14 @@ const workspacesRoutes = daemonFactory
   // Refuses the operation if the entity is referenced by other items.
   .delete(
     "/:workspaceId/items/:kind/:id",
-    zValidator("param", z.object({
-      workspaceId: z.string().min(1),
-      kind: z.enum(["agent", "signal", "job"] as const),
-      id: z.string().min(1),
-    })),
+    zValidator(
+      "param",
+      z.object({
+        workspaceId: z.string().min(1),
+        kind: z.enum(["agent", "signal", "job"] as const),
+        id: z.string().min(1),
+      }),
+    ),
     async (c) => {
       const { workspaceId, kind, id } = c.req.valid("param");
       const ctx = c.get("app");
@@ -2594,7 +2596,10 @@ const workspacesRoutes = daemonFactory
         const result = await removeLiveItem(workspace.path, kind as DraftItemKind, id);
         if (!result.ok) {
           if (result.reason === "referenced") {
-            return c.json({ ok: false, error: { code: "referenced", dependents: result.dependents } }, 422);
+            return c.json(
+              { ok: false, error: { code: "referenced", dependents: result.dependents } },
+              422,
+            );
           }
           const status = result.error.includes("not found") ? 404 : 500;
           return c.json({ ok: false, error: result.error }, status);
@@ -2615,14 +2620,17 @@ const workspacesRoutes = daemonFactory
   // Upsert an entity (agent/signal/job) into the draft config
   .post(
     "/:workspaceId/draft/items/:kind",
-    zValidator("param", z.object({
-      workspaceId: z.string().min(1),
-      kind: z.enum(["agent", "signal", "job"] as const),
-    })),
-    zValidator("json", z.object({
-      id: z.string().min(1),
-      config: z.record(z.string(), z.unknown()),
-    })),
+    zValidator(
+      "param",
+      z.object({
+        workspaceId: z.string().min(1),
+        kind: z.enum(["agent", "signal", "job"] as const),
+      }),
+    ),
+    zValidator(
+      "json",
+      z.object({ id: z.string().min(1), config: z.record(z.string(), z.unknown()) }),
+    ),
     async (c) => {
       const { workspaceId, kind } = c.req.valid("param");
       const { id, config } = c.req.valid("json");
@@ -2640,11 +2648,14 @@ const workspacesRoutes = daemonFactory
           }
           return c.json({ ok: false, error: result.error }, 400);
         }
-        return c.json({
-          ok: result.value.ok,
-          diff: result.value.diff,
-          structural_issues: result.value.structuralIssues,
-        }, 200);
+        return c.json(
+          {
+            ok: result.value.ok,
+            diff: result.value.diff,
+            structural_issues: result.value.structuralIssues,
+          },
+          200,
+        );
       } catch (error) {
         return c.json({ success: false, error: stringifyError(error) }, 500);
       }
@@ -2653,11 +2664,14 @@ const workspacesRoutes = daemonFactory
   // Delete an entity (agent/signal/job) from the draft config
   .delete(
     "/:workspaceId/draft/items/:kind/:id",
-    zValidator("param", z.object({
-      workspaceId: z.string().min(1),
-      kind: z.enum(["agent", "signal", "job"] as const),
-      id: z.string().min(1),
-    })),
+    zValidator(
+      "param",
+      z.object({
+        workspaceId: z.string().min(1),
+        kind: z.enum(["agent", "signal", "job"] as const),
+        id: z.string().min(1),
+      }),
+    ),
     async (c) => {
       const { workspaceId, kind, id } = c.req.valid("param");
       const ctx = c.get("app");
@@ -2674,16 +2688,16 @@ const workspacesRoutes = daemonFactory
           }
           return c.json({ success: false, error: result.error }, 409);
         }
-        const structuralIssues = result.value.report.status === "error"
-          ? result.value.report.errors
-          : null;
-        return c.json({
-          ok: true,
-          diff: {
-            removed: [{ path: `${kind}s.${id}`, oldValue: result.value.oldValue }],
+        const structuralIssues =
+          result.value.report.status === "error" ? result.value.report.errors : null;
+        return c.json(
+          {
+            ok: true,
+            diff: { removed: [{ path: `${kind}s.${id}`, oldValue: result.value.oldValue }] },
+            structural_issues: structuralIssues,
           },
-          structural_issues: structuralIssues,
-        }, 200);
+          200,
+        );
       } catch (error) {
         return c.json({ success: false, error: stringifyError(error) }, 500);
       }

--- a/apps/atlasd/routes/workspaces/index.ts
+++ b/apps/atlasd/routes/workspaces/index.ts
@@ -43,6 +43,7 @@ import {
 } from "@atlas/core/mcp-registry/credential-resolver";
 import { mcpServersRegistry } from "@atlas/core/mcp-registry/registry-consolidated";
 import { createDefaultResolvers } from "@atlas/core/mcp-registry/resolvers";
+import type { MCPServerMetadata } from "@atlas/core/mcp-registry/schemas";
 import { getMCPRegistryAdapter } from "@atlas/core/mcp-registry/storage";
 import type { ResourceMetadata, ResourceVersion } from "@atlas/ledger";
 import { createLogger, logger } from "@atlas/logger";
@@ -165,8 +166,7 @@ async function buildMcpToolRegistry(config: WorkspaceConfig): Promise<Registry> 
 
   for (const serverId of declaredServers) {
     try {
-      const staticServer = mcpServersRegistry.servers[serverId];
-      let server = staticServer;
+      let server: MCPServerMetadata | undefined = mcpServersRegistry.servers[serverId];
       if (!server) {
         const adapter = await getMCPRegistryAdapter();
         server = (await adapter.get(serverId)) ?? undefined;

--- a/apps/atlasd/routes/workspaces/mcp.test.ts
+++ b/apps/atlasd/routes/workspaces/mcp.test.ts
@@ -199,7 +199,7 @@ describe("GET /mcp", () => {
     const res = await app.request("/ws-test-id/mcp");
 
     expect(res.status).toBe(200);
-    const body = (await res.json()) as JsonBody;
+    const body = (await res.json()) as { enabled: JsonBody[]; available: JsonBody[] };
     expect(body.enabled).toHaveLength(1);
     expect(body.enabled[0]).toMatchObject({ id: "github", name: "GitHub" });
     expect(body.available).toHaveLength(0);
@@ -474,7 +474,7 @@ describe("DELETE /mcp/:serverId", () => {
           },
         },
       },
-    } as WorkspaceConfig;
+    } as unknown as WorkspaceConfig;
     await writeFile(join(testDir, "workspace.yml"), stringify(config));
     const { app, destroyWorkspaceRuntime } = createTestApp({
       workspace,
@@ -509,7 +509,7 @@ describe("DELETE /mcp/:serverId", () => {
           },
         },
       },
-    } as WorkspaceConfig;
+    } as unknown as WorkspaceConfig;
     await writeFile(join(testDir, "workspace.yml"), stringify(config));
     const { app, destroyWorkspaceRuntime } = createTestApp({
       workspace,
@@ -542,7 +542,7 @@ describe("DELETE /mcp/:serverId", () => {
           },
         },
       },
-    } as WorkspaceConfig;
+    } as unknown as WorkspaceConfig;
     // Draft has the server enabled; live does too (draft was copied from live)
     const draftConfig = {
       ...makeWorkspaceConfig({ github: { transport: { type: "stdio", command: "echo" } } }),
@@ -558,7 +558,7 @@ describe("DELETE /mcp/:serverId", () => {
           },
         },
       },
-    } as WorkspaceConfig;
+    } as unknown as WorkspaceConfig;
     await writeFile(join(testDir, "workspace.yml"), stringify(liveConfig));
     await writeFile(join(testDir, "workspace.yml.draft"), stringify(draftConfig));
     const { app, destroyWorkspaceRuntime } = createTestApp({

--- a/apps/atlasd/routes/workspaces/mcp.test.ts
+++ b/apps/atlasd/routes/workspaces/mcp.test.ts
@@ -179,9 +179,7 @@ describe("GET /mcp", () => {
   });
 
   test("reads from draft when draft exists", async () => {
-    mockDiscoverMCPServers.mockResolvedValue([
-      makeCandidate("github", "GitHub", "static"),
-    ]);
+    mockDiscoverMCPServers.mockResolvedValue([makeCandidate("github", "GitHub", "static")]);
 
     const testDir = getTestDir();
     const workspace = createMockWorkspace({ path: testDir });
@@ -196,10 +194,7 @@ describe("GET /mcp", () => {
     await writeFile(join(testDir, "workspace.yml"), stringify(liveConfig));
     await writeFile(join(testDir, "workspace.yml.draft"), stringify(draftConfig));
 
-    const { app } = createTestApp({
-      workspace,
-      config: createMergedConfig(liveConfig),
-    });
+    const { app } = createTestApp({ workspace, config: createMergedConfig(liveConfig) });
 
     const res = await app.request("/ws-test-id/mcp");
 
@@ -583,7 +578,7 @@ describe("DELETE /mcp/:serverId", () => {
     const draftContent = await readFile(join(testDir, "workspace.yml.draft"), "utf-8");
     expect(draftContent).not.toContain("github");
     // Agent tools should also be stripped in draft
-    expect(draftContent).not.toContain("tools: [\"github\"]");
+    expect(draftContent).not.toContain('tools: ["github"]');
 
     const liveContent = await readFile(join(testDir, "workspace.yml"), "utf-8");
     expect(liveContent).toContain("github");

--- a/apps/atlasd/routes/workspaces/mcp.ts
+++ b/apps/atlasd/routes/workspaces/mcp.ts
@@ -162,10 +162,7 @@ const handleEnableMCPServer = async (c: import("hono").Context<AppVariables>) =>
     // Load editable config (draft if exists, live otherwise) for idempotency and catalog lookup
     const editableResult = await getEditableConfig(workspace.path);
     if (!editableResult.ok) {
-      return c.json(
-        { success: false, error: "internal", message: editableResult.error },
-        500,
-      );
+      return c.json({ success: false, error: "internal", message: editableResult.error }, 500);
     }
     const editableConfig = editableResult.value;
 

--- a/docs/plans/2026-04-27-workspace-creation-redesign-handoff-brief.md
+++ b/docs/plans/2026-04-27-workspace-creation-redesign-handoff-brief.md
@@ -139,7 +139,7 @@ Rationale: The workspace-api skill is already loaded when the LLM is creating or
 **Test script (from `docs/qa/plans/workspace-creation-redesign-cases.md` Case 10):**
 ```
 1. Navigate to workspace-chat
-2. Send: "I'd love to create a new workspace that works as a personal assistant 
+2. Send: "I'd love to create a new workspace that works as a personal assistant
    to help me review my emails and get to inbox zero..."
 3. Observe chat's tool calls:
    - list_mcp_servers (should show google-gmail as available)

--- a/packages/config/mod.ts
+++ b/packages/config/mod.ts
@@ -33,10 +33,10 @@ export * from "./src/signals.ts";
 // Skill schemas
 export * from "./src/skills.ts";
 export * from "./src/topology.ts";
-export * from "./src/workspace.ts";
+export type { Issue, Registry, ValidationReport } from "./src/validate-workspace.ts";
 // Workspace structural validator
 export { validateWorkspace } from "./src/validate-workspace.ts";
-export type { Issue, Registry, ValidationReport } from "./src/validate-workspace.ts";
+export * from "./src/workspace.ts";
 
 // ==============================================================================
 // HELPER FUNCTIONS

--- a/packages/config/src/mutations/mcp-servers.test.ts
+++ b/packages/config/src/mutations/mcp-servers.test.ts
@@ -242,7 +242,11 @@ describe("findServerReferences", () => {
       agents: {
         "gmail-agent": llmAgent({
           description: "Gmail agent",
-          tools: ["google-gmail/search_gmail_messages", "google-gmail/draft_gmail_message", "memory_read"],
+          tools: [
+            "google-gmail/search_gmail_messages",
+            "google-gmail/draft_gmail_message",
+            "memory_read",
+          ],
         }),
       },
     });
@@ -285,12 +289,7 @@ describe("findServerReferences", () => {
 
   test("does not match partial server-id prefixes", () => {
     const config = createTestConfig({
-      agents: {
-        agent: llmAgent({
-          description: "Agent",
-          tools: ["google-gmail-extra/search"],
-        }),
-      },
+      agents: { agent: llmAgent({ description: "Agent", tools: ["google-gmail-extra/search"] }) },
     });
 
     // "google-gmail" should NOT match "google-gmail-extra/search"

--- a/packages/config/src/mutations/mcp-servers.ts
+++ b/packages/config/src/mutations/mcp-servers.ts
@@ -79,7 +79,10 @@ export function findServerReferences(config: WorkspaceConfig, serverId: string):
         for (const action of state.entry) {
           if (action?.type === "llm") {
             const tools = action.tools;
-            if (Array.isArray(tools) && tools.some((t) => t === serverId || t.startsWith(`${serverId}/`))) {
+            if (
+              Array.isArray(tools) &&
+              tools.some((t) => t === serverId || t.startsWith(`${serverId}/`))
+            ) {
               jobIdSet.add(jobId);
               break; // deduplicate per job
             }

--- a/packages/config/src/mutations/signals.ts
+++ b/packages/config/src/mutations/signals.ts
@@ -114,18 +114,12 @@ export function patchSignalConfig(
   }
 
   // Extra validation: schedule signals need a valid cron expression.
-  if (
-    parseResult.data.provider === "schedule" &&
-    parseResult.data.config.schedule
-  ) {
+  if (parseResult.data.provider === "schedule" && parseResult.data.config.schedule) {
     try {
       CronExpressionParser.parse(parseResult.data.config.schedule);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      return {
-        ok: false,
-        error: validationError(`Invalid cron expression: ${message}`),
-      };
+      return { ok: false, error: validationError(`Invalid cron expression: ${message}`) };
     }
   }
 

--- a/packages/config/src/signals.ts
+++ b/packages/config/src/signals.ts
@@ -17,9 +17,7 @@ export const HTTPProviderConfigSchema = z.strictObject({
 export type HTTPProviderConfig = z.infer<typeof HTTPProviderConfigSchema>;
 
 export const ScheduleProviderConfigSchema = z.strictObject({
-  schedule: z
-    .string()
-    .describe("Cron expression (e.g., '0 9 * * *' for daily at 9 AM)"),
+  schedule: z.string().describe("Cron expression (e.g., '0 9 * * *' for daily at 9 AM)"),
   timezone: z.string().optional().default("UTC").describe("Timezone for the schedule"),
 });
 export type ScheduleProviderConfig = z.infer<typeof ScheduleProviderConfigSchema>;

--- a/packages/config/src/validate-workspace.test.ts
+++ b/packages/config/src/validate-workspace.test.ts
@@ -111,9 +111,7 @@ describe("validateWorkspace structural layer", () => {
     const result = validateWorkspace({
       version: "1.0",
       workspace: { name: "Test" },
-      signals: {
-        "review-inbox": { provider: "http", config: { path: "/review" } },
-      },
+      signals: { "review-inbox": { provider: "http", config: { path: "/review" } } },
     });
     expect(result.status).toBe("error");
     const err = result.errors.find((e) => e.path === "signals.review-inbox.description");
@@ -127,11 +125,13 @@ describe("validateWorkspace structural layer", () => {
     const bad = validateWorkspace({
       version: 2.0,
       workspace: { name: "Test" },
-      signals: {
-        "review-inbox": { provider: "http", config: { path: "/review" } },
-      },
+      signals: { "review-inbox": { provider: "http", config: { path: "/review" } } },
       agents: {
-        orphan: { type: "llm", description: "Orphan", config: { provider: "anthropic", model: "claude-sonnet-4-5", prompt: "Hi" } },
+        orphan: {
+          type: "llm",
+          description: "Orphan",
+          config: { provider: "anthropic", model: "claude-sonnet-4-5", prompt: "Hi" },
+        },
       },
     });
     const allIssues = [...bad.errors, ...bad.warnings];
@@ -173,19 +173,16 @@ describe("validateWorkspace structural layer", () => {
             provider: "anthropic",
             model: "claude-sonnet-4-5",
             prompt: "Hi",
-            tools: ["google-gmail/search_gmail_messages", "google-gmail/draft_gmail_message", "memory_read"],
+            tools: [
+              "google-gmail/search_gmail_messages",
+              "google-gmail/draft_gmail_message",
+              "memory_read",
+            ],
           },
         },
       },
-      jobs: {
-        my_job: {
-          triggers: [{ signal: "s1" }],
-          execution: { agents: ["my_agent"] },
-        },
-      },
-      signals: {
-        s1: { provider: "http", description: "S1", config: { path: "/s1" } },
-      },
+      jobs: { my_job: { triggers: [{ signal: "s1" }], execution: { agents: ["my_agent"] } } },
+      signals: { s1: { provider: "http", description: "S1", config: { path: "/s1" } } },
     });
     expect(result.status).toBe("ok");
     expect(result.errors).toEqual([]);
@@ -199,9 +196,7 @@ describe("validateWorkspace structural layer", () => {
       tools: {
         mcp: {
           servers: {
-            "google-gmail": {
-              transport: { type: "http", url: "http://localhost:8002/mcp" },
-            },
+            "google-gmail": { transport: { type: "http", url: "http://localhost:8002/mcp" } },
           },
         },
       },
@@ -232,9 +227,7 @@ describe("validateWorkspace structural layer", () => {
       tools: {
         mcp: {
           servers: {
-            "google-gmail": {
-              transport: { type: "http", url: "http://localhost:8002/mcp" },
-            },
+            "google-gmail": { transport: { type: "http", url: "http://localhost:8002/mcp" } },
           },
         },
       },
@@ -266,9 +259,7 @@ describe("validateWorkspace structural layer", () => {
         tools: {
           mcp: {
             servers: {
-              "google-gmail": {
-                transport: { type: "http", url: "http://localhost:8002/mcp" },
-              },
+              "google-gmail": { transport: { type: "http", url: "http://localhost:8002/mcp" } },
             },
           },
         },
@@ -291,9 +282,7 @@ describe("validateWorkspace structural layer", () => {
               id: "fsm1",
               initial: "step1",
               states: {
-                step1: {
-                  entry: [{ type: "agent", agentId: "my_agent", outputTo: "out" }],
-                },
+                step1: { entry: [{ type: "agent", agentId: "my_agent", outputTo: "out" }] },
               },
             },
           },
@@ -316,9 +305,7 @@ describe("validateWorkspace structural layer", () => {
         tools: {
           mcp: {
             servers: {
-              "google-gmail": {
-                transport: { type: "http", url: "http://localhost:8002/mcp" },
-              },
+              "google-gmail": { transport: { type: "http", url: "http://localhost:8002/mcp" } },
             },
           },
         },
@@ -341,19 +328,14 @@ describe("validateWorkspace structural layer", () => {
               id: "fsm1",
               initial: "step1",
               states: {
-                step1: {
-                  entry: [{ type: "agent", agentId: "my_agent", outputTo: "out" }],
-                },
+                step1: { entry: [{ type: "agent", agentId: "my_agent", outputTo: "out" }] },
               },
             },
           },
         },
         signals: { s1: { provider: "http", description: "S1", config: { path: "/s1" } } },
       },
-      {
-        mcpServers: ["google-gmail"],
-        mcpTools: { "google-gmail": ["search_gmail_messages"] },
-      },
+      { mcpServers: ["google-gmail"], mcpTools: { "google-gmail": ["search_gmail_messages"] } },
     );
     expect(result.status).toBe("error");
     const err = result.errors.find((e) => e.code === "unknown_tool");
@@ -370,9 +352,7 @@ describe("validateWorkspace structural layer", () => {
         tools: {
           mcp: {
             servers: {
-              "google-gmail": {
-                transport: { type: "http", url: "http://localhost:8002/mcp" },
-              },
+              "google-gmail": { transport: { type: "http", url: "http://localhost:8002/mcp" } },
             },
           },
         },
@@ -395,19 +375,14 @@ describe("validateWorkspace structural layer", () => {
               id: "fsm1",
               initial: "step1",
               states: {
-                step1: {
-                  entry: [{ type: "agent", agentId: "my_agent", outputTo: "out" }],
-                },
+                step1: { entry: [{ type: "agent", agentId: "my_agent", outputTo: "out" }] },
               },
             },
           },
         },
         signals: { s1: { provider: "http", description: "S1", config: { path: "/s1" } } },
       },
-      {
-        mcpServers: ["google-gmail"],
-        mcpTools: { "google-gmail": ["search_gmail_messages"] },
-      },
+      { mcpServers: ["google-gmail"], mcpTools: { "google-gmail": ["search_gmail_messages"] } },
     );
     expect(result.status).toBe("ok");
   });
@@ -420,9 +395,7 @@ describe("validateWorkspace structural layer", () => {
         tools: {
           mcp: {
             servers: {
-              "google-gmail": {
-                transport: { type: "http", url: "http://localhost:8002/mcp" },
-              },
+              "google-gmail": { transport: { type: "http", url: "http://localhost:8002/mcp" } },
             },
           },
         },
@@ -445,9 +418,7 @@ describe("validateWorkspace structural layer", () => {
               id: "fsm1",
               initial: "step1",
               states: {
-                step1: {
-                  entry: [{ type: "agent", agentId: "my_agent", outputTo: "out" }],
-                },
+                step1: { entry: [{ type: "agent", agentId: "my_agent", outputTo: "out" }] },
               },
             },
           },
@@ -465,7 +436,13 @@ describe("validateWorkspace reference integrity", () => {
     const result = validateWorkspace({
       version: "1.0",
       workspace: { name: "Test" },
-      agents: { known: { type: "llm", description: "Known", config: { provider: "anthropic", model: "claude-sonnet-4-5", prompt: "Hi" } } },
+      agents: {
+        known: {
+          type: "llm",
+          description: "Known",
+          config: { provider: "anthropic", model: "claude-sonnet-4-5", prompt: "Hi" },
+        },
+      },
       jobs: {
         my_job: {
           triggers: [{ signal: "s1" }],
@@ -473,9 +450,7 @@ describe("validateWorkspace reference integrity", () => {
             id: "fsm1",
             initial: "step1",
             states: {
-              step1: {
-                entry: [{ type: "agent", agentId: "unknown-agent", outputTo: "out" }],
-              },
+              step1: { entry: [{ type: "agent", agentId: "unknown-agent", outputTo: "out" }] },
             },
           },
         },
@@ -496,7 +471,12 @@ describe("validateWorkspace reference integrity", () => {
         my_agent: {
           type: "llm",
           description: "Test agent",
-          config: { provider: "anthropic", model: "claude-sonnet-4-5", prompt: "Hi", tools: ["bogus_tool"] },
+          config: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-5",
+            prompt: "Hi",
+            tools: ["bogus_tool"],
+          },
         },
       },
     });
@@ -514,7 +494,11 @@ describe("validateWorkspace reference integrity", () => {
         my_agent: {
           type: "llm",
           description: "Test agent",
-          config: { provider: "anthropic", model: "claude-sonnet-4-5", prompt: 'Use "ghost-store" memory to save data.' },
+          config: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-5",
+            prompt: 'Use "ghost-store" memory to save data.',
+          },
         },
       },
     });
@@ -531,17 +515,18 @@ describe("validateWorkspace semantic warnings", () => {
       version: "1.0",
       workspace: { name: "Test" },
       tools: {
-        mcp: {
-          servers: {
-            some_server: { transport: { type: "stdio", command: "echo" } },
-          },
-        },
+        mcp: { servers: { some_server: { transport: { type: "stdio", command: "echo" } } } },
       },
       agents: {
         my_agent: {
           type: "llm",
           description: "Test agent",
-          config: { provider: "anthropic", model: "claude-sonnet-4-5", prompt: "Hi", tool_choice: "auto" },
+          config: {
+            provider: "anthropic",
+            model: "claude-sonnet-4-5",
+            prompt: "Hi",
+            tool_choice: "auto",
+          },
         },
       },
     });
@@ -555,9 +540,7 @@ describe("validateWorkspace semantic warnings", () => {
     const result = validateWorkspace({
       version: "1.0",
       workspace: { name: "Test" },
-      signals: {
-        unused: { provider: "http", description: "Unused", config: { path: "/unused" } },
-      },
+      signals: { unused: { provider: "http", description: "Unused", config: { path: "/unused" } } },
     });
     expect(result.status).toBe("warning");
     const warn = result.warnings.find((w) => w.code === "dead_signal");
@@ -570,17 +553,14 @@ describe("validateWorkspace semantic warnings", () => {
       version: "1.0",
       workspace: { name: "Test" },
       agents: {
-        orphan: { type: "llm", description: "Orphan", config: { provider: "anthropic", model: "claude-sonnet-4-5", prompt: "Hi" } },
-      },
-      jobs: {
-        my_job: {
-          triggers: [{ signal: "s1" }],
-          execution: { agents: ["other"] },
+        orphan: {
+          type: "llm",
+          description: "Orphan",
+          config: { provider: "anthropic", model: "claude-sonnet-4-5", prompt: "Hi" },
         },
       },
-      signals: {
-        s1: { provider: "http", description: "S1", config: { path: "/s1" } },
-      },
+      jobs: { my_job: { triggers: [{ signal: "s1" }], execution: { agents: ["other"] } } },
+      signals: { s1: { provider: "http", description: "S1", config: { path: "/s1" } } },
     });
     expect(result.status).toBe("warning");
     const warn = result.warnings.find((w) => w.code === "orphan_agent");
@@ -593,7 +573,11 @@ describe("validateWorkspace semantic warnings", () => {
       version: "1.0",
       workspace: { name: "Test" },
       agents: {
-        triager: { type: "llm", description: "Triager", config: { provider: "anthropic", model: "claude-sonnet-4-5", prompt: "Hi" } },
+        triager: {
+          type: "llm",
+          description: "Triager",
+          config: { provider: "anthropic", model: "claude-sonnet-4-5", prompt: "Hi" },
+        },
       },
       jobs: {
         my_job: {
@@ -601,17 +585,11 @@ describe("validateWorkspace semantic warnings", () => {
           fsm: {
             id: "fsm1",
             initial: "step1",
-            states: {
-              step1: {
-                entry: [{ type: "agent", agentId: "triager", outputTo: "out" }],
-              },
-            },
+            states: { step1: { entry: [{ type: "agent", agentId: "triager", outputTo: "out" }] } },
           },
         },
       },
-      signals: {
-        s1: { provider: "http", description: "S1", config: { path: "/s1" } },
-      },
+      signals: { s1: { provider: "http", description: "S1", config: { path: "/s1" } } },
     });
     expect(result.warnings.find((w) => w.code === "orphan_agent")).toBeUndefined();
   });
@@ -650,7 +628,10 @@ describe("validateWorkspace semantic warnings", () => {
   });
 
   it("validates Meeting-Scheduler workspace as clean", async () => {
-    const yaml = await readFile("/Users/ericskram/Desktop/Meeting-Scheduler/workspace.yml", "utf-8");
+    const yaml = await readFile(
+      "/Users/ericskram/Desktop/Meeting-Scheduler/workspace.yml",
+      "utf-8",
+    );
     const parsed: unknown = parse(yaml);
     const result = validateWorkspace(parsed);
     expect(result.status).toBe("ok");

--- a/packages/config/src/validate-workspace.test.ts
+++ b/packages/config/src/validate-workspace.test.ts
@@ -1,23 +1,5 @@
-import { readFile } from "node:fs/promises";
-import { parse } from "@std/yaml";
 import { describe, expect, it } from "vitest";
 import { validateWorkspace } from "./validate-workspace.ts";
-
-const inboxZeroRegistry = {
-  mcpServers: ["google-gmail"],
-  mcpTools: {
-    "google-gmail": [
-      "search_gmail_messages",
-      "get_gmail_message_content",
-      "get_gmail_messages_content_batch",
-      "get_gmail_thread_content",
-      "modify_gmail_message_labels",
-      "list_gmail_labels",
-      "draft_gmail_message",
-      "send_gmail_message",
-    ],
-  },
-};
 
 describe("validateWorkspace structural layer", () => {
   it("returns ok for a minimal valid config", () => {
@@ -140,15 +122,6 @@ describe("validateWorkspace structural layer", () => {
       expect(issue.message).not.toContain("ZodError");
       expect(issue.message).not.toContain("JSON.stringify");
     }
-  });
-
-  it("validates Ken's Inbox-Zero workspace as clean", async () => {
-    const yaml = await readFile("/Users/ericskram/Desktop/Inbox-Zero/workspace.yml", "utf-8");
-    const parsed: unknown = parse(yaml);
-    const result = validateWorkspace(parsed, inboxZeroRegistry);
-    expect(result.status).toBe("ok");
-    expect(result.errors).toEqual([]);
-    expect(result.warnings).toEqual([]);
   });
 
   it("resolves MCP tools from declared servers in config without explicit registry", () => {
@@ -625,17 +598,5 @@ describe("validateWorkspace semantic warnings", () => {
     const warn = result.warnings.find((w) => w.code === "http_path_collision");
     expect(warn).toBeDefined();
     expect(warn!.message).toContain("/same");
-  });
-
-  it("validates Meeting-Scheduler workspace as clean", async () => {
-    const yaml = await readFile(
-      "/Users/ericskram/Desktop/Meeting-Scheduler/workspace.yml",
-      "utf-8",
-    );
-    const parsed: unknown = parse(yaml);
-    const result = validateWorkspace(parsed);
-    expect(result.status).toBe("ok");
-    expect(result.errors).toEqual([]);
-    expect(result.warnings).toEqual([]);
   });
 });

--- a/packages/config/src/validate-workspace.ts
+++ b/packages/config/src/validate-workspace.ts
@@ -168,9 +168,8 @@ function checkToolReferences(config: WorkspaceConfig, registry: Registry, issues
       if (validTools.has(tool)) continue;
 
       const prefix = tool.split("/")[0];
-      const bareName = tool.slice(prefix.length + 1);
-
       if (prefix) {
+        const bareName = tool.slice(prefix.length + 1);
         if (serverTools.has(prefix)) {
           // Registry has resolved tools for this server — verify the bare name exists
           if (serverTools.get(prefix)?.has(bareName)) continue;

--- a/packages/config/src/validate-workspace.ts
+++ b/packages/config/src/validate-workspace.ts
@@ -1,8 +1,8 @@
 import { PLATFORM_TOOL_NAMES } from "@atlas/agent-sdk";
 import { CronExpressionParser } from "cron-parser";
 import { z } from "zod";
-import { WorkspaceConfigSchema, type WorkspaceConfig } from "./workspace.ts";
 import { extractFSMAgents } from "./mutations/fsm-agents.ts";
+import { type WorkspaceConfig, WorkspaceConfigSchema } from "./workspace.ts";
 
 const AgentIdSpecSchema = z.union([z.string(), z.object({ id: z.string() })]);
 
@@ -129,11 +129,7 @@ function checkAgentReferences(config: WorkspaceConfig, issues: Issue[]): void {
   }
 }
 
-function checkToolReferences(
-  config: WorkspaceConfig,
-  registry: Registry,
-  issues: Issue[],
-): void {
+function checkToolReferences(config: WorkspaceConfig, registry: Registry, issues: Issue[]): void {
   const validTools = new Set(PLATFORM_TOOL_NAMES);
   const serverPrefixes = new Set<string>();
   // serverId -> Set<bareToolName> for precise prefixed-tool verification
@@ -237,8 +233,7 @@ function checkMemoryReferences(config: WorkspaceConfig, issues: Issue[]): void {
 // ==============================================================================
 
 function checkMissingToolsArray(config: WorkspaceConfig, issues: Issue[]): void {
-  const hasMcpServers =
-    Object.keys(config.tools?.mcp?.servers ?? {}).length > 0;
+  const hasMcpServers = Object.keys(config.tools?.mcp?.servers ?? {}).length > 0;
   if (!hasMcpServers) return;
 
   for (const [agentName, agent] of Object.entries(config.agents ?? {})) {
@@ -379,11 +374,11 @@ function findMemoryReferences(text: string): string[] {
   // Quoted string followed by memory/corpus/store
   const quotedPattern = /["']([a-zA-Z0-9_-]+)["']\s+(memory|corpus|store)\b/g;
 
-  let match: RegExpExecArray | null;
-
-  while ((match = quotedPattern.exec(text)) !== null) {
+  let match = quotedPattern.exec(text);
+  while (match !== null) {
     const name = match[1];
     if (name) refs.add(name);
+    match = quotedPattern.exec(text);
   }
 
   return [...refs];

--- a/packages/fsm-engine/fsm-engine.ts
+++ b/packages/fsm-engine/fsm-engine.ts
@@ -406,7 +406,6 @@ export class FSMEngine {
   private static readonly MAX_RECURSION_DEPTH = 10;
   private static readonly MAX_PROCESSED_SIGNALS = 100;
   private _processedSignalsCount = 0;
-  private _hasProcessedSignal = false;
 
   constructor(
     private _definition: FSMDefinition,
@@ -586,7 +585,6 @@ export class FSMEngine {
   }
 
   private async processSingleSignal(sig: SignalWithContext): Promise<void> {
-    this._hasProcessedSignal = true;
     await withOtelSpan(
       "fsm.signal",
       {
@@ -2083,7 +2081,6 @@ export class FSMEngine {
     this._emittedEvents = [];
     this._recursionDepth = 0;
     this._processedSignalsCount = 0;
-    this._hasProcessedSignal = false;
     this._processing = false;
 
     // Re-run idle entry actions (like initialize() does)

--- a/packages/system/agents/workspace-chat/tools/disable-mcp-server.test.ts
+++ b/packages/system/agents/workspace-chat/tools/disable-mcp-server.test.ts
@@ -9,14 +9,10 @@ import { createDisableMcpServerTool } from "./disable-mcp-server.ts";
 const mockDelete = vi.hoisted(() => vi.fn());
 const mockWorkspaceMcp = vi.hoisted(() => vi.fn());
 
-vi.mock("@atlas/client/v2", () => ({
-  client: { workspaceMcp: mockWorkspaceMcp },
-}));
+vi.mock("@atlas/client/v2", () => ({ client: { workspaceMcp: mockWorkspaceMcp } }));
 
-function setupMock(workspaceId: string) {
-  mockWorkspaceMcp.mockReturnValue({
-    ":serverId": { $delete: mockDelete },
-  });
+function setupMock(_workspaceId: string) {
+  mockWorkspaceMcp.mockReturnValue({ ":serverId": { $delete: mockDelete } });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/system/agents/workspace-chat/tools/disable-mcp-server.test.ts
+++ b/packages/system/agents/workspace-chat/tools/disable-mcp-server.test.ts
@@ -204,7 +204,7 @@ describe("createDisableMcpServerTool", () => {
     });
 
     const tools = createDisableMcpServerTool("ws-1", logger);
-    const result = await tools.disable_mcp_server!.execute(
+    const result = await tools.disable_mcp_server!.execute!(
       { serverId: "github", workspaceId: "ws-other" },
       TOOL_CALL_OPTS,
     );

--- a/packages/system/agents/workspace-chat/tools/disable-mcp-server.ts
+++ b/packages/system/agents/workspace-chat/tools/disable-mcp-server.ts
@@ -62,7 +62,11 @@ export function createDisableMcpServerTool(workspaceId: string, logger: Logger):
         "Safe by default — if agents or jobs still reference it, the call fails and lists them. " +
         "Set force=true to override and strip all references automatically.",
       inputSchema: DisableInputSchema,
-      execute: async ({ serverId, force, workspaceId: targetWorkspaceId }): Promise<DisableResult> => {
+      execute: async ({
+        serverId,
+        force,
+        workspaceId: targetWorkspaceId,
+      }): Promise<DisableResult> => {
         const effectiveWorkspaceId = targetWorkspaceId ?? workspaceId;
 
         try {
@@ -75,7 +79,11 @@ export function createDisableMcpServerTool(workspaceId: string, logger: Logger):
           const body = await res.json();
 
           if (res.status === 200) {
-            logger.info("disable_mcp_server succeeded", { workspaceId: effectiveWorkspaceId, serverId, force });
+            logger.info("disable_mcp_server succeeded", {
+              workspaceId: effectiveWorkspaceId,
+              serverId,
+              force,
+            });
             return {
               success: true,
               removed: serverId,
@@ -88,7 +96,10 @@ export function createDisableMcpServerTool(workspaceId: string, logger: Logger):
             const errorMsg = String(
               errorBody.message ?? `Server "${serverId}" is not enabled in this workspace.`,
             );
-            logger.info("disable_mcp_server: not enabled", { workspaceId: effectiveWorkspaceId, serverId });
+            logger.info("disable_mcp_server: not enabled", {
+              workspaceId: effectiveWorkspaceId,
+              serverId,
+            });
             return { success: false, error: errorMsg };
           }
 
@@ -105,7 +116,11 @@ export function createDisableMcpServerTool(workspaceId: string, logger: Logger):
                 })
               : undefined;
 
-            logger.info("disable_mcp_server: conflict", { workspaceId: effectiveWorkspaceId, serverId, willUnlinkFrom });
+            logger.info("disable_mcp_server: conflict", {
+              workspaceId: effectiveWorkspaceId,
+              serverId,
+              willUnlinkFrom,
+            });
             return {
               success: false,
               error: errorMsg,
@@ -119,7 +134,10 @@ export function createDisableMcpServerTool(workspaceId: string, logger: Logger):
               errorBody.message ??
                 "This workspace uses a blueprint — direct config mutations are not supported.",
             );
-            logger.info("disable_mcp_server: blueprint rejected", { workspaceId: effectiveWorkspaceId, serverId });
+            logger.info("disable_mcp_server: blueprint rejected", {
+              workspaceId: effectiveWorkspaceId,
+              serverId,
+            });
             return { success: false, error: errorMsg };
           }
 
@@ -136,7 +154,11 @@ export function createDisableMcpServerTool(workspaceId: string, logger: Logger):
           return { success: false, error: errorMsg };
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          logger.warn("disable_mcp_server threw", { workspaceId: effectiveWorkspaceId, serverId, error: message });
+          logger.warn("disable_mcp_server threw", {
+            workspaceId: effectiveWorkspaceId,
+            serverId,
+            error: message,
+          });
           return { success: false, error: `Disable failed: ${message}` };
         }
       },

--- a/packages/system/agents/workspace-chat/tools/draft-tools.test.ts
+++ b/packages/system/agents/workspace-chat/tools/draft-tools.test.ts
@@ -13,11 +13,7 @@ const mockDraftDelete = vi.hoisted(() => vi.fn<() => Promise<unknown>>());
 const mockLintPost = vi.hoisted(() => vi.fn<() => Promise<unknown>>());
 
 function mockResponse(ok: boolean, status: number, body: unknown): unknown {
-  return {
-    ok,
-    status,
-    json: () => Promise.resolve(body),
-  };
+  return { ok, status, json: () => Promise.resolve(body) };
 }
 
 vi.mock("@atlas/client/v2", () => ({
@@ -56,7 +52,10 @@ describe("createDraftTools", () => {
     expect(tools).toHaveProperty("begin_draft");
 
     const result = await tools.begin_draft!.execute!({}, TOOL_CALL_OPTS);
-    expect(result).toMatchObject({ success: false, error: expect.stringContaining("begin_draft must be called") });
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("begin_draft must be called"),
+    });
   });
 
   it("returns placeholder publish_draft that errors without workspaceId", async () => {
@@ -64,7 +63,10 @@ describe("createDraftTools", () => {
     expect(tools).toHaveProperty("publish_draft");
 
     const result = await tools.publish_draft!.execute!({}, TOOL_CALL_OPTS);
-    expect(result).toMatchObject({ success: false, error: expect.stringContaining("publish_draft must be called") });
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("publish_draft must be called"),
+    });
   });
 
   it("returns placeholder validate_workspace that errors without workspaceId", async () => {
@@ -72,7 +74,10 @@ describe("createDraftTools", () => {
     expect(tools).toHaveProperty("validate_workspace");
 
     const result = await tools.validate_workspace!.execute!({}, TOOL_CALL_OPTS);
-    expect(result).toMatchObject({ success: false, error: expect.stringContaining("validate_workspace must be called") });
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("validate_workspace must be called"),
+    });
   });
 
   it("returns placeholder discard_draft that errors without workspaceId", async () => {
@@ -80,7 +85,10 @@ describe("createDraftTools", () => {
     expect(tools).toHaveProperty("discard_draft");
 
     const result = await tools.discard_draft!.execute!({}, TOOL_CALL_OPTS);
-    expect(result).toMatchObject({ success: false, error: expect.stringContaining("discard_draft must be called") });
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("discard_draft must be called"),
+    });
   });
 });
 
@@ -136,7 +144,11 @@ describe("createBoundDraftTools", () => {
 
   it("publish_draft calls the draft publish endpoint", async () => {
     mockDraftPublishPost.mockResolvedValueOnce(
-      mockResponse(true, 200, { success: true, livePath: "/tmp/ws-1/workspace.yml", runtimeReloaded: false }),
+      mockResponse(true, 200, {
+        success: true,
+        livePath: "/tmp/ws-1/workspace.yml",
+        runtimeReloaded: false,
+      }),
     );
 
     const tools = createBoundDraftTools(logger, "ws-1");
@@ -151,7 +163,11 @@ describe("createBoundDraftTools", () => {
   });
 
   it("publish_draft returns report on validation failure", async () => {
-    const report = { status: "error", errors: [{ code: "unknown_agent_id", path: "jobs.test.fsm", message: "Missing agent" }], warnings: [] };
+    const report = {
+      status: "error",
+      errors: [{ code: "unknown_agent_id", path: "jobs.test.fsm", message: "Missing agent" }],
+      warnings: [],
+    };
     mockDraftPublishPost.mockResolvedValueOnce(
       mockResponse(false, 422, { success: false, error: "Validation failed", report }),
     );
@@ -186,9 +202,7 @@ describe("createBoundDraftTools", () => {
 
   it("validate_workspace returns draft report when draft exists", async () => {
     const report = { status: "ok", errors: [], warnings: [] };
-    mockDraftValidatePost.mockResolvedValueOnce(
-      mockResponse(true, 200, { success: true, report }),
-    );
+    mockDraftValidatePost.mockResolvedValueOnce(mockResponse(true, 200, { success: true, report }));
 
     const tools = createBoundDraftTools(logger, "ws-1");
     const result = await tools.validate_workspace!.execute!({}, TOOL_CALL_OPTS);
@@ -202,9 +216,7 @@ describe("createBoundDraftTools", () => {
     mockDraftValidatePost.mockResolvedValueOnce(
       mockResponse(false, 409, { success: false, error: "No draft exists" }),
     );
-    mockLintPost.mockResolvedValueOnce(
-      mockResponse(true, 200, { report }),
-    );
+    mockLintPost.mockResolvedValueOnce(mockResponse(true, 200, { report }));
 
     const tools = createBoundDraftTools(logger, "ws-1");
     const result = await tools.validate_workspace!.execute!({}, TOOL_CALL_OPTS);
@@ -225,9 +237,7 @@ describe("createBoundDraftTools", () => {
   });
 
   it("discard_draft succeeds when draft is deleted", async () => {
-    mockDraftDelete.mockResolvedValueOnce(
-      mockResponse(true, 200, { success: true }),
-    );
+    mockDraftDelete.mockResolvedValueOnce(mockResponse(true, 200, { success: true }));
 
     const tools = createBoundDraftTools(logger, "ws-1");
     const result = await tools.discard_draft!.execute!({}, TOOL_CALL_OPTS);

--- a/packages/system/agents/workspace-chat/tools/draft-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/draft-tools.ts
@@ -22,14 +22,13 @@ export function createDraftTools(_logger: Logger): AtlasTools {
         "stage changes safely. Idempotent — calling again when a draft already " +
         "exists is a no-op.",
       inputSchema: z.object({ workspaceId: z.string().optional() }),
-      execute: async () => {
-        return {
+      execute: () =>
+        Promise.resolve({
           success: false,
           error:
             "begin_draft must be called with a workspaceId context. " +
             "This is handled automatically by the workspace-chat agent.",
-        };
-      },
+        }),
     }),
 
     publish_draft: tool({
@@ -40,14 +39,13 @@ export function createDraftTools(_logger: Logger): AtlasTools {
         "the draft is left untouched and you receive a structured error report " +
         "to fix before retrying.",
       inputSchema: z.object({ workspaceId: z.string().optional() }),
-      execute: async () => {
-        return {
+      execute: () =>
+        Promise.resolve({
           success: false,
           error:
             "publish_draft must be called with a workspaceId context. " +
             "This is handled automatically by the workspace-chat agent.",
-        };
-      },
+        }),
     }),
 
     validate_workspace: tool({
@@ -56,28 +54,26 @@ export function createDraftTools(_logger: Logger): AtlasTools {
         "the draft; otherwise validates the live config. Returns a full validation " +
         "report with errors and warnings.",
       inputSchema: z.object({ workspaceId: z.string().optional() }),
-      execute: async () => {
-        return {
+      execute: () =>
+        Promise.resolve({
           success: false,
           error:
             "validate_workspace must be called with a workspaceId context. " +
             "This is handled automatically by the workspace-chat agent.",
-        };
-      },
+        }),
     }),
 
     discard_draft: tool({
       description:
         "Discard the current workspace draft without publishing. No-op if no draft exists.",
       inputSchema: z.object({ workspaceId: z.string().optional() }),
-      execute: async () => {
-        return {
+      execute: () =>
+        Promise.resolve({
           success: false,
           error:
             "discard_draft must be called with a workspaceId context. " +
             "This is handled automatically by the workspace-chat agent.",
-        };
-      },
+        }),
     }),
   };
 }
@@ -144,11 +140,7 @@ export function createBoundDraftTools(logger: Logger, workspaceId: string): Atla
 
         const data = await res.json();
         logger.info("publish_draft succeeded", { workspaceId: targetId });
-        return {
-          success: true,
-          livePath: data.livePath,
-          runtimeReloaded: data.runtimeReloaded,
-        };
+        return { success: true, livePath: data.livePath, runtimeReloaded: data.runtimeReloaded };
       },
     }),
 
@@ -186,12 +178,18 @@ export function createBoundDraftTools(logger: Logger, workspaceId: string): Atla
           }
 
           const body = await lintRes.json().catch(() => ({ error: "Live validation failed" }));
-          logger.warn("validate_workspace live validation failed", { error: body.error, workspaceId: targetId });
+          logger.warn("validate_workspace live validation failed", {
+            error: body.error,
+            workspaceId: targetId,
+          });
           return { success: false, error: body.error ?? "Live validation failed" };
         }
 
         const body = await draftRes.json().catch(() => ({ error: "Draft validation failed" }));
-        logger.warn("validate_workspace draft validation failed", { error: body.error, workspaceId: targetId });
+        logger.warn("validate_workspace draft validation failed", {
+          error: body.error,
+          workspaceId: targetId,
+        });
         return { success: false, error: body.error ?? "Draft validation failed" };
       },
     }),
@@ -210,7 +208,10 @@ export function createBoundDraftTools(logger: Logger, workspaceId: string): Atla
         });
 
         if (res.ok || res.status === 409) {
-          logger.info("discard_draft succeeded", { workspaceId: targetId, noOp: res.status === 409 });
+          logger.info("discard_draft succeeded", {
+            workspaceId: targetId,
+            noOp: res.status === 409,
+          });
           return { success: true, noOp: res.status === 409 };
         }
 

--- a/packages/system/agents/workspace-chat/tools/draft-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/draft-tools.ts
@@ -13,6 +13,8 @@ import type { Logger } from "@atlas/logger";
 import { tool } from "ai";
 import { z } from "zod";
 
+const ErrorBodySchema = z.object({ error: z.string().optional(), report: z.unknown().optional() });
+
 export function createDraftTools(_logger: Logger): AtlasTools {
   return {
     begin_draft: tool({
@@ -102,7 +104,12 @@ export function createBoundDraftTools(logger: Logger, workspaceId: string): Atla
         });
 
         if (!res.ok) {
-          const body = await res.json().catch(() => ({ error: "begin_draft failed" }));
+          let body: z.infer<typeof ErrorBodySchema>;
+          try {
+            body = ErrorBodySchema.parse(await res.json());
+          } catch {
+            body = { error: "begin_draft failed" };
+          }
           logger.warn("begin_draft failed", { error: body.error, workspaceId: targetId });
           return { success: false, error: body.error ?? "begin_draft failed" };
         }
@@ -129,7 +136,12 @@ export function createBoundDraftTools(logger: Logger, workspaceId: string): Atla
         });
 
         if (!res.ok) {
-          const body = await res.json().catch(() => ({ error: "publish_draft failed" }));
+          let body: z.infer<typeof ErrorBodySchema>;
+          try {
+            body = ErrorBodySchema.parse(await res.json());
+          } catch {
+            body = { error: "publish_draft failed" };
+          }
           logger.warn("publish_draft failed", { error: body.error, workspaceId: targetId });
           return {
             success: false,
@@ -177,7 +189,12 @@ export function createBoundDraftTools(logger: Logger, workspaceId: string): Atla
             return data.report;
           }
 
-          const body = await lintRes.json().catch(() => ({ error: "Live validation failed" }));
+          let body: z.infer<typeof ErrorBodySchema>;
+          try {
+            body = ErrorBodySchema.parse(await lintRes.json());
+          } catch {
+            body = { error: "Live validation failed" };
+          }
           logger.warn("validate_workspace live validation failed", {
             error: body.error,
             workspaceId: targetId,
@@ -185,7 +202,12 @@ export function createBoundDraftTools(logger: Logger, workspaceId: string): Atla
           return { success: false, error: body.error ?? "Live validation failed" };
         }
 
-        const body = await draftRes.json().catch(() => ({ error: "Draft validation failed" }));
+        let body: z.infer<typeof ErrorBodySchema>;
+        try {
+          body = ErrorBodySchema.parse(await draftRes.json());
+        } catch {
+          body = { error: "Draft validation failed" };
+        }
         logger.warn("validate_workspace draft validation failed", {
           error: body.error,
           workspaceId: targetId,
@@ -215,7 +237,12 @@ export function createBoundDraftTools(logger: Logger, workspaceId: string): Atla
           return { success: true, noOp: res.status === 409 };
         }
 
-        const body = await res.json().catch(() => ({ error: "discard_draft failed" }));
+        let body: z.infer<typeof ErrorBodySchema>;
+        try {
+          body = ErrorBodySchema.parse(await res.json());
+        } catch {
+          body = { error: "discard_draft failed" };
+        }
         logger.warn("discard_draft failed", { error: body.error, workspaceId: targetId });
         return { success: false, error: body.error ?? "discard_draft failed" };
       },

--- a/packages/system/agents/workspace-chat/tools/enable-mcp-server.test.ts
+++ b/packages/system/agents/workspace-chat/tools/enable-mcp-server.test.ts
@@ -159,7 +159,7 @@ describe("createEnableMcpServerTool", () => {
     });
 
     const tools = createEnableMcpServerTool("ws-1", logger);
-    const result = await tools.enable_mcp_server!.execute(
+    const result = await tools.enable_mcp_server!.execute!(
       { serverId: "github", workspaceId: "ws-other" },
       TOOL_CALL_OPTS,
     );

--- a/packages/system/agents/workspace-chat/tools/enable-mcp-server.test.ts
+++ b/packages/system/agents/workspace-chat/tools/enable-mcp-server.test.ts
@@ -9,14 +9,10 @@ import { createEnableMcpServerTool } from "./enable-mcp-server.ts";
 const mockPut = vi.hoisted(() => vi.fn());
 const mockWorkspaceMcp = vi.hoisted(() => vi.fn());
 
-vi.mock("@atlas/client/v2", () => ({
-  client: { workspaceMcp: mockWorkspaceMcp },
-}));
+vi.mock("@atlas/client/v2", () => ({ client: { workspaceMcp: mockWorkspaceMcp } }));
 
-function setupMock(workspaceId: string) {
-  mockWorkspaceMcp.mockReturnValue({
-    ":serverId": { $put: mockPut },
-  });
+function setupMock(_workspaceId: string) {
+  mockWorkspaceMcp.mockReturnValue({ ":serverId": { $put: mockPut } });
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/system/agents/workspace-chat/tools/enable-mcp-server.ts
+++ b/packages/system/agents/workspace-chat/tools/enable-mcp-server.ts
@@ -61,7 +61,11 @@ export function createEnableMcpServerTool(workspaceId: string, logger: Logger): 
               .safeParse(body);
 
             const name = parsed.success && parsed.data.server ? parsed.data.server.name : serverId;
-            logger.info("enable_mcp_server succeeded", { workspaceId: effectiveWorkspaceId, serverId, name });
+            logger.info("enable_mcp_server succeeded", {
+              workspaceId: effectiveWorkspaceId,
+              serverId,
+              name,
+            });
             return {
               success: true,
               server: { id: serverId, name },
@@ -74,14 +78,21 @@ export function createEnableMcpServerTool(workspaceId: string, logger: Logger): 
             const errorMsg = String(
               errorBody.message ?? `Server "${serverId}" not found in catalog.`,
             );
-            logger.info("enable_mcp_server: not found", { workspaceId: effectiveWorkspaceId, serverId });
+            logger.info("enable_mcp_server: not found", {
+              workspaceId: effectiveWorkspaceId,
+              serverId,
+            });
             return { success: false, error: errorMsg };
           }
 
           if (res.status === 409) {
             const errorBody = body as Record<string, unknown>;
             const errorMsg = String(errorBody.message ?? "Conflict enabling MCP server.");
-            logger.info("enable_mcp_server: conflict", { workspaceId: effectiveWorkspaceId, serverId, error: errorMsg });
+            logger.info("enable_mcp_server: conflict", {
+              workspaceId: effectiveWorkspaceId,
+              serverId,
+              error: errorMsg,
+            });
             return { success: false, error: errorMsg };
           }
 
@@ -91,7 +102,10 @@ export function createEnableMcpServerTool(workspaceId: string, logger: Logger): 
               errorBody.message ??
                 "This workspace uses a blueprint — direct config mutations are not supported.",
             );
-            logger.info("enable_mcp_server: blueprint rejected", { workspaceId: effectiveWorkspaceId, serverId });
+            logger.info("enable_mcp_server: blueprint rejected", {
+              workspaceId: effectiveWorkspaceId,
+              serverId,
+            });
             return { success: false, error: errorMsg };
           }
 
@@ -108,7 +122,11 @@ export function createEnableMcpServerTool(workspaceId: string, logger: Logger): 
           return { success: false, error: errorMsg };
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          logger.warn("enable_mcp_server threw", { workspaceId: effectiveWorkspaceId, serverId, error: message });
+          logger.warn("enable_mcp_server threw", {
+            workspaceId: effectiveWorkspaceId,
+            serverId,
+            error: message,
+          });
           return { success: false, error: `Enable failed: ${message}` };
         }
       },

--- a/packages/system/agents/workspace-chat/tools/list-mcp-tools.test.ts
+++ b/packages/system/agents/workspace-chat/tools/list-mcp-tools.test.ts
@@ -65,7 +65,7 @@ describe("createListMcpToolsTool", () => {
     });
 
     const tools = createListMcpToolsTool(logger);
-    const result = await tools.list_mcp_tools!.execute(
+    const result = await tools.list_mcp_tools!.execute!(
       { serverId: "google-gmail" },
       TOOL_CALL_OPTS,
     );
@@ -91,7 +91,7 @@ describe("createListMcpToolsTool", () => {
     });
 
     const tools = createListMcpToolsTool(logger);
-    const result = await tools.list_mcp_tools!.execute(
+    const result = await tools.list_mcp_tools!.execute!(
       { serverId: "minimal-server" },
       TOOL_CALL_OPTS,
     );
@@ -106,7 +106,7 @@ describe("createListMcpToolsTool", () => {
     });
 
     const tools = createListMcpToolsTool(logger);
-    const result = await tools.list_mcp_tools!.execute(
+    const result = await tools.list_mcp_tools!.execute!(
       { serverId: "google-gmail" },
       TOOL_CALL_OPTS,
     );
@@ -129,7 +129,10 @@ describe("createListMcpToolsTool", () => {
     });
 
     const tools = createListMcpToolsTool(logger);
-    const result = await tools.list_mcp_tools!.execute({ serverId: "nonexistent" }, TOOL_CALL_OPTS);
+    const result = await tools.list_mcp_tools!.execute!(
+      { serverId: "nonexistent" },
+      TOOL_CALL_OPTS,
+    );
 
     expect(result).toEqual({
       ok: false,
@@ -146,7 +149,7 @@ describe("createListMcpToolsTool", () => {
     });
 
     const tools = createListMcpToolsTool(logger);
-    const result = await tools.list_mcp_tools!.execute(
+    const result = await tools.list_mcp_tools!.execute!(
       { serverId: "google-gmail" },
       TOOL_CALL_OPTS,
     );
@@ -158,7 +161,7 @@ describe("createListMcpToolsTool", () => {
     mockGet.mockRejectedValueOnce(new Error("Network failure"));
 
     const tools = createListMcpToolsTool(logger);
-    const result = await tools.list_mcp_tools!.execute(
+    const result = await tools.list_mcp_tools!.execute!(
       { serverId: "google-gmail" },
       TOOL_CALL_OPTS,
     );

--- a/packages/system/agents/workspace-chat/tools/list-mcp-tools.test.ts
+++ b/packages/system/agents/workspace-chat/tools/list-mcp-tools.test.ts
@@ -129,14 +129,12 @@ describe("createListMcpToolsTool", () => {
     });
 
     const tools = createListMcpToolsTool(logger);
-    const result = await tools.list_mcp_tools!.execute(
-      { serverId: "nonexistent" },
-      TOOL_CALL_OPTS,
-    );
+    const result = await tools.list_mcp_tools!.execute({ serverId: "nonexistent" }, TOOL_CALL_OPTS);
 
     expect(result).toEqual({
       ok: false,
-      error: 'MCP server "nonexistent" not found in catalog. Use search_mcp_servers or list_mcp_servers to find valid IDs.',
+      error:
+        'MCP server "nonexistent" not found in catalog. Use search_mcp_servers or list_mcp_servers to find valid IDs.',
       phase: "connect",
     });
   });
@@ -153,11 +151,7 @@ describe("createListMcpToolsTool", () => {
       TOOL_CALL_OPTS,
     );
 
-    expect(result).toEqual({
-      ok: false,
-      error: "Registry timeout",
-      phase: "tools",
-    });
+    expect(result).toEqual({ ok: false, error: "Registry timeout", phase: "tools" });
   });
 
   it("returns error when fetch throws", async () => {
@@ -169,17 +163,10 @@ describe("createListMcpToolsTool", () => {
       TOOL_CALL_OPTS,
     );
 
-    expect(result).toEqual({
-      ok: false,
-      error: "Probe failed: Network failure",
-      phase: "tools",
-    });
+    expect(result).toEqual({ ok: false, error: "Probe failed: Network failure", phase: "tools" });
     expect(logger.warn).toHaveBeenCalledWith(
       "list_mcp_tools threw",
-      expect.objectContaining({
-        serverId: "google-gmail",
-        error: "Network failure",
-      }),
+      expect.objectContaining({ serverId: "google-gmail", error: "Network failure" }),
     );
   });
 });

--- a/packages/system/agents/workspace-chat/tools/list-mcp-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/list-mcp-tools.ts
@@ -14,10 +14,7 @@ const ListMcpToolsInput = z.object({
     ),
 });
 
-const ToolItemSchema = z.object({
-  name: z.string(),
-  description: z.string().optional(),
-});
+const ToolItemSchema = z.object({ name: z.string(), description: z.string().optional() });
 
 export interface ListMcpToolsSuccess {
   ok: true;
@@ -49,17 +46,12 @@ export function createListMcpToolsTool(logger: Logger): AtlasTools {
       inputSchema: ListMcpToolsInput,
       execute: async ({ serverId }): Promise<ListMcpToolsSuccess | ListMcpToolsError> => {
         try {
-          const res = await client.mcpRegistry[":id"].tools.$get({
-            param: { id: serverId },
-          });
+          const res = await client.mcpRegistry[":id"].tools.$get({ param: { id: serverId } });
           const body = await res.json();
 
           if (res.status === 200) {
             const parsed = z
-              .object({
-                ok: z.literal(true),
-                tools: z.array(ToolItemSchema),
-              })
+              .object({ ok: z.literal(true), tools: z.array(ToolItemSchema) })
               .safeParse(body);
 
             if (parsed.success) {
@@ -69,10 +61,7 @@ export function createListMcpToolsTool(logger: Logger): AtlasTools {
               });
               return {
                 ok: true,
-                tools: parsed.data.tools.map((t) => ({
-                  ...t,
-                  name: `${serverId}/${t.name}`,
-                })),
+                tools: parsed.data.tools.map((t) => ({ ...t, name: `${serverId}/${t.name}` })),
               };
             }
 

--- a/packages/system/agents/workspace-chat/tools/upsert-tools.test.ts
+++ b/packages/system/agents/workspace-chat/tools/upsert-tools.test.ts
@@ -17,14 +17,8 @@ vi.mock("@atlas/client/v2", () => ({
   client: {
     workspace: {
       ":workspaceId": {
-        draft: {
-          items: {
-            ":kind": { $post: mockDraftItemsPost },
-          },
-        },
-        items: {
-          ":kind": { $post: mockDirectItemsPost },
-        },
+        draft: { items: { ":kind": { $post: mockDraftItemsPost } } },
+        items: { ":kind": { $post: mockDirectItemsPost } },
       },
     },
   },
@@ -46,11 +40,7 @@ function makeLogger(): Logger {
 const TOOL_CALL_OPTS = { toolCallId: "test-call", messages: [] as never[] };
 
 function makeResponse(body: unknown, status = 200, ok = true): Response {
-  return {
-    ok,
-    status,
-    json: async () => body,
-  } as Response;
+  return { ok, status, json: () => Promise.resolve(body) } as Response;
 }
 
 describe("createUpsertTools", () => {
@@ -60,10 +50,7 @@ describe("createUpsertTools", () => {
     expect(tools).toHaveProperty("upsert_signal");
     expect(tools).toHaveProperty("upsert_job");
 
-    const result = await tools.upsert_agent!.execute!(
-      { id: "a", config: {} },
-      TOOL_CALL_OPTS,
-    );
+    const result = await tools.upsert_agent!.execute!({ id: "a", config: {} }, TOOL_CALL_OPTS);
     expect(result).toMatchObject({
       ok: false,
       error: expect.stringContaining("upsert_agent must be called"),
@@ -102,17 +89,20 @@ describe("createBoundUpsertTools", () => {
       param: { workspaceId: "ws-1", kind: "agent" },
       json: { id: "email-triager", config: { type: "llm" } },
     });
-    expect(result).toEqual({
-      ok: true,
-      diff: { type: { to: "llm" } },
-      structural_issues: null,
-    });
+    expect(result).toEqual({ ok: true, diff: { type: { to: "llm" } }, structural_issues: null });
   });
 
   it("upsert_agent falls back to direct endpoint when no draft (409)", async () => {
-    mockDraftItemsPost.mockResolvedValueOnce(makeResponse({ error: "No draft exists" }, 409, false));
+    mockDraftItemsPost.mockResolvedValueOnce(
+      makeResponse({ error: "No draft exists" }, 409, false),
+    );
     mockDirectItemsPost.mockResolvedValueOnce(
-      makeResponse({ ok: true, diff: { type: { to: "llm" } }, structuralIssues: null, runtimeReloaded: false }),
+      makeResponse({
+        ok: true,
+        diff: { type: { to: "llm" } },
+        structuralIssues: null,
+        runtimeReloaded: false,
+      }),
     );
 
     const tools = createBoundUpsertTools(logger, "ws-1");
@@ -129,11 +119,7 @@ describe("createBoundUpsertTools", () => {
       param: { workspaceId: "ws-1", kind: "agent" },
       json: { id: "email-triager", config: { type: "llm" } },
     });
-    expect(result).toEqual({
-      ok: true,
-      diff: { type: { to: "llm" } },
-      structural_issues: null,
-    });
+    expect(result).toEqual({ ok: true, diff: { type: { to: "llm" } }, structural_issues: null });
   });
 
   it("upsert_signal calls draft endpoint with correct kind", async () => {
@@ -201,16 +187,15 @@ describe("createBoundUpsertTools", () => {
   });
 
   it("returns structured error when direct endpoint fails", async () => {
-    mockDraftItemsPost.mockResolvedValueOnce(makeResponse({ error: "No draft exists" }, 409, false));
+    mockDraftItemsPost.mockResolvedValueOnce(
+      makeResponse({ error: "No draft exists" }, 409, false),
+    );
     mockDirectItemsPost.mockResolvedValueOnce(
       makeResponse({ error: "Direct upsert failed" }, 500, false),
     );
 
     const tools = createBoundUpsertTools(logger, "ws-1");
-    const result = await tools.upsert_agent!.execute!(
-      { id: "agent", config: {} },
-      TOOL_CALL_OPTS,
-    );
+    const result = await tools.upsert_agent!.execute!({ id: "agent", config: {} }, TOOL_CALL_OPTS);
 
     expect(result).toEqual({
       ok: false,
@@ -221,14 +206,20 @@ describe("createBoundUpsertTools", () => {
   });
 
   it("preserves diff and structural_issues when direct endpoint returns 422", async () => {
-    mockDraftItemsPost.mockResolvedValueOnce(makeResponse({ error: "No draft exists" }, 409, false));
+    mockDraftItemsPost.mockResolvedValueOnce(
+      makeResponse({ error: "No draft exists" }, 409, false),
+    );
     mockDirectItemsPost.mockResolvedValueOnce(
       makeResponse(
         {
           ok: false,
           diff: { "config.tools": { added: ["google-gmail/search_gmail_messages"] } },
           structural_issues: [
-            { code: "unknown_tool", path: "agents.email-triage.config.tools[0]", message: "unknown tool" },
+            {
+              code: "unknown_tool",
+              path: "agents.email-triage.config.tools[0]",
+              message: "unknown tool",
+            },
           ],
         },
         422,
@@ -246,7 +237,11 @@ describe("createBoundUpsertTools", () => {
       ok: false,
       diff: { "config.tools": { added: ["google-gmail/search_gmail_messages"] } },
       structural_issues: [
-        { code: "unknown_tool", path: "agents.email-triage.config.tools[0]", message: "unknown tool" },
+        {
+          code: "unknown_tool",
+          path: "agents.email-triage.config.tools[0]",
+          message: "unknown tool",
+        },
       ],
       error: "Validation failed",
     });
@@ -256,16 +251,11 @@ describe("createBoundUpsertTools", () => {
     mockDraftItemsPost.mockResolvedValueOnce({
       ok: false,
       status: 500,
-      json: async () => {
-        throw new Error("JSON parse error");
-      },
+      json: () => Promise.reject(new Error("JSON parse error")),
     } as Response);
 
     const tools = createBoundUpsertTools(logger, "ws-1");
-    const result = await tools.upsert_agent!.execute!(
-      { id: "agent", config: {} },
-      TOOL_CALL_OPTS,
-    );
+    const result = await tools.upsert_agent!.execute!({ id: "agent", config: {} }, TOOL_CALL_OPTS);
 
     expect(result).toEqual({
       ok: false,

--- a/packages/system/agents/workspace-chat/tools/upsert-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/upsert-tools.ts
@@ -17,10 +17,12 @@ import { z } from "zod";
 
 const StructuralIssueSchema = z.object({ code: z.string(), path: z.string(), message: z.string() });
 
-const FieldDiffEntrySchema = z.union([
-  z.object({ from: z.unknown().optional(), to: z.unknown().optional() }),
-  z.object({ added: z.array(z.unknown()).optional(), removed: z.array(z.unknown()).optional() }),
-]);
+const FieldDiffEntrySchema = z.object({
+  from: z.unknown().optional(),
+  to: z.unknown().optional(),
+  added: z.array(z.unknown()).optional(),
+  removed: z.array(z.unknown()).optional(),
+});
 
 const FieldDiffSchema = z.record(z.string(), FieldDiffEntrySchema);
 

--- a/packages/system/agents/workspace-chat/tools/upsert-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/upsert-tools.ts
@@ -43,7 +43,8 @@ const UPSERT_INPUT_SCHEMA = {
     },
     workspaceId: {
       type: "string" as const,
-      description: "Optional. Target a specific workspace instead of the current session workspace. Pass the workspace id returned by create_workspace.",
+      description:
+        "Optional. Target a specific workspace instead of the current session workspace. Pass the workspace id returned by create_workspace.",
     },
   },
   required: ["id", "config"],
@@ -53,14 +54,15 @@ function makePlaceholder(kind: string) {
   return tool({
     description: `Upsert a ${kind} into the current workspace. Respects draft mode.`,
     inputSchema: jsonSchema(UPSERT_INPUT_SCHEMA),
-    execute: async () => ({
-      ok: false,
-      diff: {} as FieldDiff,
-      structural_issues: null,
-      error:
-        `upsert_${kind} must be called with a workspaceId context. ` +
-        "This is handled automatically by the workspace-chat agent.",
-    }),
+    execute: () =>
+      Promise.resolve({
+        ok: false,
+        diff: {} as FieldDiff,
+        structural_issues: null,
+        error:
+          `upsert_${kind} must be called with a workspaceId context. ` +
+          "This is handled automatically by the workspace-chat agent.",
+      }),
   });
 }
 
@@ -96,14 +98,18 @@ export function createBoundUpsertTools(logger: Logger, workspaceId: string): Atl
 
     if (!draftRes.ok && draftRes.status === 409) {
       // No draft exists — fall back to the direct (live) endpoint.
-      logger.info(`No draft for workspace ${targetWorkspaceId}, falling back to direct ${kind} upsert`);
+      logger.info(
+        `No draft for workspace ${targetWorkspaceId}, falling back to direct ${kind} upsert`,
+      );
       const directRes = await client.workspace[":workspaceId"].items[":kind"].$post({
         param: { workspaceId: targetWorkspaceId, kind },
         json: { id, config },
       });
 
       if (!directRes.ok) {
-        const body = await directRes.json().catch(() => ({ error: `Direct ${kind} upsert failed` }));
+        const body = await directRes
+          .json()
+          .catch(() => ({ error: `Direct ${kind} upsert failed` }));
         const structuralIssues = body.structuralIssues ?? body.structural_issues ?? null;
         const hasStructuredIssues = Array.isArray(structuralIssues) && structuralIssues.length > 0;
         logger.warn(`Direct ${kind} upsert failed`, {
@@ -116,7 +122,9 @@ export function createBoundUpsertTools(logger: Logger, workspaceId: string): Atl
           ok: false,
           diff: body.diff ?? {},
           structural_issues: structuralIssues,
-          error: body.error ?? (hasStructuredIssues ? "Validation failed" : `Direct ${kind} upsert failed`),
+          error:
+            body.error ??
+            (hasStructuredIssues ? "Validation failed" : `Direct ${kind} upsert failed`),
         };
       }
 
@@ -131,7 +139,11 @@ export function createBoundUpsertTools(logger: Logger, workspaceId: string): Atl
 
     if (!draftRes.ok) {
       const body = await draftRes.json().catch(() => ({ error: `Draft ${kind} upsert failed` }));
-      logger.warn(`Draft ${kind} upsert failed`, { workspaceId: targetWorkspaceId, id, error: body.error });
+      logger.warn(`Draft ${kind} upsert failed`, {
+        workspaceId: targetWorkspaceId,
+        id,
+        error: body.error,
+      });
       return {
         ok: false,
         diff: {},
@@ -157,8 +169,15 @@ export function createBoundUpsertTools(logger: Logger, workspaceId: string): Atl
         "Returns `{ ok, diff, structural_issues }` so you can confirm what changed before publishing. " +
         "Optional: pass workspaceId to target a different workspace (e.g. after create_workspace).",
       inputSchema: jsonSchema(UPSERT_INPUT_SCHEMA),
-      execute: async ({ id, config, workspaceId: providedId }: { id: string; config: Record<string, unknown>; workspaceId?: string }) =>
-        executeUpsert("agent", id, config, providedId ?? workspaceId),
+      execute: ({
+        id,
+        config,
+        workspaceId: providedId,
+      }: {
+        id: string;
+        config: Record<string, unknown>;
+        workspaceId?: string;
+      }) => executeUpsert("agent", id, config, providedId ?? workspaceId),
     }),
 
     upsert_signal: tool({
@@ -168,8 +187,15 @@ export function createBoundUpsertTools(logger: Logger, workspaceId: string): Atl
         "Returns `{ ok, diff, structural_issues }` so you can confirm what changed before publishing. " +
         "Optional: pass workspaceId to target a different workspace (e.g. after create_workspace).",
       inputSchema: jsonSchema(UPSERT_INPUT_SCHEMA),
-      execute: async ({ id, config, workspaceId: providedId }: { id: string; config: Record<string, unknown>; workspaceId?: string }) =>
-        executeUpsert("signal", id, config, providedId ?? workspaceId),
+      execute: ({
+        id,
+        config,
+        workspaceId: providedId,
+      }: {
+        id: string;
+        config: Record<string, unknown>;
+        workspaceId?: string;
+      }) => executeUpsert("signal", id, config, providedId ?? workspaceId),
     }),
 
     upsert_job: tool({
@@ -179,8 +205,15 @@ export function createBoundUpsertTools(logger: Logger, workspaceId: string): Atl
         "Returns `{ ok, diff, structural_issues }` so you can confirm what changed before publishing. " +
         "Optional: pass workspaceId to target a different workspace (e.g. after create_workspace).",
       inputSchema: jsonSchema(UPSERT_INPUT_SCHEMA),
-      execute: async ({ id, config, workspaceId: providedId }: { id: string; config: Record<string, unknown>; workspaceId?: string }) =>
-        executeUpsert("job", id, config, providedId ?? workspaceId),
+      execute: ({
+        id,
+        config,
+        workspaceId: providedId,
+      }: {
+        id: string;
+        config: Record<string, unknown>;
+        workspaceId?: string;
+      }) => executeUpsert("job", id, config, providedId ?? workspaceId),
     }),
   };
 }

--- a/packages/system/agents/workspace-chat/tools/upsert-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/upsert-tools.ts
@@ -13,6 +13,31 @@ import type { AtlasTools } from "@atlas/agent-sdk";
 import { client } from "@atlas/client/v2";
 import type { Logger } from "@atlas/logger";
 import { jsonSchema, tool } from "ai";
+import { z } from "zod";
+
+const StructuralIssueSchema = z.object({ code: z.string(), path: z.string(), message: z.string() });
+
+const FieldDiffEntrySchema = z.union([
+  z.object({ from: z.unknown().optional(), to: z.unknown().optional() }),
+  z.object({ added: z.array(z.unknown()).optional(), removed: z.array(z.unknown()).optional() }),
+]);
+
+const FieldDiffSchema = z.record(z.string(), FieldDiffEntrySchema);
+
+const UpsertErrorBodySchema = z.object({
+  error: z.string().optional(),
+  diff: FieldDiffSchema.optional(),
+  structuralIssues: z.array(StructuralIssueSchema).nullable().optional(),
+  structural_issues: z.array(StructuralIssueSchema).nullable().optional(),
+});
+
+type UpsertErrorBody = z.infer<typeof UpsertErrorBodySchema>;
+
+function parseStructuralIssues(
+  body: UpsertErrorBody,
+): Array<{ code: string; path: string; message: string }> | null {
+  return body.structuralIssues ?? body.structural_issues ?? null;
+}
 
 export interface FieldDiff {
   [field: string]: { from?: unknown; to?: unknown } | { added?: unknown[]; removed?: unknown[] };
@@ -107,11 +132,14 @@ export function createBoundUpsertTools(logger: Logger, workspaceId: string): Atl
       });
 
       if (!directRes.ok) {
-        const body = await directRes
-          .json()
-          .catch(() => ({ error: `Direct ${kind} upsert failed` }));
-        const structuralIssues = body.structuralIssues ?? body.structural_issues ?? null;
-        const hasStructuredIssues = Array.isArray(structuralIssues) && structuralIssues.length > 0;
+        let body: UpsertErrorBody;
+        try {
+          body = UpsertErrorBodySchema.parse(await directRes.json());
+        } catch {
+          body = { error: `Direct ${kind} upsert failed` };
+        }
+        const structuralIssues = parseStructuralIssues(body);
+        const hasStructuredIssues = structuralIssues !== null && structuralIssues.length > 0;
         logger.warn(`Direct ${kind} upsert failed`, {
           workspaceId: targetWorkspaceId,
           id,
@@ -133,12 +161,17 @@ export function createBoundUpsertTools(logger: Logger, workspaceId: string): Atl
       return {
         ok: body.ok,
         diff: body.diff ?? {},
-        structural_issues: body.structuralIssues ?? body.structural_issues ?? null,
+        structural_issues: body.structural_issues ?? null,
       };
     }
 
     if (!draftRes.ok) {
-      const body = await draftRes.json().catch(() => ({ error: `Draft ${kind} upsert failed` }));
+      let body: UpsertErrorBody;
+      try {
+        body = UpsertErrorBodySchema.parse(await draftRes.json());
+      } catch {
+        body = { error: `Draft ${kind} upsert failed` };
+      }
       logger.warn(`Draft ${kind} upsert failed`, {
         workspaceId: targetWorkspaceId,
         id,
@@ -157,7 +190,7 @@ export function createBoundUpsertTools(logger: Logger, workspaceId: string): Atl
     return {
       ok: body.ok,
       diff: body.diff ?? {},
-      structural_issues: body.structuralIssues ?? body.structural_issues ?? null,
+      structural_issues: body.structural_issues ?? null,
     };
   }
 

--- a/packages/system/agents/workspace-chat/tools/workspace-ops.test.ts
+++ b/packages/system/agents/workspace-chat/tools/workspace-ops.test.ts
@@ -20,11 +20,7 @@ vi.mock("@atlas/client/v2", () => ({
       create: { $post: mockWorkspaceCreatePost },
       ":workspaceId": {
         $delete: mockWorkspaceDelete,
-        items: {
-          ":kind": {
-            ":id": { $delete: mockItemsDelete },
-          },
-        },
+        items: { ":kind": { ":id": { $delete: mockItemsDelete } } },
       },
     },
   },
@@ -81,7 +77,10 @@ describe("createWorkspaceOpsTools", () => {
 
     expect(mockWorkspaceCreatePost).toHaveBeenCalledWith({
       json: {
-        config: { version: "1.0", workspace: { name: "Test Workspace", description: "A test workspace" } },
+        config: {
+          version: "1.0",
+          workspace: { name: "Test Workspace", description: "A test workspace" },
+        },
         workspaceName: undefined,
         ephemeral: false,
       },
@@ -166,11 +165,7 @@ describe("createWorkspaceOpsTools", () => {
 });
 
 function mockResponse(ok: boolean, status: number, body: unknown): unknown {
-  return {
-    ok,
-    status,
-    json: () => Promise.resolve(body),
-  };
+  return { ok, status, json: () => Promise.resolve(body) };
 }
 
 describe("createBoundWorkspaceOpsTools", () => {
@@ -192,7 +187,11 @@ describe("createBoundWorkspaceOpsTools", () => {
 
   it("calls DELETE /items/:kind/:id and returns success", async () => {
     mockItemsDelete.mockResolvedValueOnce(
-      mockResponse(true, 200, { ok: true, livePath: "/tmp/ws-1/workspace.yml", runtimeReloaded: false }),
+      mockResponse(true, 200, {
+        ok: true,
+        livePath: "/tmp/ws-1/workspace.yml",
+        runtimeReloaded: false,
+      }),
     );
 
     const tools = createBoundWorkspaceOpsTools(logger, "ws-1");
@@ -204,12 +203,19 @@ describe("createBoundWorkspaceOpsTools", () => {
     expect(mockItemsDelete).toHaveBeenCalledWith({
       param: { workspaceId: "ws-1", kind: "agent", id: "test-agent" },
     });
-    expect(result).toEqual({ ok: true, livePath: "/tmp/ws-1/workspace.yml", runtimeReloaded: false });
+    expect(result).toEqual({
+      ok: true,
+      livePath: "/tmp/ws-1/workspace.yml",
+      runtimeReloaded: false,
+    });
   });
 
   it("returns structured error when remove_item fails", async () => {
     mockItemsDelete.mockResolvedValueOnce(
-      mockResponse(false, 422, { ok: false, error: { code: "referenced", dependents: ["test-job"] } }),
+      mockResponse(false, 422, {
+        ok: false,
+        error: { code: "referenced", dependents: ["test-job"] },
+      }),
     );
 
     const tools = createBoundWorkspaceOpsTools(logger, "ws-1");

--- a/packages/system/agents/workspace-chat/tools/workspace-ops.ts
+++ b/packages/system/agents/workspace-chat/tools/workspace-ops.ts
@@ -47,13 +47,11 @@ const REMOVE_ITEM_INPUT_SCHEMA = {
       enum: ["agent", "signal", "job"] as const,
       description: "Type of entity to remove",
     },
-    id: {
-      type: "string" as const,
-      description: "Unique identifier of the entity to remove",
-    },
+    id: { type: "string" as const, description: "Unique identifier of the entity to remove" },
     workspaceId: {
       type: "string" as const,
-      description: "Optional. Target a specific workspace instead of the current session workspace.",
+      description:
+        "Optional. Target a specific workspace instead of the current session workspace.",
     },
   },
   required: ["kind", "id"],
@@ -97,10 +95,7 @@ export function createWorkspaceOpsTools(logger: Logger): AtlasTools {
 
         const config = {
           version: "1.0" as const,
-          workspace: {
-            name,
-            ...(description !== undefined && { description }),
-          },
+          workspace: { name, ...(description !== undefined && { description }) },
         };
 
         const result = await parseResult(
@@ -137,7 +132,15 @@ export function createBoundWorkspaceOpsTools(logger: Logger, workspaceId: string
         "Refuses the operation if the item is still referenced by other workspace entities. " +
         "Optional: pass workspaceId to target a different workspace (e.g. after create_workspace).",
       inputSchema: jsonSchema(REMOVE_ITEM_INPUT_SCHEMA),
-      execute: async ({ kind, id, workspaceId: providedId }: { kind: "agent" | "signal" | "job"; id: string; workspaceId?: string }) => {
+      execute: async ({
+        kind,
+        id,
+        workspaceId: providedId,
+      }: {
+        kind: "agent" | "signal" | "job";
+        id: string;
+        workspaceId?: string;
+      }) => {
         const targetId = providedId ?? workspaceId;
         logger.info("remove_item tool invoked", { workspaceId: targetId, kind, id });
 
@@ -153,11 +156,7 @@ export function createBoundWorkspaceOpsTools(logger: Logger, workspaceId: string
 
         const data = await res.json();
         logger.info("remove_item succeeded", { workspaceId: targetId, kind, id });
-        return {
-          ok: true,
-          livePath: data.livePath,
-          runtimeReloaded: data.runtimeReloaded,
-        };
+        return { ok: true, livePath: data.livePath, runtimeReloaded: data.runtimeReloaded };
       },
     }),
   };

--- a/packages/system/agents/workspace-chat/tools/workspace-ops.ts
+++ b/packages/system/agents/workspace-chat/tools/workspace-ops.ts
@@ -25,7 +25,7 @@ const CREATE_WORKSPACE_INPUT_SCHEMA = {
     },
   },
   required: ["name"],
-} as const;
+};
 
 const WORKSPACE_DELETE_INPUT_SCHEMA = z.object({
   workspaceId: z
@@ -44,7 +44,7 @@ const REMOVE_ITEM_INPUT_SCHEMA = {
   properties: {
     kind: {
       type: "string" as const,
-      enum: ["agent", "signal", "job"] as const,
+      enum: ["agent", "signal", "job"],
       description: "Type of entity to remove",
     },
     id: { type: "string" as const, description: "Unique identifier of the entity to remove" },
@@ -55,7 +55,7 @@ const REMOVE_ITEM_INPUT_SCHEMA = {
     },
   },
   required: ["kind", "id"],
-} as const;
+};
 
 export function createWorkspaceOpsTools(logger: Logger): AtlasTools {
   return {
@@ -149,7 +149,13 @@ export function createBoundWorkspaceOpsTools(logger: Logger, workspaceId: string
         });
 
         if (!res.ok) {
-          const body = await res.json().catch(() => ({ error: "remove_item failed" }));
+          const errorSchema = z.object({ error: z.unknown().optional() });
+          let body: z.infer<typeof errorSchema>;
+          try {
+            body = errorSchema.parse(await res.json());
+          } catch {
+            body = { error: "remove_item failed" };
+          }
           logger.warn("remove_item failed", { workspaceId: targetId, kind, id, error: body.error });
           return { ok: false, error: body.error ?? "remove_item failed" };
         }

--- a/packages/system/agents/workspace-chat/workspace-chat.agent.ts
+++ b/packages/system/agents/workspace-chat/workspace-chat.agent.ts
@@ -53,7 +53,6 @@ import { createCreateMcpServerTool } from "./tools/create-mcp-server.ts";
 import { createDelegateTool } from "./tools/delegate/index.ts";
 import { createDisableMcpServerTool } from "./tools/disable-mcp-server.ts";
 import { createBoundDraftTools } from "./tools/draft-tools.ts";
-import { createBoundUpsertTools } from "./tools/upsert-tools.ts";
 import { createEnableMcpServerTool } from "./tools/enable-mcp-server.ts";
 import { createFileIOTools } from "./tools/file-io.ts";
 import { createInstallMcpServerTool } from "./tools/install-mcp-server.ts";
@@ -63,13 +62,11 @@ import { createListMcpToolsTool } from "./tools/list-mcp-tools.ts";
 import { createMemorySaveTool } from "./tools/memory-save.ts";
 import { createResourceChatTools, RESOURCE_CHAT_TOOL_NAMES } from "./tools/resource-tools.ts";
 import { createSearchMcpServersTool } from "./tools/search-mcp-servers.ts";
+import { createBoundUpsertTools } from "./tools/upsert-tools.ts";
 import { createWebFetchTool } from "./tools/web-fetch.ts";
 import { createWebSearchTool } from "./tools/web-search.ts";
 import { createGetWorkspaceMcpStatusTool } from "./tools/workspace-mcp-status.ts";
-import {
-  createBoundWorkspaceOpsTools,
-  createWorkspaceOpsTools,
-} from "./tools/workspace-ops.ts";
+import { createBoundWorkspaceOpsTools, createWorkspaceOpsTools } from "./tools/workspace-ops.ts";
 import { fetchUserIdentitySection } from "./user-identity.ts";
 import { fetchUserProfileState } from "./user-profile.ts";
 

--- a/packages/system/skills/writing-workspace-jobs/SKILL.md
+++ b/packages/system/skills/writing-workspace-jobs/SKILL.md
@@ -236,7 +236,8 @@ These pass validation but fail or misbehave at runtime.
 The config schema accepts `execution:` for backward compatibility, but the
 runtime **only executes FSM jobs**. Non-FSM jobs are silently skipped.
 
-Symptom: `"No FSM job handles signal '<name>'"`  
+Symptom: `"No FSM job handles signal '<name>'"`
+
 Fix: Rewrite as `fsm:` with `initial` and `states`.
 
 ### Initial state with no signal handler
@@ -244,7 +245,8 @@ Fix: Rewrite as `fsm:` with `initial` and `states`.
 The `initial` state must handle the trigger signal name in its `on` map.
 Without it, the signal is silently ignored.
 
-Symptom: Job triggers but produces no output, no error, no session.  
+Symptom: Job triggers but produces no output, no error, no session.
+
 Fix: Add `on: { <signal-name>: { target: <work-state> } }` to the initial state.
 
 ### Non-final state with no outgoing transitions
@@ -253,7 +255,8 @@ The FSM engine catches this in `validateFSMStructure`, but the workspace
 config validator does not validate FSM internals (fsm is `z.any()` in
 `JobSpecificationSchema`).
 
-Symptom: FSM reaches a stuck state and the session hangs.  
+Symptom: FSM reaches a stuck state and the session hangs.
+
 Fix: Add transitions to every non-final state, or mark it `type: final`.
 
 ### `type: action` in states
@@ -262,7 +265,8 @@ The FSM engine supports `agent`, `llm`, and `emit` action types. `type: action`
 is a legacy pre-FSM shape.
 
 Symptom: `fsm_structural_error` at the MCP-registry validator (the second
-validation layer).  
+validation layer).
+
 Fix: Use `entry: [ { type: agent, agentId: ... } ]`.
 
 ### Emit / transition name mismatch
@@ -281,7 +285,8 @@ on:
 If you emit `COMPLETE` but transition on `DONE`, the event is queued but
 never consumed.
 
-Symptom: Agent runs but session never completes.  
+Symptom: Agent runs but session never completes.
+
 Fix: Match emit event name to `on` key exactly.
 
 ### Missing `outputTo` in pipelines
@@ -289,7 +294,8 @@ Fix: Match emit event name to `on` key exactly.
 Without `outputTo`, an agent's result is not saved as a document. The next
 step's `inputFrom` has nothing to read.
 
-Symptom: Second agent receives empty or undefined input.  
+Symptom: Second agent receives empty or undefined input.
+
 Fix: Add `outputTo: <doc-id>` to the producer and `inputFrom: <same-doc-id>`
 to the consumer.
 


### PR DESCRIPTION
## Summary

`main` is currently red across lint, type-check, knip, and test (see runs on `dba40d908`). The new dependabot PR #90 (undici 7.24.6 → 7.25.0) is also blocked, but the failures are **not** caused by it — they all came in with the `workspace-creation-redesign` merge.

This PR repairs main:
- **lint (13 errors)**: drop unnecessary `async` on placeholder tool/mock executes; underscore-prefix unused mock params; switch a `regex.exec` while-assignment out of the condition; `Number.isNaN` over global `isNaN`. Also runs biome auto-format on the touched files (formatting drifted on the merge).
- **type-check (28+ errors)**: in `workspace-chat` tools (`draft-tools`, `upsert-tools`, `workspace-ops`), parse error response bodies through small Zod schemas instead of fluent `.json().catch()` (the chained `.catch` doesn't unify across Hono's typed response union). Drop snake_case `structuralIssues` fallback (server uses `structural_issues`). Strip outer `as const` on JSON Schemas so `required`/`enum` aren't readonly. Annotate `server` in `buildMcpToolRegistry` with `MCPServerMetadata | undefined` for svelte-check. Hoist the `prefix` narrowing in `validate-workspace`. Cast inline configs in `mcp.test.ts` through `unknown` (Zod's defaulted `temperature` makes the narrow cast fail). Add the missing `!` after `.execute` on optional Tool methods in mcp tool tests.
- **knip**: demote unused `DRAFT_FILE_NAME` / `LIVE_FILE_NAME` to module-private.
- **tests**: delete two `validate-workspace.test.ts` cases that read from `/Users/ericskram/Desktop/...` — those were dev-only fixtures that never pass in CI. Loosen the upsert `FieldDiff` Zod schema to a flat optional shape so `{ added: [...] }` round-trips (the previous union's first arm was matching empty-object and stripping fields).

After this lands, dependabot should rebase #90 onto green main and that PR can merge cleanly.

## Test plan
- [x] `deno task lint:check` clean
- [x] `deno task typecheck` clean
- [x] `npx knip` clean (only pre-existing config hints)
- [x] `deno task test` — 5658 passed, 5 skipped, 0 failed (with daemon running for the integration tests)