### PR TITLE
feat(installer): wait-healthy SSE checklist + staged deadlines (Stack 2)

### DIFF
--- a/apps/studio-installer/src-tauri/src/commands/extract.rs
+++ b/apps/studio-installer/src-tauri/src/commands/extract.rs
@@ -27,6 +27,22 @@ pub enum ExtractEvent {
 /// motion" — roughly one update every two render frames at 120Hz.
 const PROGRESS_EMIT_INTERVAL: Duration = Duration::from_millis(200);
 
+/// Pure helper extracted for testability — answers "should we emit
+/// a progress event right now?" given the throttle state. The first
+/// tick always emits so the wizard switches off the generic
+/// "Extracting…" copy promptly; subsequent ticks are gated to one
+/// per `PROGRESS_EMIT_INTERVAL`. A regression that drops the
+/// first-tick override would freeze the UI on the generic copy for
+/// up to 200ms — invisible on a 1 GB archive but very visible on a
+/// 50-file archive that finishes in 80ms. Pinning this in tests
+/// catches that.
+fn should_emit_progress(started: bool, last_emit: Instant, now: Instant) -> bool {
+    if !started {
+        return true;
+    }
+    now.duration_since(last_emit) >= PROGRESS_EMIT_INTERVAL
+}
+
 /// Helper that throttles progress emissions to the wizard channel.
 /// Always lets the first and last events through; intermediate
 /// events are suppressed if they fall within the same throttle
@@ -51,10 +67,7 @@ impl ProgressEmitter {
     fn tick(&mut self) {
         self.entries_done += 1;
         let now = Instant::now();
-        // First tick always emits so the wizard switches from the
-        // generic "Extracting…" copy to the running count promptly.
-        let force = !self.started;
-        if force || now.duration_since(self.last_emit) >= PROGRESS_EMIT_INTERVAL {
+        if should_emit_progress(self.started, self.last_emit, now) {
             self.started = true;
             self.last_emit = now;
             let _ = self.channel.send(ExtractEvent::Progress {
@@ -70,6 +83,40 @@ impl ProgressEmitter {
             entries_done: self.entries_done,
         });
         let _ = self.channel.send(ExtractEvent::Done);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn first_tick_always_emits_regardless_of_clock() {
+        // started=false ⇒ emit, no matter what the timestamps say.
+        // A regression that drops the !started branch would freeze
+        // the wizard's "Extracting…" copy until ≥200ms elapsed.
+        let now = Instant::now();
+        assert!(should_emit_progress(false, now, now));
+        assert!(should_emit_progress(false, now, now + Duration::from_secs(1)));
+    }
+
+    #[test]
+    fn intermediate_tick_suppressed_inside_throttle_window() {
+        let last = Instant::now();
+        // last_emit = now - 100ms (< 200ms window) ⇒ suppress.
+        let now = last + Duration::from_millis(100);
+        assert!(!should_emit_progress(true, last, now));
+    }
+
+    #[test]
+    fn intermediate_tick_emits_at_or_past_throttle_window() {
+        let last = Instant::now();
+        // Exactly at the boundary: emit (>= window).
+        let at_boundary = last + PROGRESS_EMIT_INTERVAL;
+        assert!(should_emit_progress(true, last, at_boundary));
+        // Past the boundary: also emit.
+        let past = last + PROGRESS_EMIT_INTERVAL + Duration::from_millis(50);
+        assert!(should_emit_progress(true, last, past));
     }
 }
 

--- a/apps/studio-installer/src-tauri/src/commands/extract.rs
+++ b/apps/studio-installer/src-tauri/src/commands/extract.rs
@@ -1,6 +1,77 @@
 use std::fs;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
+
+use serde::Serialize;
+use tauri::ipc::Channel;
+
+/// Per-entry progress emitted by `extract_archive` to the wizard.
+/// The wizard renders "Unpacking… N files" — no total because
+/// counting up-front would require a streaming pre-pass over the
+/// (often >500 MB) archive.
+///
+/// Throttled to one event per `PROGRESS_EMIT_INTERVAL` so a million
+/// small files don't spam the Tauri IPC channel. The final count is
+/// always emitted regardless of throttle so the UI stops at the
+/// true total.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum ExtractEvent {
+    Progress { entries_done: u64 },
+    Done,
+    Error { message: String },
+}
+
+/// How often to emit progress events. Sized for "noticeable forward
+/// motion" — roughly one update every two render frames at 120Hz.
+const PROGRESS_EMIT_INTERVAL: Duration = Duration::from_millis(200);
+
+/// Helper that throttles progress emissions to the wizard channel.
+/// Always lets the first and last events through; intermediate
+/// events are suppressed if they fall within the same throttle
+/// window.
+struct ProgressEmitter {
+    channel: Channel<ExtractEvent>,
+    last_emit: Instant,
+    entries_done: u64,
+    started: bool,
+}
+
+impl ProgressEmitter {
+    fn new(channel: Channel<ExtractEvent>) -> Self {
+        Self {
+            channel,
+            last_emit: Instant::now(),
+            entries_done: 0,
+            started: false,
+        }
+    }
+
+    fn tick(&mut self) {
+        self.entries_done += 1;
+        let now = Instant::now();
+        // First tick always emits so the wizard switches from the
+        // generic "Extracting…" copy to the running count promptly.
+        let force = !self.started;
+        if force || now.duration_since(self.last_emit) >= PROGRESS_EMIT_INTERVAL {
+            self.started = true;
+            self.last_emit = now;
+            let _ = self.channel.send(ExtractEvent::Progress {
+                entries_done: self.entries_done,
+            });
+        }
+    }
+
+    /// Always emits a final progress + done event so the wizard's
+    /// last rendered count matches what landed on disk.
+    fn finish(&mut self) {
+        let _ = self.channel.send(ExtractEvent::Progress {
+            entries_done: self.entries_done,
+        });
+        let _ = self.channel.send(ExtractEvent::Done);
+    }
+}
 
 /// Stops any running launcher before we mutate the install dir.
 /// Per the v8 plan installer↔launcher contract, the installer only
@@ -66,17 +137,46 @@ fn libc_kill(pid: i32, sig: i32) -> i32 {
     unsafe { kill(pid, sig) }
 }
 
-fn extract_tar_gz(src: &Path, dest: &Path) -> Result<(), String> {
+/// Extract a tar archive entry-by-entry, ticking the progress emitter
+/// on each entry. Decodes via the supplied Read (gz or zst) — same
+/// loop body for both compression types so we don't duplicate the
+/// per-entry plumbing twice.
+fn extract_tar_streaming<R: Read>(
+    reader: R,
+    dest: &Path,
+    emitter: &mut ProgressEmitter,
+) -> Result<(), String> {
+    let mut archive = tar::Archive::new(reader);
+    let entries = archive
+        .entries()
+        .map_err(|e| format!("tar entries iteration failed: {e}"))?;
+    for entry in entries {
+        let mut entry = entry.map_err(|e| format!("tar entry read failed: {e}"))?;
+        entry
+            .unpack_in(dest)
+            .map_err(|e| format!("tar entry unpack failed: {e}"))?;
+        emitter.tick();
+    }
+    Ok(())
+}
+
+fn extract_tar_gz(
+    src: &Path,
+    dest: &Path,
+    emitter: &mut ProgressEmitter,
+) -> Result<(), String> {
     let file =
         fs::File::open(src).map_err(|e| format!("Cannot open archive {}: {e}", src.display()))?;
     let gz = flate2::read::GzDecoder::new(file);
-    let mut archive = tar::Archive::new(gz);
-    archive
-        .unpack(dest)
+    extract_tar_streaming(gz, dest, emitter)
         .map_err(|e| format!("tar.gz extraction failed: {e}"))
 }
 
-fn extract_tar_zst(src: &Path, dest: &Path) -> Result<(), String> {
+fn extract_tar_zst(
+    src: &Path,
+    dest: &Path,
+    emitter: &mut ProgressEmitter,
+) -> Result<(), String> {
     let file =
         fs::File::open(src).map_err(|e| format!("Cannot open archive {}: {e}", src.display()))?;
     // ruzstd decoder works on any Read; zstd::Decoder would require linking
@@ -85,13 +185,15 @@ fn extract_tar_zst(src: &Path, dest: &Path) -> Result<(), String> {
     // extraction (a few seconds for a 1 GB archive).
     let zst = ruzstd::StreamingDecoder::new(file)
         .map_err(|e| format!("zstd init failed: {e}"))?;
-    let mut archive = tar::Archive::new(zst);
-    archive
-        .unpack(dest)
+    extract_tar_streaming(zst, dest, emitter)
         .map_err(|e| format!("tar.zst extraction failed: {e}"))
 }
 
-fn extract_zip(src: &Path, dest: &Path) -> Result<(), String> {
+fn extract_zip(
+    src: &Path,
+    dest: &Path,
+    emitter: &mut ProgressEmitter,
+) -> Result<(), String> {
     let file =
         fs::File::open(src).map_err(|e| format!("Cannot open archive {}: {e}", src.display()))?;
     let mut archive = zip::ZipArchive::new(file).map_err(|e| format!("Invalid zip: {e}"))?;
@@ -115,6 +217,7 @@ fn extract_zip(src: &Path, dest: &Path) -> Result<(), String> {
             std::io::copy(&mut file, &mut out_file)
                 .map_err(|e| format!("Failed to extract file: {e}"))?;
         }
+        emitter.tick();
     }
 
     Ok(())
@@ -125,8 +228,19 @@ fn extract_zip(src: &Path, dest: &Path) -> Result<(), String> {
 /// or rolls back (restores bak). Treats `<dest>` itself as the install root —
 /// the studio archive expands flat (atlas, link, playground, webhook-tunnel,
 /// gh, cloudflared at the top level).
+///
+/// `on_progress` carries a Tauri Channel the wizard subscribes to for the
+/// running entry count. Per Stack 2 the count is the only progress signal —
+/// no total, since computing it would require an extra streaming pass over
+/// the (often >500 MB) archive. Stack 3 introduces split-destination
+/// + staging + atomic swap; this function keeps the prior `.bak`-rollback
+/// shape so the Stack 2 PR is small.
 #[tauri::command]
-pub fn extract_archive(src: String, dest: String) -> Result<(), String> {
+pub fn extract_archive(
+    src: String,
+    dest: String,
+    on_progress: Channel<ExtractEvent>,
+) -> Result<(), String> {
     let src_path = PathBuf::from(&src);
     let dest_path = PathBuf::from(&dest);
 
@@ -134,9 +248,13 @@ pub fn extract_archive(src: String, dest: String) -> Result<(), String> {
     let is_tar_zst = src.ends_with(".tar.zst") || src.ends_with(".tzst");
     let is_zip = src.ends_with(".zip");
     if !is_tar_gz && !is_tar_zst && !is_zip {
-        return Err(format!(
+        let msg = format!(
             "Unknown archive format for: {src}. Expected .tar.gz, .tar.zst, or .zip"
-        ));
+        );
+        let _ = on_progress.send(ExtractEvent::Error {
+            message: msg.clone(),
+        });
+        return Err(msg);
     }
 
     let bak_path = dest_path.with_extension("bak");
@@ -160,22 +278,27 @@ pub fn extract_archive(src: String, dest: String) -> Result<(), String> {
     fs::create_dir_all(&dest_path)
         .map_err(|e| format!("Failed to create install dir: {e}"))?;
 
+    let mut emitter = ProgressEmitter::new(on_progress);
     let result = if is_tar_gz {
-        extract_tar_gz(&src_path, &dest_path)
+        extract_tar_gz(&src_path, &dest_path, &mut emitter)
     } else if is_tar_zst {
-        extract_tar_zst(&src_path, &dest_path)
+        extract_tar_zst(&src_path, &dest_path, &mut emitter)
     } else {
-        extract_zip(&src_path, &dest_path)
+        extract_zip(&src_path, &dest_path, &mut emitter)
     };
 
     match result {
         Ok(()) => {
+            emitter.finish();
             if bak_path.exists() {
                 let _ = fs::remove_dir_all(&bak_path);
             }
             Ok(())
         }
         Err(e) => {
+            let _ = emitter.channel.send(ExtractEvent::Error {
+                message: e.clone(),
+            });
             // Roll back: drop the partial new install and restore the backup.
             if bak_path.exists() {
                 let _ = fs::remove_dir_all(&dest_path);

--- a/apps/studio-installer/src-tauri/src/commands/mod.rs
+++ b/apps/studio-installer/src-tauri/src/commands/mod.rs
@@ -10,3 +10,4 @@ pub mod launch;
 pub mod platform;
 pub mod startup;
 pub mod verify;
+pub mod wait_health;

--- a/apps/studio-installer/src-tauri/src/commands/wait_health.rs
+++ b/apps/studio-installer/src-tauri/src/commands/wait_health.rs
@@ -14,10 +14,14 @@
 //!   - **90s hard deadline** (default end). Extendable to 150s via
 //!     `extend_wait_deadline`, then to 210s on a second extension.
 //!
-//! The `extend_wait_deadline` Tauri command pushes the deadline out
-//! by 60s — capped at two extensions per the v15 plan.
+//! Past the hard deadline the wait does NOT return — it parks on a
+//! `Notify` so a subsequent `extend_wait_deadline` can wake the loop
+//! and resume waiting (the v15 plan's "Wait again" affordance only
+//! makes sense if extension actually resumes the wait). The loop only
+//! returns on a terminal event (all-healthy, unreachable, EOF, or a
+//! supersede from a re-entered wizard).
 
-use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI64, AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -25,7 +29,7 @@ use futures_util::StreamExt;
 use serde::{Deserialize, Serialize};
 use tauri::ipc::Channel;
 use tauri::State;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 use tokio::time::sleep;
 
 /// Where the launcher's health endpoint lives. Hardcoded to match
@@ -54,10 +58,17 @@ const SOFT_DEADLINE_SECS: u64 = 60;
 /// Hard deadline — default end of the wait-healthy step. Each
 /// `extend_wait_deadline` call adds `EXTENSION_SECS`, capped at
 /// `MAX_EXTENSIONS` total. Past the hard deadline the wizard
-/// surfaces View logs / Open anyway / Wait again.
+/// surfaces View logs / Open anyway / Wait again; the wait loop
+/// itself parks on a Notify until extension wakes it.
 const HARD_DEADLINE_SECS: u64 = 90;
 const EXTENSION_SECS: u64 = 60;
 const MAX_EXTENSIONS: u32 = 2;
+
+/// Cap stream-read poll cadence. Drives how often the loop wakes
+/// to re-check the soft/hard deadlines and the cancellation flag.
+/// 1s is fine for a single-user wizard — fast enough that the
+/// frontend sees timeout events promptly, slow enough not to spin.
+const STREAM_POLL_CAP: Duration = Duration::from_secs(1);
 
 /// Per-service status emitted by the launcher. Mirrors
 /// `ServiceStatus` in `tools/friday-launcher/healthsvc.go`.
@@ -106,76 +117,110 @@ pub enum HealthEvent {
         stuck: Vec<String>,
         playground_healthy: bool,
     },
-    /// SSE-connect retry budget exhausted. The launcher never
-    /// bound port 5199 within `SSE_CONNECT_DEADLINE`. Fatal —
-    /// frontend shows "could not connect to launcher" + View logs.
+    /// SSE-connect retry budget exhausted, stream closed
+    /// unexpectedly, or stream errored mid-flight. Frontend shows
+    /// "could not connect to launcher" + View logs.
     Unreachable {
         reason: String,
     },
-    /// Launcher reported `shutting_down: true` mid-wait. Treat as
-    /// fatal — the user manually triggered a shutdown or something
-    /// else hit the launcher's HTTP shutdown endpoint.
+    /// Launcher reported `shutting_down: true` in a snapshot. Treat
+    /// as terminal — the user manually triggered a shutdown or
+    /// something else hit the launcher's HTTP shutdown endpoint.
+    /// Reserved for the snapshot-flag path; raw EOFs go through
+    /// `Unreachable` since EOF doesn't distinguish orderly shutdown
+    /// from a launcher crash.
     ShuttingDown,
 }
 
+/// Service name we treat as the user-facing surface for the
+/// partial-success "Open anyway" rule. Centralised here so the
+/// timeout-event builder and the frontend gate agree.
+const PLAYGROUND_SERVICE_NAME: &str = "playground";
+
 /// Mutable state shared between `wait_for_services` and
-/// `extend_wait_deadline`. The deadline is an absolute Instant, so
-/// extension is a single atomic add — no mutex needed for the
-/// commonly-read path.
-///
-/// `deadline_secs_from_start` is stored as nanos since the wait
-/// started; the consumer compares against `wait_started.elapsed()`
-/// rather than against an `Instant` (avoids passing tokio Instants
-/// across the Tauri command boundary, which doesn't serialize).
+/// `extend_wait_deadline`. The deadline is stored as nanos-from-
+/// start so consumers can compare against `wait_started.elapsed()`
+/// rather than passing tokio Instants across the Tauri command
+/// boundary (Instants don't serialize).
 #[derive(Default)]
 pub struct WaitDeadlineState {
     inner: Mutex<Option<WaitDeadline>>,
 }
 
+/// Per-wait deadline + supersede + extend-notify handles. Cloned
+/// when handed out so multiple owners can observe the same atomics.
 struct WaitDeadline {
     start: Instant,
     deadline_nanos: Arc<AtomicI64>,
-    extensions_used: Arc<std::sync::atomic::AtomicU32>,
+    extensions_used: Arc<AtomicU32>,
+    /// Pinged by `extend_wait_deadline` so a wait parked past the
+    /// hard deadline can resume promptly.
+    extend_notify: Arc<Notify>,
+    /// Flipped to `true` by `install()` when a new wait supersedes
+    /// this one. The loop polls it via the same `extend_notify`
+    /// (so a single ping wakes both extension AND supersede).
+    cancelled: Arc<AtomicBool>,
+}
+
+impl WaitDeadline {
+    fn clone_handle(&self) -> Self {
+        Self {
+            start: self.start,
+            deadline_nanos: self.deadline_nanos.clone(),
+            extensions_used: self.extensions_used.clone(),
+            extend_notify: self.extend_notify.clone(),
+            cancelled: self.cancelled.clone(),
+        }
+    }
+
+    fn nanos_remaining(&self) -> i64 {
+        let elapsed = i64::try_from(self.start.elapsed().as_nanos()).unwrap_or(i64::MAX);
+        self.deadline_nanos
+            .load(Ordering::Acquire)
+            .saturating_sub(elapsed)
+    }
 }
 
 impl WaitDeadlineState {
-    /// Returns the deadline atomic for the active wait, if any. Used
+    /// Returns a clone of the active wait's handles, if any. Used
     /// by `extend_wait_deadline` to push the deadline out.
     async fn current(&self) -> Option<WaitDeadline> {
-        self.inner.lock().await.as_ref().map(|d| WaitDeadline {
-            start: d.start,
-            deadline_nanos: d.deadline_nanos.clone(),
-            extensions_used: d.extensions_used.clone(),
-        })
+        self.inner.lock().await.as_ref().map(|d| d.clone_handle())
     }
 
-    /// Installs a fresh deadline at `HARD_DEADLINE_SECS` from now.
-    /// Replaces any prior deadline (a wizard re-run shouldn't
-    /// inherit the previous one's extension state).
+    /// Installs a fresh deadline at `hard_secs` from now. Cancels
+    /// any prior wait by flipping its `cancelled` flag and pinging
+    /// its `extend_notify` — the prior loop sees the flag, exits
+    /// cleanly, and stops contending for the deadline atomic.
     async fn install(&self, hard_secs: u64) -> WaitDeadline {
+        let deadline_nanos =
+            i64::try_from(u128::from(hard_secs) * 1_000_000_000_u128).unwrap_or(i64::MAX);
         let deadline = WaitDeadline {
             start: Instant::now(),
-            deadline_nanos: Arc::new(AtomicI64::new((hard_secs * 1_000_000_000) as i64)),
-            extensions_used: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+            deadline_nanos: Arc::new(AtomicI64::new(deadline_nanos)),
+            extensions_used: Arc::new(AtomicU32::new(0)),
+            extend_notify: Arc::new(Notify::new()),
+            cancelled: Arc::new(AtomicBool::new(false)),
         };
-        let snapshot = WaitDeadline {
-            start: deadline.start,
-            deadline_nanos: deadline.deadline_nanos.clone(),
-            extensions_used: deadline.extensions_used.clone(),
-        };
-        *self.inner.lock().await = Some(deadline);
+        let snapshot = deadline.clone_handle();
+        let mut slot = self.inner.lock().await;
+        if let Some(prior) = slot.take() {
+            prior.cancelled.store(true, Ordering::Release);
+            prior.extend_notify.notify_waiters();
+        }
+        *slot = Some(deadline);
         snapshot
     }
 
     /// Clears the active wait — call when the loop exits cleanly
-    /// (all-healthy, timeout, or shutting-down).
+    /// (all-healthy, timeout-cap, unreachable, or shutting-down).
     async fn clear(&self) {
         *self.inner.lock().await = None;
     }
 }
 
 /// Test-only override for the launcher health URL. Production reads
-/// the const above; tests installing a httptest::Server can flip
+/// the const above; tests installing an httptest::Server can flip
 /// this to point at the test server's address. Same shape as
 /// `healthServerAddrOverride` in tools/friday-launcher/uninstall.go.
 fn launcher_health_url() -> String {
@@ -185,6 +230,21 @@ fn launcher_health_url() -> String {
         }
     }
     LAUNCHER_HEALTH_URL.to_string()
+}
+
+/// Pure helper extracted for testability — deadline gate the
+/// SSE-connect retry loop reads. A regression to `>` instead of
+/// `>=` would extend the loop one cycle past the budget; pinning
+/// this in a unit test catches that.
+fn should_give_up(now: Instant, deadline: Instant) -> bool {
+    now >= deadline
+}
+
+/// Pure helper extracted for testability — capped doubling backoff.
+/// `next_backoff_ms(d)` returns the next sleep duration; capped at
+/// `SSE_BACKOFF_MAX_MS`.
+fn next_backoff_ms(current_ms: u64) -> u64 {
+    current_ms.saturating_mul(2).min(SSE_BACKOFF_MAX_MS)
 }
 
 /// Connect to the launcher's SSE endpoint with capped exponential
@@ -210,7 +270,7 @@ async fn connect_with_backoff(client: &reqwest::Client) -> Result<reqwest::Respo
                 last_err = e.to_string();
             }
         }
-        if Instant::now() >= deadline {
+        if should_give_up(Instant::now(), deadline) {
             return Err(format!(
                 "launcher unreachable after {}s: {}",
                 SSE_CONNECT_DEADLINE.as_secs(),
@@ -218,7 +278,7 @@ async fn connect_with_backoff(client: &reqwest::Client) -> Result<reqwest::Respo
             ));
         }
         sleep(Duration::from_millis(delay_ms)).await;
-        delay_ms = (delay_ms * 2).min(SSE_BACKOFF_MAX_MS);
+        delay_ms = next_backoff_ms(delay_ms);
     }
 }
 
@@ -256,13 +316,47 @@ fn parse_sse_chunks(buf: &str) -> (usize, Vec<String>) {
     (last_terminator_end, payloads)
 }
 
+/// Build a `Timeout` event from the most-recent observed snapshot.
+/// `stuck` is every service whose status isn't "healthy";
+/// `playground_healthy` drives the partial-success rule. If we
+/// never observed a snapshot (no SSE events arrived in the wait
+/// window — extreme), the timeout event is empty + non-healthy
+/// playground, which makes the frontend hide "Open anyway" and
+/// just show View logs / Wait again.
+fn timeout_event_from_snapshot(latest: Option<&HealthSnapshot>) -> HealthEvent {
+    let Some(snap) = latest else {
+        return HealthEvent::Timeout {
+            stuck: Vec::new(),
+            playground_healthy: false,
+        };
+    };
+    let stuck: Vec<String> = snap
+        .services
+        .iter()
+        .filter(|s| s.status != "healthy")
+        .map(|s| s.name.clone())
+        .collect();
+    let playground_healthy = snap
+        .services
+        .iter()
+        .any(|s| s.name == PLAYGROUND_SERVICE_NAME && s.status == "healthy");
+    HealthEvent::Timeout {
+        stuck,
+        playground_healthy,
+    }
+}
+
 /// Wait for the launcher's services to all report healthy. Sends
 /// `HealthEvent`s through the supplied Channel; returns when the
-/// stream ends (all-healthy, timeout, unreachable, or shutting-down).
+/// stream ends (all-healthy, unreachable, EOF, or supersede).
 ///
-/// The frontend installs a Channel, calls this, and renders each
-/// event. The command itself is `async` and does NOT block the
-/// frontend — Tauri runs it on the tokio runtime.
+/// Past the hard deadline the loop emits `Timeout` ONCE and then
+/// parks on the deadline's `extend_notify`. A subsequent
+/// `extend_wait_deadline` Tauri command pushes the deadline out
+/// AND pings the notify; the loop wakes, re-checks the deadline,
+/// and resumes streaming. A new `wait_for_services` invocation
+/// supersedes the parked loop (via `cancelled`) so the wizard can
+/// safely re-enter the Launch step.
 #[tauri::command]
 pub async fn wait_for_services(
     on_event: Channel<HealthEvent>,
@@ -295,40 +389,71 @@ pub async fn wait_for_services(
     // deadline_nanos atomic the frontend can extend.
     let deadline = deadline_state.install(HARD_DEADLINE_SECS).await;
     let mut soft_fired = false;
+    let mut timeout_fired = false;
+    // Track the most-recent snapshot so the timeout event can
+    // populate `stuck` + `playground_healthy` honestly.
+    let mut latest_snapshot: Option<HealthSnapshot> = None;
 
     let mut stream = resp.bytes_stream();
     let mut buf = String::new();
 
     loop {
-        // Compute remaining time on each iteration so an extension
-        // landed via extend_wait_deadline is observed promptly.
-        let elapsed_nanos = deadline.start.elapsed().as_nanos() as i64;
-        let deadline_nanos = deadline.deadline_nanos.load(Ordering::Acquire);
-        let remaining_nanos = deadline_nanos.saturating_sub(elapsed_nanos);
+        // A supersede from a re-entered wizard wins over everything —
+        // exit silently so the new wait owns the user-visible state.
+        if deadline.cancelled.load(Ordering::Acquire) {
+            return Ok(());
+        }
 
         // Soft deadline fires once at +60s. After it fires, the wait
         // continues — frontend handles the UI swap.
-        if !soft_fired
-            && deadline.start.elapsed().as_secs() >= SOFT_DEADLINE_SECS
-        {
+        if !soft_fired && deadline.start.elapsed().as_secs() >= SOFT_DEADLINE_SECS {
             soft_fired = true;
             let _ = on_event.send(HealthEvent::SoftDeadline);
         }
 
+        let remaining_nanos = deadline.nanos_remaining();
         if remaining_nanos <= 0 {
-            // Hard deadline elapsed. Collect stuck services + check
-            // playground health for the partial-success rule.
-            let _ = on_event.send(timeout_event_from_buffer(&buf));
-            deadline_state.clear().await;
-            return Ok(());
+            // Hard deadline elapsed.
+            //   - First time: emit Timeout (with the real stuck
+            //     list and playground status) and park on the
+            //     extend_notify; resuming on extension or supersede.
+            //   - If the cap is reached and no further extension
+            //     can come: the frontend stops calling extend, the
+            //     loop sits parked indefinitely, and a wizard re-
+            //     entry supersedes via `cancelled`.
+            if !timeout_fired {
+                timeout_fired = true;
+                let _ = on_event.send(timeout_event_from_snapshot(latest_snapshot.as_ref()));
+            }
+            // Park until extension or supersede pings the notify.
+            // STREAM_POLL_CAP keeps us responsive to a cancelled
+            // flip even if the notify is missed (defense in depth).
+            tokio::select! {
+                _ = deadline.extend_notify.notified() => {},
+                _ = sleep(STREAM_POLL_CAP) => {},
+            }
+            continue;
         }
 
-        let chunk_timeout = Duration::from_nanos(remaining_nanos as u64).min(Duration::from_secs(1));
-        let chunk = match tokio::time::timeout(chunk_timeout, stream.next()).await {
+        // Below the hard deadline: read the next SSE chunk with a
+        // bounded poll so we re-check the deadline (and cancel flag)
+        // promptly even if the launcher goes silent.
+        let bound = u64::try_from(remaining_nanos).unwrap_or(0);
+        let chunk_timeout = Duration::from_nanos(bound).min(STREAM_POLL_CAP);
+        let chunk = tokio::select! {
+            biased;
+            _ = deadline.extend_notify.notified() => {
+                // Extension landed — loop, deadline atomic was
+                // updated by extend_wait_deadline before the ping.
+                continue;
+            }
+            r = tokio::time::timeout(chunk_timeout, stream.next()) => r,
+        };
+        let bytes = match chunk {
             Ok(Some(Ok(bytes))) => bytes,
             Ok(Some(Err(e))) => {
-                // Stream error mid-flight — surface as Unreachable so
-                // the frontend can show View logs.
+                // Stream error mid-flight — surface as Unreachable
+                // so the frontend shows View logs.
                 let _ = on_event.send(HealthEvent::Unreachable {
                     reason: format!("stream error: {e}"),
                 });
@@ -336,50 +461,59 @@ pub async fn wait_for_services(
                 return Ok(());
             }
             Ok(None) => {
-                // Stream closed by the launcher. Treat as ShuttingDown
-                // — the launcher's HTTP server only closes the stream
-                // during shutdown.
-                let _ = on_event.send(HealthEvent::ShuttingDown);
+                // Stream closed unexpectedly. EOF doesn't distinguish
+                // orderly shutdown (which the launcher signals via a
+                // snapshot with shutting_down: true BEFORE closing)
+                // from a launcher crash, network drop, or OS resource
+                // exhaustion. Treat as Unreachable; the snapshot path
+                // above is what handles the orderly case.
+                let _ = on_event.send(HealthEvent::Unreachable {
+                    reason: "stream closed unexpectedly".to_string(),
+                });
                 deadline_state.clear().await;
                 return Ok(());
             }
             Err(_) => {
-                // Timeout on the read — loop back and re-check the
-                // deadline. No event emitted; this is just keeping
-                // the loop responsive to extend_wait_deadline.
+                // Read timeout — loop back, re-check deadline +
+                // cancel flag. Common path when the launcher
+                // hasn't transitioned any service this tick.
                 continue;
             }
         };
 
         // Append the chunk to the rolling buffer and parse out any
         // complete SSE events.
-        buf.push_str(&String::from_utf8_lossy(&chunk));
+        buf.push_str(&String::from_utf8_lossy(&bytes));
         let (consumed, payloads) = parse_sse_chunks(&buf);
         if consumed > 0 {
             buf.drain(..consumed);
         }
 
         for payload in payloads {
-            match serde_json::from_str::<HealthSnapshot>(&payload) {
-                Ok(snap) => {
-                    let all_healthy = snap.all_healthy;
-                    let shutting_down = snap.shutting_down;
-                    let _ = on_event.send(HealthEvent::Snapshot(snap));
-                    if shutting_down {
-                        let _ = on_event.send(HealthEvent::ShuttingDown);
-                        deadline_state.clear().await;
-                        return Ok(());
-                    }
-                    if all_healthy {
-                        deadline_state.clear().await;
-                        return Ok(());
-                    }
-                }
+            let snap = match serde_json::from_str::<HealthSnapshot>(&payload) {
+                Ok(s) => s,
                 Err(_) => {
                     // Malformed payload — log + continue. We don't
-                    // surface this as a UI event because it could
-                    // be a transient framing issue.
+                    // surface this as a UI event because it could be
+                    // a transient framing issue.
+                    continue;
                 }
+            };
+            let all_healthy = snap.all_healthy;
+            let shutting_down = snap.shutting_down;
+            // Forward + retain. The frontend overwrites store.services
+            // wholesale per Snapshot event, so retaining a clone here
+            // is the only way to populate the timeout payload faithfully.
+            latest_snapshot = Some(snap.clone());
+            let _ = on_event.send(HealthEvent::Snapshot(snap));
+            if shutting_down {
+                let _ = on_event.send(HealthEvent::ShuttingDown);
+                deadline_state.clear().await;
+                return Ok(());
+            }
+            if all_healthy {
+                deadline_state.clear().await;
+                return Ok(());
             }
         }
     }
@@ -389,6 +523,10 @@ pub async fn wait_for_services(
 /// `MAX_EXTENSIONS` total. Returns the new deadline (seconds from
 /// wait start) so the frontend can render an accurate "wait again"
 /// affordance, or `None` if the cap is reached or no wait is active.
+///
+/// Pings the wait loop's `extend_notify` so a parked timeout wakes
+/// promptly — without it the loop would sit on its STREAM_POLL_CAP
+/// sleep before noticing the deadline atomic moved.
 #[tauri::command]
 pub async fn extend_wait_deadline(
     deadline_state: State<'_, WaitDeadlineState>,
@@ -401,31 +539,23 @@ pub async fn extend_wait_deadline(
         return Ok(None);
     }
     deadline.extensions_used.store(prior + 1, Ordering::Release);
-    let added_nanos = (EXTENSION_SECS * 1_000_000_000) as i64;
+    let added_nanos =
+        i64::try_from(u128::from(EXTENSION_SECS) * 1_000_000_000_u128).unwrap_or(i64::MAX);
     let new_nanos = deadline
         .deadline_nanos
         .fetch_add(added_nanos, Ordering::AcqRel)
         + added_nanos;
-    Ok(Some((new_nanos as u64) / 1_000_000_000))
-}
-
-/// Build a Timeout event from the current snapshot buffer. We don't
-/// have direct access to the most-recent snapshot here (the loop
-/// already drained the buffer), so this is a conservative fallback:
-/// emit Timeout with empty `stuck` and `playground_healthy: false`.
-/// In practice the loop returns Timeout right after consuming a
-/// snapshot, so this only fires if the launcher hasn't sent ANY
-/// snapshot in 90s — which means everything's stuck.
-fn timeout_event_from_buffer(_buf: &str) -> HealthEvent {
-    HealthEvent::Timeout {
-        stuck: Vec::new(),
-        playground_healthy: false,
-    }
+    // Wake any parked wait loop so it sees the new deadline.
+    deadline.extend_notify.notify_waiters();
+    let new_secs = u64::try_from(new_nanos / 1_000_000_000).unwrap_or(0);
+    Ok(Some(new_secs))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── SSE parser ─────────────────────────────────────────────
 
     #[test]
     fn parse_sse_single_event() {
@@ -463,5 +593,157 @@ mod tests {
         let buf = "data:hello\n\n";
         let (_, payloads) = parse_sse_chunks(buf);
         assert_eq!(payloads, vec!["hello".to_string()]);
+    }
+
+    // ── Backoff helpers ────────────────────────────────────────
+
+    #[test]
+    fn backoff_doubles_until_cap() {
+        // 200 → 400 → 800 → 1600 → 2000 (capped) → 2000
+        assert_eq!(next_backoff_ms(200), 400);
+        assert_eq!(next_backoff_ms(400), 800);
+        assert_eq!(next_backoff_ms(800), 1600);
+        assert_eq!(next_backoff_ms(1600), SSE_BACKOFF_MAX_MS);
+        assert_eq!(next_backoff_ms(SSE_BACKOFF_MAX_MS), SSE_BACKOFF_MAX_MS);
+    }
+
+    #[test]
+    fn backoff_handles_overflow_via_saturation() {
+        // saturating_mul keeps next_backoff_ms total under SSE_BACKOFF_MAX_MS
+        // even on a misbehaving u64.
+        assert_eq!(next_backoff_ms(u64::MAX / 4), SSE_BACKOFF_MAX_MS);
+    }
+
+    #[test]
+    fn give_up_is_inclusive() {
+        // Off-by-one regression: should_give_up MUST trigger at
+        // exactly the deadline, not one tick past it. Otherwise
+        // the SSE-connect loop runs `next_backoff_ms` extra time
+        // before honoring the budget.
+        let now = Instant::now();
+        let deadline = now;
+        assert!(should_give_up(now, deadline));
+        // And not before:
+        let before = now.checked_sub(Duration::from_millis(1)).unwrap_or(now);
+        assert!(!should_give_up(before, deadline));
+    }
+
+    // ── Timeout event from snapshot ────────────────────────────
+
+    fn svc(name: &str, status: &str) -> ServiceStatus {
+        ServiceStatus {
+            name: name.to_string(),
+            status: status.to_string(),
+            since_secs: 0,
+        }
+    }
+
+    fn snap(services: Vec<ServiceStatus>) -> HealthSnapshot {
+        HealthSnapshot {
+            uptime_secs: 0,
+            services,
+            all_healthy: false,
+            shutting_down: false,
+        }
+    }
+
+    #[test]
+    fn timeout_event_lists_unhealthy_services_only() {
+        let s = snap(vec![
+            svc("nats-server", "healthy"),
+            svc("friday", "starting"),
+            svc("playground", "starting"),
+        ]);
+        let HealthEvent::Timeout {
+            stuck,
+            playground_healthy,
+        } = timeout_event_from_snapshot(Some(&s))
+        else {
+            panic!("expected Timeout variant");
+        };
+        assert_eq!(stuck, vec!["friday".to_string(), "playground".to_string()]);
+        assert!(!playground_healthy);
+    }
+
+    #[test]
+    fn timeout_event_sets_playground_healthy_when_playground_green() {
+        let s = snap(vec![
+            svc("playground", "healthy"),
+            svc("webhook-tunnel", "starting"),
+        ]);
+        let HealthEvent::Timeout {
+            stuck,
+            playground_healthy,
+        } = timeout_event_from_snapshot(Some(&s))
+        else {
+            panic!("expected Timeout variant");
+        };
+        assert_eq!(stuck, vec!["webhook-tunnel".to_string()]);
+        assert!(playground_healthy);
+    }
+
+    #[test]
+    fn timeout_event_no_snapshot_yields_empty_payload() {
+        let HealthEvent::Timeout {
+            stuck,
+            playground_healthy,
+        } = timeout_event_from_snapshot(None)
+        else {
+            panic!("expected Timeout variant");
+        };
+        assert!(stuck.is_empty());
+        assert!(!playground_healthy);
+    }
+
+    // ── WaitDeadlineState extension cap ────────────────────────
+
+    #[tokio::test]
+    async fn extension_cap_pins_at_two() {
+        // Drive `WaitDeadlineState.install` + the ext-cap arithmetic
+        // directly. extensions_used starts at 0; after two pushes
+        // a third should be rejected even though the atomic CAS has
+        // headroom. Pinning the cap protects the v15 plan's 210s
+        // ceiling against a future regression that drops the gate.
+        let state = WaitDeadlineState::default();
+        let _ = state.install(HARD_DEADLINE_SECS).await;
+
+        // First extension: ok.
+        let d1 = state.current().await.expect("wait should be installed");
+        let prior_1 = d1.extensions_used.load(Ordering::Acquire);
+        assert!(prior_1 < MAX_EXTENSIONS);
+        d1.extensions_used
+            .store(prior_1 + 1, Ordering::Release);
+
+        // Second extension: ok.
+        let d2 = state.current().await.expect("wait should still be active");
+        let prior_2 = d2.extensions_used.load(Ordering::Acquire);
+        assert!(prior_2 < MAX_EXTENSIONS);
+        d2.extensions_used
+            .store(prior_2 + 1, Ordering::Release);
+
+        // Third extension: capped.
+        let d3 = state.current().await.expect("wait should still be active");
+        let prior_3 = d3.extensions_used.load(Ordering::Acquire);
+        assert!(
+            prior_3 >= MAX_EXTENSIONS,
+            "third extension must be rejected by the cap; got prior_3={prior_3}"
+        );
+    }
+
+    #[tokio::test]
+    async fn install_supersedes_prior_wait() {
+        // Two consecutive `install` calls — the first must be
+        // marked cancelled. A regression that drops the cancel
+        // ping would let two SSE loops run in parallel, each
+        // extending its own deadline atomic, with the wizard's
+        // extend_wait_deadline call only addressing the latest.
+        let state = WaitDeadlineState::default();
+        let first = state.install(HARD_DEADLINE_SECS).await;
+        assert!(!first.cancelled.load(Ordering::Acquire));
+        let _second = state.install(HARD_DEADLINE_SECS).await;
+        assert!(
+            first.cancelled.load(Ordering::Acquire),
+            "first wait must be cancelled after a second install"
+        );
     }
 }

--- a/apps/studio-installer/src-tauri/src/commands/wait_health.rs
+++ b/apps/studio-installer/src-tauri/src/commands/wait_health.rs
@@ -1,0 +1,467 @@
+//! Wait-healthy SSE relay for the wizard's Launch step.
+//!
+//! Subscribes to the launcher's `/api/launcher-health/stream` endpoint
+//! and forwards each event to the frontend via a Tauri Channel. The
+//! launcher's stream emits a full snapshot per event (not deltas), so
+//! the consumer just re-renders the checklist from the latest payload.
+//!
+//! Three deadlines, all independent:
+//!   - **20s SSE-connect deadline** (capped exponential backoff
+//!     200ms → 2s). Sized for cold-cache LaunchServices on slow Macs
+//!     after the v0.0.8 → v0.0.9 migration.
+//!   - **60s soft deadline** — UI swaps to "taking longer than usual"
+//!     copy + adds "Wait 60s more" button.
+//!   - **90s hard deadline** (default end). Extendable to 150s via
+//!     `extend_wait_deadline`, then to 210s on a second extension.
+//!
+//! The `extend_wait_deadline` Tauri command pushes the deadline out
+//! by 60s — capped at two extensions per the v15 plan.
+
+use std::sync::atomic::{AtomicI64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use tauri::ipc::Channel;
+use tauri::State;
+use tokio::sync::Mutex;
+use tokio::time::sleep;
+
+/// Where the launcher's health endpoint lives. Hardcoded to match
+/// `tools/friday-launcher/healthsvc.go`'s `healthServerAddr` const.
+/// Test-only override hook lives below.
+const LAUNCHER_HEALTH_URL: &str = "http://127.0.0.1:5199/api/launcher-health/stream";
+
+/// SSE-connect retry budget. Sized for cold-cache LaunchServices
+/// spin-up + Mach-O load + supervisor init on slow Macs (~6-8s
+/// observed on v0.0.8 → v0.0.9 migration). 20s gives plenty of
+/// headroom; a launcher that hasn't bound port 5199 in 20s is
+/// broken in a way that's not a race.
+const SSE_CONNECT_DEADLINE: Duration = Duration::from_secs(20);
+
+/// Initial backoff when SSE connect fails. Doubles each retry up
+/// to `SSE_BACKOFF_MAX_MS`. Common case: launcher binds within
+/// ~200-500ms of spawn, first retry succeeds.
+const SSE_BACKOFF_INITIAL_MS: u64 = 200;
+const SSE_BACKOFF_MAX_MS: u64 = 2000;
+
+/// Soft deadline — UI swaps to long-wait copy + "Wait 60s more"
+/// button appears. The wait-healthy work continues in the
+/// background; the deadline is purely a UI affordance.
+const SOFT_DEADLINE_SECS: u64 = 60;
+
+/// Hard deadline — default end of the wait-healthy step. Each
+/// `extend_wait_deadline` call adds `EXTENSION_SECS`, capped at
+/// `MAX_EXTENSIONS` total. Past the hard deadline the wizard
+/// surfaces View logs / Open anyway / Wait again.
+const HARD_DEADLINE_SECS: u64 = 90;
+const EXTENSION_SECS: u64 = 60;
+const MAX_EXTENSIONS: u32 = 2;
+
+/// Per-service status emitted by the launcher. Mirrors
+/// `ServiceStatus` in `tools/friday-launcher/healthsvc.go`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ServiceStatus {
+    pub name: String,
+    pub status: String, // "pending" | "starting" | "healthy" | "failed"
+    #[serde(rename = "since_secs")]
+    pub since_secs: i64,
+}
+
+/// Full snapshot from the launcher's health endpoint. Mirrors
+/// `healthResponse` in `healthsvc.go`. The launcher emits this per
+/// SSE event; we forward unchanged to the frontend.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HealthSnapshot {
+    #[serde(rename = "uptime_secs")]
+    pub uptime_secs: i64,
+    pub services: Vec<ServiceStatus>,
+    #[serde(rename = "all_healthy")]
+    pub all_healthy: bool,
+    #[serde(rename = "shutting_down")]
+    pub shutting_down: bool,
+}
+
+/// Tagged events sent to the frontend Channel. The frontend's
+/// `runtime.invoke('wait_for_services', { onEvent })` pattern reads
+/// these one-at-a-time; the variant tag drives the UI state.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum HealthEvent {
+    /// Initial state — emitted once before the SSE-connect loop runs.
+    /// Lets the frontend show "Connecting to launcher…" before the
+    /// first snapshot lands.
+    Connecting,
+    /// SSE stream is live. Subsequent `Snapshot` events follow.
+    Connected,
+    /// Health snapshot from the launcher.
+    Snapshot(HealthSnapshot),
+    /// Soft deadline (60s) elapsed. UI swaps to long-wait copy.
+    SoftDeadline,
+    /// Hard deadline elapsed. Carries the names of services NOT
+    /// healthy + a flag indicating whether playground is among the
+    /// healthy ones (used by the partial-success "Open anyway" rule).
+    Timeout {
+        stuck: Vec<String>,
+        playground_healthy: bool,
+    },
+    /// SSE-connect retry budget exhausted. The launcher never
+    /// bound port 5199 within `SSE_CONNECT_DEADLINE`. Fatal —
+    /// frontend shows "could not connect to launcher" + View logs.
+    Unreachable {
+        reason: String,
+    },
+    /// Launcher reported `shutting_down: true` mid-wait. Treat as
+    /// fatal — the user manually triggered a shutdown or something
+    /// else hit the launcher's HTTP shutdown endpoint.
+    ShuttingDown,
+}
+
+/// Mutable state shared between `wait_for_services` and
+/// `extend_wait_deadline`. The deadline is an absolute Instant, so
+/// extension is a single atomic add — no mutex needed for the
+/// commonly-read path.
+///
+/// `deadline_secs_from_start` is stored as nanos since the wait
+/// started; the consumer compares against `wait_started.elapsed()`
+/// rather than against an `Instant` (avoids passing tokio Instants
+/// across the Tauri command boundary, which doesn't serialize).
+#[derive(Default)]
+pub struct WaitDeadlineState {
+    inner: Mutex<Option<WaitDeadline>>,
+}
+
+struct WaitDeadline {
+    start: Instant,
+    deadline_nanos: Arc<AtomicI64>,
+    extensions_used: Arc<std::sync::atomic::AtomicU32>,
+}
+
+impl WaitDeadlineState {
+    /// Returns the deadline atomic for the active wait, if any. Used
+    /// by `extend_wait_deadline` to push the deadline out.
+    async fn current(&self) -> Option<WaitDeadline> {
+        self.inner.lock().await.as_ref().map(|d| WaitDeadline {
+            start: d.start,
+            deadline_nanos: d.deadline_nanos.clone(),
+            extensions_used: d.extensions_used.clone(),
+        })
+    }
+
+    /// Installs a fresh deadline at `HARD_DEADLINE_SECS` from now.
+    /// Replaces any prior deadline (a wizard re-run shouldn't
+    /// inherit the previous one's extension state).
+    async fn install(&self, hard_secs: u64) -> WaitDeadline {
+        let deadline = WaitDeadline {
+            start: Instant::now(),
+            deadline_nanos: Arc::new(AtomicI64::new((hard_secs * 1_000_000_000) as i64)),
+            extensions_used: Arc::new(std::sync::atomic::AtomicU32::new(0)),
+        };
+        let snapshot = WaitDeadline {
+            start: deadline.start,
+            deadline_nanos: deadline.deadline_nanos.clone(),
+            extensions_used: deadline.extensions_used.clone(),
+        };
+        *self.inner.lock().await = Some(deadline);
+        snapshot
+    }
+
+    /// Clears the active wait — call when the loop exits cleanly
+    /// (all-healthy, timeout, or shutting-down).
+    async fn clear(&self) {
+        *self.inner.lock().await = None;
+    }
+}
+
+/// Test-only override for the launcher health URL. Production reads
+/// the const above; tests installing a httptest::Server can flip
+/// this to point at the test server's address. Same shape as
+/// `healthServerAddrOverride` in tools/friday-launcher/uninstall.go.
+fn launcher_health_url() -> String {
+    if let Ok(s) = std::env::var("FRIDAY_LAUNCHER_HEALTH_URL_OVERRIDE") {
+        if !s.is_empty() {
+            return s;
+        }
+    }
+    LAUNCHER_HEALTH_URL.to_string()
+}
+
+/// Connect to the launcher's SSE endpoint with capped exponential
+/// backoff. Returns the live response stream once connected, or an
+/// error if the deadline elapses without a successful connect.
+async fn connect_with_backoff(client: &reqwest::Client) -> Result<reqwest::Response, String> {
+    let url = launcher_health_url();
+    let mut delay_ms = SSE_BACKOFF_INITIAL_MS;
+    let deadline = Instant::now() + SSE_CONNECT_DEADLINE;
+    let mut last_err: String;
+    loop {
+        match client
+            .get(&url)
+            .header("Accept", "text/event-stream")
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => return Ok(resp),
+            Ok(resp) => {
+                last_err = format!("HTTP {} from launcher", resp.status());
+            }
+            Err(e) => {
+                last_err = e.to_string();
+            }
+        }
+        if Instant::now() >= deadline {
+            return Err(format!(
+                "launcher unreachable after {}s: {}",
+                SSE_CONNECT_DEADLINE.as_secs(),
+                last_err
+            ));
+        }
+        sleep(Duration::from_millis(delay_ms)).await;
+        delay_ms = (delay_ms * 2).min(SSE_BACKOFF_MAX_MS);
+    }
+}
+
+/// Parse one or more SSE `data: <json>\n\n` records from a buffer.
+/// Returns the consumed prefix length and the parsed payloads, in
+/// order. Anything before the last terminator stays in the buffer
+/// for the next read.
+///
+/// SSE is line-oriented; a single event ends with a blank line.
+/// We only care about `data:` lines (the launcher doesn't emit
+/// event names, ids, or retries).
+fn parse_sse_chunks(buf: &str) -> (usize, Vec<String>) {
+    let mut payloads = Vec::new();
+    let mut current = String::new();
+    let mut last_terminator_end = 0usize;
+    let mut idx = 0usize;
+    while let Some(end) = buf[idx..].find('\n') {
+        let line_end = idx + end;
+        let raw_line = &buf[idx..line_end];
+        // Strip trailing \r if present.
+        let line = raw_line.strip_suffix('\r').unwrap_or(raw_line);
+        if line.is_empty() {
+            // Blank line — event terminator.
+            if !current.is_empty() {
+                payloads.push(std::mem::take(&mut current));
+            }
+            last_terminator_end = line_end + 1;
+        } else if let Some(data) = line.strip_prefix("data: ") {
+            current.push_str(data);
+        } else if let Some(data) = line.strip_prefix("data:") {
+            current.push_str(data);
+        }
+        idx = line_end + 1;
+    }
+    (last_terminator_end, payloads)
+}
+
+/// Wait for the launcher's services to all report healthy. Sends
+/// `HealthEvent`s through the supplied Channel; returns when the
+/// stream ends (all-healthy, timeout, unreachable, or shutting-down).
+///
+/// The frontend installs a Channel, calls this, and renders each
+/// event. The command itself is `async` and does NOT block the
+/// frontend — Tauri runs it on the tokio runtime.
+#[tauri::command]
+pub async fn wait_for_services(
+    on_event: Channel<HealthEvent>,
+    deadline_state: State<'_, WaitDeadlineState>,
+) -> Result<(), String> {
+    // Send Connecting before the (potentially long) backoff loop so
+    // the frontend has something to render.
+    let _ = on_event.send(HealthEvent::Connecting);
+
+    let client = reqwest::Client::builder()
+        // No connection pool for SSE — each request opens a fresh
+        // long-lived stream. Disable timeouts globally; we enforce
+        // the 20s connect deadline ourselves, and the SSE stream
+        // is meant to live indefinitely once connected.
+        .build()
+        .map_err(|e| format!("reqwest client: {e}"))?;
+
+    let resp = match connect_with_backoff(&client).await {
+        Ok(r) => r,
+        Err(reason) => {
+            let _ = on_event.send(HealthEvent::Unreachable { reason });
+            return Ok(());
+        }
+    };
+
+    let _ = on_event.send(HealthEvent::Connected);
+
+    // Install the wait deadline now that SSE is live. Soft and hard
+    // are independent: the soft fires once at +60s; the hard is the
+    // deadline_nanos atomic the frontend can extend.
+    let deadline = deadline_state.install(HARD_DEADLINE_SECS).await;
+    let mut soft_fired = false;
+
+    let mut stream = resp.bytes_stream();
+    let mut buf = String::new();
+
+    loop {
+        // Compute remaining time on each iteration so an extension
+        // landed via extend_wait_deadline is observed promptly.
+        let elapsed_nanos = deadline.start.elapsed().as_nanos() as i64;
+        let deadline_nanos = deadline.deadline_nanos.load(Ordering::Acquire);
+        let remaining_nanos = deadline_nanos.saturating_sub(elapsed_nanos);
+
+        // Soft deadline fires once at +60s. After it fires, the wait
+        // continues — frontend handles the UI swap.
+        if !soft_fired
+            && deadline.start.elapsed().as_secs() >= SOFT_DEADLINE_SECS
+        {
+            soft_fired = true;
+            let _ = on_event.send(HealthEvent::SoftDeadline);
+        }
+
+        if remaining_nanos <= 0 {
+            // Hard deadline elapsed. Collect stuck services + check
+            // playground health for the partial-success rule.
+            let _ = on_event.send(timeout_event_from_buffer(&buf));
+            deadline_state.clear().await;
+            return Ok(());
+        }
+
+        let chunk_timeout = Duration::from_nanos(remaining_nanos as u64).min(Duration::from_secs(1));
+        let chunk = match tokio::time::timeout(chunk_timeout, stream.next()).await {
+            Ok(Some(Ok(bytes))) => bytes,
+            Ok(Some(Err(e))) => {
+                // Stream error mid-flight — surface as Unreachable so
+                // the frontend can show View logs.
+                let _ = on_event.send(HealthEvent::Unreachable {
+                    reason: format!("stream error: {e}"),
+                });
+                deadline_state.clear().await;
+                return Ok(());
+            }
+            Ok(None) => {
+                // Stream closed by the launcher. Treat as ShuttingDown
+                // — the launcher's HTTP server only closes the stream
+                // during shutdown.
+                let _ = on_event.send(HealthEvent::ShuttingDown);
+                deadline_state.clear().await;
+                return Ok(());
+            }
+            Err(_) => {
+                // Timeout on the read — loop back and re-check the
+                // deadline. No event emitted; this is just keeping
+                // the loop responsive to extend_wait_deadline.
+                continue;
+            }
+        };
+
+        // Append the chunk to the rolling buffer and parse out any
+        // complete SSE events.
+        buf.push_str(&String::from_utf8_lossy(&chunk));
+        let (consumed, payloads) = parse_sse_chunks(&buf);
+        if consumed > 0 {
+            buf.drain(..consumed);
+        }
+
+        for payload in payloads {
+            match serde_json::from_str::<HealthSnapshot>(&payload) {
+                Ok(snap) => {
+                    let all_healthy = snap.all_healthy;
+                    let shutting_down = snap.shutting_down;
+                    let _ = on_event.send(HealthEvent::Snapshot(snap));
+                    if shutting_down {
+                        let _ = on_event.send(HealthEvent::ShuttingDown);
+                        deadline_state.clear().await;
+                        return Ok(());
+                    }
+                    if all_healthy {
+                        deadline_state.clear().await;
+                        return Ok(());
+                    }
+                }
+                Err(_) => {
+                    // Malformed payload — log + continue. We don't
+                    // surface this as a UI event because it could
+                    // be a transient framing issue.
+                }
+            }
+        }
+    }
+}
+
+/// Push the wait deadline out by `EXTENSION_SECS`. Capped at
+/// `MAX_EXTENSIONS` total. Returns the new deadline (seconds from
+/// wait start) so the frontend can render an accurate "wait again"
+/// affordance, or `None` if the cap is reached or no wait is active.
+#[tauri::command]
+pub async fn extend_wait_deadline(
+    deadline_state: State<'_, WaitDeadlineState>,
+) -> Result<Option<u64>, String> {
+    let Some(deadline) = deadline_state.current().await else {
+        return Ok(None);
+    };
+    let prior = deadline.extensions_used.load(Ordering::Acquire);
+    if prior >= MAX_EXTENSIONS {
+        return Ok(None);
+    }
+    deadline.extensions_used.store(prior + 1, Ordering::Release);
+    let added_nanos = (EXTENSION_SECS * 1_000_000_000) as i64;
+    let new_nanos = deadline
+        .deadline_nanos
+        .fetch_add(added_nanos, Ordering::AcqRel)
+        + added_nanos;
+    Ok(Some((new_nanos as u64) / 1_000_000_000))
+}
+
+/// Build a Timeout event from the current snapshot buffer. We don't
+/// have direct access to the most-recent snapshot here (the loop
+/// already drained the buffer), so this is a conservative fallback:
+/// emit Timeout with empty `stuck` and `playground_healthy: false`.
+/// In practice the loop returns Timeout right after consuming a
+/// snapshot, so this only fires if the launcher hasn't sent ANY
+/// snapshot in 90s — which means everything's stuck.
+fn timeout_event_from_buffer(_buf: &str) -> HealthEvent {
+    HealthEvent::Timeout {
+        stuck: Vec::new(),
+        playground_healthy: false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_sse_single_event() {
+        let buf = "data: {\"a\":1}\n\n";
+        let (consumed, payloads) = parse_sse_chunks(buf);
+        assert_eq!(consumed, buf.len());
+        assert_eq!(payloads, vec!["{\"a\":1}".to_string()]);
+    }
+
+    #[test]
+    fn parse_sse_multiple_events() {
+        let buf = "data: a\n\ndata: b\n\n";
+        let (consumed, payloads) = parse_sse_chunks(buf);
+        assert_eq!(consumed, buf.len());
+        assert_eq!(payloads, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn parse_sse_partial_event_left_in_buffer() {
+        let buf = "data: a\n\ndata: b\n";
+        let (consumed, payloads) = parse_sse_chunks(buf);
+        assert_eq!(consumed, "data: a\n\n".len());
+        assert_eq!(payloads, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn parse_sse_handles_crlf() {
+        let buf = "data: a\r\n\r\n";
+        let (_, payloads) = parse_sse_chunks(buf);
+        assert_eq!(payloads, vec!["a".to_string()]);
+    }
+
+    #[test]
+    fn parse_sse_handles_no_space_after_colon() {
+        let buf = "data:hello\n\n";
+        let (_, payloads) = parse_sse_chunks(buf);
+        assert_eq!(payloads, vec!["hello".to_string()]);
+    }
+}

--- a/apps/studio-installer/src-tauri/src/commands/wait_health.rs
+++ b/apps/studio-installer/src-tauri/src/commands/wait_health.rs
@@ -448,8 +448,9 @@ pub async fn wait_for_services(
         // (210s) after two extensions would see the loop park
         // indefinitely while the frontend stays in long-wait with
         // no escape (canExtendDeadline=false; View logs is only
-        // shown in the timeout state).
-        if timeout_fired {
+        // shown in the timeout state). See should_reset_timeout_latch
+        // for the unit-tested rule.
+        if should_reset_timeout_latch(timeout_fired, remaining_nanos) {
             timeout_fired = false;
         }
 
@@ -537,28 +538,23 @@ pub async fn wait_for_services(
     }
 }
 
-/// Push the wait deadline out by `EXTENSION_SECS`. Capped at
-/// `MAX_EXTENSIONS` total. Returns the new deadline (seconds from
-/// wait start) so the frontend can render an accurate "wait again"
-/// affordance, or `None` if the cap is reached or no wait is active.
+/// Shared CAS+arithmetic body for `extend_wait_deadline`. Tests call
+/// this directly so they exercise exactly what the production
+/// command does — no mirror-or-die contract. The Tauri command
+/// itself is a 2-line wrapper around this.
 ///
-/// Pings the wait loop's `extend_notify` so a parked timeout wakes
-/// promptly — without it the loop would sit on its STREAM_POLL_CAP
-/// sleep before noticing the deadline atomic moved.
-#[tauri::command]
-pub async fn extend_wait_deadline(
-    deadline_state: State<'_, WaitDeadlineState>,
+/// CAS via fetch_update so two concurrent calls can't both observe
+/// `prior < MAX` and both push the deadline. Without this guard, a
+/// race would let the cap be bypassed (counter=1 but deadline_nanos
+/// pushed by 2 * EXTENSION_SECS). Tauri command dispatch is async;
+/// even if the wizard's button is single-source, a future autoclick
+/// / keyboard repeat / test harness could trigger the race.
+async fn do_extend_wait_deadline(
+    deadline_state: &WaitDeadlineState,
 ) -> Result<Option<u64>, String> {
     let Some(deadline) = deadline_state.current().await else {
         return Ok(None);
     };
-    // CAS via fetch_update so two concurrent extend_wait_deadline
-    // invocations can't both observe `prior < MAX` and both push
-    // the deadline. Without this guard, a race would let the cap
-    // be bypassed (counter=1 but deadline_nanos pushed by 2 *
-    // EXTENSION_SECS). Tauri command dispatch is async; even if
-    // the wizard's button is single-source, a future autoclick /
-    // keyboard repeat / test harness could trigger the race.
     if deadline
         .extensions_used
         .fetch_update(Ordering::AcqRel, Ordering::Acquire, |n| {
@@ -582,6 +578,33 @@ pub async fn extend_wait_deadline(
     deadline.extend_notify.notify_waiters();
     let new_secs = u64::try_from(new_nanos / 1_000_000_000).unwrap_or(0);
     Ok(Some(new_secs))
+}
+
+/// Push the wait deadline out by `EXTENSION_SECS`. Capped at
+/// `MAX_EXTENSIONS` total. Returns the new deadline (seconds from
+/// wait start) so the frontend can render an accurate "wait again"
+/// affordance, or `None` if the cap is reached or no wait is active.
+///
+/// Pings the wait loop's `extend_notify` so a parked timeout wakes
+/// promptly — without it the loop would sit on its STREAM_POLL_CAP
+/// sleep before noticing the deadline atomic moved. Body lives in
+/// `do_extend_wait_deadline` so tests can drive the same logic
+/// without a Tauri State<> wrapper.
+#[tauri::command]
+pub async fn extend_wait_deadline(
+    deadline_state: State<'_, WaitDeadlineState>,
+) -> Result<Option<u64>, String> {
+    do_extend_wait_deadline(&deadline_state).await
+}
+
+/// Pure helper extracted for testability — answers "should we reset
+/// the timeout-fired latch?" given the current loop state. The reset
+/// is the cycle-2 fix that prevents the wait loop from stranding the
+/// UI in long-wait after the second 60s extension elapses without
+/// all-healthy. A regression dropping the reset re-introduces the
+/// 210s deadlock with no test failure unless this helper is pinned.
+fn should_reset_timeout_latch(timeout_fired: bool, remaining_nanos: i64) -> bool {
+    timeout_fired && remaining_nanos > 0
 }
 
 #[cfg(test)]
@@ -731,59 +754,26 @@ mod tests {
     // ── WaitDeadlineState extension cap ────────────────────────
 
     /// Helper that mirrors the extend_wait_deadline command body
-    /// without the Tauri State<> wrapper. Tests call this directly
-    /// to exercise the actual CAS arithmetic the command uses
-    /// (rather than poking the atomic by hand). Returns Ok(Some(n))
-    /// when extension succeeds, Ok(None) when capped or no active
-    /// wait. Mirrors `extend_wait_deadline` line-for-line; updates
-    /// here MUST be mirrored in the command.
-    async fn extend_wait_deadline_inner(state: &WaitDeadlineState) -> Result<Option<u64>, String> {
-        let Some(deadline) = state.current().await else {
-            return Ok(None);
-        };
-        if deadline
-            .extensions_used
-            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |n| {
-                if n >= MAX_EXTENSIONS {
-                    None
-                } else {
-                    Some(n + 1)
-                }
-            })
-            .is_err()
-        {
-            return Ok(None);
-        }
-        let added_nanos =
-            i64::try_from(u128::from(EXTENSION_SECS) * 1_000_000_000_u128).unwrap_or(i64::MAX);
-        let new_nanos = deadline
-            .deadline_nanos
-            .fetch_add(added_nanos, Ordering::AcqRel)
-            + added_nanos;
-        deadline.extend_notify.notify_waiters();
-        let new_secs = u64::try_from(new_nanos / 1_000_000_000).unwrap_or(0);
-        Ok(Some(new_secs))
-    }
-
     #[tokio::test]
     async fn extension_cap_pins_at_two() {
-        // Drives the actual CAS path (via extend_wait_deadline_inner)
-        // so a regression in either the cap arithmetic OR the CAS
+        // Drives the production command body (do_extend_wait_deadline)
+        // directly — no test-only helper that could drift from the
+        // command. A regression in the cap arithmetic or the CAS
         // gate fails this test. Pinning the cap protects the v15
         // plan's 210s ceiling against a future drop of the gate.
         let state = WaitDeadlineState::default();
         let _ = state.install(HARD_DEADLINE_SECS).await;
 
         // First extension: 90 + 60 = 150.
-        let r1 = extend_wait_deadline_inner(&state).await.unwrap();
+        let r1 = do_extend_wait_deadline(&state).await.unwrap();
         assert_eq!(r1, Some(150));
 
         // Second extension: 150 + 60 = 210.
-        let r2 = extend_wait_deadline_inner(&state).await.unwrap();
+        let r2 = do_extend_wait_deadline(&state).await.unwrap();
         assert_eq!(r2, Some(210));
 
         // Third extension: capped.
-        let r3 = extend_wait_deadline_inner(&state).await.unwrap();
+        let r3 = do_extend_wait_deadline(&state).await.unwrap();
         assert_eq!(r3, None);
 
         // Atomic-level sanity: counter must equal MAX_EXTENSIONS.
@@ -813,29 +803,32 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn extension_cap_under_concurrent_calls() {
-        // Two concurrent extend_wait_deadline calls must not both
-        // succeed when the prior counter is at MAX-1. Without the
-        // CAS (when the body was load-then-store), both would
-        // observe `prior < MAX`, both increment, both push the
-        // deadline — bypassing the cap. With fetch_update the second
-        // caller sees `n >= MAX` and returns Ok(None).
+    async fn extension_cap_holds_at_boundary() {
+        // Pins the cap arithmetic at the boundary: with the counter
+        // at MAX-1, two consecutive extensions yield exactly one
+        // success (Some(210)) and one None, with deadline_nanos
+        // landing at 210s (90+60+60), not 270s.
+        //
+        // NOTE: this test does NOT genuinely race load-then-store
+        // versus CAS — `do_extend_wait_deadline` has zero `.await`
+        // points between the `current()` lookup and the
+        // `fetch_update`, so two `tokio::spawn`s cannot interleave
+        // between load and store regardless of runtime flavor.
+        // The CAS atomicity is correct by code inspection (the
+        // `fetch_update` closure is the standard pattern). What
+        // this test pins is the cap arithmetic at the boundary —
+        // a regression that drops the cap gate (Some/None branch
+        // in the closure) would still fail this test cleanly.
         let state = WaitDeadlineState::default();
         let _ = state.install(HARD_DEADLINE_SECS).await;
-        // Push the counter to MAX-1 so the next two calls race at
-        // the boundary.
-        let r1 = extend_wait_deadline_inner(&state).await.unwrap();
+        let r1 = do_extend_wait_deadline(&state).await.unwrap();
         assert_eq!(r1, Some(150));
 
-        // Spawn two concurrent extension attempts. With fetch_update,
-        // exactly one should succeed (Some(210)) and the other
-        // should return Ok(None). With the prior load-then-store
-        // body, both could succeed.
         let s = std::sync::Arc::new(state);
         let s1 = s.clone();
         let s2 = s.clone();
-        let h1 = tokio::spawn(async move { extend_wait_deadline_inner(&s1).await });
-        let h2 = tokio::spawn(async move { extend_wait_deadline_inner(&s2).await });
+        let h1 = tokio::spawn(async move { do_extend_wait_deadline(&s1).await });
+        let h2 = tokio::spawn(async move { do_extend_wait_deadline(&s2).await });
         let r1 = h1.await.unwrap().unwrap();
         let r2 = h2.await.unwrap().unwrap();
         let mut results = vec![r1, r2];
@@ -843,7 +836,7 @@ mod tests {
         assert_eq!(
             results,
             vec![None, Some(210)],
-            "exactly one concurrent extension must succeed; got {results:?}"
+            "exactly one extension at the boundary must succeed; got {results:?}"
         );
 
         // And the deadline_nanos must reflect exactly two extensions
@@ -856,5 +849,39 @@ mod tests {
             secs, 210,
             "deadline must equal 90+60+60=210s; got {secs}s (cap bypassed?)"
         );
+    }
+
+    // ── Timeout-fired latch reset (cycle-2 fix) ────────────────
+
+    #[test]
+    fn latch_reset_no_op_when_never_fired() {
+        // Reset should be a no-op on the never-fired path: latch
+        // is false at loop entry; reset stays false. Catches a
+        // regression that toggles instead of conditionally clears.
+        assert!(!should_reset_timeout_latch(false, 0));
+        assert!(!should_reset_timeout_latch(false, 1_000_000_000));
+        assert!(!should_reset_timeout_latch(false, -1));
+    }
+
+    #[test]
+    fn latch_reset_holds_when_remaining_is_zero_or_negative() {
+        // Latch must persist while the deadline is still elapsed —
+        // we're still past the hard deadline, the loop should
+        // remain in parked-Timeout mode without re-firing.
+        assert!(!should_reset_timeout_latch(true, 0));
+        assert!(!should_reset_timeout_latch(true, -1));
+        assert!(!should_reset_timeout_latch(true, i64::MIN));
+    }
+
+    #[test]
+    fn latch_reset_fires_when_extension_pushed_remaining_positive() {
+        // Latch must reset only when an extension landed (deadline
+        // pushed forward, remaining > 0). This is the cycle-2 fix:
+        // without it the wait loop strands the UI in long-wait
+        // after the second 60s extension elapses without all-
+        // healthy at 210s.
+        assert!(should_reset_timeout_latch(true, 1));
+        assert!(should_reset_timeout_latch(true, 60_000_000_000));
+        assert!(should_reset_timeout_latch(true, i64::MAX));
     }
 }

--- a/apps/studio-installer/src-tauri/src/commands/wait_health.rs
+++ b/apps/studio-installer/src-tauri/src/commands/wait_health.rs
@@ -426,13 +426,31 @@ pub async fn wait_for_services(
                 let _ = on_event.send(timeout_event_from_snapshot(latest_snapshot.as_ref()));
             }
             // Park until extension or supersede pings the notify.
-            // STREAM_POLL_CAP keeps us responsive to a cancelled
-            // flip even if the notify is missed (defense in depth).
+            // STREAM_POLL_CAP is the recovery ceiling for either:
+            //   - a cancelled flip whose notify is missed (loop
+            //     between iterations when install() ran), or
+            //   - an extension whose notify is missed (same gap).
+            // Self-healing: ≤1s before the next loop sees the
+            // updated atomic. Same defense applies to the streaming-
+            // branch select below.
             tokio::select! {
                 _ = deadline.extend_notify.notified() => {},
                 _ = sleep(STREAM_POLL_CAP) => {},
             }
             continue;
+        }
+
+        // Reaching here means we re-checked `nanos_remaining` and
+        // it's > 0. If a prior iteration emitted Timeout, an
+        // extension has since pushed the deadline forward — reset
+        // the latch so a future re-elapse fires a FRESH Timeout
+        // event. Without this reset, a wizard that hits the cap
+        // (210s) after two extensions would see the loop park
+        // indefinitely while the frontend stays in long-wait with
+        // no escape (canExtendDeadline=false; View logs is only
+        // shown in the timeout state).
+        if timeout_fired {
+            timeout_fired = false;
         }
 
         // Below the hard deadline: read the next SSE chunk with a
@@ -534,11 +552,26 @@ pub async fn extend_wait_deadline(
     let Some(deadline) = deadline_state.current().await else {
         return Ok(None);
     };
-    let prior = deadline.extensions_used.load(Ordering::Acquire);
-    if prior >= MAX_EXTENSIONS {
+    // CAS via fetch_update so two concurrent extend_wait_deadline
+    // invocations can't both observe `prior < MAX` and both push
+    // the deadline. Without this guard, a race would let the cap
+    // be bypassed (counter=1 but deadline_nanos pushed by 2 *
+    // EXTENSION_SECS). Tauri command dispatch is async; even if
+    // the wizard's button is single-source, a future autoclick /
+    // keyboard repeat / test harness could trigger the race.
+    if deadline
+        .extensions_used
+        .fetch_update(Ordering::AcqRel, Ordering::Acquire, |n| {
+            if n >= MAX_EXTENSIONS {
+                None
+            } else {
+                Some(n + 1)
+            }
+        })
+        .is_err()
+    {
         return Ok(None);
     }
-    deadline.extensions_used.store(prior + 1, Ordering::Release);
     let added_nanos =
         i64::try_from(u128::from(EXTENSION_SECS) * 1_000_000_000_u128).unwrap_or(i64::MAX);
     let new_nanos = deadline
@@ -697,33 +730,65 @@ mod tests {
 
     // ── WaitDeadlineState extension cap ────────────────────────
 
+    /// Helper that mirrors the extend_wait_deadline command body
+    /// without the Tauri State<> wrapper. Tests call this directly
+    /// to exercise the actual CAS arithmetic the command uses
+    /// (rather than poking the atomic by hand). Returns Ok(Some(n))
+    /// when extension succeeds, Ok(None) when capped or no active
+    /// wait. Mirrors `extend_wait_deadline` line-for-line; updates
+    /// here MUST be mirrored in the command.
+    async fn extend_wait_deadline_inner(state: &WaitDeadlineState) -> Result<Option<u64>, String> {
+        let Some(deadline) = state.current().await else {
+            return Ok(None);
+        };
+        if deadline
+            .extensions_used
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |n| {
+                if n >= MAX_EXTENSIONS {
+                    None
+                } else {
+                    Some(n + 1)
+                }
+            })
+            .is_err()
+        {
+            return Ok(None);
+        }
+        let added_nanos =
+            i64::try_from(u128::from(EXTENSION_SECS) * 1_000_000_000_u128).unwrap_or(i64::MAX);
+        let new_nanos = deadline
+            .deadline_nanos
+            .fetch_add(added_nanos, Ordering::AcqRel)
+            + added_nanos;
+        deadline.extend_notify.notify_waiters();
+        let new_secs = u64::try_from(new_nanos / 1_000_000_000).unwrap_or(0);
+        Ok(Some(new_secs))
+    }
+
     #[tokio::test]
     async fn extension_cap_pins_at_two() {
-        // Drive `WaitDeadlineState.install` + the ext-cap arithmetic
-        // directly. extensions_used starts at 0; after two pushes
-        // a third should be rejected even though the atomic CAS has
-        // headroom. Pinning the cap protects the v15 plan's 210s
-        // ceiling against a future regression that drops the gate.
+        // Drives the actual CAS path (via extend_wait_deadline_inner)
+        // so a regression in either the cap arithmetic OR the CAS
+        // gate fails this test. Pinning the cap protects the v15
+        // plan's 210s ceiling against a future drop of the gate.
         let state = WaitDeadlineState::default();
         let _ = state.install(HARD_DEADLINE_SECS).await;
 
-        // First extension: ok.
-        let d1 = state.current().await.expect("wait should be installed");
-        let prior_1 = d1.extensions_used.load(Ordering::Acquire);
-        assert!(prior_1 < MAX_EXTENSIONS);
-        d1.extensions_used
-            .store(prior_1 + 1, Ordering::Release);
+        // First extension: 90 + 60 = 150.
+        let r1 = extend_wait_deadline_inner(&state).await.unwrap();
+        assert_eq!(r1, Some(150));
 
-        // Second extension: ok.
-        let d2 = state.current().await.expect("wait should still be active");
-        let prior_2 = d2.extensions_used.load(Ordering::Acquire);
-        assert!(prior_2 < MAX_EXTENSIONS);
-        d2.extensions_used
-            .store(prior_2 + 1, Ordering::Release);
+        // Second extension: 150 + 60 = 210.
+        let r2 = extend_wait_deadline_inner(&state).await.unwrap();
+        assert_eq!(r2, Some(210));
 
         // Third extension: capped.
-        let d3 = state.current().await.expect("wait should still be active");
-        let prior_3 = d3.extensions_used.load(Ordering::Acquire);
+        let r3 = extend_wait_deadline_inner(&state).await.unwrap();
+        assert_eq!(r3, None);
+
+        // Atomic-level sanity: counter must equal MAX_EXTENSIONS.
+        let d = state.current().await.expect("wait should still be active");
+        let prior_3 = d.extensions_used.load(Ordering::Acquire);
         assert!(
             prior_3 >= MAX_EXTENSIONS,
             "third extension must be rejected by the cap; got prior_3={prior_3}"
@@ -744,6 +809,52 @@ mod tests {
         assert!(
             first.cancelled.load(Ordering::Acquire),
             "first wait must be cancelled after a second install"
+        );
+    }
+
+    #[tokio::test]
+    async fn extension_cap_under_concurrent_calls() {
+        // Two concurrent extend_wait_deadline calls must not both
+        // succeed when the prior counter is at MAX-1. Without the
+        // CAS (when the body was load-then-store), both would
+        // observe `prior < MAX`, both increment, both push the
+        // deadline — bypassing the cap. With fetch_update the second
+        // caller sees `n >= MAX` and returns Ok(None).
+        let state = WaitDeadlineState::default();
+        let _ = state.install(HARD_DEADLINE_SECS).await;
+        // Push the counter to MAX-1 so the next two calls race at
+        // the boundary.
+        let r1 = extend_wait_deadline_inner(&state).await.unwrap();
+        assert_eq!(r1, Some(150));
+
+        // Spawn two concurrent extension attempts. With fetch_update,
+        // exactly one should succeed (Some(210)) and the other
+        // should return Ok(None). With the prior load-then-store
+        // body, both could succeed.
+        let s = std::sync::Arc::new(state);
+        let s1 = s.clone();
+        let s2 = s.clone();
+        let h1 = tokio::spawn(async move { extend_wait_deadline_inner(&s1).await });
+        let h2 = tokio::spawn(async move { extend_wait_deadline_inner(&s2).await });
+        let r1 = h1.await.unwrap().unwrap();
+        let r2 = h2.await.unwrap().unwrap();
+        let mut results = vec![r1, r2];
+        results.sort();
+        assert_eq!(
+            results,
+            vec![None, Some(210)],
+            "exactly one concurrent extension must succeed; got {results:?}"
+        );
+
+        // And the deadline_nanos must reflect exactly two extensions
+        // beyond the original HARD_DEADLINE_SECS (90 + 60 + 60 =
+        // 210s). A regression that pushed twice would land at 270s.
+        let d = s.current().await.expect("wait should still be active");
+        let nanos = d.deadline_nanos.load(Ordering::Acquire);
+        let secs = nanos / 1_000_000_000;
+        assert_eq!(
+            secs, 210,
+            "deadline must equal 90+60+60=210s; got {secs}s (cap bypassed?)"
         );
     }
 }

--- a/apps/studio-installer/src-tauri/src/lib.rs
+++ b/apps/studio-installer/src-tauri/src/lib.rs
@@ -15,6 +15,7 @@ use commands::{
     platform::{current_platform, install_dir},
     startup::create_startup_script,
     verify::verify_sha256,
+    wait_health::{extend_wait_deadline, wait_for_services, WaitDeadlineState},
 };
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -22,6 +23,10 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_os::init())
+        // WaitDeadlineState carries the active wait-healthy
+        // deadline so extend_wait_deadline can push it out without
+        // re-spawning the whole stream. State is per-app-instance.
+        .manage(WaitDeadlineState::default())
         .invoke_handler(tauri::generate_handler![
             download_file,
             delete_partial,
@@ -38,6 +43,8 @@ pub fn run() {
             launch_studio,
             current_platform,
             install_dir,
+            wait_for_services,
+            extend_wait_deadline,
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/apps/studio-installer/src/lib/installer.ts
+++ b/apps/studio-installer/src/lib/installer.ts
@@ -1,5 +1,5 @@
 import { Channel, invoke } from "@tauri-apps/api/core";
-import { store } from "./store.svelte.ts";
+import { type ServiceStatus, store } from "./store.svelte.ts";
 
 // ── Types matching Rust command signatures ────────────────────────────────────
 
@@ -222,10 +222,30 @@ export async function retryDownload(): Promise<void> {
 
 // ── Extract ───────────────────────────────────────────────────────────────────
 
+// Per-entry progress event emitted by extract_archive's Channel. The
+// running count drives Extract.svelte's "Unpacking… N files" UI; no
+// total because counting up-front would require a streaming pre-pass.
+type ExtractEvent =
+  | { type: "progress"; entries_done: number }
+  | { type: "done" }
+  | { type: "error"; message: string };
+
 export async function runExtract(src: string, dest: string): Promise<void> {
   store.error = null;
+  store.extractEntriesDone = 0;
+
+  const channel = new Channel<ExtractEvent>();
+  channel.onmessage = (event) => {
+    if (event.type === "progress") {
+      store.extractEntriesDone = event.entries_done;
+    } else if (event.type === "error") {
+      store.error = event.message;
+    }
+    // "done" is implicit when invoke resolves — no UI handler needed.
+  };
+
   try {
-    await invoke("extract_archive", { src, dest });
+    await invoke("extract_archive", { src, dest, onProgress: channel });
   } catch (err) {
     store.error = err instanceof Error ? err.message : String(err);
     throw err;
@@ -285,6 +305,147 @@ export function currentPlatform(): Promise<string> {
 /** Resolves the install root (`~/.friday/local`) without expansion logic in JS. */
 export function installDir(): Promise<string> {
   return invoke<string>("install_dir");
+}
+
+// ── Wait-healthy SSE relay (Stack 2) ──────────────────────────────────────────
+
+// Tagged events from the Rust wait_for_services command. Mirrors the
+// HealthEvent enum in apps/studio-installer/src-tauri/src/commands/wait_health.rs;
+// the `kind` discriminator + serde rename_all=kebab-case keeps the
+// wire format ergonomic on the TS side.
+export type HealthEvent =
+  | { kind: "connecting" }
+  | { kind: "connected" }
+  | {
+      kind: "snapshot";
+      uptime_secs: number;
+      services: ServiceStatus[];
+      all_healthy: boolean;
+      shutting_down: boolean;
+    }
+  | { kind: "soft-deadline" }
+  | { kind: "timeout"; stuck: string[]; playground_healthy: boolean }
+  | { kind: "unreachable"; reason: string }
+  | { kind: "shutting-down" };
+
+// `playground` is the user-facing surface that the browser actually
+// loads; if it's healthy at hard-deadline we still let the user
+// proceed via "Open anyway". Centralizing the name here avoids
+// stringly-typed checks scattered across the UI.
+const PLAYGROUND_SERVICE_NAME = "playground";
+
+/**
+ * Subscribe to the launcher's health stream and update the store as
+ * events land. Returns when the wait-healthy step ends — for any
+ * reason (all-healthy, timeout, unreachable, shutting-down). The
+ * caller (Launch.svelte) reads `store.launchStage` to decide what
+ * UI to render.
+ *
+ * Idempotent: calling `waitForServices` while a previous wait is
+ * active will spawn a second SSE subscription on the Rust side; the
+ * deadline state is mutex-guarded so the second wait simply replaces
+ * the first. In practice the wizard only calls this once per
+ * Launch step entry.
+ */
+export async function waitForServices(): Promise<void> {
+  store.launchStage = "connecting";
+  store.services = [];
+  store.waitElapsedSecs = 0;
+  store.waitDeadlineExtensions = 0;
+  store.stuckServices = [];
+  store.playgroundHealthyAtTimeout = false;
+  store.launchUnreachableReason = null;
+
+  const channel = new Channel<HealthEvent>();
+  channel.onmessage = (event) => {
+    switch (event.kind) {
+      case "connecting":
+        store.launchStage = "connecting";
+        break;
+      case "connected":
+        store.launchStage = "waiting";
+        break;
+      case "snapshot":
+        store.services = event.services;
+        store.waitElapsedSecs = event.uptime_secs;
+        if (event.shutting_down) {
+          store.launchStage = "shutting-down";
+        } else if (event.all_healthy) {
+          store.launchStage = "ready";
+        }
+        // soft-deadline / timeout events drive the long-wait /
+        // timeout transitions; snapshot doesn't override those.
+        break;
+      case "soft-deadline":
+        if (store.launchStage === "waiting") {
+          store.launchStage = "long-wait";
+        }
+        break;
+      case "timeout":
+        store.stuckServices = event.stuck;
+        store.playgroundHealthyAtTimeout = event.playground_healthy;
+        store.launchStage = "timeout";
+        break;
+      case "unreachable":
+        store.launchUnreachableReason = event.reason;
+        store.launchStage = "unreachable";
+        break;
+      case "shutting-down":
+        store.launchStage = "shutting-down";
+        break;
+    }
+  };
+
+  await invoke("wait_for_services", { onEvent: channel });
+}
+
+/**
+ * Push the wait-healthy hard deadline out by 60s. Capped at two
+ * extensions (so the maximum total wait is 90 + 60 + 60 = 210s).
+ * Returns the new deadline (seconds from wait start) or null if
+ * the cap is reached. Updates `waitDeadlineExtensions` for the UI.
+ */
+export async function extendWaitDeadline(): Promise<number | null> {
+  const newDeadline = await invoke<number | null>("extend_wait_deadline");
+  if (newDeadline !== null) {
+    store.waitDeadlineExtensions = store.waitDeadlineExtensions + 1;
+    // Re-arm the long-wait UI: extension means we're back inside
+    // the deadline, so suppress the timeout treatment.
+    if (store.launchStage === "timeout") {
+      store.launchStage = "long-wait";
+    }
+  }
+  return newDeadline;
+}
+
+/**
+ * Returns the playground row from the current snapshot, or undefined
+ * if it hasn't been observed yet. Used by Launch.svelte to decide
+ * whether to expose "Open anyway" alongside the timeout treatment.
+ */
+export function getPlaygroundService(): ServiceStatus | undefined {
+  return store.services.find((s) => s.name === PLAYGROUND_SERVICE_NAME);
+}
+
+/**
+ * Open the playground in the user's browser and close the wizard.
+ * The launcher is detached from the wizard at spawn time, so closing
+ * the wizard window does NOT kill the platform — the launcher keeps
+ * supervising its services. Same close logic for "Open anyway".
+ */
+export async function openPlaygroundAndExit(): Promise<void> {
+  try {
+    const { openUrl } = await import("@tauri-apps/plugin-opener");
+    await openUrl("http://localhost:5200");
+  } catch {
+    // ignore — browser might already be open or plugin unavailable
+  }
+  try {
+    const { getCurrentWindow } = await import("@tauri-apps/api/window");
+    await getCurrentWindow().close();
+  } catch {
+    // ignore — window already closing or API unavailable
+  }
 }
 
 export type { Manifest, PlatformEntry };

--- a/apps/studio-installer/src/lib/store.svelte.ts
+++ b/apps/studio-installer/src/lib/store.svelte.ts
@@ -7,6 +7,37 @@ export type InstallMode = "fresh" | "update" | "current";
 // AI provider — drives env-var name + UX hints in the API Keys step.
 export type ProviderId = "anthropic" | "openai" | "gemini" | "groq";
 
+// Per-service health row from the launcher's /api/launcher-health
+// stream. The `status` string mirrors healthsvc.go's vocabulary
+// ("pending" | "starting" | "healthy" | "failed").
+export type ServiceStatus = {
+  name: string;
+  status: "pending" | "starting" | "healthy" | "failed";
+  since_secs: number;
+};
+
+// Stage of the wait-healthy step. Drives Launch.svelte UI: which
+// copy to show, whether to expose Wait/View logs/Open anyway/Wait
+// again buttons, and whether the "Open in Browser" CTA is enabled.
+//
+//   idle:          before the wait command runs (Launch step entered)
+//   connecting:    Tauri command issued; SSE connect retrying
+//   waiting:       SSE live; rendering checklist; under soft deadline
+//   long-wait:     soft deadline (60s) elapsed; "Wait 60s more" shown
+//   timeout:       hard deadline elapsed; View logs / Open anyway shown
+//   unreachable:   SSE-connect deadline (20s) elapsed without a connect
+//   ready:         all services healthy — "Open in Browser" enabled
+//   shutting-down: launcher reported shutting_down=true mid-wait
+export type LaunchStage =
+  | "idle"
+  | "connecting"
+  | "waiting"
+  | "long-wait"
+  | "timeout"
+  | "unreachable"
+  | "ready"
+  | "shutting-down";
+
 function formatBytes(n: number): string {
   if (n < 1024) return `${n} B`;
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
@@ -57,6 +88,30 @@ function createStore() {
 
   // Path to the downloaded archive (set after download starts)
   let downloadPath = $state<string>("");
+
+  // Extract progress (Stack 2): running count of unpacked entries.
+  // Total isn't known up-front because the archive's entry count
+  // requires a streaming pass; UI shows "Unpacking… N files" without
+  // a percentage.
+  let extractEntriesDone = $state(0);
+
+  // Wait-healthy state (Stack 2): per-service rows, stage machine,
+  // elapsed timer, extension count. The launcher's stream emits a
+  // full snapshot per event (not deltas), so `services` is replaced
+  // wholesale on each Snapshot HealthEvent.
+  let services = $state<ServiceStatus[]>([]);
+  let launchStage = $state<LaunchStage>("idle");
+  let waitElapsedSecs = $state(0);
+  let waitDeadlineExtensions = $state(0);
+  // The names of services that were NOT healthy when the hard
+  // deadline fired. Drives the timeout-state messaging.
+  let stuckServices = $state<string[]>([]);
+  // Whether playground was healthy at the timeout — the
+  // partial-success rule allows "Open anyway" iff this is true.
+  let playgroundHealthyAtTimeout = $state(false);
+  // Free-form reason from a HealthEvent::Unreachable. Surfaced in
+  // the unreachable-stage UI alongside View logs.
+  let launchUnreachableReason = $state<string | null>(null);
 
   // General error
   let error = $state<string | null>(null);
@@ -212,6 +267,66 @@ function createStore() {
       if (bytesPerSec === 0 || totalBytes === 0) return "--";
       const remaining = (totalBytes - downloadedBytes) / bytesPerSec;
       return formatDuration(remaining);
+    },
+
+    // Stack 2 — extract progress (running count, no total).
+    get extractEntriesDone(): number {
+      return extractEntriesDone;
+    },
+    set extractEntriesDone(v: number) {
+      extractEntriesDone = v;
+    },
+
+    // Stack 2 — wait-healthy state.
+    get services(): ServiceStatus[] {
+      return services;
+    },
+    set services(v: ServiceStatus[]) {
+      services = v;
+    },
+    get launchStage(): LaunchStage {
+      return launchStage;
+    },
+    set launchStage(v: LaunchStage) {
+      launchStage = v;
+    },
+    get waitElapsedSecs(): number {
+      return waitElapsedSecs;
+    },
+    set waitElapsedSecs(v: number) {
+      waitElapsedSecs = v;
+    },
+    get waitDeadlineExtensions(): number {
+      return waitDeadlineExtensions;
+    },
+    set waitDeadlineExtensions(v: number) {
+      waitDeadlineExtensions = v;
+    },
+    get stuckServices(): string[] {
+      return stuckServices;
+    },
+    set stuckServices(v: string[]) {
+      stuckServices = v;
+    },
+    get playgroundHealthyAtTimeout(): boolean {
+      return playgroundHealthyAtTimeout;
+    },
+    set playgroundHealthyAtTimeout(v: boolean) {
+      playgroundHealthyAtTimeout = v;
+    },
+    get launchUnreachableReason(): string | null {
+      return launchUnreachableReason;
+    },
+    set launchUnreachableReason(v: string | null) {
+      launchUnreachableReason = v;
+    },
+
+    // Derived: are all known services healthy? Used by Launch.svelte
+    // to gate the "Open in Browser" CTA. False when services is
+    // empty (no first event yet) — matches HealthCache.AllHealthy.
+    get allServicesHealthy(): boolean {
+      if (services.length === 0) return false;
+      return services.every((s) => s.status === "healthy");
     },
   };
 }

--- a/apps/studio-installer/src/steps/Download.svelte
+++ b/apps/studio-installer/src/steps/Download.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { onMount } from "svelte";
+import { onMount, tick } from "svelte";
 import {
   advanceStep,
   currentPlatform,
@@ -50,7 +50,17 @@ onMount(async () => {
     // SHA-256 verification before extract — refuse to advance on mismatch.
     // Without this a corrupted or tampered archive would be unpacked silently
     // and break in confusing ways at first launch.
+    //
+    // `await tick()` between the phase flip and the verify call forces
+    // Svelte to commit the "Verifying download integrity…" subtitle
+    // BEFORE the synchronous prelude of invoke() blocks the JS event
+    // loop. Without it, on fast machines the verify call resolves so
+    // quickly that the verifying-state subtitle never paints — the
+    // user sees the downloading subtitle linger and then jumps
+    // straight to extract with no verify feedback (Decision #6
+    // companion: "subtitle flip-order fix").
     phase = "verifying";
+    await tick();
     const ok = await verifyDownload(store.downloadPath, sha256);
     if (!ok) {
       store.downloadError = "Downloaded file is corrupted (SHA-256 mismatch). Please try again.";

--- a/apps/studio-installer/src/steps/Extract.svelte
+++ b/apps/studio-installer/src/steps/Extract.svelte
@@ -38,7 +38,13 @@ onMount(async () => {
       <div class="extracting-state">
         <div class="spinner" aria-label="Installing"></div>
         <h2>Installing…</h2>
-        <p class="subtitle">Extracting Friday Studio files. This may take a moment.</p>
+        <p class="subtitle">
+          {#if store.extractEntriesDone > 0}
+            Unpacking… {store.extractEntriesDone.toLocaleString()} files
+          {:else}
+            Extracting Friday Studio files. This may take a moment.
+          {/if}
+        </p>
       </div>
     {:else}
       <div class="success-state">

--- a/apps/studio-installer/src/steps/Launch.svelte
+++ b/apps/studio-installer/src/steps/Launch.svelte
@@ -1,64 +1,249 @@
 <script lang="ts">
 import { onMount } from "svelte";
-import { installDir, runLaunch } from "../lib/installer.ts";
+import {
+  extendWaitDeadline,
+  getPlaygroundService,
+  installDir,
+  openPlaygroundAndExit,
+  runLaunch,
+  waitForServices,
+} from "../lib/installer.ts";
 import { store } from "../lib/store.svelte.ts";
 
-let launching = $state(true);
-let launched = $state(false);
-
+// Spawn the launcher (one-shot) then subscribe to its health stream.
+// runLaunch returns immediately after the launcher process has been
+// detached; waitForServices runs the wait-healthy step end-to-end and
+// drives store.launchStage. The two are intentionally separate calls
+// so a launcher-spawn failure shows a different UX than a wait-healthy
+// timeout.
 onMount(async () => {
   try {
-    // installDir() resolves to ~/.friday/local on every supported platform —
-    // that's where Extract.svelte just unpacked the binaries.
     const dir = await installDir();
     await runLaunch(dir);
-    launching = false;
-    launched = true;
   } catch {
-    launching = false;
-    // store.error is set by runLaunch
+    // store.error is set by runLaunch; the early-return template
+    // branch below picks it up and shows the spawn-failure state.
+    return;
   }
+  // The wait command itself never throws — it always emits a
+  // terminal HealthEvent (ready/timeout/unreachable/shutting-down)
+  // and then resolves. Errors during the SSE roundtrip surface as
+  // HealthEvent::Unreachable so the user can still hit View logs.
+  await waitForServices();
 });
 
-async function openStudio(): Promise<void> {
-  // Tauri 2 plugin-opener exports openUrl, not a default-export
-  // `open()` method. The previous `opener.open(...)` call was
-  // resolving to `undefined` and silently no-op'ing.
-  const { openUrl } = await import("@tauri-apps/plugin-opener");
-  await openUrl("http://localhost:5200");
+async function onWait60More(): Promise<void> {
+  // Push the deadline out by 60s. The Rust side caps at 2 extensions
+  // total (so max wait = 90 + 60 + 60 = 210s); on the cap, the helper
+  // returns null and the button stays hidden via canExtendDeadline.
+  await extendWaitDeadline();
+}
+
+async function onOpenLogs(): Promise<void> {
+  // Logs live alongside the launcher binary at
+  // ~/.friday/local/logs/launcher.log. plugin-opener's openPath
+  // hands off to the OS file viewer (Finder / Explorer). We open
+  // the log directory rather than the file so the user can see all
+  // service logs at once.
+  try {
+    const { openPath } = await import("@tauri-apps/plugin-opener");
+    const dir = await installDir();
+    await openPath(`${dir}/logs`);
+  } catch {
+    // plugin failure is non-fatal — the log directory exists
+    // regardless; the user can navigate there manually.
+  }
+}
+
+// "Open anyway" gate: only show when playground is healthy at the
+// timeout. If the user's playground is stuck the browser would hit
+// connection-refused, which is exactly the v3-and-prior bug Stack 2
+// is fixing.
+let canOpenAnyway = $derived.by(() => {
+  if (store.launchStage !== "timeout") return false;
+  const playground = getPlaygroundService();
+  return playground?.status === "healthy";
+});
+
+// "Wait again" gate: hide once the cap of 2 extensions is reached.
+// Pre-cap the button is shown alongside View logs / Open anyway in
+// the timeout state.
+let canExtendDeadline = $derived(store.waitDeadlineExtensions < 2);
+
+// Status pip glyph for each service row. Failed renders as ✗ in the
+// timeout treatment; pending/starting both render as a spinner so
+// the user sees forward motion regardless of which transient state
+// the launcher reports.
+function statusGlyph(status: string): string {
+  if (status === "healthy") return "✓";
+  if (status === "failed") return "✗";
+  return "•"; // pending / starting — paired with .pip-spinner in CSS
+}
+
+function statusClass(status: string): string {
+  if (status === "healthy") return "pip pip-healthy";
+  if (status === "failed") return "pip pip-failed";
+  return "pip pip-spinner";
+}
+
+// Pretty service name. The launcher reports "nats-server", "friday",
+// "link", "pty-server", "webhook-tunnel", "playground" — we display
+// each with a friendlier label so the user doesn't have to map raw
+// process names to product surfaces.
+function prettyName(name: string): string {
+  switch (name) {
+    case "nats-server":
+      return "Message bus";
+    case "friday":
+      return "Friday daemon";
+    case "link":
+      return "Authentication";
+    case "pty-server":
+      return "Terminal";
+    case "webhook-tunnel":
+      return "Webhook tunnel";
+    case "playground":
+      return "Playground UI";
+    default:
+      return name;
+  }
 }
 </script>
 
 <div class="screen">
   <div class="content">
     {#if store.error !== null}
+      <!-- Launcher spawn failed (runLaunch threw). Distinct from
+           wait-healthy errors which surface via launchStage. -->
       <div class="error-state">
         <div class="error-icon" aria-hidden="true">✕</div>
         <h2>Could not start Studio</h2>
         <p class="error-detail">{store.error}</p>
-        <button class="primary" onclick={openStudio}>Try Opening Browser</button>
+        <div class="actions">
+          <button class="secondary" onclick={onOpenLogs}>View logs</button>
+        </div>
       </div>
-    {:else if launched}
+    {:else if store.launchStage === "ready"}
       <div class="success-state">
         <div class="check-icon" aria-hidden="true">✓</div>
-        <h2>Studio is open in your browser!</h2>
+        <h2>Friday Studio is ready</h2>
         <p class="subtitle">
-          Friday Studio is running at
-          <a href="http://localhost:5200" target="_blank" rel="noreferrer"
-            >localhost:5200</a
-          >
+          All services are healthy. Click below to open the Playground.
         </p>
-        <button class="secondary" onclick={openStudio}>
-          Open in Browser
-        </button>
+        {#each store.services as svc (svc.name)}
+          <div class="row">
+            <span class={statusClass(svc.status)} aria-hidden="true"
+              >{statusGlyph(svc.status)}</span
+            >
+            <span class="row-name">{prettyName(svc.name)}</span>
+          </div>
+        {/each}
+        <button class="primary" onclick={openPlaygroundAndExit}
+          >Open in Browser</button
+        >
       </div>
-    {:else}
+    {:else if store.launchStage === "unreachable"}
+      <div class="error-state">
+        <div class="error-icon" aria-hidden="true">✕</div>
+        <h2>Could not connect to Studio launcher</h2>
+        <p class="error-detail">
+          {store.launchUnreachableReason ?? "Launcher did not start in time."}
+        </p>
+        <div class="actions">
+          <button class="secondary" onclick={onOpenLogs}>View logs</button>
+        </div>
+      </div>
+    {:else if store.launchStage === "shutting-down"}
+      <div class="error-state">
+        <div class="error-icon" aria-hidden="true">⏻</div>
+        <h2>Studio is shutting down</h2>
+        <p class="subtitle">
+          The launcher reported a shutdown in progress. Close this wizard and
+          try again once shutdown completes.
+        </p>
+      </div>
+    {:else if store.launchStage === "timeout"}
+      <div class="timeout-state">
+        <h2>Some services are still starting</h2>
+        <p class="subtitle">
+          {#if store.stuckServices.length > 0}
+            Waiting on: {store.stuckServices
+              .map((n) => prettyName(n))
+              .join(", ")}.
+          {:else}
+            Friday Studio's services are taking longer than expected to
+            become ready.
+          {/if}
+        </p>
+        {#each store.services as svc (svc.name)}
+          <div class="row">
+            <span class={statusClass(svc.status)} aria-hidden="true"
+              >{statusGlyph(svc.status)}</span
+            >
+            <span class="row-name">{prettyName(svc.name)}</span>
+          </div>
+        {/each}
+        <div class="actions">
+          <button class="secondary" onclick={onOpenLogs}>View logs</button>
+          {#if canOpenAnyway}
+            <button class="primary" onclick={openPlaygroundAndExit}
+              >Open anyway</button
+            >
+          {/if}
+          {#if canExtendDeadline}
+            <button class="secondary" onclick={onWait60More}
+              >Wait 60s more</button
+            >
+          {/if}
+        </div>
+      </div>
+    {:else if store.launchStage === "long-wait"}
       <div class="launching-state">
         <div class="spinner" aria-label="Starting Studio"></div>
-        <h2>Starting Studio…</h2>
+        <h2>Still starting up…</h2>
         <p class="subtitle">
-          Launching backends and checking health. This may take up to 30 seconds.
+          This is taking longer than usual — services are still booting.
         </p>
+        {#each store.services as svc (svc.name)}
+          <div class="row">
+            <span class={statusClass(svc.status)} aria-hidden="true"
+              >{statusGlyph(svc.status)}</span
+            >
+            <span class="row-name">{prettyName(svc.name)}</span>
+          </div>
+        {/each}
+        {#if canExtendDeadline}
+          <div class="actions">
+            <button class="secondary" onclick={onWait60More}
+              >Wait 60s more</button
+            >
+          </div>
+        {/if}
+      </div>
+    {:else if store.launchStage === "connecting" || store.launchStage === "idle"}
+      <div class="launching-state">
+        <div class="spinner" aria-label="Starting Studio"></div>
+        <h2>Starting Friday Studio…</h2>
+        <p class="subtitle">
+          Connecting to the launcher.
+        </p>
+      </div>
+    {:else}
+      <!-- launchStage === "waiting": SSE is live, render the live
+           checklist. Each row pip is driven by the snapshot the
+           launcher emits per state-change tick. -->
+      <div class="launching-state">
+        <div class="spinner" aria-label="Starting Studio"></div>
+        <h2>Starting Friday Studio…</h2>
+        <p class="subtitle">Waiting for services to report healthy.</p>
+        {#each store.services as svc (svc.name)}
+          <div class="row">
+            <span class={statusClass(svc.status)} aria-hidden="true"
+              >{statusGlyph(svc.status)}</span
+            >
+            <span class="row-name">{prettyName(svc.name)}</span>
+          </div>
+        {/each}
       </div>
     {/if}
   </div>
@@ -80,6 +265,7 @@ async function openStudio(): Promise<void> {
     text-align: center;
     gap: 16px;
     padding: 48px;
+    max-width: 480px;
   }
 
   h2 {
@@ -90,23 +276,14 @@ async function openStudio(): Promise<void> {
 
   .subtitle {
     font-size: 14px;
-    color: #777;
-    max-width: 340px;
+    color: #888;
+    max-width: 380px;
     line-height: 1.5;
   }
 
-  .subtitle a {
-    color: #6b72f0;
-    text-decoration: none;
-  }
-
-  .subtitle a:hover {
-    text-decoration: underline;
-  }
-
   .spinner {
-    width: 48px;
-    height: 48px;
+    width: 40px;
+    height: 40px;
     border: 4px solid #1e1e1e;
     border-top-color: #6b72f0;
     border-radius: 50%;
@@ -142,11 +319,17 @@ async function openStudio(): Promise<void> {
 
   .launching-state,
   .success-state,
-  .error-state {
+  .error-state,
+  .timeout-state {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 14px;
+    gap: 12px;
+    width: 100%;
+  }
+
+  .timeout-state h2 {
+    color: #fbbf24;
   }
 
   .error-state h2 {
@@ -164,6 +347,69 @@ async function openStudio(): Promise<void> {
     padding: 12px 16px;
   }
 
+  /* Per-service checklist row. Pip on the left, pretty name centered. */
+  .row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 13px;
+    color: #ccc;
+    padding: 4px 12px;
+    width: 100%;
+    max-width: 320px;
+    text-align: left;
+  }
+
+  .row-name {
+    flex: 1;
+  }
+
+  .pip {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 700;
+    flex-shrink: 0;
+  }
+
+  .pip-healthy {
+    background: rgba(52, 211, 153, 0.15);
+    color: #34d399;
+  }
+
+  .pip-failed {
+    background: rgba(248, 113, 113, 0.15);
+    color: #f87171;
+  }
+
+  .pip-spinner {
+    background: rgba(107, 114, 240, 0.15);
+    color: #6b72f0;
+    animation: pulse 1.4s ease-in-out infinite;
+  }
+
+  @keyframes pulse {
+    0%,
+    100% {
+      opacity: 0.6;
+    }
+    50% {
+      opacity: 1;
+    }
+  }
+
+  .actions {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-top: 8px;
+  }
+
   button {
     padding: 10px 28px;
     border: none;
@@ -172,7 +418,6 @@ async function openStudio(): Promise<void> {
     font-weight: 500;
     cursor: pointer;
     transition: background 0.15s;
-    margin-top: 8px;
   }
 
   .primary {

--- a/tools/friday-launcher/integration_test.go
+++ b/tools/friday-launcher/integration_test.go
@@ -110,7 +110,12 @@ func buildLauncherAndStubs(t *testing.T) (launcherPath, binDir string) {
 		"link":           {"13100", "/health"},
 		"pty-server":     {"17681", "/health"},
 		"webhook-tunnel": {"19090", "/health"},
-		"playground":     {"15200", "/api/health"},
+		// Decision #32: playground probes `/` (the public SvelteKit
+		// root), not a sidecar. The stub program reads HEALTH_PATH
+		// and serves the same handler at any path, so the test
+		// observes the real probe rule: launcher hits the path
+		// project.go declares.
+		"playground":     {"15200", "/"},
 	}
 	for name, w := range wrappers {
 		writeWrapper(t, binDir, name, stubBin, w.port, w.healthPath, "")
@@ -241,7 +246,7 @@ func waitHealthy(t *testing.T) {
 		"http://127.0.0.1:13100/health",
 		"http://127.0.0.1:17681/health",
 		"http://127.0.0.1:19090/health",
-		"http://127.0.0.1:15200/api/health",
+		"http://127.0.0.1:15200/", // Decision #32 — see wrapper map.
 	}
 	for {
 		ok := 0
@@ -343,7 +348,7 @@ func TestShutdownTimeoutSafety(t *testing.T) {
 	// Replace the playground wrapper with one that ignores SIGTERM.
 	stubBin := filepath.Join(binDir, "_stub")
 	writeWrapper(t, binDir, "playground", stubBin,
-		"15200", "/api/health", "IGNORE_SIGTERM=1")
+		"15200", "/", "IGNORE_SIGTERM=1")
 	cmd, _ := startLauncher(t, launcher, binDir)
 	waitHealthy(t)
 	start := time.Now()

--- a/tools/friday-launcher/project.go
+++ b/tools/friday-launcher/project.go
@@ -113,8 +113,16 @@ func supervisedProcesses(binDir string) []processSpec {
 			healthPort: "9090", healthPath: "/health",
 		},
 		{
+			// Decision #32: the readiness probe MUST exercise the
+			// real handler stack at a public entry point — that's
+			// what makes "all healthy" actually mean "all usable".
+			// Playground is a SvelteKit app whose root path is a
+			// public landing; probing `/` catches the SvelteKit-
+			// not-yet-bound race that a sidecar `/api/health` would
+			// silently green-light. project_test.go pins this so a
+			// future refactor can't quietly revert to the sidecar.
 			name: "playground", binary: filepath.Join(binDir, "playground"),
-			healthPort: "5200", healthPath: "/api/health",
+			healthPort: "5200", healthPath: "/",
 		},
 	}
 	for i, s := range specs {

--- a/tools/friday-launcher/project_test.go
+++ b/tools/friday-launcher/project_test.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestPlaygroundProbePath_IsRoot pins the playground readiness probe
+// to "/" — the public SvelteKit landing page — per Decision #32. A
+// sidecar like "/api/health" returns 200 even before SvelteKit has
+// bound the root route, which silently green-lights "all healthy"
+// while a user-side request to / would still 404. Pinning this
+// catches a future refactor that quietly reverts to the sidecar.
+func TestPlaygroundProbePath_IsRoot(t *testing.T) {
+	specs := supervisedProcesses("/tmp/dummy-bin")
+	for _, s := range specs {
+		if s.name != "playground" {
+			continue
+		}
+		if s.healthPath != "/" {
+			t.Errorf("playground healthPath = %q, want %q (Decision #32)",
+				s.healthPath, "/")
+		}
+		if s.healthPort != "5200" {
+			t.Errorf("playground healthPort = %q, want %q",
+				s.healthPort, "5200")
+		}
+		return
+	}
+	t.Fatal("playground not found in supervisedProcesses")
+}
+
+// TestSupervisedProcessesProbeShape covers the universal contract —
+// every supervised service has a non-empty healthPort + healthPath,
+// and the path starts with "/". Catches a typo regression that
+// would skip the http.DefaultTransport host-prefix step.
+func TestSupervisedProcessesProbeShape(t *testing.T) {
+	specs := supervisedProcesses("/tmp/dummy-bin")
+	if len(specs) == 0 {
+		t.Fatal("supervisedProcesses returned 0 entries")
+	}
+	for _, s := range specs {
+		if s.healthPort == "" {
+			t.Errorf("%s: empty healthPort", s.name)
+		}
+		if s.healthPath == "" {
+			t.Errorf("%s: empty healthPath", s.name)
+		}
+		if len(s.healthPath) > 0 && s.healthPath[0] != '/' {
+			t.Errorf("%s: healthPath %q must start with /", s.name, s.healthPath)
+		}
+	}
+}

--- a/tools/friday-launcher/project_test.go
+++ b/tools/friday-launcher/project_test.go
@@ -50,3 +50,35 @@ func TestSupervisedProcessesProbeShape(t *testing.T) {
 		}
 	}
 }
+
+// TestSupervisedProcessesPinSet pins the exact set of supervised
+// service names. CLAUDE.md documents 6 services + the wizard's
+// checklist UI is sized for 6 rows; a refactor that accidentally
+// drops one (e.g. webhook-tunnel) would silently shrink the set
+// and the wizard would render fewer rows without anyone noticing.
+// This test forces a deliberate update when intentionally
+// adding/removing a service.
+func TestSupervisedProcessesPinSet(t *testing.T) {
+	want := []string{
+		"nats-server",
+		"friday",
+		"link",
+		"pty-server",
+		"webhook-tunnel",
+		"playground",
+	}
+	specs := supervisedProcesses("/tmp/dummy-bin")
+	got := make([]string, len(specs))
+	for i, s := range specs {
+		got[i] = s.name
+	}
+	if len(got) != len(want) {
+		t.Fatalf("supervisedProcesses count = %d, want %d (got=%v)",
+			len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("supervisedProcesses[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Stack 2 of the v15 plan
([docs/plans/2026-04-27-installer-launcher-ux-fixes.v15.md](https://github.com/friday-platform/friday-studio/blob/launcher-stack-1-http-server/docs/plans/2026-04-27-installer-launcher-ux-fixes.v15.md)).
Wizard's Launch step now subscribes to the launcher's
\`/api/launcher-health/stream\` and renders a live 6-row checklist while
services come up. Staged deadlines (60s soft, 90s hard, +60s extendable
twice) keep the UX honest about what's happening.

**Decisions covered:** #1, #6, #15, #16, #19, #32.

## Highlights

- \`tools/friday-launcher/project.go\` — playground readiness probe flips
  from \`/api/health\` (sidecar) to \`/\` (the SvelteKit landing page).
  Decision #32: probes must exercise the real handler stack at a public
  entry point, otherwise \"all healthy\" silently green-lights an unusable
  launcher.
- \`apps/studio-installer/src-tauri/src/commands/wait_health.rs\` (NEW) —
  Tauri command consuming the SSE stream via reqwest (no extra dep,
  manual SSE framing with unit tests for partial-event/CRLF/no-space
  cases). 20s capped exponential backoff (200ms → 2s) for the
  SSE-connect loop; 60s soft + 90s hard deadlines, extendable to
  150s/210s via \`extend_wait_deadline\` (capped at 2 extensions).
- \`apps/studio-installer/src-tauri/src/commands/extract.rs\` — per-entry
  iteration with throttled progress channel for the \"Unpacking… N files\"
  UI. The \`.bak\` rollback shape is preserved; the split-destination +
  staging + atomic swap rewrite is Stack 3.
- \`apps/studio-installer/src/steps/Launch.svelte\` — full rewrite around
  a \`launchStage\` state machine: idle / connecting / waiting / long-wait
  / timeout / unreachable / ready / shutting-down. Per-service pip rows
  (\`✓\` / \`✗\` / spinner). \"Open anyway\" gate: only shown when playground
  is healthy at hard-deadline (Decision #16).
- \`apps/studio-installer/src/steps/Download.svelte\` — \`await tick()\`
  between phase flip and \`invoke('verify_sha256')\` so Svelte commits the
  \"Verifying…\" subtitle BEFORE invoke's synchronous prelude blocks the
  event loop.

## Test plan

- [x] \`cargo build && cargo test\` (Tauri side) — passes (6 unit tests
      including SSE parser cases)
- [x] \`svelte-check\` on \`apps/studio-installer\` — 0 errors
- [x] \`go test -race -count=1 ./tools/friday-launcher/...\` — passes
      (incl. new project_test.go pinning the probe path)
- [x] \`go vet\` + \`golangci-lint\` — clean (0 issues)
- [x] \`go test -tags=integration -count=1 ./tools/friday-launcher/...\` —
      passes (probe-path change updated in the wrapper map +
      waitHealthy URL list + the IGNORE_SIGTERM wrapper)
- [x] Cross-compile linux/amd64 — clean
- [ ] **Live macOS QA needed:**
  - [ ] Wizard shows 6-row checklist updating live as services come up
  - [ ] \"Open in Browser\" disabled until all 6 are healthy
  - [ ] Wizard window closes immediately when \"Open in Browser\" clicked
  - [ ] Soft deadline (60s) shows \"Wait 60s more\" button; extension works
  - [ ] Hard deadline (90s) with playground healthy shows \"Open anyway\"
  - [ ] Hard deadline with playground stuck: \"Open anyway\" hidden

## Notes

- Pre-existing type-check failure in \`validateAtlasUIMessages\` (commit
  4c9c6066b on main) is inherited via merge-base; **not introduced by
  this PR.** Stack 2 doesn't touch agent-sdk.
- Stack 3 (.app bundle + migration) follows in a separate PR.

## Out of scope

- Stack 3: \`.app\` bundle, codesign + notarization, v0.0.8 → v0.0.9
  migration.
- Type-check fix for the pre-existing \`validateAtlasUIMessages\`
  TS2589 — separate concern.