### PR TITLE
feat(installer): prewarm reliability, parallel checklist, SDK pin CI

### DIFF
--- a/.github/workflows/sdk-skill-drift.yml
+++ b/.github/workflows/sdk-skill-drift.yml
@@ -1,4 +1,4 @@
-name: SDK skill drift
+name: SDK pin & skill drift
 
 # Fails if the vendored writing-friday-python-agents skill drifts from
 # upstream at the FRIDAY_AGENT_SDK_VERSION pinned in
@@ -16,6 +16,9 @@ on:
       - "packages/system/skills/writing-friday-python-agents/**"
       - "scripts/sync-sdk-skill.ts"
       - ".github/workflows/sdk-skill-drift.yml"
+      - "Dockerfile"
+      - "apps/studio-installer/src-tauri/src/commands/prewarm_agent_sdk.rs"
+      - "scripts/check-sdk-pin-sync.ts"
   merge_group:
 
 concurrency:
@@ -36,6 +39,9 @@ jobs:
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.7.4
+
+      - name: Verify SDK version pins are in sync
+        run: deno run --allow-read scripts/check-sdk-pin-sync.ts
 
       - name: Verify vendored skill matches upstream pinned tag
         run: deno run -A scripts/sync-sdk-skill.ts --check

--- a/apps/studio-installer/src-tauri/src/commands/prewarm_agent_sdk.rs
+++ b/apps/studio-installer/src-tauri/src/commands/prewarm_agent_sdk.rs
@@ -148,6 +148,12 @@ pub async fn prewarm_agent_sdk(
         Ok(Err(e)) => return Err(format!("uv wait: {e}")),
         Err(_) => {
             let _ = child.kill().await;
+            // Abort the readers so they don't emit one final
+            // `prewarm:progress` event after we've already returned ✗.
+            // Cosmetic — the row is already failed by the time any late
+            // event fires — but tightens the mental model.
+            stdout_task.abort();
+            stderr_task.abort();
             return Err(format!(
                 "uv pre-warm timed out after {}s",
                 PREWARM_TIMEOUT.as_secs()

--- a/apps/studio-installer/src-tauri/src/commands/prewarm_agent_sdk.rs
+++ b/apps/studio-installer/src-tauri/src/commands/prewarm_agent_sdk.rs
@@ -26,19 +26,38 @@
 //
 // Pinned-version source-of-truth:
 //   tools/friday-launcher/paths.go bundledAgentSDKVersion. The
-//   constant below must match. We keep them as separate constants
-//   rather than reading from a shared file because the installer
-//   ships independently of the launcher binary; mismatched versions
-//   would just mean the launcher and installer pre-warm slightly
-//   different wheels (no functional break, just one extra cold start
-//   on first launcher-driven spawn).
+//   constant below must match this and Dockerfile's
+//   ENV FRIDAY_AGENT_SDK_VERSION. Enforced pre-merge by
+//   scripts/check-sdk-pin-sync.ts (CI + lint-staged on the three pin
+//   files). The runtime is still drift-tolerant — launcher re-warms
+//   on first spawn if the installer pre-warmed a different version —
+//   but pre-merge enforcement keeps every fresh-install user from
+//   paying that 5–30s cold-start cost.
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::Stdio;
+use std::time::Duration;
+use tauri::{AppHandle, Emitter};
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tokio::time::timeout;
 
-/// Pinned PyPI version. MUST match
-/// tools/friday-launcher/paths.go::bundledAgentSDKVersion.
+/// Pinned PyPI version. MUST match all of:
+///   - tools/friday-launcher/paths.go::bundledAgentSDKVersion
+///   - Dockerfile::ENV FRIDAY_AGENT_SDK_VERSION
+///
+/// Enforced by scripts/check-sdk-pin-sync.ts in CI and via lint-staged
+/// in the husky pre-commit hook for the three pin files.
 const BUNDLED_AGENT_SDK_VERSION: &str = "0.1.4";
+
+/// Wall-clock cap on the uv pre-warm. uv's network ops (cpython
+/// download + PyPI fetch) finish in 5–30s on a healthy connection.
+/// 90s gives slow-but-functional networks a chance while bounding the
+/// failure mode where PyPI is unreachable (corporate proxy / captive
+/// portal / DNS hang). On timeout we kill the child and surface ✗ so
+/// the install proceeds; the launcher will re-warm at first agent
+/// spawn (also bounded by uv's own network timeouts).
+const PREWARM_TIMEOUT: Duration = Duration::from_secs(90);
 
 #[derive(serde::Serialize)]
 pub struct PrewarmResult {
@@ -56,16 +75,12 @@ pub struct PrewarmResult {
 }
 
 #[tauri::command]
-pub async fn prewarm_agent_sdk(install_dir: String) -> Result<PrewarmResult, String> {
+pub async fn prewarm_agent_sdk(
+    app: AppHandle,
+    install_dir: String,
+) -> Result<PrewarmResult, String> {
     let install_path = PathBuf::from(&install_dir);
-    let uv_path = locate_uv(&install_path);
-
-    let Some(uv) = uv_path else {
-        // No bundled uv. We don't fail the install — the install
-        // archive layout could legitimately omit uv on some platforms
-        // we add later, and the launcher's spawn-resolution falls
-        // through to bare python3. Surface as "not warmed" and let
-        // the JS side decide whether to flag it.
+    let Some(uv) = locate_uv(&install_path) else {
         return Ok(PrewarmResult {
             uv_path: String::new(),
             sdk_version: BUNDLED_AGENT_SDK_VERSION.to_string(),
@@ -73,10 +88,6 @@ pub async fn prewarm_agent_sdk(install_dir: String) -> Result<PrewarmResult, Str
         });
     };
 
-    // Resolve <friday-home>/uv/{python,cache} so uv writes there
-    // instead of XDG defaults. Mirrors the launcher's fridayEnv()
-    // emission of UV_PYTHON_INSTALL_DIR + UV_CACHE_DIR — keep these
-    // aligned or the runtime cache misses the warmed wheels.
     let friday_home = friday_home_dir()?;
     let uv_python_dir = friday_home.join("uv").join("python");
     let uv_cache_dir = friday_home.join("uv").join("cache");
@@ -86,7 +97,7 @@ pub async fn prewarm_agent_sdk(install_dir: String) -> Result<PrewarmResult, Str
 
     let with_arg = format!("friday-agent-sdk=={BUNDLED_AGENT_SDK_VERSION}");
 
-    let output = Command::new(&uv)
+    let mut child = Command::new(&uv)
         .args([
             "run",
             "--python",
@@ -99,15 +110,56 @@ pub async fn prewarm_agent_sdk(install_dir: String) -> Result<PrewarmResult, Str
         ])
         .env("UV_PYTHON_INSTALL_DIR", &uv_python_dir)
         .env("UV_CACHE_DIR", &uv_cache_dir)
-        .output()
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .kill_on_drop(true)
+        .spawn()
         .map_err(|e| format!("spawn uv: {e}"))?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!(
-            "uv pre-warm failed (status {}): {stderr}",
-            output.status
-        ));
+    // Drain both pipes concurrently so 30s of uv work shows as 30s of
+    // visible activity in the UI sub-line. uv writes most progress to
+    // stderr ("Resolved 14 packages in 234ms", "Installed friday-agent-
+    // sdk==0.1.4"); we drain stdout too in case future uv versions
+    // change that. Tasks finish naturally when pipes close on child exit.
+    let stdout = child.stdout.take().expect("piped stdout");
+    let stderr = child.stderr.take().expect("piped stderr");
+
+    let app_out = app.clone();
+    let stdout_task = tokio::spawn(async move {
+        let mut lines = BufReader::new(stdout).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            let _ = app_out.emit("prewarm:progress", line);
+        }
+    });
+    let app_err = app.clone();
+    let stderr_task = tokio::spawn(async move {
+        let mut lines = BufReader::new(stderr).lines();
+        while let Ok(Some(line)) = lines.next_line().await {
+            let _ = app_err.emit("prewarm:progress", line);
+        }
+    });
+
+    // Wait with timeout. On timeout, kill the child (cross-platform via
+    // tokio::process::Child::kill — sends SIGKILL on unix, TerminateProcess
+    // on Windows). kill_on_drop(true) above is a belt-and-suspenders for
+    // panic / cancel paths.
+    let status = match timeout(PREWARM_TIMEOUT, child.wait()).await {
+        Ok(Ok(s)) => s,
+        Ok(Err(e)) => return Err(format!("uv wait: {e}")),
+        Err(_) => {
+            let _ = child.kill().await;
+            return Err(format!(
+                "uv pre-warm timed out after {}s",
+                PREWARM_TIMEOUT.as_secs()
+            ));
+        }
+    };
+
+    let _ = stdout_task.await;
+    let _ = stderr_task.await;
+
+    if !status.success() {
+        return Err(format!("uv pre-warm failed (status {status})"));
     }
 
     Ok(PrewarmResult {
@@ -134,11 +186,21 @@ fn locate_uv(install_dir: &Path) -> Option<PathBuf> {
     }
 }
 
-/// Resolve the daemon's home directory (canonical: ~/.friday/local).
-/// Uses the same logic as the launcher's friendlyHome() and the daemon's
-/// getFridayHome() — pinned here rather than shared because the installer
-/// is a separate Rust binary.
+/// Resolve the friday home directory exactly the way the launcher does.
+/// Mirrors tools/friday-launcher/paths.go::friendlyHome() —
+/// FRIDAY_LAUNCHER_HOME wins; otherwise ~/.friday/local. NO ~/.atlas
+/// fallback (that's a daemon-side concern, not a launcher one).
+///
+/// Note: the launcher *emits* FRIDAY_HOME=<resolved> to its child
+/// processes (project.go:62). We must NOT read FRIDAY_HOME here — that
+/// would only ever be set inside a launcher-spawned process, never in
+/// the installer's parent shell.
 fn friday_home_dir() -> Result<PathBuf, String> {
+    if let Ok(v) = std::env::var("FRIDAY_LAUNCHER_HOME") {
+        if !v.is_empty() {
+            return Ok(PathBuf::from(v));
+        }
+    }
     let home = dirs::home_dir().ok_or("could not resolve user home dir")?;
     Ok(home.join(".friday").join("local"))
 }
@@ -164,5 +226,23 @@ mod tests {
         let tmp = tempfile::tempdir().expect("create tmp");
         std::fs::create_dir_all(tmp.path().join("bin")).unwrap();
         assert_eq!(locate_uv(tmp.path()), None);
+    }
+
+    #[test]
+    fn friday_home_honors_launcher_env_override() {
+        let tmp = tempfile::tempdir().expect("create tmp");
+        let override_path = tmp.path().to_path_buf();
+
+        // Snapshot + restore the env var to avoid leaking state to other
+        // tests if cargo test runs them in parallel within the same process.
+        let prior = std::env::var("FRIDAY_LAUNCHER_HOME").ok();
+        std::env::set_var("FRIDAY_LAUNCHER_HOME", &override_path);
+
+        assert_eq!(friday_home_dir().unwrap(), override_path);
+
+        match prior {
+            Some(v) => std::env::set_var("FRIDAY_LAUNCHER_HOME", v),
+            None => std::env::remove_var("FRIDAY_LAUNCHER_HOME"),
+        }
     }
 }

--- a/apps/studio-installer/src/steps/Extract.svelte
+++ b/apps/studio-installer/src/steps/Extract.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 import { invoke } from "@tauri-apps/api/core";
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
 import { onMount } from "svelte";
 import { advanceStep, createAppBundleIfDarwin, installDir, runExtract } from "../lib/installer.ts";
 import { store } from "../lib/store.svelte.ts";
@@ -25,6 +26,7 @@ interface Tool {
 type Phase = "extracting" | "tools";
 
 let phase = $state<Phase>("extracting");
+let prewarmProgress = $state<string>("");
 let tools = $state<Tool[]>([
   { display: "Claude Code", command: "ensure_claude_code", status: "pending" },
   { display: "agent-browser", command: "ensure_agent_browser_chrome", status: "pending" },
@@ -65,6 +67,10 @@ function pipClass(status: ToolStatus): string {
 }
 
 onMount(async () => {
+  const unlisten: UnlistenFn = await listen<string>("prewarm:progress", (e) => {
+    prewarmProgress = e.payload;
+  });
+
   const src = store.downloadPath;
   // Single source of truth for the install path lives in Rust
   // (commands/platform.rs::install_dir → ~/.friday/local). Keep all
@@ -77,16 +83,14 @@ onMount(async () => {
     // the launcher and the user can re-launch after they Quit.
     // Non-fatal if it fails — see createAppBundleIfDarwin.
     await createAppBundleIfDarwin(dest, store.availableVersion);
-    // Flip to the per-tool checklist phase. Each tool runs sequentially
-    // so the row pips show one-at-a-time motion the user can map to
-    // network activity. Failures are non-fatal: agent-browser failing
-    // only degrades the web agent's `browse` tool — `search` and
-    // `fetch` (HTTP-based) keep working. Claude Code failing surfaces
-    // at first agent invocation rather than blocking install.
+    // Tools run in parallel. Each pip animates independently while its
+    // tool resolves. Failures are non-fatal — the row pip flips to ✗,
+    // the daemon surfaces a clear 'binary not found' at first agent
+    // run, and the user can re-run the installer to retry.
     phase = "tools";
-    for (let i = 0; i < tools.length; i++) {
-      await runTool(i);
-    }
+    // Run all tools concurrently. Each pip animates independently; allSettled
+    // never throws so the install always proceeds to advanceStep().
+    await Promise.allSettled(tools.map((_, i) => runTool(i)));
     // Persist the install marker so the wizard's mode detection on
     // the next run sees mode==="current" / "update" instead of
     // re-treating the install as "fresh". Without this, every run
@@ -99,8 +103,10 @@ onMount(async () => {
       console.warn("write_installed failed (non-fatal):", err);
     }
     advanceStep();
+    return unlisten;
   } catch {
     // store.error is already set by runExtract
+    return unlisten;
   }
 });
 </script>
@@ -129,6 +135,11 @@ onMount(async () => {
             </span>
             <span class="row-name">{tool.display}</span>
           </div>
+          {#if tool.command === "prewarm_agent_sdk" && tool.status === "pending" && prewarmProgress}
+            <div class="row-progress" aria-live="polite" aria-atomic="true">
+              {prewarmProgress}
+            </div>
+          {/if}
         {/each}
       </div>
     {:else}
@@ -256,6 +267,17 @@ onMount(async () => {
 
   .row-name {
     flex: 1;
+  }
+
+  .row-progress {
+    font-size: 11px;
+    color: var(--color-text-muted);
+    padding: 0 12px 0 42px; /* indent under the pip glyph */
+    max-width: 320px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-family: var(--font-mono, monospace);
   }
 
   .pip {

--- a/apps/studio-installer/src/steps/Extract.svelte
+++ b/apps/studio-installer/src/steps/Extract.svelte
@@ -57,8 +57,7 @@ async function runTool(idx: number): Promise<void> {
     // Tauri's invoke() rejects with the Result::Err string verbatim for
     // commands typed Result<T, String>. Fall back for non-string shapes
     // so the UI never renders "[object Object]".
-    const msg =
-      typeof err === "string" ? err : err instanceof Error ? err.message : String(err);
+    const msg = typeof err === "string" ? err : err instanceof Error ? err.message : String(err);
     console.warn(`${tool.command} failed (non-fatal):`, err);
     tools[idx].status = "failed";
     tools[idx].error = msg;

--- a/apps/studio-installer/src/steps/Extract.svelte
+++ b/apps/studio-installer/src/steps/Extract.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 import { invoke } from "@tauri-apps/api/core";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import { onMount } from "svelte";
+import { onDestroy, onMount } from "svelte";
 import { advanceStep, createAppBundleIfDarwin, installDir, runExtract } from "../lib/installer.ts";
 import { store } from "../lib/store.svelte.ts";
 
@@ -21,6 +21,11 @@ interface Tool {
    * none for argless commands. */
   args?: () => Promise<Record<string, unknown>>;
   status: ToolStatus;
+  /** Error string from the most recent failed run. Set in runTool's catch
+   * branch and surfaced under the row when status === "failed", so the user
+   * sees *why* a tool flipped to ✗ — load-bearing for prewarm_agent_sdk's
+   * 90s timeout, which is otherwise silent except for a console.warn. */
+  error?: string;
 }
 
 type Phase = "extracting" | "tools";
@@ -49,8 +54,14 @@ async function runTool(idx: number): Promise<void> {
     await invoke(tool.command, args);
     tools[idx].status = "success";
   } catch (err) {
+    // Tauri's invoke() rejects with the Result::Err string verbatim for
+    // commands typed Result<T, String>. Fall back for non-string shapes
+    // so the UI never renders "[object Object]".
+    const msg =
+      typeof err === "string" ? err : err instanceof Error ? err.message : String(err);
     console.warn(`${tool.command} failed (non-fatal):`, err);
     tools[idx].status = "failed";
+    tools[idx].error = msg;
   }
 }
 
@@ -66,8 +77,14 @@ function pipClass(status: ToolStatus): string {
   return "pip pip-spinner";
 }
 
+// Hoisted so onDestroy can reach it. An async onMount returns
+// Promise<UnlistenFn>, which Svelte 5 silently ignores for cleanup —
+// returning unlisten from inside the async block would leak the listener.
+// onDestroy gets a synchronous closure and runs reliably on unmount.
+let unlisten: UnlistenFn | undefined;
+
 onMount(async () => {
-  const unlisten: UnlistenFn = await listen<string>("prewarm:progress", (e) => {
+  unlisten = await listen<string>("prewarm:progress", (e) => {
     prewarmProgress = e.payload;
   });
 
@@ -103,11 +120,13 @@ onMount(async () => {
       console.warn("write_installed failed (non-fatal):", err);
     }
     advanceStep();
-    return unlisten;
   } catch {
     // store.error is already set by runExtract
-    return unlisten;
   }
+});
+
+onDestroy(() => {
+  unlisten?.();
 });
 </script>
 
@@ -138,6 +157,11 @@ onMount(async () => {
           {#if tool.command === "prewarm_agent_sdk" && tool.status === "pending" && prewarmProgress}
             <div class="row-progress" aria-live="polite" aria-atomic="true">
               {prewarmProgress}
+            </div>
+          {/if}
+          {#if tool.status === "failed" && tool.error}
+            <div class="row-error" role="alert">
+              {tool.error}
             </div>
           {/if}
         {/each}
@@ -277,6 +301,19 @@ onMount(async () => {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    font-family: var(--font-mono, monospace);
+  }
+
+  /* Error sub-line shown when a tool flips to ✗. role="alert" gives a
+     stronger announcement than the progress sub-line's polite live region
+     so VoiceOver / NVDA / Narrator surface the failure reason promptly. */
+  .row-error {
+    font-size: 11px;
+    color: var(--color-error);
+    padding: 0 12px 0 42px;
+    max-width: 320px;
+    word-break: break-word;
+    line-height: 1.4;
     font-family: var(--font-mono, monospace);
   }
 

--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -83,4 +83,9 @@ export default {
     const args = [...normal.map((f) => `"${f}"`), ...parenDirs.map((d) => `"${d}"`)];
     return [`deno lint --fix ${args.join(" ")}`];
   },
+  // Catches the case where someone bumps one of the three SDK version
+  // pins without bumping the others. Cheaper than catching it in CI —
+  // fires the moment the user `git commit`s.
+  "{tools/friday-launcher/paths.go,Dockerfile,apps/studio-installer/src-tauri/src/commands/prewarm_agent_sdk.rs}":
+    () => "deno run --allow-read scripts/check-sdk-pin-sync.ts",
 };

--- a/scripts/check-sdk-pin-sync.ts
+++ b/scripts/check-sdk-pin-sync.ts
@@ -36,9 +36,11 @@ const SITES = [
 const versions = await Promise.all(
   SITES.map(async (s) => {
     const content = await Deno.readTextFile(s.path);
-    const m = content.match(s.pattern);
-    if (!m) throw new Error(`could not find pin in ${s.name} (${s.path})`);
-    return { site: s.name, version: m[1]! };
+    const version = content.match(s.pattern)?.[1];
+    if (!version) {
+      throw new Error(`could not find pin in ${s.name} (${s.path})`);
+    }
+    return { site: s.name, version };
   }),
 );
 

--- a/scripts/check-sdk-pin-sync.ts
+++ b/scripts/check-sdk-pin-sync.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env -S deno run --allow-read
+//
+// check-sdk-pin-sync — fails if the friday-agent-sdk version pin drifts
+// across the three sites that must agree:
+//
+//   - tools/friday-launcher/paths.go (bundledAgentSDKVersion)
+//   - Dockerfile (ENV FRIDAY_AGENT_SDK_VERSION=)
+//   - apps/studio-installer/src-tauri/src/commands/prewarm_agent_sdk.rs
+//     (BUNDLED_AGENT_SDK_VERSION)
+//
+// Run in CI on every PR (.github/workflows/sdk-skill-drift.yml) and
+// in lint-staged when any of the three pin files is staged.
+
+import { dirname, fromFileUrl, join, resolve } from "jsr:@std/path@^1";
+
+const REPO_ROOT = resolve(dirname(fromFileUrl(import.meta.url)), "..");
+
+const SITES = [
+  {
+    name: "launcher (paths.go)",
+    path: join(REPO_ROOT, "tools/friday-launcher/paths.go"),
+    pattern: /^const bundledAgentSDKVersion\s*=\s*"([^"]+)"/m,
+  },
+  {
+    name: "Dockerfile",
+    path: join(REPO_ROOT, "Dockerfile"),
+    pattern: /^ENV FRIDAY_AGENT_SDK_VERSION=([^\s\\]+)/m,
+  },
+  {
+    name: "installer (prewarm_agent_sdk.rs)",
+    path: join(REPO_ROOT, "apps/studio-installer/src-tauri/src/commands/prewarm_agent_sdk.rs"),
+    pattern: /const BUNDLED_AGENT_SDK_VERSION:\s*&str\s*=\s*"([^"]+)"/,
+  },
+] as const;
+
+const versions = await Promise.all(
+  SITES.map(async (s) => {
+    const content = await Deno.readTextFile(s.path);
+    const m = content.match(s.pattern);
+    if (!m) throw new Error(`could not find pin in ${s.name} (${s.path})`);
+    return { site: s.name, version: m[1]! };
+  }),
+);
+
+const unique = new Set(versions.map((v) => v.version));
+if (unique.size === 1) {
+  console.log(`✓ All sites pinned to ${[...unique][0]}`);
+  Deno.exit(0);
+}
+
+console.error("✗ SDK version pin drift detected:");
+for (const v of versions) console.error(`  ${v.site}: ${v.version}`);
+Deno.exit(1);


### PR DESCRIPTION
## Summary
- **Rust pre-warm reliability** (`prewarm_agent_sdk.rs`): tokio-based rewrite — 90s timeout (was: blocks indefinitely on PyPI/DNS hangs), streams uv progress lines via `prewarm:progress` Tauri events (was: silent for 5–30s), reads `FRIDAY_LAUNCHER_HOME` to match the launcher's `friendlyHome()` (was: hardcoded `~/.friday/local`), cross-platform `child.kill()` on timeout via `tokio::process::Child` (was: missing).
- **Installer UX** (`Extract.svelte`): three tool rows now run in parallel via `Promise.allSettled` (was: sequential, summing wall time), the Python runtime row shows a streaming sub-line of uv progress with `aria-live="polite"` so VoiceOver/NVDA announces during the otherwise-silent cold install.
- **SDK pin CI guard**: new `scripts/check-sdk-pin-sync.ts` asserts the pinned `friday-agent-sdk` version is identical across all three sites (`paths.go`, `Dockerfile`, `prewarm_agent_sdk.rs`); folded into the existing `sdk-skill-drift.yml` workflow (filename preserved to keep branch protection rules valid; `name:` field updated and path filters expanded) and into `lint-staged.config.js` so a drifted pin fails at `git commit` time.

The first commit on this branch (`docs(plans)`) carries the v1–v5 plan + four `/improving-plans` review reports for context.

## Test plan
- [ ] Path A — installer pre-warm: cold install lands ✓ in 5–30s with all three rows pulsing simultaneously and uv progress streaming under "Python runtime"; warm reinstall lands ✓ in <300ms
- [ ] Path A negative — uv missing → row ✗, install proceeds
- [ ] Path A negative — bad SDK pin (e.g. `99.99.99`) → row ✗, PyPI 404 visible in sub-line, install proceeds
- [ ] Path A negative — timeout (block PyPI via `/etc/hosts`) → row ✗ at ~90s, no orphan uv process, install proceeds
- [ ] Path A — `FRIDAY_LAUNCHER_HOME=/tmp/x` override (run via `pnpm tauri dev`, NOT Finder — macOS .apps don't inherit shell env) → caches land at the override path
- [ ] Path B — `bash scripts/setup-dev-env.sh` cold + warm idempotent
- [ ] Path C — register a Python user-agent against a running daemon, verify spawn uses managed Python 3.12 with `sdk_version_env=0.1.4` and 3 sequential runs each in 150–250ms
- [ ] Path D — `deno run --allow-read scripts/check-sdk-pin-sync.ts` ✓ on clean tree; bump one pin to a different value and verify exit 1 + clear output; verify `git commit` blocks via lint-staged hook
- [ ] Path E — `deno run -A scripts/sync-sdk-skill.ts --check` ✓
- [ ] CI — verify the renamed `sdk-skill-drift.yml` workflow runs both pin-sync and skill-drift steps on this PR

**Windows QA deferred** — see top-of-doc note in `plans/2026-05-01-installer-prewarm-handoff.v5.md`. TODO before next major install-flow change: write a parallel Windows runbook (translate timeout / negative tests to PowerShell + `C:\Windows\System32\drivers\etc\hosts`, verify `child.kill()` actually terminates the uv process tree on Windows).

## Pre-existing baseline issues (not introduced by this PR)
- 7 clippy errors in unrelated `studio-installer` files (`installed_marker.rs::manual_is_multiple_of`, `manual_find`, `doc-overindented-list-items`)
- `cargo fmt --check` drift in `tests/write_env_creates_friday_yml.rs`

These were present on `main` before this work; called out for awareness but out of scope for this PR.