### PR TITLE
fix(ui): adapt to @tanstack/svelte-table alpha.37 type changes

### DIFF
--- a/packages/ui/src/app.d.ts
+++ b/packages/ui/src/app.d.ts
@@ -1,5 +1,7 @@
 // See https://svelte.dev/docs/kit/types#app.d.ts
 // for information about these interfaces
+import type { CellData, RowData, TableFeatures } from "@tanstack/svelte-table";
+
 declare global {
   namespace App {
     // interface Error {}
@@ -11,7 +13,11 @@ declare global {
 }
 
 declare module "@tanstack/svelte-table" {
-  interface ColumnMeta<TData extends import("@tanstack/svelte-table").RowData, TValue> {
+  interface ColumnMeta<
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+    TValue extends CellData = CellData,
+  > {
     bold?: boolean;
     faded?: boolean;
     align?: "left" | "center" | "right" | "full";

--- a/packages/ui/src/lib/table/root.svelte
+++ b/packages/ui/src/lib/table/root.svelte
@@ -1,10 +1,15 @@
-<script lang="ts" generics="T extends unknown">
-  import { FlexRender, type Row, type Table } from "@tanstack/svelte-table";
+<script lang="ts" generics="T extends import('@tanstack/svelte-table').RowData">
+  import {
+    FlexRender,
+    type Row,
+    type StockFeatures,
+    type Table,
+  } from "@tanstack/svelte-table";
   import TableCell from "./cell.svelte";
   import Header from "./header.svelte";
 
   type Props = {
-    table: Table<T>;
+    table: Table<StockFeatures, T>;
     padded?: boolean;
     rowSize?: "small" | "large" | "medium" | "auto";
     grow?: boolean;
@@ -43,7 +48,15 @@
   }
 </script>
 
-{#snippet row({ item, href, index }: { item: Row<T>; href: string | undefined; index: number })}
+{#snippet row({
+  item,
+  href,
+  index,
+}: {
+  item: Row<StockFeatures, T>;
+  href: string | undefined;
+  index: number;
+})}
   <svelte:element
     this={href !== undefined && !item.getCanExpand() ? "a" : "div"}
     role={href !== undefined && !item.getCanExpand() ? "link" : "row"}
@@ -69,7 +82,7 @@
         size={cell.column.columnDef.meta?.size ?? "regular"}
         inset={cellIndex === 0 ? item.depth : 0}
       >
-        <FlexRender content={cell.column.columnDef.cell} context={cell.getContext()} />
+        <FlexRender cell={cell} />
       </TableCell>
     {/each}
   </svelte:element>
@@ -89,7 +102,7 @@
               maxWidth={header.column.columnDef.meta?.maxWidth}
               width={header.column.columnDef.meta?.width}
             >
-              <FlexRender content={header.column.columnDef.header} context={header.getContext()} />
+              <FlexRender header={header} />
             </Header>
           {/each}
         {/each}

--- a/tools/agent-playground/src/app.d.ts
+++ b/tools/agent-playground/src/app.d.ts
@@ -1,7 +1,13 @@
 /// <reference types="@sveltejs/kit" />
 
+import type { CellData, RowData, TableFeatures } from "@tanstack/svelte-table";
+
 declare module "@tanstack/svelte-table" {
-  interface ColumnMeta<TData extends import("@tanstack/svelte-table").RowData, TValue> {
+  interface ColumnMeta<
+    TFeatures extends TableFeatures,
+    TData extends RowData,
+    TValue extends CellData = CellData,
+  > {
     bold?: boolean;
     faded?: boolean;
     align?: "left" | "center" | "right" | "full";


### PR DESCRIPTION
## Summary

Fixes the `type-check` regression introduced by #80 (alpha.10 → alpha.37 of `@tanstack/svelte-table`). The auto-merge workflow merged #80 despite the failing check, so `main` is currently red on type-check.

The alpha.37 release reworks the table generics:
- `ColumnMeta` now takes `<TFeatures, TData, TValue>` instead of `<TData, TValue>` — module augmentations had to match.
- `Row<T>` and `Table<T>` became `Row<TFeatures, T>` / `Table<TFeatures, T>`, with feature methods (`getCanExpand`, `getIsSelected`, `getVisibleCells`, `getVisibleLeafColumns`) conditionally included only when their feature appears in `TFeatures`. Hard-coded `StockFeatures` in `packages/ui/src/lib/table/root.svelte` (the only consumer) so all stock methods resolve.
- `FlexRender` accepts `cell={cell}` / `header={header}` directly; the `content + context` pair now requires a union type, so swapped to the typed forms.

## Test plan
- [x] `deno task typecheck` passes locally (0 errors)
- [ ] CI `type-check` green
- [ ] CI `test` green

## Follow-up
Auto-merge fired on #80 even though `type-check` failed — branch protection should require `type-check` for Dependabot PRs to prevent a repeat.