### PR TITLE
feat(launcher): pre-flight binaries check + bundle-ID autostart + .app cleanup (Stack 3, launcher side)

### DIFF
--- a/packages/fsm-engine/fsm-engine.ts
+++ b/packages/fsm-engine/fsm-engine.ts
@@ -210,8 +210,8 @@ export function getInputSnapshot(
     // item with its id so the consuming LLM can tell sources apart.
     const task = Array.isArray(inputFrom)
       ? items
-        .map(({ id, data }) => `${id}: ${typeof data === "string" ? data : JSON.stringify(data)}`)
-        .join("\n\n")
+          .map(({ id, data }) => `${id}: ${typeof data === "string" ? data : JSON.stringify(data)}`)
+          .join("\n\n")
       : typeof items[0]!.data === "string"
         ? (items[0]!.data as string)
         : JSON.stringify(items[0]!.data);

--- a/packages/mcp/mod.ts
+++ b/packages/mcp/mod.ts
@@ -11,10 +11,10 @@
 
 export type { CreateMCPToolsOptions, MCPToolsResult } from "./src/create-mcp-tools.ts";
 export { createMCPTools, MCPAuthError, MCPStartupError } from "./src/create-mcp-tools.ts";
-export { sharedMCPProcesses } from "./src/process-registry.ts";
 export type {
   ProcessRegistry,
   ProcessRegistryDeps,
   SharedProcessHandle,
   SharedProcessSpec,
 } from "./src/process-registry.ts";
+export { sharedMCPProcesses } from "./src/process-registry.ts";

--- a/packages/mcp/src/create-mcp-tools.ts
+++ b/packages/mcp/src/create-mcp-tools.ts
@@ -315,11 +315,7 @@ export async function connectHttp(
   resolvedEnv: Record<string, string>,
   serverId: string,
   logger: Logger,
-  deps: {
-    spawn?: typeof defaultSpawn;
-    fetch?: typeof fetch;
-    pidFile?: PidFileWriter;
-  } = {},
+  deps: { spawn?: typeof defaultSpawn; fetch?: typeof fetch; pidFile?: PidFileWriter } = {},
 ): Promise<ConnectedServer> {
   const { transport, auth, startup } = config;
   if (transport.type !== "http") {

--- a/packages/mcp/src/process-registry.test.ts
+++ b/packages/mcp/src/process-registry.test.ts
@@ -349,11 +349,7 @@ describe("ProcessRegistry pid-file lifecycle", () => {
     await sharedMCPProcesses.acquire("calendar", makeSpec(), deps, fakeLogger);
 
     expect(pidFile.write).toHaveBeenCalledTimes(1);
-    expect(pidFile.write).toHaveBeenCalledWith(
-      "calendar",
-      54321,
-      expect.any(Number),
-    );
+    expect(pidFile.write).toHaveBeenCalledWith("calendar", 54321, expect.any(Number));
   });
 
   it("does not write pid file when child has no pid", async () => {

--- a/tools/friday-launcher/autostart_darwin.go
+++ b/tools/friday-launcher/autostart_darwin.go
@@ -10,10 +10,22 @@ import (
 	"howett.net/plist"
 )
 
-// plistTemplate has three %s slots: Label, executable path, first arg.
-// KeepAlive=false because the launcher's process-compose handles
-// child restart internally; we only want launchd to (re-)launch us
-// at login. RunAtLoad=true triggers that.
+// plistTemplate has one %s slot: the bundle ID. ProgramArguments
+// is `/usr/bin/open -b <bundle-id> --args --no-browser`, which
+// dispatches via LaunchServices to whichever Friday Studio.app is
+// currently registered (Decision #29). Targeting the bundle ID
+// rather than a raw executable path means the plist doesn't go
+// stale if the user moves Friday Studio.app to a new location —
+// LaunchServices indexes /Applications and finds it.
+//
+// `--args --no-browser` propagates the headless-launch flag to the
+// launcher binary inside the bundle. `open`'s --args separator
+// switches `open` from "treat remaining tokens as document paths"
+// to "pass them as argv to the bundled executable."
+//
+// KeepAlive=false because process-compose handles child restart
+// internally; we only want launchd to (re-)launch us at login.
+// RunAtLoad=true triggers that.
 const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -22,8 +34,11 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
   <string>%s</string>
   <key>ProgramArguments</key>
   <array>
+    <string>/usr/bin/open</string>
+    <string>-b</string>
     <string>%s</string>
-    <string>%s</string>
+    <string>--args</string>
+    <string>--no-browser</string>
   </array>
   <key>RunAtLoad</key>
   <true/>
@@ -46,11 +61,7 @@ func plistPath() string {
 }
 
 func enableAutostart() error {
-	exe, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("os.Executable: %w", err)
-	}
-	body := fmt.Sprintf(plistTemplate, launchAgentLabel, exe, "--no-browser")
+	body := fmt.Sprintf(plistTemplate, launchAgentLabel, launcherBundleID)
 	return atomicWriteFile(plistPath(), []byte(body), 0o644)
 }
 
@@ -67,11 +78,15 @@ func isAutostartEnabled() bool {
 	return err == nil
 }
 
-// currentAutostartPath returns the executable path currently registered
-// in the LaunchAgent plist, or "" if no plist exists / unreadable.
-// Used by goroutine E to detect staleness when the user has moved
-// the launcher binary to a new location.
-func currentAutostartPath() string {
+// currentAutostartBundleID returns the bundle ID currently
+// registered in the LaunchAgent plist, or "" if the plist is
+// missing / unreadable / not in the bundle-ID format. Stack 3
+// switched ProgramArguments from `[<exe-path>, "--no-browser"]`
+// to `["/usr/bin/open", "-b", <bundle-id>, "--args", "--no-browser"]`,
+// so staleness is now "different bundle ID" not "different exe
+// path." A v0.0.8-format plist (where ProgramArguments[0] is the
+// raw exe path) returns "" so the migration code knows to rewrite.
+func currentAutostartBundleID() string {
 	data, err := os.ReadFile(plistPath())
 	if err != nil {
 		return ""
@@ -80,8 +95,25 @@ func currentAutostartPath() string {
 	if _, err := plist.Unmarshal(data, &agent); err != nil {
 		return ""
 	}
-	if len(agent.ProgramArguments) == 0 {
+	args := agent.ProgramArguments
+	// Expected shape: ["/usr/bin/open", "-b", "<bundle-id>", ...]
+	if len(args) < 3 {
 		return ""
 	}
-	return agent.ProgramArguments[0]
+	if args[0] != "/usr/bin/open" || args[1] != "-b" {
+		return ""
+	}
+	return args[2]
+}
+
+// isAutostartStale reports whether the LaunchAgent plist needs to
+// be rewritten. Cross-platform contract — see autostart_linux.go +
+// autostart_windows.go for the per-OS interpretation.
+//
+// Darwin: stale iff the registered bundle ID differs from
+// launcherBundleID (covers both the v0.0.8-format plist and a
+// future bundle-ID rename).
+func isAutostartStale() bool {
+	registered := currentAutostartBundleID()
+	return registered != launcherBundleID
 }

--- a/tools/friday-launcher/autostart_darwin_test.go
+++ b/tools/friday-launcher/autostart_darwin_test.go
@@ -5,7 +5,6 @@ package main
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -61,7 +60,7 @@ func TestCurrentAutostartBundleID_V008FormatReturnsEmpty(t *testing.T) {
   <key>Label</key><string>ai.hellofriday.studio</string>
   <key>ProgramArguments</key>
   <array>
-    <string>/Users/lcf/.friday/local/friday-launcher</string>
+    <string>/usr/local/friday-launcher</string>
     <string>--no-browser</string>
   </array>
   <key>RunAtLoad</key><true/>
@@ -192,7 +191,4 @@ func TestCurrentAutostartBundleID_WrongPrefixReturnsEmpty(t *testing.T) {
 	if got := currentAutostartBundleID(); got != "" {
 		t.Errorf("got %q, want \"\" for non-/usr/bin/open prefix", got)
 	}
-	// strings is referenced once via the string concatenation
-	// above — placate any future unused-import lint pass.
-	_ = strings.HasPrefix
 }

--- a/tools/friday-launcher/autostart_darwin_test.go
+++ b/tools/friday-launcher/autostart_darwin_test.go
@@ -1,0 +1,198 @@
+//go:build darwin
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// withFakePlist points plistPath() at a temp file so tests can plant
+// arbitrary content without clobbering the user's real LaunchAgent.
+// HOME drives `os.UserHomeDir()` which `plistPath()` reads.
+func withFakePlist(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	if err := os.MkdirAll(filepath.Join(home, "Library/LaunchAgents"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return plistPath()
+}
+
+// TestCurrentAutostartBundleID_AbsentReturnsEmpty: no plist on
+// disk → "". The staleness check then treats this as "not stale"
+// (autostartSelfRegister handles the first-run case via state.json).
+func TestCurrentAutostartBundleID_AbsentReturnsEmpty(t *testing.T) {
+	withFakePlist(t)
+	if got := currentAutostartBundleID(); got != "" {
+		t.Errorf("got %q, want \"\" for missing plist", got)
+	}
+}
+
+// TestCurrentAutostartBundleID_MalformedXMLReturnsEmpty: pre-flight
+// migration safety — a hand-edited or corrupted plist must not
+// crash the launcher. plist.Unmarshal failures collapse to "" so
+// the staleness path rewrites cleanly.
+func TestCurrentAutostartBundleID_MalformedXMLReturnsEmpty(t *testing.T) {
+	path := withFakePlist(t)
+	if err := os.WriteFile(path, []byte("not actual XML"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := currentAutostartBundleID(); got != "" {
+		t.Errorf("got %q, want \"\" for malformed XML", got)
+	}
+}
+
+// TestCurrentAutostartBundleID_V008FormatReturnsEmpty: the v0.0.8
+// plist had `[<exe-path>, "--no-browser"]`. Decision #29's bundle-
+// ID format is `["/usr/bin/open", "-b", "<bundle-id>", ...]`. The
+// parser must reject the v0.0.8 shape so the staleness check
+// returns true and the plist gets rewritten on first v0.0.9 boot.
+// THIS IS THE LOAD-BEARING PATH FOR THE v0.0.8 → v0.0.9 MIGRATION.
+func TestCurrentAutostartBundleID_V008FormatReturnsEmpty(t *testing.T) {
+	path := withFakePlist(t)
+	v008Plist := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>ai.hellofriday.studio</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Users/lcf/.friday/local/friday-launcher</string>
+    <string>--no-browser</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><false/>
+</dict>
+</plist>`
+	if err := os.WriteFile(path, []byte(v008Plist), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := currentAutostartBundleID(); got != "" {
+		t.Errorf("got %q, want \"\" for v0.0.8-format plist (must be marked stale)", got)
+	}
+}
+
+// TestCurrentAutostartBundleID_CurrentFormatReturnsBundleID: the
+// happy path — a Stack 3 plist returns its bundle ID. Pinned
+// against the canonical launcherBundleID const so a future ID
+// rename forces a deliberate test update.
+func TestCurrentAutostartBundleID_CurrentFormatReturnsBundleID(t *testing.T) {
+	path := withFakePlist(t)
+	currentPlist := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>ai.hellofriday.studio</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/open</string>
+    <string>-b</string>
+    <string>` + launcherBundleID + `</string>
+    <string>--args</string>
+    <string>--no-browser</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><false/>
+</dict>
+</plist>`
+	if err := os.WriteFile(path, []byte(currentPlist), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := currentAutostartBundleID(); got != launcherBundleID {
+		t.Errorf("got %q, want %q", got, launcherBundleID)
+	}
+}
+
+// TestCurrentAutostartBundleID_DifferentBundleIDReturnsThatID:
+// future-proofs against a launcherBundleID rename — the parser
+// returns whatever bundle ID is registered, even if it doesn't
+// match the current const. isAutostartStale() then compares
+// against launcherBundleID and decides to rewrite. Pinning this
+// catches a parser regression that hardcoded the expected ID.
+func TestCurrentAutostartBundleID_DifferentBundleIDReturnsThatID(t *testing.T) {
+	path := withFakePlist(t)
+	otherPlist := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>ai.hellofriday.studio</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/open</string>
+    <string>-b</string>
+    <string>com.example.somethingelse</string>
+  </array>
+</dict>
+</plist>`
+	if err := os.WriteFile(path, []byte(otherPlist), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := currentAutostartBundleID(); got != "com.example.somethingelse" {
+		t.Errorf("got %q, want %q", got, "com.example.somethingelse")
+	}
+	// And isAutostartStale should fire — the registered ID
+	// differs from launcherBundleID.
+	if !isAutostartStale() {
+		t.Error("isAutostartStale = false, want true (bundle ID mismatch)")
+	}
+}
+
+// TestCurrentAutostartBundleID_TooFewArgsReturnsEmpty: the parser
+// guards `len(args) < 3` — a 2-element array has no bundle-ID
+// slot, return empty. Catches a regression that swapped < for <=.
+func TestCurrentAutostartBundleID_TooFewArgsReturnsEmpty(t *testing.T) {
+	path := withFakePlist(t)
+	shortPlist := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>ai.hellofriday.studio</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/open</string>
+    <string>-b</string>
+  </array>
+</dict>
+</plist>`
+	if err := os.WriteFile(path, []byte(shortPlist), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := currentAutostartBundleID(); got != "" {
+		t.Errorf("got %q, want \"\" for ProgramArguments len < 3", got)
+	}
+}
+
+// TestCurrentAutostartBundleID_WrongPrefixReturnsEmpty: a plist
+// with the right shape but a different invocation (not
+// `/usr/bin/open -b`) is treated as v0.0.8-format-equivalent —
+// rewrite. Catches a regression that just checked args[2] without
+// validating the leading verb.
+func TestCurrentAutostartBundleID_WrongPrefixReturnsEmpty(t *testing.T) {
+	path := withFakePlist(t)
+	wrongPrefix := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>ai.hellofriday.studio</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/some/other/binary</string>
+    <string>-x</string>
+    <string>` + launcherBundleID + `</string>
+  </array>
+</dict>
+</plist>`
+	if err := os.WriteFile(path, []byte(wrongPrefix), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if got := currentAutostartBundleID(); got != "" {
+		t.Errorf("got %q, want \"\" for non-/usr/bin/open prefix", got)
+	}
+	// strings is referenced once via the string concatenation
+	// above — placate any future unused-import lint pass.
+	_ = strings.HasPrefix
+}

--- a/tools/friday-launcher/autostart_linux.go
+++ b/tools/friday-launcher/autostart_linux.go
@@ -14,8 +14,9 @@ package main
 // otherwise touch it.
 
 var _ = launchAgentLabel
+var _ = launcherBundleID
 
-func enableAutostart() error       { return nil }
-func disableAutostart() error      { return nil }
-func isAutostartEnabled() bool     { return false }
-func currentAutostartPath() string { return "" }
+func enableAutostart() error    { return nil }
+func disableAutostart() error   { return nil }
+func isAutostartEnabled() bool  { return false }
+func isAutostartStale() bool    { return false }

--- a/tools/friday-launcher/autostart_linux.go
+++ b/tools/friday-launcher/autostart_linux.go
@@ -13,10 +13,12 @@ package main
 // `unusedfunc` check stays happy across all targets — Linux doesn't
 // otherwise touch it.
 
-var _ = launchAgentLabel
-var _ = launcherBundleID
+var (
+	_ = launchAgentLabel
+	_ = launcherBundleID
+)
 
-func enableAutostart() error    { return nil }
-func disableAutostart() error   { return nil }
-func isAutostartEnabled() bool  { return false }
-func isAutostartStale() bool    { return false }
+func enableAutostart() error   { return nil }
+func disableAutostart() error  { return nil }
+func isAutostartEnabled() bool { return false }
+func isAutostartStale() bool   { return false }

--- a/tools/friday-launcher/autostart_windows.go
+++ b/tools/friday-launcher/autostart_windows.go
@@ -64,6 +64,7 @@ func isAutostartEnabled() bool {
 // currentAutostartPath reads the registered command and extracts the
 // executable path (stripping the surrounding quotes and the
 // --no-browser tail). Returns "" if not registered or malformed.
+// Internal — exposed only for isAutostartStale below.
 func currentAutostartPath() string {
 	k, err := registry.OpenKey(registry.CURRENT_USER, runKey,
 		registry.READ)
@@ -91,4 +92,20 @@ func currentAutostartPath() string {
 		return ""
 	}
 	return val[1:endQuote]
+}
+
+// isAutostartStale reports whether the registry entry needs to be
+// rewritten. Cross-platform contract — see autostart_darwin.go.
+//
+// Windows: stale iff the registered exe path differs from
+// os.Executable(). Stack 3 doesn't change the Windows autostart
+// shape (no .app bundle on Windows), so the v0.0.8 behavior carries
+// forward unchanged.
+func isAutostartStale() bool {
+	exe, err := os.Executable()
+	if err != nil {
+		return false
+	}
+	registered := currentAutostartPath()
+	return registered != "" && registered != exe
 }

--- a/tools/friday-launcher/integration_test.go
+++ b/tools/friday-launcher/integration_test.go
@@ -675,7 +675,6 @@ func TestAutostartStalenessRepair(t *testing.T) {
 		data, err := os.ReadFile(plistPath)
 		if err == nil && !strings.Contains(string(data), stalePath) &&
 			strings.Contains(string(data), "ai.hellofriday.studio-launcher") {
-			_ = launcher
 			return // success
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/tools/friday-launcher/integration_test.go
+++ b/tools/friday-launcher/integration_test.go
@@ -202,8 +202,11 @@ func startLauncher(t *testing.T, launcherPath, binDir string) (*exec.Cmd, string
 
 // testStubPorts is the fixed-port set every integration test pins
 // against. Listed once so killStaleStubs and the post-shutdown port
-// assertion stay in sync.
-var testStubPorts = []int{18222, 18080, 13100, 17681, 19090, 15200}
+// assertion stay in sync. Port 29999 is the unsupervised "orphan-test"
+// wrapper used by TestUninstall_AlwaysSweepsEvenWhenLauncherStopsCleanly;
+// added here so a prior interrupted run doesn't leave a 29999 stub
+// alive that interferes with the next run's launcher startup.
+var testStubPorts = []int{18222, 18080, 13100, 17681, 19090, 15200, 29999}
 
 // killStaleStubs frees the test ports before a test starts. Each test
 // runs in its own t.TempDir() bin path; the per-test cleanup only
@@ -581,9 +584,14 @@ func TestAutostartSelfRegister(t *testing.T) {
 	if err != nil {
 		t.Fatalf("plist not written: %v", err)
 	}
-	if !strings.Contains(string(data), launcher) {
-		t.Errorf("plist doesn't reference launcher path %q\n--- plist ---\n%s",
-			launcher, string(data))
+	// Stack 3: ProgramArguments is the bundle-ID variant
+	// `["/usr/bin/open", "-b", "ai.hellofriday.studio-launcher", ...]`
+	// rather than a raw exe path. Decision #29.
+	if !strings.Contains(string(data), "<string>/usr/bin/open</string>") {
+		t.Errorf("plist missing /usr/bin/open\n--- plist ---\n%s", string(data))
+	}
+	if !strings.Contains(string(data), "<string>ai.hellofriday.studio-launcher</string>") {
+		t.Errorf("plist missing bundle id\n--- plist ---\n%s", string(data))
 	}
 	if !strings.Contains(string(data), "<string>--no-browser</string>") {
 		t.Error("plist missing --no-browser arg")
@@ -658,11 +666,16 @@ func TestAutostartStalenessRepair(t *testing.T) {
 		_ = cmd2.Process.Signal(syscall.SIGTERM)
 		_ = cmd2.Wait()
 	})
-	// Poll for the plist to be repaired.
+	// Poll for the plist to be repaired. Stack 3 plists target the
+	// bundle ID rather than a raw path, so success is "stale path
+	// gone AND bundle ID present" rather than "launcher path
+	// present" (the launcher binary path is no longer in the
+	// plist).
 	for range 60 {
 		data, err := os.ReadFile(plistPath)
-		if err == nil && strings.Contains(string(data), launcher) &&
-			!strings.Contains(string(data), stalePath) {
+		if err == nil && !strings.Contains(string(data), stalePath) &&
+			strings.Contains(string(data), "ai.hellofriday.studio-launcher") {
+			_ = launcher
 			return // success
 		}
 		time.Sleep(100 * time.Millisecond)
@@ -743,7 +756,9 @@ func TestUninstall(t *testing.T) {
 		}
 	})
 
-	uninst := exec.Command(launcher, "--uninstall")
+	// --bin-dir is required post-Stack-3 because the default
+	// (~/.friday/local/bin/) doesn't match the per-test binDir.
+	uninst := exec.Command(launcher, "--uninstall", "--bin-dir="+binDir)
 	uninst.Env = append(os.Environ(),
 		"FRIDAY_LAUNCHER_HOME="+home,
 		"FRIDAY_LAUNCHER_BROWSER_DISABLED=1",
@@ -884,7 +899,7 @@ func TestUninstall_AlwaysSweepsEvenWhenLauncherStopsCleanly(t *testing.T) {
 		}
 	})
 
-	uninst := exec.Command(launcher, "--uninstall")
+	uninst := exec.Command(launcher, "--uninstall", "--bin-dir="+binDir)
 	uninst.Env = append(os.Environ(),
 		"FRIDAY_LAUNCHER_HOME="+home,
 		"FRIDAY_LAUNCHER_BROWSER_DISABLED=1",

--- a/tools/friday-launcher/main.go
+++ b/tools/friday-launcher/main.go
@@ -152,6 +152,16 @@ func main() {
 		log.Fatal("writePid", "error", err)
 	}
 
+	// Pre-flight: every supervised binary must exist + be runnable.
+	// Decision #12 + #21. Runs AFTER --uninstall / --autostart
+	// dispatch (those don't need binaries) but BEFORE the orphan
+	// sweep / health-server bind / tray boot — so a missing-binary
+	// install fails fast with a useful dialog instead of process-
+	// compose spawning then crashing supervised stubs in a loop.
+	// runPreflight calls os.Exit(1) on failure; control returns
+	// here only when binaries are confirmed present.
+	runPreflight(binDir)
+
 	// Best-effort: clean up orphan supervised processes from a prior
 	// SIGKILL'd launcher (Unix only — Windows Job Object handles it).
 	// Two passes:
@@ -205,7 +215,8 @@ func parseFlags() (autostart string, uninstall bool) {
 	flag.BoolVar(&noBrowser, "no-browser", false,
 		"do not auto-open the browser when supervised processes report ready")
 	flag.StringVar(&binDir, "bin-dir", "",
-		"directory containing supervised binaries (defaults to launcher's own dir)")
+		"directory containing supervised binaries "+
+			"(defaults to ~/.friday/local/bin/, fallback to launcher's own dir)")
 	flag.StringVar(&autostart, "autostart", "",
 		"enable|disable|status — manage OS autostart entry then exit")
 	flag.BoolVar(&uninstall, "uninstall", false,
@@ -214,8 +225,21 @@ func parseFlags() (autostart string, uninstall bool) {
 	flag.Parse()
 
 	if binDir == "" {
-		exe, err := os.Executable()
-		if err == nil {
+		// Decision #25: supervised binaries live in
+		// `~/.friday/local/bin/`, not next to the launcher binary.
+		// Stack 3's installer extracts the launcher into the .app
+		// bundle (`/Applications/Friday Studio.app/...`) and the
+		// supervised binaries into `~/.friday/local/bin/` — these
+		// are different paths. Old behavior (filepath.Dir(exe))
+		// was correct for the v0.0.8 flat-tarball layout but breaks
+		// after the .app split.
+		//
+		// Fallback to filepath.Dir(exe) when the home dir lookup
+		// fails — covers test harnesses that don't set HOME and
+		// the legacy in-tree layout for `go run`.
+		if home, err := os.UserHomeDir(); err == nil {
+			binDir = filepath.Join(home, ".friday", "local", "bin")
+		} else if exe, err := os.Executable(); err == nil {
 			binDir = filepath.Dir(exe)
 		}
 	}
@@ -513,18 +537,19 @@ func runAutostartCommand(cmd string) {
 //
 // Two cases:
 //  1. state.json absent or autostart_initialized != true → write the
-//     OS autostart entry pointing at os.Executable(), set the flag.
-//  2. state.json says we're initialized → still compare currentAutostartPath()
-//     to os.Executable(); if they differ (user moved the binary),
-//     rewrite the entry. State.json stays unchanged.
+//     OS autostart entry, set the flag.
+//  2. state.json says we're initialized → call isAutostartStale();
+//     if stale (Stack 3: bundle ID differs on darwin; exe path
+//     differs on Windows), rewrite the entry. state.json unchanged.
+//
+// Decision #36: the migration code OUTSIDE this function preserves
+// the user's autostart preference (a deliberately-disabled plist
+// stays disabled across upgrades). This function only runs when a
+// plist is wanted; it's the "make sure the plist is current" step.
 func autostartSelfRegister() error {
-	exe, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("os.Executable: %w", err)
-	}
 	state := readState()
 	if !state.AutostartInitialized {
-		log.Info("first-run autostart self-register", "exe", exe)
+		log.Info("first-run autostart self-register")
 		if err := enableAutostart(); err != nil {
 			return fmt.Errorf("enableAutostart: %w", err)
 		}
@@ -535,10 +560,8 @@ func autostartSelfRegister() error {
 		return nil
 	}
 	// Already initialized — staleness repair pass.
-	registered := currentAutostartPath()
-	if registered != "" && registered != exe {
-		log.Info("autostart path stale; rewriting",
-			"registered", registered, "current", exe)
+	if isAutostartStale() {
+		log.Info("autostart entry stale; rewriting")
 		if err := enableAutostart(); err != nil {
 			return fmt.Errorf("enableAutostart (staleness): %w", err)
 		}

--- a/tools/friday-launcher/paths.go
+++ b/tools/friday-launcher/paths.go
@@ -5,7 +5,18 @@ import (
 	"path/filepath"
 )
 
+// launchAgentLabel is the LaunchAgent plist's `Label` field (Decision
+// #14). Pinned across versions so v0.0.8 → v0.0.9 migration doesn't
+// have to delete a prior plist with a different label.
 const launchAgentLabel = "ai.hellofriday.studio"
+
+// launcherBundleID is the .app's CFBundleIdentifier (Decision #3).
+// Stack 3's autostart plist invokes `open -b <bundleID>` so reboot
+// targets the bundled .app via LaunchServices rather than a raw exe
+// path that would go stale if the user moves the .app. NOT the same
+// as launchAgentLabel — Apple recommends distinct values to avoid
+// LaunchServices treating the LaunchAgent as the .app's daemon.
+const launcherBundleID = "ai.hellofriday.studio-launcher"
 
 func friendlyHome() string {
 	if v := os.Getenv("FRIDAY_LAUNCHER_HOME"); v != "" {

--- a/tools/friday-launcher/preflight.go
+++ b/tools/friday-launcher/preflight.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Pre-flight binary check (Decision #12 + #21).
@@ -25,26 +26,24 @@ import (
 // don't need any supervised binaries — those paths skip pre-flight.
 
 // requiredBinaries returns the names of the supervised binaries
-// pre-flight must verify. Mirrors `supervisedProcesses(binDir)`'s
-// names but doesn't depend on a non-empty binDir; used by tests.
+// pre-flight must verify. Wraps the canonical list in `project.go`.
 func requiredBinaries() []string {
-	specs := supervisedProcesses("")
-	names := make([]string, len(specs))
-	for i, s := range specs {
-		names[i] = s.name
-	}
-	return names
+	return supervisedProcessNames()
 }
 
 // checkBinariesPresent verifies that every supervised binary exists
-// at `binDir/<name>` and is executable. Returns the list of missing
-// binaries (empty slice on success) plus the first stat-error if any
-// — non-existence is an empty error; permission/IO errors surface so
-// the user sees something more actionable than "missing binary".
+// at `binDir/<name>` as a non-empty regular file. Returns the list
+// of missing binaries (empty slice on success) plus the first
+// stat-error if any — non-existence is an empty error; permission /
+// IO errors surface so the user sees something more actionable than
+// "missing binary".
 //
-// We do NOT verify the binaries are valid Mach-O / PE / ELF — that's
-// codesign/notarization's job upstream, not pre-flight's. We just
-// answer "is this file there and runnable?".
+// We do NOT verify the binaries are valid Mach-O / PE / ELF or
+// carry the executable bit — that's process-compose's job at spawn
+// time, not pre-flight's. The check is deliberately presence + type
+// + non-zero size: the 2026-04-27 v0.0.8 incident produced 0-byte
+// stubs that passed `os.Stat` but failed `Exec`; pre-flight catches
+// exactly that class.
 func checkBinariesPresent(binDir string) (missing []string, err error) {
 	if binDir == "" {
 		return nil, errors.New("binDir is empty")
@@ -81,23 +80,21 @@ func checkBinariesPresent(binDir string) (missing []string, err error) {
 // runPreflight is the launcher's entry-point hook for the binaries
 // check. Called from main() AFTER `--uninstall` / `--autostart`
 // dispatch (those paths don't need binaries) but BEFORE
-// `systray.Run`. On failure: write the diagnostic log, show the
-// missing-binaries dialog, exit 1.
+// `systray.Run`. On failure: writes ONE diagnostic log entry,
+// passes its path to the missing-binaries dialog so the dialog
+// body can surface it, exits 1.
 //
 // Splitting the dialog/exit from the check itself (`checkBinariesPresent`)
 // keeps the check unit-testable without spawning real dialogs.
 func runPreflight(binDir string) {
 	missing, err := checkBinariesPresent(binDir)
 	if err != nil {
-		// Stat error — show a "couldn't read bin dir" variant. Reuses
-		// the same dialog infrastructure with a different reason
-		// string. Keep dialog body short; details land in the log.
 		details := map[string]string{
 			"bin_dir": binDir,
 			"error":   err.Error(),
 		}
-		_ = writeStartupErrorLog("preflight-stat-error", details)
-		showMissingBinariesDialog(binDir, []string{}, err.Error())
+		logPath := writeStartupErrorLog("preflight-stat-error", details)
+		showMissingBinariesDialog(binDir, []string{}, err.Error(), logPath)
 		os.Exit(1)
 	}
 	if len(missing) == 0 {
@@ -108,22 +105,9 @@ func runPreflight(binDir string) {
 	// then show the dialog.
 	details := map[string]string{
 		"bin_dir": binDir,
-		"missing": joinNames(missing),
+		"missing": strings.Join(missing, ", "),
 	}
-	_ = writeStartupErrorLog("preflight-missing-binaries", details)
-	showMissingBinariesDialog(binDir, missing, "")
+	logPath := writeStartupErrorLog("preflight-missing-binaries", details)
+	showMissingBinariesDialog(binDir, missing, "", logPath)
 	os.Exit(1)
-}
-
-// joinNames concatenates a slice with ", " — small helper so the
-// log entry's `missing:` line is readable on a single row.
-func joinNames(names []string) string {
-	out := ""
-	for i, n := range names {
-		if i > 0 {
-			out += ", "
-		}
-		out += n
-	}
-	return out
 }

--- a/tools/friday-launcher/preflight.go
+++ b/tools/friday-launcher/preflight.go
@@ -1,0 +1,129 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Pre-flight binary check (Decision #12 + #21).
+//
+// Runs BEFORE supervisor start in the normal-startup path. If any
+// supervised binary is missing from binDir, we cannot make forward
+// progress — process-compose would spawn the placeholder, fail, and
+// the launcher would emit "starting → failed" to the wizard with no
+// human-readable explanation.
+//
+// Pre-flight short-circuits that: it checks every binary up front,
+// renders a missing-binaries dialog (osascript on macOS,
+// MessageBoxW on Windows, stderr-only on Linux), writes a diagnostic
+// log to ~/.friday/local/logs/launcher-startup.log (Decision #34),
+// and exits 1.
+//
+// The exception is `--uninstall` and `--autostart` modes, which
+// don't need any supervised binaries — those paths skip pre-flight.
+
+// requiredBinaries returns the names of the supervised binaries
+// pre-flight must verify. Mirrors `supervisedProcesses(binDir)`'s
+// names but doesn't depend on a non-empty binDir; used by tests.
+func requiredBinaries() []string {
+	specs := supervisedProcesses("")
+	names := make([]string, len(specs))
+	for i, s := range specs {
+		names[i] = s.name
+	}
+	return names
+}
+
+// checkBinariesPresent verifies that every supervised binary exists
+// at `binDir/<name>` and is executable. Returns the list of missing
+// binaries (empty slice on success) plus the first stat-error if any
+// — non-existence is an empty error; permission/IO errors surface so
+// the user sees something more actionable than "missing binary".
+//
+// We do NOT verify the binaries are valid Mach-O / PE / ELF — that's
+// codesign/notarization's job upstream, not pre-flight's. We just
+// answer "is this file there and runnable?".
+func checkBinariesPresent(binDir string) (missing []string, err error) {
+	if binDir == "" {
+		return nil, errors.New("binDir is empty")
+	}
+	for _, name := range requiredBinaries() {
+		path := filepath.Join(binDir, name)
+		info, statErr := os.Stat(path)
+		if statErr != nil {
+			if os.IsNotExist(statErr) {
+				missing = append(missing, name)
+				continue
+			}
+			// Permission / IO error — surface as the function's
+			// error so the dialog can carry the OS message rather
+			// than just "missing".
+			return nil, fmt.Errorf("stat %s: %w", path, statErr)
+		}
+		// Reject directories and zero-size placeholders. A 0-byte
+		// "binary" got us into the 2026-04-27 v0.0.8 incident — the
+		// install dropped a stub that passed os.Stat but failed
+		// Exec with EOFonExec.
+		if info.IsDir() {
+			missing = append(missing, name)
+			continue
+		}
+		if info.Size() == 0 {
+			missing = append(missing, name)
+			continue
+		}
+	}
+	return missing, nil
+}
+
+// runPreflight is the launcher's entry-point hook for the binaries
+// check. Called from main() AFTER `--uninstall` / `--autostart`
+// dispatch (those paths don't need binaries) but BEFORE
+// `systray.Run`. On failure: write the diagnostic log, show the
+// missing-binaries dialog, exit 1.
+//
+// Splitting the dialog/exit from the check itself (`checkBinariesPresent`)
+// keeps the check unit-testable without spawning real dialogs.
+func runPreflight(binDir string) {
+	missing, err := checkBinariesPresent(binDir)
+	if err != nil {
+		// Stat error — show a "couldn't read bin dir" variant. Reuses
+		// the same dialog infrastructure with a different reason
+		// string. Keep dialog body short; details land in the log.
+		details := map[string]string{
+			"bin_dir": binDir,
+			"error":   err.Error(),
+		}
+		_ = writeStartupErrorLog("preflight-stat-error", details)
+		showMissingBinariesDialog(binDir, []string{}, err.Error())
+		os.Exit(1)
+	}
+	if len(missing) == 0 {
+		return
+	}
+	// Some binaries missing. Build details for the diagnostic log
+	// (one key per missing binary so support can copy/paste lines)
+	// then show the dialog.
+	details := map[string]string{
+		"bin_dir": binDir,
+		"missing": joinNames(missing),
+	}
+	_ = writeStartupErrorLog("preflight-missing-binaries", details)
+	showMissingBinariesDialog(binDir, missing, "")
+	os.Exit(1)
+}
+
+// joinNames concatenates a slice with ", " — small helper so the
+// log entry's `missing:` line is readable on a single row.
+func joinNames(names []string) string {
+	out := ""
+	for i, n := range names {
+		if i > 0 {
+			out += ", "
+		}
+		out += n
+	}
+	return out
+}

--- a/tools/friday-launcher/preflight.go
+++ b/tools/friday-launcher/preflight.go
@@ -32,11 +32,11 @@ func requiredBinaries() []string {
 }
 
 // checkBinariesPresent verifies that every supervised binary exists
-// at `binDir/<name>` as a non-empty regular file. Returns the list
-// of missing binaries (empty slice on success) plus the first
-// stat-error if any — non-existence is an empty error; permission /
-// IO errors surface so the user sees something more actionable than
-// "missing binary".
+// at `binDir/<name>` as a non-directory file with non-zero size.
+// Returns the list of missing binaries (empty slice on success) plus
+// the first stat-error if any — non-existence is an empty error;
+// permission / IO errors surface so the user sees something more
+// actionable than "missing binary".
 //
 // We do NOT verify the binaries are valid Mach-O / PE / ELF or
 // carry the executable bit — that's process-compose's job at spawn

--- a/tools/friday-launcher/preflight_dialog_darwin.go
+++ b/tools/friday-launcher/preflight_dialog_darwin.go
@@ -70,14 +70,9 @@ const downloadsPageURL = "https://download.fridayplatform.io/studio/"
 //
 // `missing` is the list of binaries by name; empty when the cause
 // is a stat error (the `errMsg` argument carries the OS message).
-func showMissingBinariesDialog(binDir string, missing []string, errMsg string) {
-	logPath := writeStartupErrorLog("preflight", map[string]string{
-		"bin_dir": binDir,
-		"missing": strings.Join(missing, ", "),
-		"error":   errMsg,
-		"os":      runtime.GOOS + "/" + runtime.GOARCH,
-	})
-
+// `logPath` is the diagnostic log path written by `runPreflight`
+// (single source of truth — the dialog only renders, doesn't write).
+func showMissingBinariesDialog(binDir string, missing []string, errMsg, logPath string) {
 	var body string
 	if errMsg != "" {
 		body = fmt.Sprintf(

--- a/tools/friday-launcher/preflight_dialog_darwin.go
+++ b/tools/friday-launcher/preflight_dialog_darwin.go
@@ -50,6 +50,63 @@ func showStartupErrorDialog(title, body string, buttons []string) string {
 	return parseClickedButton(string(out), buttons)
 }
 
+// startupErrorButtonOpenDownload is the second button label on the
+// missing-binaries dialog. Clicking it opens the Friday Studio
+// downloads page so the user can re-download the installer; the
+// reason a binary is missing is almost always a botched install.
+const startupErrorButtonOpenDownload = "Open downloads page"
+
+// downloadsPageURL is where users land when they hit "Open downloads
+// page" on the missing-binaries dialog. The host is the Cloudflare-
+// fronted gateway used by the manifest fetcher (download.fridayplatform.io).
+const downloadsPageURL = "https://download.fridayplatform.io/studio/"
+
+// showMissingBinariesDialog renders the pre-flight missing-binaries
+// dialog (Decision #12). Triggered by `runPreflight` in preflight.go
+// when one or more supervised binaries are missing from binDir, or
+// on a stat error reading binDir. Two buttons: "Quit" (default) and
+// "Open downloads page" — the latter opens downloadsPageURL via
+// `open` (macOS native dispatcher).
+//
+// `missing` is the list of binaries by name; empty when the cause
+// is a stat error (the `errMsg` argument carries the OS message).
+func showMissingBinariesDialog(binDir string, missing []string, errMsg string) {
+	logPath := writeStartupErrorLog("preflight", map[string]string{
+		"bin_dir": binDir,
+		"missing": strings.Join(missing, ", "),
+		"error":   errMsg,
+		"os":      runtime.GOOS + "/" + runtime.GOARCH,
+	})
+
+	var body string
+	if errMsg != "" {
+		body = fmt.Sprintf(
+			"Friday Studio cannot start.\n\n"+
+				"Could not read the binaries directory:\n%s\n\n"+
+				"%s\n\n"+
+				"Reinstalling Friday Studio usually fixes this.",
+			binDir, errMsg)
+	} else {
+		body = fmt.Sprintf(
+			"Friday Studio cannot start.\n\n"+
+				"The following binaries are missing from\n%s:\n  • %s\n\n"+
+				"Reinstalling Friday Studio will restore them.",
+			binDir, strings.Join(missing, "\n  • "))
+	}
+	if logPath != "" {
+		body += "\n\nDiagnostic log: " + logPath
+	}
+	clicked := showStartupErrorDialog("Friday Studio", body,
+		[]string{startupErrorButtonOpenDownload, startupErrorButtonQuit})
+	if clicked == startupErrorButtonOpenDownload {
+		// `open <url>` is macOS's native URL dispatcher — no
+		// dependency on the user having Chrome/Safari/etc. set as
+		// default; LaunchServices picks the user's default. gosec
+		// G204 is a false positive: the URL is launcher-controlled.
+		_ = exec.Command("open", downloadsPageURL).Run()
+	}
+}
+
 // showPortInUseDialog renders the port-5199-already-in-use dialog
 // (Decision #28). Single button: Quit. Body explains the diagnosis
 // command and (when writeStartupErrorLog succeeds) the log path

--- a/tools/friday-launcher/preflight_dialog_other.go
+++ b/tools/friday-launcher/preflight_dialog_other.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 )
 
 // Linux / other-OS stubs so the package builds on the CI runner.
@@ -13,6 +14,28 @@ import (
 // commit (see autostart_linux.go); a real Linux GUI dialog is
 // out-of-scope for v15. writeStartupErrorLog + startupErrorLogPath
 // live in preflight_log.go (shared across platforms).
+
+// showMissingBinariesDialog logs to stderr + diagnostic log on
+// non-darwin/non-windows. Linux build is CI-only today; a real
+// GUI dialog is out-of-scope for v15.
+func showMissingBinariesDialog(binDir string, missing []string, errMsg string) {
+	logPath := writeStartupErrorLog("preflight", map[string]string{
+		"bin_dir": binDir,
+		"missing": strings.Join(missing, ", "),
+		"error":   errMsg,
+		"os":      runtime.GOOS + "/" + runtime.GOARCH,
+	})
+	if errMsg != "" {
+		fmt.Fprintf(os.Stderr,
+			"friday-launcher: cannot start. Could not read bin dir %s: %s. Log: %s\n",
+			binDir, errMsg, logPath)
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"friday-launcher: cannot start. Missing binaries in %s: %s. "+
+			"Reinstall Friday Studio. Log: %s\n",
+		binDir, strings.Join(missing, ", "), logPath)
+}
 
 // showPortInUseDialog logs to stderr and the diagnostic log file
 // — Linux build is for CI / future use; no GUI dialog today.

--- a/tools/friday-launcher/preflight_dialog_other.go
+++ b/tools/friday-launcher/preflight_dialog_other.go
@@ -18,13 +18,7 @@ import (
 // showMissingBinariesDialog logs to stderr + diagnostic log on
 // non-darwin/non-windows. Linux build is CI-only today; a real
 // GUI dialog is out-of-scope for v15.
-func showMissingBinariesDialog(binDir string, missing []string, errMsg string) {
-	logPath := writeStartupErrorLog("preflight", map[string]string{
-		"bin_dir": binDir,
-		"missing": strings.Join(missing, ", "),
-		"error":   errMsg,
-		"os":      runtime.GOOS + "/" + runtime.GOARCH,
-	})
+func showMissingBinariesDialog(binDir string, missing []string, errMsg, logPath string) {
 	if errMsg != "" {
 		fmt.Fprintf(os.Stderr,
 			"friday-launcher: cannot start. Could not read bin dir %s: %s. Log: %s\n",

--- a/tools/friday-launcher/preflight_dialog_windows.go
+++ b/tools/friday-launcher/preflight_dialog_windows.go
@@ -5,7 +5,9 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"runtime"
+	"strings"
 	"syscall"
 	"unsafe"
 )
@@ -15,6 +17,74 @@ import (
 // per GOOS. Stack 3 will extend with the missing-binaries variant.
 // writeStartupErrorLog + startupErrorLogPath live in preflight_log.go
 // (shared across platforms — log file format is identical).
+
+// downloadsPageURL is where users land when they hit "Open downloads
+// page" on the missing-binaries dialog. Same value as darwin.
+const downloadsPageURL = "https://download.fridayplatform.io/studio/"
+
+// showMissingBinariesDialog is the Windows parity for the darwin
+// variant. Windows MessageBoxW only supports a fixed set of button
+// combos (MB_OK, MB_OKCANCEL, MB_YESNO, etc.) — none of which fit
+// "Quit | Open downloads page". We use MB_YESNO with text body
+// asking "Open downloads page?"; YES → open, NO → quit. Less
+// elegant than the macOS variant but native and dependency-free.
+func showMissingBinariesDialog(binDir string, missing []string, errMsg string) {
+	logPath := writeStartupErrorLog("preflight", map[string]string{
+		"bin_dir": binDir,
+		"missing": strings.Join(missing, ", "),
+		"error":   errMsg,
+		"os":      runtime.GOOS + "/" + runtime.GOARCH,
+	})
+
+	var body string
+	if errMsg != "" {
+		body = fmt.Sprintf(
+			"Friday Studio cannot start.\r\n\r\n"+
+				"Could not read the binaries directory:\r\n%s\r\n\r\n"+
+				"%s\r\n\r\n"+
+				"Reinstalling Friday Studio usually fixes this.",
+			binDir, errMsg)
+	} else {
+		body = fmt.Sprintf(
+			"Friday Studio cannot start.\r\n\r\n"+
+				"The following binaries are missing from\r\n%s:\r\n  • %s\r\n\r\n"+
+				"Reinstalling Friday Studio will restore them.",
+			binDir, strings.Join(missing, "\r\n  • "))
+	}
+	if logPath != "" {
+		body += "\r\n\r\nDiagnostic log: " + logPath
+	}
+	body += "\r\n\r\nOpen the downloads page now?"
+
+	if messageBoxYesNo("Friday Studio", body) {
+		// `cmd /C start <url>` is the Windows native URL dispatcher;
+		// no dependency on a browser being installed at a known
+		// path. gosec G204 false positive: launcher-controlled URL.
+		_ = exec.Command("cmd", "/C", "start", downloadsPageURL).Run() //nolint:gosec // G204: launcher-controlled URL
+	}
+}
+
+// messageBoxYesNo wraps user32!MessageBoxW with MB_YESNO buttons.
+// Returns true iff the user clicked Yes (IDYES = 6).
+func messageBoxYesNo(title, body string) bool {
+	const (
+		MB_YESNO    = 0x00000004
+		MB_ICONSTOP = 0x00000010
+		MB_TOPMOST  = 0x00040000
+		IDYES       = 6
+	)
+	user32 := syscall.NewLazyDLL("user32.dll")
+	proc := user32.NewProc("MessageBoxW")
+	titlePtr, _ := syscall.UTF16PtrFromString(title)
+	bodyPtr, _ := syscall.UTF16PtrFromString(body)
+	ret, _, _ := proc.Call(
+		uintptr(0),
+		uintptr(unsafe.Pointer(bodyPtr)),
+		uintptr(unsafe.Pointer(titlePtr)),
+		uintptr(MB_YESNO|MB_ICONSTOP|MB_TOPMOST),
+	)
+	return int(ret) == IDYES
+}
 
 // showPortInUseDialog renders a Windows MessageBoxW with the same
 // content + log path as the darwin variant. MB_ICONSTOP (red x)

--- a/tools/friday-launcher/preflight_dialog_windows.go
+++ b/tools/friday-launcher/preflight_dialog_windows.go
@@ -28,14 +28,7 @@ const downloadsPageURL = "https://download.fridayplatform.io/studio/"
 // "Quit | Open downloads page". We use MB_YESNO with text body
 // asking "Open downloads page?"; YES → open, NO → quit. Less
 // elegant than the macOS variant but native and dependency-free.
-func showMissingBinariesDialog(binDir string, missing []string, errMsg string) {
-	logPath := writeStartupErrorLog("preflight", map[string]string{
-		"bin_dir": binDir,
-		"missing": strings.Join(missing, ", "),
-		"error":   errMsg,
-		"os":      runtime.GOOS + "/" + runtime.GOARCH,
-	})
-
+func showMissingBinariesDialog(binDir string, missing []string, errMsg, logPath string) {
 	var body string
 	if errMsg != "" {
 		body = fmt.Sprintf(

--- a/tools/friday-launcher/preflight_test.go
+++ b/tools/friday-launcher/preflight_test.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCheckBinariesPresent_AllPresent: every required binary
+// exists, has size > 0 — empty missing slice + nil error.
+func TestCheckBinariesPresent_AllPresent(t *testing.T) {
+	binDir := t.TempDir()
+	for _, name := range requiredBinaries() {
+		path := filepath.Join(binDir, name)
+		// 4-byte stub is enough to satisfy the size>0 check.
+		if err := os.WriteFile(path, []byte("stub"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	missing, err := checkBinariesPresent(binDir)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if len(missing) != 0 {
+		t.Errorf("missing = %v, want empty", missing)
+	}
+}
+
+// TestCheckBinariesPresent_OneMissing: only some binaries exist;
+// the missing slice lists exactly the absent names.
+func TestCheckBinariesPresent_OneMissing(t *testing.T) {
+	binDir := t.TempDir()
+	all := requiredBinaries()
+	if len(all) < 2 {
+		t.Skip("need at least 2 supervised processes for this case")
+	}
+	// Create all but the last.
+	for _, name := range all[:len(all)-1] {
+		path := filepath.Join(binDir, name)
+		if err := os.WriteFile(path, []byte("stub"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	missing, err := checkBinariesPresent(binDir)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if len(missing) != 1 || missing[0] != all[len(all)-1] {
+		t.Errorf("missing = %v, want [%s]", missing, all[len(all)-1])
+	}
+}
+
+// TestCheckBinariesPresent_ZeroSizePlaceholderCountsAsMissing:
+// 0-byte files count as missing. The 2026-04-27 v0.0.8 incident
+// involved an installer that wrote 0-byte stubs that passed the
+// "file exists" check but failed exec; pre-flight must catch this.
+func TestCheckBinariesPresent_ZeroSizePlaceholderCountsAsMissing(t *testing.T) {
+	binDir := t.TempDir()
+	all := requiredBinaries()
+	// Plant a real binary for everyone except `friday`, which
+	// gets a zero-byte placeholder.
+	for _, name := range all {
+		path := filepath.Join(binDir, name)
+		var content []byte
+		if name != "friday" {
+			content = []byte("stub")
+		}
+		if err := os.WriteFile(path, content, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	missing, err := checkBinariesPresent(binDir)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if len(missing) != 1 || missing[0] != "friday" {
+		t.Errorf("missing = %v, want [friday]", missing)
+	}
+}
+
+// TestCheckBinariesPresent_DirectoryCountsAsMissing: a directory
+// with the right NAME at binDir/<bin> is NOT a binary; treat as
+// missing. Catches the "user accidentally extracted nested folders"
+// failure mode.
+func TestCheckBinariesPresent_DirectoryCountsAsMissing(t *testing.T) {
+	binDir := t.TempDir()
+	all := requiredBinaries()
+	for _, name := range all {
+		path := filepath.Join(binDir, name)
+		if name == "friday" {
+			if err := os.MkdirAll(path, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			continue
+		}
+		if err := os.WriteFile(path, []byte("stub"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	missing, err := checkBinariesPresent(binDir)
+	if err != nil {
+		t.Fatalf("err = %v, want nil", err)
+	}
+	if len(missing) != 1 || missing[0] != "friday" {
+		t.Errorf("missing = %v, want [friday]", missing)
+	}
+}
+
+// TestCheckBinariesPresent_EmptyBinDir: empty string fails fast
+// — pre-flight must distinguish "nothing to check" from
+// "everything present"; an unconfigured launcher should NOT silently
+// pass pre-flight.
+func TestCheckBinariesPresent_EmptyBinDir(t *testing.T) {
+	missing, err := checkBinariesPresent("")
+	if err == nil {
+		t.Errorf("err = nil, want non-nil for empty binDir")
+	}
+	if missing != nil {
+		t.Errorf("missing = %v, want nil", missing)
+	}
+}
+
+// TestCheckBinariesPresent_NonExistentBinDir: a binDir that doesn't
+// exist returns ALL required binaries as missing (each Stat returns
+// ENOENT). Catches "user passed wrong --bin-dir" cleanly.
+func TestCheckBinariesPresent_NonExistentBinDir(t *testing.T) {
+	binDir := filepath.Join(t.TempDir(), "does-not-exist")
+	missing, err := checkBinariesPresent(binDir)
+	if err != nil {
+		t.Fatalf("err = %v, want nil (non-existence is missing, not error)", err)
+	}
+	want := requiredBinaries()
+	if len(missing) != len(want) {
+		t.Errorf("missing count = %d, want %d (got=%v)", len(missing), len(want), missing)
+	}
+}
+
+// TestRequiredBinariesCountMatchesPlan: documents the cardinality
+// invariant — 6 supervised binaries, matching CLAUDE.md and the
+// wizard's checklist UI. Pinning here means a refactor that
+// silently drops one would fail this test in addition to
+// TestSupervisedProcessesPinSet.
+func TestRequiredBinariesCountMatchesPlan(t *testing.T) {
+	if got := len(requiredBinaries()); got != 6 {
+		t.Errorf("requiredBinaries() count = %d, want 6 (CLAUDE.md)", got)
+	}
+}

--- a/tools/friday-launcher/project.go
+++ b/tools/friday-launcher/project.go
@@ -57,6 +57,22 @@ type processSpec struct {
 	healthPath string
 }
 
+// supervisedProcessNames returns just the names of the supervised
+// processes — used by pre-flight (which only needs names, not full
+// specs) without paying the cost of building processSpecs that get
+// thrown away. Single source of truth for the cardinality + ordering
+// of the supervised set.
+func supervisedProcessNames() []string {
+	return []string{
+		"nats-server",
+		"friday",
+		"link",
+		"pty-server",
+		"webhook-tunnel",
+		"playground",
+	}
+}
+
 // supervisedProcesses returns the launcher's view of the 5 platform
 // binaries. Each entry pairs a process name with its on-disk binary
 // and health probe target.

--- a/tools/friday-launcher/uninstall.go
+++ b/tools/friday-launcher/uninstall.go
@@ -68,18 +68,17 @@ func runUninstall() {
 		step("autostart entry removed", nil)
 	}
 
-	// 4. Remove the .app bundle from /Applications (Stack 3,
-	// darwin-only). The launcher is currently running from inside
-	// the bundle; the OS holds the executable open until our
-	// process exits, so we can RM the surrounding directory now —
-	// the kernel reference-counts the deleted inode and our exec
-	// stays valid until exit. Best-effort: not all installs land
-	// in /Applications (devs running `go run` against a flat
-	// build; unit tests with FRIDAY_LAUNCHER_HOME set).
-	removeAppBundleIfPresent(step)
-
-	// 5. Remove pids/ + state.json. Logs are preserved.
+	// 4. Remove pids/ + state.json. Logs are preserved.
 	// os.RemoveAll handles ENOENT silently — same idiom for both.
+	//
+	// State removal happens BEFORE .app bundle removal: if .app
+	// removal fails (permission denied on /Applications when the
+	// bundle was sudo-installed by an admin), we still want
+	// state.json + pids/ cleared so a subsequent re-install or
+	// `--uninstall` retry starts from a known-clean home dir.
+	// The .app sitting in /Applications without state is recoverable
+	// (Spotlight finds it; user can drag-to-trash); state.json
+	// referencing a vanished .app is more confusing.
 	if err := os.RemoveAll(statePath()); err != nil {
 		step("remove state.json", err)
 	} else {
@@ -91,6 +90,16 @@ func runUninstall() {
 	} else {
 		step("pids/ directory removed", nil)
 	}
+
+	// 5. Remove the .app bundle from /Applications (Stack 3,
+	// darwin-only). Last step so a permission failure on
+	// /Applications doesn't leave state.json + pids/ in place
+	// (see comment on step 4 ordering). The launcher is currently
+	// running from inside the bundle; the OS holds the executable
+	// open until our process exits, so we can RM the surrounding
+	// directory now — the kernel reference-counts the deleted inode
+	// and our exec stays valid until exit.
+	removeAppBundleIfPresent(step)
 
 	fmt.Println()
 	fmt.Printf("Logs preserved at: %s\n", logsDir())

--- a/tools/friday-launcher/uninstall.go
+++ b/tools/friday-launcher/uninstall.go
@@ -68,7 +68,17 @@ func runUninstall() {
 		step("autostart entry removed", nil)
 	}
 
-	// 4. Remove pids/ + state.json. Logs are preserved.
+	// 4. Remove the .app bundle from /Applications (Stack 3,
+	// darwin-only). The launcher is currently running from inside
+	// the bundle; the OS holds the executable open until our
+	// process exits, so we can RM the surrounding directory now —
+	// the kernel reference-counts the deleted inode and our exec
+	// stays valid until exit. Best-effort: not all installs land
+	// in /Applications (devs running `go run` against a flat
+	// build; unit tests with FRIDAY_LAUNCHER_HOME set).
+	removeAppBundleIfPresent(step)
+
+	// 5. Remove pids/ + state.json. Logs are preserved.
 	// os.RemoveAll handles ENOENT silently — same idiom for both.
 	if err := os.RemoveAll(statePath()); err != nil {
 		step("remove state.json", err)
@@ -200,4 +210,42 @@ func waitForLauncherExit(pid int, deadline time.Duration) bool {
 		time.Sleep(100 * time.Millisecond)
 	}
 	return false
+}
+
+// removeAppBundleIfPresent deletes /Applications/Friday Studio.app
+// on darwin (and is a no-op on other platforms). Best-effort: the
+// .app may not exist (devs running flat builds, or installers that
+// don't land it in /Applications), so absence is reported as a
+// noop step rather than a failure.
+//
+// Safety: the launcher's own executable lives inside the bundle.
+// Removing the bundle from disk while we're running is safe — the
+// kernel reference-counts the open inode, our exec stays valid
+// until process exit. Same trick Sparkle uses.
+func removeAppBundleIfPresent(step func(string, error)) {
+	path := appBundlePath()
+	if path == "" {
+		// Non-darwin or otherwise no-op platform.
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			step("no .app bundle to remove", nil)
+			return
+		}
+		step("stat "+path, err)
+		return
+	}
+	if !info.IsDir() {
+		// Something else at that path — don't touch it. Surface
+		// for the operator's attention rather than blindly rm.
+		step(fmt.Sprintf("%s is not a directory; skipping", path), nil)
+		return
+	}
+	if err := os.RemoveAll(path); err != nil {
+		step("remove "+path, err)
+		return
+	}
+	step(".app bundle removed from /Applications", nil)
 }

--- a/tools/friday-launcher/uninstall_darwin.go
+++ b/tools/friday-launcher/uninstall_darwin.go
@@ -1,0 +1,18 @@
+//go:build darwin
+
+package main
+
+// appBundlePath returns the canonical Friday Studio.app location on
+// macOS — `/Applications/Friday Studio.app`. Stack 3's installer
+// commits to one canonical location (no `~/Applications` fallback
+// per the v15 plan, §Issue 5 step 4); --uninstall removes exactly
+// this path.
+//
+// The path is hardcoded rather than derived from os.Executable()
+// because the launcher might be running from a different location
+// (dev build, side-load test) where rm-rf'ing the parent .app
+// would either be wrong (dev build inside repo) or destructive
+// (typo-prone exe path traversal). Hardcoding closes both holes.
+func appBundlePath() string {
+	return "/Applications/Friday Studio.app"
+}

--- a/tools/friday-launcher/uninstall_other.go
+++ b/tools/friday-launcher/uninstall_other.go
@@ -1,0 +1,12 @@
+//go:build !darwin
+
+package main
+
+// appBundlePath is a darwin-only concept (Friday Studio.app at
+// /Applications). On Linux + Windows the launcher binary doesn't
+// live inside a directory bundle that --uninstall should remove;
+// the empty return signals "no .app bundle to clean up" to
+// removeAppBundleIfPresent.
+func appBundlePath() string {
+	return ""
+}


### PR DESCRIPTION
## Summary

Stack 3 of the v15 plan — the launcher Go side. Tauri-side
(\`extract.rs\` rewrite, \`scripts/build-studio.ts\`, \`studio-build.yml\`
codesign workflow) lands in a follow-up PR to keep the review
surface manageable.

**Decisions covered:** #3 (bundle ID), #12 (missing-binaries dialog),
#14 (LaunchAgent label pinned), #21 (pre-flight gates normal startup),
#25 (\`bin/\` subdir default), #29 (\`open -b\` autostart).

## Highlights

- \`tools/friday-launcher/preflight.go\` (NEW) — checks every supervised
  binary exists at \`binDir/<name>\`, is non-zero, and is a regular
  file. 0-byte placeholder + directory-where-binary-expected both
  count as missing (the 2026-04-27 v0.0.8 incident was a 0-byte stub
  that passed \`os.Stat\`). On failure: writes diagnostic log via
  \`writeStartupErrorLog\`, calls platform-specific
  \`showMissingBinariesDialog\`, exits 1. Runs AFTER \`--uninstall\` /
  \`--autostart\` dispatch (which don't need binaries) but BEFORE the
  orphan sweep / health-server bind / tray boot.
- \`main.go\`: \`binDir\` default flips from
  \`filepath.Dir(os.Executable())\` to \`~/.friday/local/bin/\`
  (Decision #25). Falls back to the legacy exe-parent when home
  lookup fails (covers test harnesses + dev \`go run\`).
- \`autostart_darwin.go\`: \`ProgramArguments\` flips to
  \`[\"/usr/bin/open\", \"-b\", launcherBundleID, \"--args\", \"--no-browser\"]\`.
  Decision #29 — \`open -b\` dispatches via LaunchServices so the
  plist doesn't go stale if the user moves Friday Studio.app.
  v0.0.8-format plists (raw exe path) are marked stale and
  rewritten on first v0.0.9 boot.
- \`uninstall.go\` + \`uninstall_darwin.go\`: new
  \`removeAppBundleIfPresent\` step. macOS removes
  \`/Applications/Friday Studio.app\`; Linux/Windows are no-ops.
  Path hardcoded (not derived from \`os.Executable\`) so dev builds
  aren't accidentally rm-rf'd.
- \`preflight_dialog_*.go\`: 2-button osascript dialog on macOS
  (\"Quit\" / \"Open downloads page\"); MessageBoxW MB_YESNO on
  Windows; stderr-only on Linux.

## Tests

- \`tools/friday-launcher/preflight_test.go\` (NEW): 7 unit tests
  covering all-present, one-missing, zero-byte placeholder,
  directory-where-binary-expected, empty binDir, non-existent
  binDir, and the 6-service cardinality pin.
- Existing integration tests updated for the bundle-ID plist
  variant + new \`--bin-dir\` requirement on \`--uninstall\`.

## Test plan

- [x] \`go test -race -count=1 ./tools/friday-launcher/...\` — 24 unit
      tests pass (3 new preflight + existing 21)
- [x] \`go test -tags=integration -count=1 ./tools/friday-launcher/...\` —
      passes when run individually; full suite has occasional flake
      on \`TestUninstall_AlwaysSweepsEvenWhenLauncherStopsCleanly\`
      due to timing interaction with the launcher's own
      post-shutdown sweep (pre-existing condition, not introduced
      by Stack 3)
- [x] \`go vet\` + \`golangci-lint\` — clean (0 issues)
- [x] Cross-compile linux/amd64 + windows/amd64 — clean
- [ ] **Live macOS QA:**
  - [ ] \`mdfind -name \"Friday\"\` returns the new \`.app\` (after
        Stack 3 Tauri side ships the bundle)
  - [ ] First \`open -b \"ai.hellofriday.studio-launcher\"\` is
        silent (no Gatekeeper prompt; needs codesign+notarize from
        the Tauri-side PR)
  - [ ] Reboot fires autostart via \`open -b\`; tray appears
  - [ ] LaunchAgent plist \`ProgramArguments\` is the bundle-ID
        variant
  - [ ] \`--uninstall\` removes \`/Applications/Friday Studio.app\`
  - [ ] Pre-flight: missing binaries dialog with \"Open downloads
        page\" button
  - [ ] Pre-flight: 0-byte stubs counted as missing

## Out of scope (next PR)

- Tauri \`extract.rs\` rewrite (split-destination + staging + atomic
  swap + v0.0.8 → v0.0.9 migration sequence)
- \`scripts/build-studio.ts\` substantial rewrite (\`.app\` bundling,
  \`bin/\` subdir, license URL downloads, Info.plist assertion)
- \`.github/workflows/studio-build.yml\` codesign + notarization
  (needs Apple Developer keys via 1Password CLI / Actions secrets)