### PR TITLE
docs: document atlas agent MCP tool boundary

### DIFF
--- a/packages/system/agents/workspace-chat/tools/upsert-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/upsert-tools.ts
@@ -206,6 +206,8 @@ export function createBoundUpsertTools(logger: Logger, workspaceId: string): Atl
         'Use when the work is open-ended ("figure out what to do") and no bundled agent fits.\n' +
         '- `type: "atlas"` — bundled platform agent (web, email, slack, gh, etc.). Shape: ' +
         "`{ type, agent, description, prompt, config?, env? }`. " +
+        "Does not accept a `tools` array — the bundled agent is a self-contained black box. " +
+        "If you need to call MCP tools, use `type: \"llm\"`. " +
         "Discover available `agent` ids by calling `list_capabilities` first. " +
         "The `prompt` is task-specific context layered on the agent's bundled behavior — " +
         "describe the user's intent, not the mechanics. " +

--- a/packages/system/skills/workspace-api/SKILL.md
+++ b/packages/system/skills/workspace-api/SKILL.md
@@ -16,7 +16,7 @@ Create and manage Friday workspaces. This skill is where LLM judgment lives: whe
 
 | Type | When | Example |
 |---|---|---|
-| `atlas` | A bundled platform agent fits the task | `type: atlas, agent: "web"` |
+| `atlas` | A bundled platform agent fits the task **and its `constraints` allow it** | `type: atlas, agent: "web"` |
 | `user` | Mechanical / deterministic work, custom Python or TS SDK agent | `type: user, agent: "csv-parser"` |
 | `llm` | Open-ended reasoning with no bundled fit | `type: llm, config: { prompt, tools }` |
 
@@ -85,6 +85,8 @@ Follow this order exactly. Skipping steps produces the failure modes documented 
 Call `list_capabilities` once at the start of any new workspace work. The response returns bundled agents first (alphabetical), then enabled MCP servers, then available MCP servers from the catalog. Scan top-down and pick the first match for each piece of work the workspace needs — bundled comes first because it is zero-config and platform-managed.
 
 The result is stable for the session — re-call only after `enable_mcp_server` (which adds to the enabled set). Bundled agents and the catalog do not change during a session. **Do not duplicate this list into the skill or your own notes; `list_capabilities` is the source of truth.**
+
+Scan top-down and pick the first match **whose `constraints` don't rule out the user's intent**. Bundled comes first because it is zero-config, but a bundled agent that cannot do what the user asked is worse than a correctly wired MCP tool.
 
 ### 2. Wire capabilities
 
@@ -326,7 +328,9 @@ The cheat-sheet table covers the decision rule. These are worked examples for ea
 
 1. **Don't reach for an MCP server when a bundled agent exists for the same domain *and* the work is open-ended.** Common over-MCP traps: `playwright-mcp` instead of `type: atlas, agent: "web"`; `smtp-mcp` instead of `type: atlas, agent: "email"`; `slack-mcp` instead of `type: atlas, agent: "slack"`. The flip side: when the work is a deterministic single call, MCP-as-tool is the right pick — don't over-bundle. Run `list_capabilities` first; if a bundled agent matches and the work is open-ended, use it.
 
