### PR TITLE
fix(installer): wire @atlas/hallucination/verdict subpath in deno.compile.json

### DIFF
--- a/deno.compile.json
+++ b/deno.compile.json
@@ -75,6 +75,7 @@
     "@atlas/workspace-builder": "./packages/workspace-builder/mod.ts",
     "@atlas/fsm-engine": "./packages/fsm-engine/mod.ts",
     "@atlas/hallucination": "./packages/hallucination/mod.ts",
+    "@atlas/hallucination/verdict": "./packages/hallucination/src/verdict.ts",
     "@atlas/resources": "./packages/resources/src/mod.ts",
     "@atlas/resources/guidance": "./packages/resources/src/guidance.ts",
     "@atlas/activity": "./packages/activity/src/mod.ts",


### PR DESCRIPTION
## Summary

Studio 0.0.22 ships compiled binaries (`friday` daemon + `playground`) that crash-loop on startup with:

```
[ERR_MODULE_NOT_FOUND] Cannot find module '.../packages/hallucination/verdict'
  imported from '.../packages/core/src/session/session-events.ts'
```

`deno.json:75` already maps `@atlas/hallucination/verdict` → `src/verdict.ts` for `deno run`/`deno test`, and `package.json` declares the same export for vitest. **`deno.compile.json` — the import map fed to `deno compile` in `scripts/build-studio.ts` — was missing the subpath**, so the bundled binaries can't resolve it at runtime.

The subpath usage itself is load-bearing: `packages/core/src/architecture.test.ts` forbids importing the `@atlas/hallucination` barrel because it transitively pulls `@atlas/sentry` → `node:process` into the playground's browser bundle. The right fix is to mirror the deno.json mapping in deno.compile.json, not to drop back to the barrel.

## Test plan

- [x] Caught while end-to-end testing 0.0.22 in a fresh macOS VM — both `friday daemon start` and `playground` exit immediately on this import; the launcher's bundle-path env vars (`FRIDAY_NPX_PATH` etc) emit correctly but the daemon never gets far enough to use them.
- [x] After the fix (verified on fresh build 0.0.23 in same VM): no `ERR_MODULE_NOT_FOUND` in `~/.friday/local/logs/friday.log`, daemon proceeds to "Atlas daemon is running"
- [ ] CI build green