### PR TITLE
feat(agents): expose sourceLocation on agent registry API

### DIFF
--- a/apps/atlasd/routes/agents/get.ts
+++ b/apps/atlasd/routes/agents/get.ts
@@ -75,6 +75,7 @@ getAgent.get(
           constraints: summary.constraints,
           inputSchema: summary.inputSchema,
           outputSchema: summary.outputSchema,
+          sourceLocation: summary.sourceLocation,
         });
       }
 

--- a/apps/atlasd/routes/agents/schemas.ts
+++ b/apps/atlasd/routes/agents/schemas.ts
@@ -10,6 +10,7 @@ export const agentMetadataSchema = z.object({
   category: z.enum(["system", "bundled", "sdk", "yaml"]),
   expertise: z.object({ examples: z.array(z.string()) }).optional(),
   metadata: z.record(z.string(), z.unknown()).optional(),
+  sourceLocation: z.string().optional(),
 });
 
 export const agentListResponseSchema = z.object({

--- a/packages/agent-sdk/src/types.ts
+++ b/packages/agent-sdk/src/types.ts
@@ -186,6 +186,10 @@ export const AgentMetadataSchema = z.object({
     .any()
     .optional()
     .meta({ description: "Optional output schema for structured output" }),
+  sourceLocation: z
+    .string()
+    .optional()
+    .meta({ description: "Absolute path to agent source directory (user agents only)" }),
 });
 
 export type AgentMetadata = z.infer<typeof AgentMetadataSchema>;
@@ -428,6 +432,7 @@ export interface AgentRegistry {
         expertise?: { examples: string[] };
         inputSchema?: Record<string, unknown>;
         outputSchema?: Record<string, unknown>;
+        sourceLocation?: string;
       }
     | undefined;
 

--- a/packages/core/src/agent-loader/adapters/types.ts
+++ b/packages/core/src/agent-loader/adapters/types.ts
@@ -79,4 +79,6 @@ export interface AgentSummary {
   inputSchema?: Record<string, unknown>;
   /** JSON Schema describing the result-output contract. */
   outputSchema?: Record<string, unknown>;
+  /** Absolute path to the agent's source directory on disk (user agents only). */
+  sourceLocation?: string;
 }

--- a/packages/core/src/agent-loader/adapters/user-adapter.ts
+++ b/packages/core/src/agent-loader/adapters/user-adapter.ts
@@ -105,6 +105,7 @@ export class UserAdapter implements AgentAdapter {
           environment: metadata.environment,
           inputSchema: metadata.inputSchema,
           outputSchema: metadata.outputSchema,
+          sourceLocation: entry.path,
         });
       } catch (error) {
         this.logger.warn("Skipping agent with unreadable metadata", { path: entry.path, error });

--- a/packages/core/src/agent-loader/registry.ts
+++ b/packages/core/src/agent-loader/registry.ts
@@ -179,6 +179,7 @@ export class AgentRegistry {
         constraints: summary.constraints,
         inputSchema: summary.inputSchema,
         outputSchema: summary.outputSchema,
+        sourceLocation: summary.sourceLocation,
       });
     }
 

--- a/packages/system/agents/workspace-chat/prompt.txt
+++ b/packages/system/agents/workspace-chat/prompt.txt
@@ -182,9 +182,14 @@ Exact sequence — no more, no less:
 
 No read-verify-read. No incremental edits. No bash loop to verify intermediate state. One read, one write, one verify — then report.
 
-Agent registration goes through `upsert_agent` only. Never `curl /api/agents/register` from `run_code`, never multipart uploads, never bash workarounds. If `upsert_agent` returns an error, fix the input shape and retry — do not shell out. The workspace-design flow is the only path that produces a valid registered agent; raw-curl registration skips the validation that makes the workspace useful.
+Two steps for shipping a user agent — don't conflate:
 
