### PR TITLE
feat(installer): bundle Node 24.15.0 + npm + npx

### DIFF
--- a/scripts/build-studio.ts
+++ b/scripts/build-studio.ts
@@ -49,10 +49,32 @@ interface ExternalCliPin {
   outName: (target: string) => string;
 }
 
+/** A bundle is a directory tree (e.g. Node's full distribution) extracted
+ * verbatim into a subdirectory of the staging tree. Single-file pins go
+ * through ExternalCliPin; trees go through this. The archive's top-level
+ * directory (e.g. node-v24.15.0-darwin-arm64/) is stripped during extract
+ * so the staged contents land flat under outDir. */
+interface ExternalBundlePin {
+  name: string;
+  version: string;
+  url: (target: string) => string;
+  /** Top-level directory inside the archive that we strip on extract. */
+  archiveRoot: (target: string) => string;
+  /** Subdirectory of staging where the contents land. */
+  outDir: string;
+  /** URL of a SHASUMS256-style file. The lookup key is the asset filename
+   * (last URL segment); the matching line's hex digest is verified before
+   * extraction. */
+  shasumsUrl: (target: string) => string;
+  /** Optional: paths under outDir to delete after extract. */
+  prune?: (target: string) => string[];
+}
+
 const GH_VERSION = "2.92.0";
 const CLOUDFLARED_VERSION = "2026.3.0";
 const NATS_SERVER_VERSION = "2.12.8";
 const UV_VERSION = "0.11.8";
+const NODE_VERSION = "24.15.0";
 
 const EXTERNAL_CLIS: readonly ExternalCliPin[] = [
   {
@@ -153,6 +175,43 @@ const EXTERNAL_CLIS: readonly ExternalCliPin[] = [
     },
     outName: (t) => (t.endsWith("windows-msvc") ? `${bin}.exe` : bin),
   })),
+];
+
+// Directory bundles — assets that ship as a tree, not a single binary.
+// Currently just Node.js: npm and npx are shell shims that delegate to
+// `bin/node` and require the sibling `lib/node_modules/npm` tree to
+// resolve their entry-point JS files. Stripping the layout breaks npm,
+// so we ship the whole distribution under node-runtime/.
+//
+// Without this the daemon logs:
+//   No FRIDAY_NPX_PATH configured, MCP servers using npx may not work
+//   No FRIDAY_NODE_PATH configured, bundled claude-code agent may not work
+const EXTERNAL_BUNDLES: readonly ExternalBundlePin[] = [
+  {
+    name: "node",
+    version: NODE_VERSION,
+    url: (t) => {
+      const map: Record<string, string> = {
+        "aarch64-apple-darwin": `https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-darwin-arm64.tar.gz`,
+        "x86_64-apple-darwin": `https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-darwin-x64.tar.gz`,
+        "x86_64-pc-windows-msvc": `https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-win-x64.zip`,
+      };
+      const url = map[t];
+      if (!url) throw new Error(`node: unsupported target ${t}`);
+      return url;
+    },
+    archiveRoot: (t) => {
+      if (t === "aarch64-apple-darwin") return `node-v${NODE_VERSION}-darwin-arm64`;
+      if (t === "x86_64-apple-darwin") return `node-v${NODE_VERSION}-darwin-x64`;
+      if (t === "x86_64-pc-windows-msvc") return `node-v${NODE_VERSION}-win-x64`;
+      throw new Error(`node: unsupported target ${t}`);
+    },
+    outDir: "node-runtime",
+    shasumsUrl: () => `https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt`,
+    // Strip the C header tree (~60 MB on macOS) — needed only for
+    // building native modules from source, which Studio doesn't do.
+    prune: () => ["include", "share", "CHANGELOG.md", "README.md"],
+  },
 ];
 
 // Pure-Go binaries built from the repo's go.mod. Cross-compile via GOOS/GOARCH;
@@ -360,6 +419,57 @@ async function extractArchive(archivePath: string, outDir: string): Promise<void
   }
 }
 