-2. **For `type: atlas`, the `prompt` field is task-specific context layered on the agent's bundled behavior.** Describe the user's intent, not the mechanics. The bundled agent already knows how to drive a browser / send email / call the GitHub API — don't re-teach it.
+2. **Atlas agents are self-contained black boxes — they do not invoke MCP tools.** Bundled agents ship with hard-wired transport (SendGrid for `email`, Playwright for `web`, etc.). If the user's intent requires calling a specific MCP tool — e.g., `google-gmail/send_gmail_message`, `github-mcp/create_issue` — `type: atlas` is the wrong choice. To call an MCP tool, use `type: llm` with the tool in `config.tools`. **Read the bundled agent's `constraints` in `list_capabilities`.** That's where the agent explicitly flags what it *cannot* do (e.g., `email` → "For reading Gmail, use the google-gmail MCP server"). If `constraints` rule out the intent, skip the bundled agent and fall through to MCP-enabled / MCP-available.
+
+3. **For `type: atlas`, the `prompt` field is task-specific context layered on the agent's bundled behavior.** Describe the user's intent, not the mechanics. The bundled agent already knows how to drive a browser / send email / call the GitHub API — don't re-teach it.
 
    ```yaml
    agents:

--- a/packages/system/skills/workspace-api/references/agent-types.md
+++ b/packages/system/skills/workspace-api/references/agent-types.md
@@ -64,6 +64,9 @@ jobs:
 
 **Key rules.**
 
+- `type: atlas` agents are black-box implementations with their own
+  built-in behavior. They do **not** call MCP tools. If the task requires
+  a specific MCP server tool, use `type: llm`.
 - The `prompt` field is task-specific intent layered on the agent's
   bundled behavior. The `web` agent already knows how to drive a
   browser, run a search, and fetch URLs — don't re-teach it those

--- a/packages/system/skills/writing-workspace-jobs/SKILL.md
+++ b/packages/system/skills/writing-workspace-jobs/SKILL.md
@@ -292,6 +292,22 @@ Symptom: `"No FSM job handles signal '<name>'"`
 
 Fix: Rewrite as `fsm:` with `initial` and `states`.
 
+### Atlas agent silently ignoring MCP tools
+
+`type: atlas` agents are self-contained — they do not use the agent's `tools`
+array. Adding `tools: ["google-gmail/send_gmail_message"]` to an `atlas` agent
+is silently ignored at runtime. The bundled agent runs its own hard-coded
+behavior instead.
+
+Symptom: Agent completes without error, but the MCP tool was never called. The
+output shows the bundled agent's default behavior (e.g., SendGrid email instead
+of Gmail, generic web search instead of GitHub API).
+
+Fix: Change to `type: llm`, set `config.provider` and `config.model`, move the
+prompt into `config.prompt`, and keep the `tools` array. Or, if the bundled
+agent already covers the domain, drop the `tools` array entirely and let the
+bundled agent do its job.
+
 ### Initial state with no signal handler
 
 The `initial` state must handle the trigger signal name in its `on` map.

--- a/tools/evals/agents/workspace-chat/bundled-agent-default.eval.ts
+++ b/tools/evals/agents/workspace-chat/bundled-agent-default.eval.ts
@@ -207,6 +207,8 @@ const UPSERT_AGENT_DESCRIPTION =
   'Use when the work is open-ended ("figure out what to do") and no bundled agent fits.\n' +
   '- `type: "atlas"` — bundled platform agent (web, email, slack, gh, etc.). Shape: ' +
   "`{ type, agent, description, prompt, config?, env? }`. " +
+  "Does not accept a `tools` array — the bundled agent is a self-contained black box. " +
+  "If you need to call MCP tools, use `type: \"llm\"`. " +
   "Discover available `agent` ids by calling `list_capabilities` first. " +
   "The `prompt` is task-specific context layered on the agent's bundled behavior — " +
   "describe the user's intent, not the mechanics. " +


### PR DESCRIPTION
Closes the gap where the LLM assumed atlas agents could invoke MCP tools. The email↔Gmail confusion (chat_UidR8je6cl) was the canonical failure mode.

**Root cause:** The LLM saw "email task" → agent: "email" → problem solved, without noticing that "Gmail" specifically requires the google-gmail MCP tool, which atlas agents cannot invoke. The skill had the bundled-vs-MCP decision (gotcha #1) but only one-way: "don't reach for MCP when bundled exists." It lacked the reverse guard: "don't reach for bundled when the task requires a specific MCP tool."

**Changes:**
- : new gotcha #2 (atlas agents are black boxes that do not call MCP tools), constraints check in recipe step 1, atlas row in cheat sheet now flags constraints check.
- : explicit bullet under atlas key rules.
- : new runtime anti-pattern "Atlas agent silently ignoring MCP tools" with symptom/fix.
-  + : atlas description now states "Does not accept a tools array" and points to .