### PR TITLE
fix(studio): unstick session detail page on user-agent runs

### DIFF
--- a/packages/core/src/session/session-events.test.ts
+++ b/packages/core/src/session/session-events.test.ts
@@ -382,8 +382,9 @@ describe("EphemeralChunkSchema", () => {
     expect(result.chunk).toEqual(chunk);
   });
 
-  test("rejects missing stepNumber", () => {
-    expect(() => EphemeralChunkSchema.parse({ chunk: { type: "text", text: "hi" } })).toThrow();
+  test("accepts missing stepNumber (user-agent SDK publishes don't include it)", () => {
+    const result = EphemeralChunkSchema.parse({ chunk: { type: "text", text: "hi" } });
+    expect(result.stepNumber).toBeUndefined();
   });
 
   test("rejects missing chunk", () => {

--- a/packages/core/src/session/session-events.ts
+++ b/packages/core/src/session/session-events.ts
@@ -162,7 +162,11 @@ export type SessionStreamEvent = z.infer<typeof SessionStreamEventSchema>;
 // ---------------------------------------------------------------------------
 
 export const EphemeralChunkSchema = z.object({
-  stepNumber: z.number(),
+  // Optional: bundled-agent chunks carry the FSM step they belong to so the
+  // reducer can attach UI deltas to the right block. User-agent SDKs publish
+  // without it (the agent subprocess doesn't know its FSM step) — the reducer
+  // falls back to the currently-running block.
+  stepNumber: z.number().optional(),
   chunk: z.custom<AtlasUIMessageChunk>((val) => val != null && typeof val === "object"),
 });
 export type EphemeralChunk = z.infer<typeof EphemeralChunkSchema>;

--- a/packages/core/src/session/session-reducer.test.ts
+++ b/packages/core/src/session/session-reducer.test.ts
@@ -676,6 +676,23 @@ describe("EphemeralChunk", () => {
     expect(view.agentBlocks).toHaveLength(0);
   });
 
+  test("attaches to running block when stepNumber is omitted", () => {
+    let view = reduceSessionEvent(initialSessionView(), sessionStart());
+    view = reduceSessionEvent(view, stepStart({ stepNumber: 1, agentName: "user-agent" }));
+
+    // User-agent SDK publishes don't include stepNumber — the agent subprocess
+    // doesn't know its FSM step. The reducer should fall back to the running
+    // block instead of dropping the chunk.
+    const noStep: EphemeralChunk = {
+      chunk: { type: "data-tool-progress", data: { toolName: "agent", content: "working..." } },
+    } as EphemeralChunk;
+    view = reduceSessionEvent(view, noStep);
+
+    const block = view.agentBlocks[0];
+    expect.assert(block !== undefined);
+    expect(block.ephemeral).toHaveLength(1);
+  });
+
   test("skips pending blocks (stepNumber undefined !== number)", () => {
     let view = reduceSessionEvent(
       initialSessionView(),

--- a/packages/core/src/session/session-reducer.ts
+++ b/packages/core/src/session/session-reducer.ts
@@ -233,7 +233,13 @@ function reduceStepSkipped(
 }
 
 function reduceEphemeral(view: SessionView, event: EphemeralChunk): SessionView {
-  const idx = view.agentBlocks.findIndex((b) => b.stepNumber === event.stepNumber);
+  // Match on stepNumber when the publisher provided it; otherwise (user-agent
+  // SDK publishes have no stepNumber — the agent subprocess doesn't know its
+  // FSM step) attach to the currently-running block.
+  const idx =
+    event.stepNumber != null
+      ? view.agentBlocks.findIndex((b) => b.stepNumber === event.stepNumber)
+      : view.agentBlocks.findIndex((b) => b.status === "running");
   if (idx === -1) {
     // No matching block — silently ignore
     return view;

--- a/tools/agent-playground/src/lib/utils/session-event-stream.ts
+++ b/tools/agent-playground/src/lib/utils/session-event-stream.ts
@@ -99,10 +99,15 @@ async function* parseTypedSSEStream(
   for await (const message of parseSSEStream(body)) {
     const json: unknown = JSON.parse(message.data);
 
+    // safeParse: unknown event shapes (e.g. an old user-agent SDK still
+    // publishing `data-tool-progress` on the durable subject) must not break
+    // the lifecycle stream. Skip what we can't recognize and keep going.
     if (message.event === "ephemeral") {
-      yield EphemeralChunkSchema.parse(json);
+      const result = EphemeralChunkSchema.safeParse(json);
+      if (result.success) yield result.data;
     } else {
-      yield SessionStreamEventSchema.parse(json);
+      const result = SessionStreamEventSchema.safeParse(json);
+      if (result.success) yield result.data;
     }
   }
 }


### PR DESCRIPTION
## Summary

The session detail page renders a completed user-agent run as **\"Running…\"** indefinitely. Repro: trigger any user-agent job (e.g. `tell-me-a-joke`), open the session URL within a few seconds — the badge never transitions to Complete even though the job finished.

### Root cause

User-agent SDKs (`ctx.stream.progress(...)` in Python; `stream.emit(...)` in TS) publish events like `{type: \"data-tool-progress\", data: {...}}` on the **durable** `sessions.{id}.events` subject. JetStream persists them; the SSE handler replays them; the client's `parseTypedSSEStream` does:

\`\`\`ts
yield SessionStreamEventSchema.parse(json);  // strict, throws on unknown
\`\`\`

`SessionStreamEventSchema` is a `z.discriminatedUnion(\"type\", [...])` over the 7 lifecycle event types. `data-tool-progress` isn't one — Zod throws partway through replay (after `step:start`, before `step:complete`). The catch block retries 3× against the same JetStream backlog and trips the same error each time. `query.isFetching` never settles, so `+page.svelte:93` keeps rendering \"This run is in progress\".

NATS-bus side-effect: each retry creates a fresh ephemeral JetStream consumer (every ~2s) on `sessions.{id}.events` with `deliver_policy: all`. In a 2-min observation that produced 76 consumer create-and-delete cycles and 38 replays of the same `session:start` for one completed session.

### Fix

**Client tolerates unknown durable event shapes** — `safeParse` and skip on miss. A future SDK version emitting a new event type can no longer brick the page; the lifecycle stream still settles.

**Schema/reducer prep for a future SDK migration off the durable subject** — `EphemeralChunkSchema.stepNumber` is now optional (the user-agent subprocess doesn't know its FSM step). The reducer attaches chunks to the currently-running block when stepNumber is omitted, which is correct for single-step jobs and good enough for multi-step (only one block runs at a time).

### Out of scope (explicit)

The actual SDK publish migration (move `data-tool-progress` from `.events` to `.ephemeral`) belongs in its own PR. I tried it here and backed out:

- Routing the new ephemeral chunks back to the parent stream emitter via the existing forward path (`process-agent-executor.ts → options.streamEmitter.emit → onStreamEvent → emitEphemeral`) creates a feedback loop because runtime.ts:1285 re-publishes anything received on that callback to `.ephemeral`.
- Skipping that forward step regresses chat-UI progress display — user-agent progress reaches the chat output stream today via `streamSubEvents` → `streamEmitter.emit`.

Both regressions need a more careful refactor than this hotfix should carry. Tracking issue can come later.

## Test plan

- [x] `deno task test packages/sdk-ts/ packages/core/src/session/` — 379 tests pass
- [x] `deno check` clean on all 5 modified files
- [x] Manual: trigger `tell-me-a-joke` (user agent) and open session page immediately → \"Joke Teller Succeeded in 3 seconds / Complete\"
- [x] Manual: trigger `random-animal-fact` (LLM agent) → \"Succeeded in 4 seconds / Complete\" — no regression on the path that already worked
- [x] Manual: open an old completed user-agent session (registry-evicted, JSON fallback) → \"Complete\" — no regression on the JSON fallback path
- [x] NATS bus check post-fix on a fresh session: 1 consumer create / 1 drain (6 events) / 1 close. Down from 76 cycles in the bug