### PR TITLE
feat(installer): strip Applications symlink from macOS DMG

### DIFF
--- a/.github/workflows/studio-installer-build.yml
+++ b/.github/workflows/studio-installer-build.yml
@@ -161,6 +161,17 @@ jobs:
             echo "dmg_name=$(basename "$renamed_dmg")"
           } >> "$GITHUB_OUTPUT"
 
+      - name: Strip Applications symlink from .dmg (macOS)
+        if: matrix.bundle_ext == 'dmg'
+        env:
+          DMG_PATH: ${{ steps.mac-artifact.outputs.dmg_path }}
+        # The Friday Studio Installer DMG is meant to be double-clicked
+        # (the wizard does the install), not drag-to-Applications. Tauri's
+        # bundler unconditionally adds an /Applications symlink and exposes
+        # no flag to skip it — strip it post-bundle. Must run BEFORE
+        # notarization so notarytool inspects the final DMG bytes.
+        run: bash apps/studio-installer/scripts/strip-dmg-applications-symlink.sh "$DMG_PATH"
+
       - name: Locate NSIS installer (Windows)
         if: matrix.bundle_ext == 'exe'
         id: win-artifact

--- a/apps/studio-installer/scripts/strip-dmg-applications-symlink.sh
+++ b/apps/studio-installer/scripts/strip-dmg-applications-symlink.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+#
+# strip-dmg-applications-symlink — removes the /Applications shortcut
+# from a Tauri-built macOS DMG.
+#
+# Why:
+#   Tauri's bundler unconditionally adds an /Applications symlink to
+#   every DMG it produces, intended for normal "drag the .app to your
+#   Applications folder" UX. The Friday Studio Installer DMG is meant
+#   to be DOUBLE-CLICKED to launch the wizard, not dragged anywhere —
+#   the symlink is misleading there. As of Tauri 2.10.x there's no
+#   bundle config flag to skip it (only position/background tweaks),
+#   so we strip it post-bundle.
+#
+# How:
+#   Tauri produces a UDZO (read-only compressed) DMG, so we can't edit
+#   in place. We convert UDZO → UDRW, mount, rm the symlink, unmount,
+#   convert back to UDZO over the original. Net effect: same DMG name,
+#   same path, no Applications shortcut in the mounted view.
+#
+# Order in the build pipeline:
+#   This MUST run AFTER `tauri build` (DMG exists) and BEFORE
+#   notarization. The DMG itself isn't signed by APPLE_SIGNING_IDENTITY
+#   — only the .app inside is — so re-compressing the DMG doesn't
+#   invalidate any signature. Notarization will inspect the DMG, find
+#   the still-signed .app inside, and notarize the new compressed DMG
+#   as a unit.
+#
+# Usage:
+#   strip-dmg-applications-symlink.sh <path-to-dmg>
+#
+# Exit codes:
+#   0  symlink stripped (or wasn't present — both are success)
+#   1  argument / preflight error
+#   2  hdiutil convert/attach/detach failure
+#
+# Idempotent: running on a DMG that already lacks the symlink is a no-op.
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <path-to-dmg>" >&2
+  exit 1
+fi
+
+DMG="$1"
+if [[ ! -f "$DMG" ]]; then
+  echo "DMG not found: $DMG" >&2
+  exit 1
+fi
+
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "This script only runs on macOS (requires hdiutil)." >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+RW="$WORK/rw.dmg"
+MOUNT="$WORK/mount"
+mkdir -p "$MOUNT"
+
+cleanup() {
+  # Best-effort detach; don't fail the script if the volume is already gone.
+  if mount | grep -F " on $MOUNT " >/dev/null 2>&1; then
+    hdiutil detach "$MOUNT" -quiet || hdiutil detach "$MOUNT" -force -quiet || true
+  fi
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+echo "→ Stripping Applications symlink from $(basename "$DMG")"
+
+echo "  1/4  convert UDZO → UDRW"
+hdiutil convert "$DMG" -format UDRW -o "$RW" -quiet
+
+echo "  2/4  mount"
+hdiutil attach "$RW" -mountpoint "$MOUNT" -nobrowse -noverify -noautoopen -quiet
+
+if [[ -L "$MOUNT/Applications" ]]; then
+  echo "  3/4  rm Applications symlink"
+  rm "$MOUNT/Applications"
+else
+  # Idempotent path: someone re-ran the script, or Tauri changed behavior.
+  echo "  3/4  no Applications symlink present (skipping)"
+fi
+
+echo "  4/4  detach and re-compress UDRW → UDZO"
+hdiutil detach "$MOUNT" -quiet
+# zlib-level=9 matches Tauri's default compression so the resulting DMG
+# size is comparable to (or slightly smaller than) the original.
+hdiutil convert "$RW" -format UDZO -imagekey zlib-level=9 -o "$DMG.tmp" -quiet
+mv "$DMG.tmp" "$DMG"
+
+echo "✓ Done: $DMG"

--- a/apps/studio-installer/scripts/strip-dmg-applications-symlink.sh
+++ b/apps/studio-installer/scripts/strip-dmg-applications-symlink.sh
@@ -88,7 +88,11 @@ echo "  4/4  detach and re-compress UDRW → UDZO"
 hdiutil detach "$MOUNT" -quiet
 # zlib-level=9 matches Tauri's default compression so the resulting DMG
 # size is comparable to (or slightly smaller than) the original.
-hdiutil convert "$RW" -format UDZO -imagekey zlib-level=9 -o "$DMG.tmp" -quiet
-mv "$DMG.tmp" "$DMG"
+#
+# Write to $WORK/stripped.dmg (inside our temp dir) rather than alongside
+# the input — hdiutil unconditionally appends ".dmg" to -o when the path
+# doesn't already end in .dmg, which would break a "$DMG.tmp" → mv pattern.
+hdiutil convert "$RW" -format UDZO -imagekey zlib-level=9 -o "$WORK/stripped.dmg" -quiet
+mv "$WORK/stripped.dmg" "$DMG"
 
 echo "✓ Done: $DMG"


### PR DESCRIPTION
## Summary

Removes the `/Applications` symlink Tauri's bundler adds to every macOS DMG. The Friday Studio Installer DMG is meant to be **double-clicked to launch the wizard**, not drag-to-Applications — the shortcut implies a UX we don't want, and Tauri 2.10.x exposes no bundle config to skip it.

The fix is a small post-bundle bash script: `apps/studio-installer/scripts/strip-dmg-applications-symlink.sh`. It converts UDZO → UDRW, mounts, removes the symlink, re-compresses back to UDZO over the original. Idempotent, ~100 lines counting comments.

## Approach picked vs alternatives

| Approach | Why not |
|---|---|
| **Don't include it in the bundler** | Tauri's bundler hardcodes the symlink; no config flag to disable as of 2.10.x. Would require forking `tauri-bundler`. |
| `chflags hidden` | Leaves an invisible-but-layout-affecting element in the DMG. Hacky. |
| Dot-prefix (`.Applications`) | Same hack with extra friction. |
| **Remove entirely** ← this PR | Cleanest for an installer DMG that's meant to be run, not dragged. |

## Pipeline placement

Slots into `.github/workflows/studio-installer-build.yml` between the existing "Locate .app + .dmg bundles" rename step and "Notarize and staple .dmg":

```
Build Tauri app → Locate (rename) → Strip Applications symlink → Notarize → Staple → Upload
```

Must run **before** notarization so notarytool inspects the final DMG bytes. The DMG itself isn't signed by `APPLE_SIGNING_IDENTITY` (only the `.app` inside is — and we don't touch the `.app`), so re-compressing doesn't invalidate any signature.

## Test plan

- [ ] Run `studio-installer-build.yml` via workflow_dispatch on this branch (mac-arm + mac-intel matrix); verify the produced DMG has no `/Applications` symlink: `hdiutil attach <dmg> && ls -la /Volumes/Friday\ Studio\ Installer*` should show only the `.app`.
- [ ] Mount the produced DMG locally and visually confirm the Finder window shows only the `Friday Studio Installer` icon (no Applications shortcut).
- [ ] Verify notarization still passes — `xcrun stapler validate <dmg>` should report `Validated`.
- [ ] Smoke-test the installer end-to-end on a fresh macOS user: download → mount → double-click `.app` → wizard runs → install completes.
- [ ] Idempotence: re-run the strip script on a stripped DMG; expect "no Applications symlink present (skipping)" + exit 0.
- [ ] Local dry-run: `bash apps/studio-installer/scripts/strip-dmg-applications-symlink.sh path/to/test.dmg` against any Tauri-built DMG.