+/** Fetches a SHASUMS256-style file and returns the hex digest matching
+ * the given asset filename. Throws if the asset isn't listed. */
+async function fetchShasum(shasumsUrl: string, assetName: string): Promise<string> {
+  const resp = await fetch(shasumsUrl, { redirect: "follow" });
+  if (!resp.ok) throw new Error(`SHASUMS fetch ${shasumsUrl} → HTTP ${resp.status}`);
+  const body = await resp.text();
+  for (const line of body.split("\n")) {
+    const [hex, name] = line.trim().split(/\s+/);
+    if (name === assetName || name === `*${assetName}`) {
+      if (!hex || hex.length !== 64)
+        throw new Error(`SHASUMS: bad digest for ${assetName}: ${hex}`);
+      return hex.toLowerCase();
+    }
+  }
+  throw new Error(`SHASUMS: ${assetName} not listed in ${shasumsUrl}`);
+}
+
+async function bundleExternalBundle(
+  target: string,
+  bundle: ExternalBundlePin,
+  outDir: string,
+  scratch: string,
+): Promise<void> {
+  const url = bundle.url(target);
+  const fileName = url.split("/").pop();
+  if (!fileName) throw new Error(`${bundle.name}: cannot derive filename from URL: ${url}`);
+  const downloadPath = join(scratch, fileName);
+  await downloadFile(url, downloadPath);
+
+  const want = await fetchShasum(bundle.shasumsUrl(target), fileName);
+  const got = await sha256OfFile(downloadPath);
+  if (got !== want) {
+    throw new Error(`${bundle.name}: sha256 mismatch for ${fileName}: got=${got} want=${want}`);
+  }
+
+  const extractDir = join(scratch, `${bundle.name}-extract`);
+  await rmRf(extractDir);
+  await extractArchive(downloadPath, extractDir);
+
+  // Strip the archive's top-level dir by moving its contents up.
+  const innerRoot = join(extractDir, bundle.archiveRoot(target));
+  const dest = join(outDir, bundle.outDir);
+  await rmRf(dest);
+  await ensureDir(outDir);
+  await Deno.rename(innerRoot, dest);
+
+  for (const path of bundle.prune?.(target) ?? []) {
+    await rmRf(join(dest, path));
+  }
+}
+
 async function bundleExternalCli(
   target: string,
   cli: ExternalCliPin,
@@ -511,6 +621,9 @@ async function main(): Promise<void> {
   if (!opts.skipExternal) {
     for (const cli of EXTERNAL_CLIS) {
       await bundleExternalCli(opts.target, cli, stagingDir, scratchDir);
+    }
+    for (const bundle of EXTERNAL_BUNDLES) {
+      await bundleExternalBundle(opts.target, bundle, stagingDir, scratchDir);
     }
   } else {
     console.log("[build-studio] --skip-external set, skipping CLI bundling");

--- a/scripts/build-studio.ts
+++ b/scripts/build-studio.ts
@@ -66,8 +66,6 @@ interface ExternalBundlePin {
    * (last URL segment); the matching line's hex digest is verified before
    * extraction. */
   shasumsUrl: (target: string) => string;
-  /** Optional: paths under outDir to delete after extract. */
-  prune?: (target: string) => string[];
 }
 
 const GH_VERSION = "2.92.0";
@@ -208,9 +206,6 @@ const EXTERNAL_BUNDLES: readonly ExternalBundlePin[] = [
     },
     outDir: "node-runtime",
     shasumsUrl: () => `https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt`,
-    // Strip the C header tree (~60 MB on macOS) — needed only for
-    // building native modules from source, which Studio doesn't do.
-    prune: () => ["include", "share", "CHANGELOG.md", "README.md"],
   },
 ];
 
@@ -464,10 +459,6 @@ async function bundleExternalBundle(
   await rmRf(dest);
   await ensureDir(outDir);
   await Deno.rename(innerRoot, dest);
-
-  for (const path of bundle.prune?.(target) ?? []) {
-    await rmRf(join(dest, path));
-  }
 }
 
 async function bundleExternalCli(

--- a/tools/friday-launcher/project.go
+++ b/tools/friday-launcher/project.go
@@ -28,11 +28,11 @@ func commonServiceEnv() []string {
 }
 
 // fridayEnv builds the env-var list specific to the friday daemon
-// process. Carries FRIDAY_CLAUDE_PATH, FRIDAY_UV_PATH, FRIDAY_UVX_PATH
-// (when bundled binaries are present in binDir), plus the .env baseline.
-// Without merging .env in here friday's platform-model validation fails
-// on every fresh install — the daemon needs ANTHROPIC_API_KEY in its
-// process environment.
+// process. Carries FRIDAY_CLAUDE_PATH, FRIDAY_UV_PATH, FRIDAY_UVX_PATH,
+// FRIDAY_NODE_PATH, FRIDAY_NPX_PATH (when bundled binaries are present
+// in binDir), plus the .env baseline. Without merging .env in here
+// friday's platform-model validation fails on every fresh install —
+// the daemon needs ANTHROPIC_API_KEY in its process environment.
 //
 // FRIDAY_CLAUDE_PATH discovery order:
 //  1. Explicit user override via FRIDAY_CLAUDE_PATH set in the
@@ -63,6 +63,30 @@ func fridayEnv(binDir string) []string {
 		}
 		if _, err := os.Stat(bin); err == nil {
 			env = append(env, "FRIDAY_"+strings.ToUpper(name)+"_PATH="+bin)
+		}
+	}
+	// Bundled Node distribution. Windows zip lays node.exe / npx.cmd flat
+	// at the runtime root; macOS tarball nests under bin/. node-runtime/
+	// is the directory the build-studio.ts EXTERNAL_BUNDLES entry stages
+	// into.
+	nodeRuntime := filepath.Join(binDir, "node-runtime")
+	type nodeBin struct {
+		envName     string
+		unixSubpath string // e.g. bin/node
+		winName     string // e.g. node.exe
+	}
+	for _, b := range []nodeBin{
+		{envName: "FRIDAY_NODE_PATH", unixSubpath: "bin/node", winName: "node.exe"},
+		{envName: "FRIDAY_NPX_PATH", unixSubpath: "bin/npx", winName: "npx.cmd"},
+	} {
+		var bin string
+		if runtime.GOOS == "windows" {
+			bin = filepath.Join(nodeRuntime, b.winName)
+		} else {
+			bin = filepath.Join(nodeRuntime, b.unixSubpath)
+		}
+		if _, err := os.Stat(bin); err == nil {
+			env = append(env, b.envName+"="+bin)
 		}
 	}
 	env = append(env, commonServiceEnv()...)


### PR DESCRIPTION
## Summary

Daemon log on every fresh install:
```
No FRIDAY_NPX_PATH configured, MCP servers using npx may not work
No FRIDAY_NODE_PATH configured, bundled claude-code agent may not work
```

Node isn't on PATH on a fresh machine and Claude Code + every npx-spawned MCP server silently degrade. Bundle Node 24.15.0 LTS into the install archive and have the launcher emit `FRIDAY_NODE_PATH` / `FRIDAY_NPX_PATH` on the friday daemon's env.

- New `ExternalBundlePin` shape in `scripts/build-studio.ts` for directory assets (parallel to the existing single-binary `ExternalCliPin`). Node ships as a tree because npm is shell shims resolving into `lib/node_modules/npm/bin/*-cli.js`; stripping the layout breaks resolution.
- `bundleExternalBundle()` verifies sha256 against Node's `SHASUMS256.txt` sidecar (cleaner than cloudflared's API-digest trick — Node publishes a canonical hash file), extracts, strips the archive's top-level dir, prunes `include/` (~62 MB of C headers), `share/`, `CHANGELOG.md`, `README.md`.
- `fridayEnv()` stats `<binDir>/node-runtime/{bin/node,bin/npx}` on Unix or `<binDir>/node-runtime/{node.exe,npx.cmd}` on Windows (macOS tarball nests under `bin/`, Windows zip is flat) and emits the env vars when present.

## Test plan

- [x] `staging/node-runtime/bin/node --version` → `v24.15.0`
- [x] `staging/node-runtime/bin/npm --version` → `11.12.1`
- [x] `npx --yes cowsay "node bundled"` — fetches cowsay from npm registry, runs through bundled node, prints output (exact case daemon agents were silently failing on)
- [x] Pruning saves ~62 MB on disk (193 MB → 130 MB for node-runtime)
- [x] Final archive: 77 MB tar.zst on darwin-arm64
- [x] `go test ./tools/friday-launcher/...` passes
- [ ] CI build succeeds on macOS arm64/x64 + Windows