-Diagnosis rule: once you can name the specific fix, stop investigating and execute it. Don't keep diagnosing because something else might also be broken. If the workspace YAML validates clean but the job fails at runtime, the broken thing is likely agent code — tell the user, then load `@friday/writing-friday-python-agents` and fix via `fs_write_file` (NOT `write_file` — agent source lives at `~/.friday/local/agents/{id}@{version}/agent.py`, outside the scratch sandbox) + re-register via `POST /api/agents/register` with the JSON `{entrypoint: "<abs path>"}`. After registering a new version, exercise it via `POST /api/agents/:id/run?workspaceId=…` with at least one fixture before declaring it fixed — registered ≠ working.
+1. **Publish source code** → `POST /api/agents/register` with `{entrypoint: "<abs path>"}` via `run_code` bash. JSON entrypoint only — multipart is rejected (400), no CLI shortcut. This is the only path that copies `agent.py` into the registry. Response includes `agent.path` (install dir).
+2. **Wire into workspace** → `upsert_agent`. Edits `workspace.yml` agents list; does not touch source code. For `type: "user"`, the `agent` field is an id reference — must already be registered via step 1.
+
+New agent → both. Edit to existing source → step 1 only; the workspace re-resolves to the latest registered semver (no version pin in `workspace.yml`).
+
+Diagnosis rule: once you can name the specific fix, stop investigating and execute it. Workspace YAML validates clean but job fails at runtime → broken thing is likely agent code. Load `@friday/writing-friday-python-agents`, find the source, edit, re-register. **Find the source path via `GET /api/agents/:id` → `sourceLocation`** — never construct it from a constant; the registry's home dir is migrating between layouts. Edit with `fs_write_file` (not `write_file` — sandbox-scoped). After registering, run a fixture via `POST /api/agents/:id/run?workspaceId=…` before declaring fixed — registered ≠ working.
 </workspace_modification>
 
 <response_style>

--- a/packages/system/skills/writing-friday-python-agents/SKILL.md
+++ b/packages/system/skills/writing-friday-python-agents/SKILL.md
@@ -328,9 +328,14 @@ curl -X POST http://localhost:8080/api/agents/register \
 
 `entrypoint` must be an absolute path. The daemon spawns it with
 `FRIDAY_VALIDATE_ID`, collects metadata over NATS, copies the source directory
-to `~/.friday/local/agents/{id}@{version}/`, and reloads the registry. No
-compilation step — the agent process is spawned per invocation and
-communicates with the host via NATS request/reply.
+into the agents registry (under `{FRIDAY_HOME}/agents/{id}@{version}/` — the
+home dir is mid-migration from `~/.atlas` to `~/.friday/local`), and reloads
+the registry. No compilation step — the agent process is spawned per
+invocation and communicates with the host via NATS request/reply.
+
+The register response returns `agent.path` (the install dir). To look up the
+source path of an existing agent, query `GET /api/agents/:id` and read
+`sourceLocation` rather than constructing the path from a constant.
 
 The Friday daemon listens on `localhost:8080` by default (configurable via
 the `FRIDAY_PORT` env var or the `--port` flag if you started the daemon


### PR DESCRIPTION
## Summary

User agents have an on-disk source path that the registry already tracks (via `UserAdapter`), but the HTTP routes were stripping it on the way out. This surfaces it so chat agents — and any other API consumer — can find an existing agent's source without constructing paths from constants. That matters during the in-progress migration of the daemon home dir from `~/.atlas` to `~/.friday/local`.

**Daemon changes:**
- `AgentSummary` + `AgentRegistry` interface: optional `sourceLocation: string`
- `UserAdapter.listAgents()`: populates from `entry.path`
- `Registry.listAgents()`: passes through when building `AgentMetadata` from user summaries
- `GET /api/agents` and `GET /api/agents/:id` (atlasd): include the field for user agents; SDK/bundled/system agents return without it

**Prompt + skill changes:**
- `workspace-chat/prompt.txt`: rewrites the agent-registration block to (a) split "publish source code" (`POST /api/agents/register`) from "wire workspace" (`upsert_agent`), removing a self-contradiction that simultaneously forbade and prescribed the register endpoint, and (b) point diagnosis flow at `GET /api/agents/:id → sourceLocation` instead of hardcoded paths.
- `writing-friday-python-agents/SKILL.md`: same — read source path from registry, not from a constant.

## Test plan

- [x] Typecheck clean for all touched files (no new errors introduced)
- [x] Daemon restart + `GET /api/agents/inbox-action-agent` returns `sourceLocation: /Users/kenneth/.atlas/agents/inbox-action-agent@1.0.3`
- [x] `GET /api/agents` includes `sourceLocation` for all 9 user agents on the test machine; SDK/bundled agents (e.g. `web`) correctly omit it
- [x] Highest-semver resolution intact (multiple versions of `inbox-autopilot-agent` on disk → returns `@1.0.4`)
- [x] 404 still works for nonexistent agents
- [x] Reported paths verified to exist on disk
- [ ] (Optional) End-to-end smoke test: chat agent in a workspace runs the new diagnose-edit-register flow following the updated prompt