### PR TITLE
feat(installer): bundle uv + uvx for MCP server-time spawn

### DIFF
--- a/scripts/build-studio.ts
+++ b/scripts/build-studio.ts
@@ -52,6 +52,7 @@ interface ExternalCliPin {
 const GH_VERSION = "2.92.0";
 const CLOUDFLARED_VERSION = "2026.3.0";
 const NATS_SERVER_VERSION = "2.12.8";
+const UV_VERSION = "0.11.8";
 
 const EXTERNAL_CLIS: readonly ExternalCliPin[] = [
   {
@@ -123,6 +124,35 @@ const EXTERNAL_CLIS: readonly ExternalCliPin[] = [
     },
     outName: (t) => (t.endsWith("windows-msvc") ? "nats-server.exe" : "nats-server"),
   },
+  // uv + uvx ship in one Astral release archive. We declare them as
+  // two pins (same URL, different innerPath) so each lands as its own
+  // entry in the staging tree. Yes the build downloads the archive
+  // twice — ~22 MB — acceptable cost for matching the existing
+  // single-binary-per-pin shape rather than introducing a new variant.
+  // Without these the daemon's MCP server-time tool fails with
+  // `spawn uvx ENOENT` on every fresh install.
+  ...(["uv", "uvx"] as const).map<ExternalCliPin>((bin) => ({
+    name: bin,
+    version: UV_VERSION,
+    url: (t) => {
+      const map: Record<string, string> = {
+        "aarch64-apple-darwin": `https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-aarch64-apple-darwin.tar.gz`,
+        "x86_64-apple-darwin": `https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-apple-darwin.tar.gz`,
+        "x86_64-pc-windows-msvc": `https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-pc-windows-msvc.zip`,
+      };
+      const url = map[t];
+      if (!url) throw new Error(`${bin}: unsupported target ${t}`);
+      return url;
+    },
+    innerPath: (t) => {
+      // macOS tarball nests under `uv-<triple>/`; Windows zip is flat.
+      if (t === "aarch64-apple-darwin") return `uv-aarch64-apple-darwin/${bin}`;
+      if (t === "x86_64-apple-darwin") return `uv-x86_64-apple-darwin/${bin}`;
+      if (t === "x86_64-pc-windows-msvc") return `${bin}.exe`;
+      throw new Error(`${bin}: unsupported target ${t}`);
+    },
+    outName: (t) => (t.endsWith("windows-msvc") ? `${bin}.exe` : bin),
+  })),
 ];
 
 // Pure-Go binaries built from the repo's go.mod. Cross-compile via GOOS/GOARCH;

--- a/tools/friday-launcher/project.go
+++ b/tools/friday-launcher/project.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/f1bonacc1/process-compose/src/command"
@@ -27,9 +28,10 @@ func commonServiceEnv() []string {
 }
 
 // fridayEnv builds the env-var list specific to the friday daemon
-// process. Carries FRIDAY_CLAUDE_PATH plus the .env baseline. Without
-// merging .env in here friday's platform-model validation fails on
-// every fresh install — the daemon needs ANTHROPIC_API_KEY in its
+// process. Carries FRIDAY_CLAUDE_PATH, FRIDAY_UV_PATH, FRIDAY_UVX_PATH
+// (when bundled binaries are present in binDir), plus the .env baseline.
+// Without merging .env in here friday's platform-model validation fails
+// on every fresh install — the daemon needs ANTHROPIC_API_KEY in its
 // process environment.
 //
 // FRIDAY_CLAUDE_PATH discovery order:
@@ -49,10 +51,19 @@ func commonServiceEnv() []string {
 // If none of the above resolves to a real file, we leave the env
 // var unset — the SDK then surfaces its native "binary not found"
 // error to the user, which is at least specific enough to act on.
-func fridayEnv() []string {
+func fridayEnv(binDir string) []string {
 	var env []string
 	if path := discoverClaudeBinary(); path != "" {
 		env = append(env, "FRIDAY_CLAUDE_PATH="+path)
+	}
+	for _, name := range []string{"uv", "uvx"} {
+		bin := filepath.Join(binDir, name)
+		if runtime.GOOS == "windows" {
+			bin += ".exe"
+		}
+		if _, err := os.Stat(bin); err == nil {
+			env = append(env, "FRIDAY_"+strings.ToUpper(name)+"_PATH="+bin)
+		}
 	}
 	env = append(env, commonServiceEnv()...)
 	return env
@@ -239,7 +250,7 @@ func supervisedProcesses(binDir string) []processSpec {
 		{
 			name: "friday", binary: filepath.Join(binDir, "friday"),
 			args:       []string{"daemon", "start"},
-			env:        fridayEnv(),
+			env:        fridayEnv(binDir),
 			healthPort: "8080", healthPath: "/health",
 		},
 		// `link` historically required LINK_DEV_MODE=true to skip the


### PR DESCRIPTION
## Summary

Daemon log on every fresh install:
```
MCP server "time" failed to start (uvx mcp-server-time): spawn uvx ENOENT
```

`uvx` isn't on PATH on a fresh macOS — Astral's `uv` doesn't ship with the OS. Bundle both binaries (~22 MB per platform) into the install archive, expose them to the daemon via `FRIDAY_UV_PATH` / `FRIDAY_UVX_PATH` from the launcher.

## Changes

- **`scripts/build-studio.ts`** — pin `UV_VERSION = "0.11.8"`, two `EXTERNAL_CLIS` rows for `uv` + `uvx` pointing at the same Astral release archive (different `innerPath` per binary). Layouts: macOS tarballs nest under `uv-<triple>/`, Windows zip is flat. Same archive downloaded twice during build — wasteful by ~22 MB but matches the existing single-binary-per-pin shape rather than introducing a new variant.
- **`tools/friday-launcher/project.go`** — `fridayEnv()` now takes `binDir`, stats `$binDir/{uv,uvx}` (with `.exe` on Windows), and emits `FRIDAY_*_PATH=<absolute>` when the file exists. No-op when the binaries aren't bundled (dev / out-of-tree launcher run).

## Test plan

- [x] `go test ./tools/friday-launcher/...` — passes
- [x] `deno run -A scripts/build-studio.ts --target aarch64-apple-darwin --version 0.0.0-test --skip-compile` — produces `staging/uv` + `staging/uvx`
- [x] `staging/uv --version` → `uv 0.11.8 (… aarch64-apple-darwin)`
- [x] `staging/uvx --from mcp-server-time mcp-server-time --help` — fetches the package from PyPI and prints the daemon's expected usage (the exact case that was failing)
- [ ] Studio install on fresh macOS — confirm daemon log no longer reports `spawn uvx ENOENT`

## Why hash verification works

`api.github.com/repos/astral-sh/uv/releases/tags/0.11.8` exposes `digest: "sha256:..."` per asset (same field cloudflared uses post-PR-#96). All 3 platform assets confirmed present.