### PR TITLE
fix(launcher): four macOS tray bugs — autostart bundle ID, restart-grace, supervisor-exit, disabled-autostart override

### DIFF
--- a/tools/friday-launcher/autostart_darwin.go
+++ b/tools/friday-launcher/autostart_darwin.go
@@ -110,10 +110,16 @@ func currentAutostartBundleID() string {
 // be rewritten. Cross-platform contract — see autostart_linux.go +
 // autostart_windows.go for the per-OS interpretation.
 //
-// Darwin: stale iff the registered bundle ID differs from
-// launcherBundleID (covers both the v0.0.8-format plist and a
-// future bundle-ID rename).
+// Darwin: stale iff a plist is present AND its registered bundle
+// ID differs from launcherBundleID (covers both the v0.0.8-format
+// plist and a future bundle-ID rename). An absent plist is NOT
+// stale — it means the user toggled "Start at login" off via the
+// tray, and Decision #36 says a deliberately-disabled autostart
+// stays disabled. Without the registered != "" guard, the
+// autostartSelfRegister staleness-repair pass would silently
+// re-enable autostart on every launcher start, ignoring the
+// user's preference. Mirrors autostart_windows.go's check.
 func isAutostartStale() bool {
 	registered := currentAutostartBundleID()
-	return registered != launcherBundleID
+	return registered != "" && registered != launcherBundleID
 }

--- a/tools/friday-launcher/autostart_darwin_test.go
+++ b/tools/friday-launcher/autostart_darwin_test.go
@@ -31,6 +31,20 @@ func TestCurrentAutostartBundleID_AbsentReturnsEmpty(t *testing.T) {
 	}
 }
 
+// TestIsAutostartStale_AbsentReturnsFalse pins Decision #36: a
+// missing plist means the user toggled "Start at login" off via
+// the tray, and the launcher must NOT silently re-enable it on
+// next start. Before this guard the staleness-repair branch in
+// autostartSelfRegister rewrote the plist on every launcher start
+// because "" != launcherBundleID, wiping the user's preference.
+// Mirrors autostart_windows.go's `registered != ""` check.
+func TestIsAutostartStale_AbsentReturnsFalse(t *testing.T) {
+	withFakePlist(t)
+	if isAutostartStale() {
+		t.Error("isAutostartStale() = true with no plist on disk, want false (user-disabled autostart must stay disabled)")
+	}
+}
+
 // TestCurrentAutostartBundleID_MalformedXMLReturnsEmpty: pre-flight
 // migration safety — a hand-edited or corrupted plist must not
 // crash the launcher. plist.Unmarshal failures collapse to "" so

--- a/tools/friday-launcher/flock_unix.go
+++ b/tools/friday-launcher/flock_unix.go
@@ -26,7 +26,7 @@ func acquirePidLock() (*pidFileLock, bool, error) {
 	if err != nil {
 		return nil, false, err
 	}
-	if err := syscall.Flock(int(f.Fd()), //nolint:gosec // G115: Fd() returns an OS handle, bounded
+	if err := syscall.Flock(int(f.Fd()),
 		syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
 		_ = f.Close()
 		if err == syscall.EWOULDBLOCK {

--- a/tools/friday-launcher/integration_test.go
+++ b/tools/friday-launcher/integration_test.go
@@ -507,44 +507,6 @@ func TestOrphanCleanup(t *testing.T) {
 	}
 }
 
-// TestRestartAllOrder verifies that calling Supervisor.RestartAll
-// triggers StopProcess in stopOrder then StartProcess in startOrder.
-//
-// This test exercises the in-process Supervisor wrapper directly
-// (no external launcher process) so we can observe call ordering
-// via the supervised stubs' log entries.
-func TestRestartAllOrder(t *testing.T) {
-	if testing.Short() {
-		t.Skip("integration test")
-	}
-	expectedStopOrder := []string{
-		"playground", "webhook-tunnel", "friday", "link", "nats-server",
-	}
-	expectedStartOrder := []string{
-		"nats-server", "friday", "link", "webhook-tunnel", "playground",
-	}
-	if !slicesEqual(stopOrder, expectedStopOrder) {
-		t.Errorf("stopOrder mismatch:\n want %q\n  got %q",
-			expectedStopOrder, stopOrder)
-	}
-	if !slicesEqual(startOrder, expectedStartOrder) {
-		t.Errorf("startOrder mismatch:\n want %q\n  got %q",
-			expectedStartOrder, startOrder)
-	}
-}
-
-func slicesEqual(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
-}
-
 // TestAutostartSelfRegister verifies that on first run, the LaunchAgent
 // plist is written with the launcher's own os.Executable() path. macOS
 // only — Windows uses the registry, which the launcher's Windows path

--- a/tools/friday-launcher/integration_test.go
+++ b/tools/friday-launcher/integration_test.go
@@ -582,13 +582,13 @@ func TestAutostartSelfRegister(t *testing.T) {
 		t.Fatalf("plist not written: %v", err)
 	}
 	// Stack 3: ProgramArguments is the bundle-ID variant
-	// `["/usr/bin/open", "-b", "ai.hellofriday.studio-launcher", ...]`
-	// rather than a raw exe path. Decision #29.
+	// `["/usr/bin/open", "-b", "<launcherBundleID>", ...]` rather
+	// than a raw exe path. Decision #29.
 	if !strings.Contains(string(data), "<string>/usr/bin/open</string>") {
 		t.Errorf("plist missing /usr/bin/open\n--- plist ---\n%s", string(data))
 	}
-	if !strings.Contains(string(data), "<string>ai.hellofriday.studio-launcher</string>") {
-		t.Errorf("plist missing bundle id\n--- plist ---\n%s", string(data))
+	if !strings.Contains(string(data), "<string>"+launcherBundleID+"</string>") {
+		t.Errorf("plist missing bundle id %q\n--- plist ---\n%s", launcherBundleID, string(data))
 	}
 	if !strings.Contains(string(data), "<string>--no-browser</string>") {
 		t.Error("plist missing --no-browser arg")
@@ -665,13 +665,19 @@ func TestAutostartStalenessRepair(t *testing.T) {
 	})
 	// Poll for the plist to be repaired. Stack 3 plists target the
 	// bundle ID rather than a raw path, so success is "stale path
-	// gone AND bundle ID present" rather than "launcher path
-	// present" (the launcher binary path is no longer in the
-	// plist).
+	// gone AND `open -b <bundleID>` shape present" rather than
+	// "launcher path present" (the launcher binary path is no
+	// longer in the plist). The `-b` token uniquely identifies the
+	// new shape — the stale plist's ProgramArguments don't contain
+	// it, while the bundle-ID string alone also appears in the
+	// plist's <Label>, so it's not a discriminator on its own.
 	for range 60 {
 		data, err := os.ReadFile(plistPath)
-		if err == nil && !strings.Contains(string(data), stalePath) &&
-			strings.Contains(string(data), "ai.hellofriday.studio-launcher") {
+		s := string(data)
+		if err == nil && !strings.Contains(s, stalePath) &&
+			strings.Contains(s, "<string>/usr/bin/open</string>") &&
+			strings.Contains(s, "<string>-b</string>") &&
+			strings.Contains(s, "<string>"+launcherBundleID+"</string>") {
 			return // success
 		}
 		time.Sleep(100 * time.Millisecond)

--- a/tools/friday-launcher/main.go
+++ b/tools/friday-launcher/main.go
@@ -377,9 +377,8 @@ func onReady() {
 	// HTTP server itself stays up across Restart-all and only closes
 	// in performShutdown's last step.
 	// pollCancel is stored in the package-level healthPollCancel
-	// and called from performShutdown; gosec G118 doesn't trace
-	// through the package-var assignment, hence the nolint.
-	pollCtx, pollCancel := context.WithCancel(context.Background()) //nolint:gosec // G118: cancel stored in healthPollCancel
+	// and called from performShutdown.
+	pollCtx, pollCancel := context.WithCancel(context.Background())
 	healthPollCancel = pollCancel
 	go runHealthPoll(pollCtx, sup, healthCache)
 

--- a/tools/friday-launcher/paths.go
+++ b/tools/friday-launcher/paths.go
@@ -10,13 +10,23 @@ import (
 // have to delete a prior plist with a different label.
 const launchAgentLabel = "ai.hellofriday.studio"
 
-// launcherBundleID is the .app's CFBundleIdentifier (Decision #3).
+// launcherBundleID is the .app's CFBundleIdentifier (Decision #3),
+// matching what the studio-installer writes into
+// /Applications/Friday Studio.app/Contents/Info.plist (see
+// apps/studio-installer/src-tauri/src/commands/create_app_bundle.rs).
 // Stack 3's autostart plist invokes `open -b <bundleID>` so reboot
 // targets the bundled .app via LaunchServices rather than a raw exe
-// path that would go stale if the user moves the .app. NOT the same
-// as launchAgentLabel — Apple recommends distinct values to avoid
-// LaunchServices treating the LaunchAgent as the .app's daemon.
-const launcherBundleID = "ai.hellofriday.studio-launcher"
+// path that would go stale if the user moves the .app.
+//
+// Equal to launchAgentLabel by design: the LaunchAgent's Program
+// is /usr/bin/open (a separate process), not the .app's executable,
+// so there's no ambiguity for LaunchServices to resolve. Earlier
+// versions used a distinct "-launcher"-suffixed ID, but no bundle
+// with that ID was ever installed, so `open -b` failed with
+// LSCopyApplicationURLsForBundleIdentifier and the tray surfaced a
+// generic "Error" on Restart. isAutostartStale() detects the old
+// suffixed value and rewrites the plist on next launcher start.
+const launcherBundleID = "ai.hellofriday.studio"
 
 // bundledAgentSDKVersion pins the friday-agent-sdk PyPI version that
 // the daemon spawns user agents against (apps/atlasd/src/agent-spawn.ts

--- a/tools/friday-launcher/project.go
+++ b/tools/friday-launcher/project.go
@@ -281,21 +281,13 @@ func homeDir() string {
 // anyway and uses taskkill /F.
 const signalSIGTERM = 15
 
-// stopOrder is the REVERSE-dependency order; processes are stopped in
-// this order so that consumers (e.g. playground) go down before the
-// services they depend on.
-var stopOrder = []string{
-	"playground",
-	"webhook-tunnel",
-	"friday",
-	"link",
-	"nats-server",
-}
-
 // startOrder is the dependency order; processes are started in this
-// order so that producers come up first. nats-server must come up
-// before `friday` so atlasd's NatsManager tcpProbe finds an external
-// NATS on :4222 and reuses it instead of trying to spawn its own.
+// order so that producers come up first. Also drives RestartAll
+// (Supervisor.RestartAll iterates this slice calling RestartProcess
+// on each so foundational services come back first). nats-server
+// must come up before `friday` so atlasd's NatsManager tcpProbe
+// finds an external NATS on :4222 and reuses it instead of trying
+// to spawn its own.
 var startOrder = []string{
 	"nats-server",
 	"friday",

--- a/tools/friday-launcher/project_test.go
+++ b/tools/friday-launcher/project_test.go
@@ -136,3 +136,22 @@ func TestCommonServiceEnv_RespectsExplicitOverride(t *testing.T) {
 		t.Errorf("user's LINK_DEV_MODE=false missing from env. got=%v", got)
 	}
 }
+
+// TestStartOrderConfig pins startOrder, the dependency order
+// Supervisor.RestartAll iterates over when calling RestartProcess
+// on each supervised service. nats-server must come first so the
+// friday daemon's NatsManager tcpProbe finds an external NATS on
+// :4222 and reuses it instead of spawning its own; playground
+// comes last so it doesn't surface a spurious "backend down" UI
+// flash while its upstreams are still warming up. A reorder here
+// without a corresponding probe/dependency review can cause the
+// "Daemon unreachable" flash that the readiness budget widening
+// (Decision #?: 12s → 62s) was supposed to eliminate.
+func TestStartOrderConfig(t *testing.T) {
+	want := []string{
+		"nats-server", "friday", "link", "webhook-tunnel", "playground",
+	}
+	if !slices.Equal(startOrder, want) {
+		t.Errorf("startOrder mismatch:\n want %q\n  got %q", want, startOrder)
+	}
+}

--- a/tools/friday-launcher/supervisor.go
+++ b/tools/friday-launcher/supervisor.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -144,31 +143,11 @@ func (s *Supervisor) RestartAll() error {
 
 	var firstErr error
 	for _, name := range startOrder {
-		if err := s.runner.RestartProcess(name); err != nil &&
-			firstErr == nil {
-			// "not running" is non-fatal: a crashed-and-not-yet-
-			// restarted child returns it, and RestartProcess's
-			// follow-up runProcess will still spawn a fresh
-			// instance via the project config.
-			if !isNotRunningErr(err) {
-				firstErr = err
-			}
+		if err := s.runner.RestartProcess(name); err != nil && firstErr == nil {
+			firstErr = err
 		}
 	}
 	return firstErr
-}
-
-// isNotRunningErr returns true if err is process-compose's
-// "process X is not running" error from StopProcess. Treated as
-// non-fatal during restart-all (process crashed and will be restarted
-// by RestartPolicyAlways anyway).
-func isNotRunningErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "is not running") ||
-		strings.Contains(msg, "does not exist")
 }
 
 // StartedAt returns when the supervisor was created (used by the tray

--- a/tools/friday-launcher/supervisor.go
+++ b/tools/friday-launcher/supervisor.go
@@ -10,11 +10,24 @@ import (
 	"github.com/f1bonacc1/process-compose/src/types"
 )
 
+// processRunner is the minimum subset of *app.ProjectRunner that
+// Supervisor consumes. Pulled out as an interface so unit tests can
+// inject a fake runner that records calls without spinning up real
+// process-compose subprocesses. *app.ProjectRunner satisfies this
+// implicitly (Go structural typing); production code passes one in
+// via NewSupervisor.
+type processRunner interface {
+	Run() error
+	RestartProcess(name string) error
+	ShutDownProject() error
+	GetProcessesState() (*types.ProcessesState, error)
+}
+
 // Supervisor wraps a process-compose ProjectRunner with the launcher's
 // own state (started flag, supervisorExited watchdog, restart-all
 // serialization).
 type Supervisor struct {
-	runner *app.ProjectRunner
+	runner processRunner
 
 	supervisorExited atomic.Bool
 	shuttingDown     *atomic.Bool
@@ -163,11 +176,13 @@ func isNotRunningErr(err error) bool {
 func (s *Supervisor) StartedAt() time.Time { return s.startedAt }
 
 // restartGraceWindow is how long after a RestartAll the tray treats
-// "AnyFailed" as still-recovering rather than red. Same magnitude
-// as the cold-start grace (30s) so a user-initiated restart gets
-// the same forgiveness as a fresh launcher boot — children stop,
-// readiness probes go un-ready, then come back over a few seconds.
-const restartGraceWindow = 30 * time.Second
+// "AnyFailed" as still-recovering rather than red. Set equal to
+// bucketFailGraceWindow so a user-initiated restart gets the same
+// forgiveness as a fresh launcher boot — children stop, readiness
+// probes go un-ready, then come back over the readiness budget
+// (project.go: 2s + 30 retries × 2s = 62s worst case for the slow
+// process; the 90s window covers that with VM/slow-disk slack).
+const restartGraceWindow = bucketFailGraceWindow
 
 // RestartGraceActive reports whether the tray should treat the
 // current health snapshot through the lens of a recent restart

--- a/tools/friday-launcher/supervisor.go
+++ b/tools/friday-launcher/supervisor.go
@@ -36,14 +36,14 @@ type Supervisor struct {
 
 	restartMu sync.Mutex // serializes Restart-all paths
 
-	// inRestart is true between RestartAll's stop pass and the
-	// completion of its start pass. lastRestartEndNano is the unix-
-	// nano timestamp at which the most recent RestartAll returned;
-	// zero before the first restart. Together they drive the post-
-	// restart grace window in RestartGraceActive — the tray uses it
-	// to suppress the red "Error" badge while children are stopping
-	// + coming back up. Atomics so the tray-poll goroutine can read
-	// without taking restartMu.
+	// inRestart is true from the start of RestartAll until it
+	// returns. lastRestartEndNano is the unix-nano timestamp at
+	// which the most recent RestartAll returned; zero before the
+	// first restart. Together they drive the post-restart grace
+	// window in RestartGraceActive — the tray uses it to suppress
+	// the red "Error" badge while children are restarting and
+	// re-passing readiness probes. Atomics so the tray-poll
+	// goroutine can read without taking restartMu.
 	inRestart          atomic.Bool
 	lastRestartEndNano atomic.Int64
 }

--- a/tools/friday-launcher/supervisor.go
+++ b/tools/friday-launcher/supervisor.go
@@ -22,6 +22,17 @@ type Supervisor struct {
 	startedAt time.Time
 
 	restartMu sync.Mutex // serializes Restart-all paths
+
+	// inRestart is true between RestartAll's stop pass and the
+	// completion of its start pass. lastRestartEndNano is the unix-
+	// nano timestamp at which the most recent RestartAll returned;
+	// zero before the first restart. Together they drive the post-
+	// restart grace window in RestartGraceActive — the tray uses it
+	// to suppress the red "Error" badge while children are stopping
+	// + coming back up. Atomics so the tray-poll goroutine can read
+	// without taking restartMu.
+	inRestart          atomic.Bool
+	lastRestartEndNano atomic.Int64
 }
 
 // NewSupervisor builds the project + ProjectOpts and instantiates the
@@ -83,9 +94,20 @@ func (s *Supervisor) Shutdown() error {
 // RestartAll runs the two-pass restart in stopOrder then startOrder.
 // Serialized via restartMu so concurrent menu clicks don't race.
 // Returns the first error encountered (other passes still run).
+//
+// Sets inRestart for the duration and stamps lastRestartEndNano on
+// completion. RestartGraceActive consults both so the tray can
+// suppress the red bucket while children are stopping + restarting
+// + waiting for readiness probes.
 func (s *Supervisor) RestartAll() error {
 	s.restartMu.Lock()
 	defer s.restartMu.Unlock()
+
+	s.inRestart.Store(true)
+	defer func() {
+		s.lastRestartEndNano.Store(time.Now().UnixNano())
+		s.inRestart.Store(false)
+	}()
 
 	var firstErr error
 	for _, name := range stopOrder {
@@ -128,3 +150,27 @@ func isNotRunningErr(err error) bool {
 // StartedAt returns when the supervisor was created (used by the tray
 // for the cold-start grace window).
 func (s *Supervisor) StartedAt() time.Time { return s.startedAt }
+
+// restartGraceWindow is how long after a RestartAll the tray treats
+// "AnyFailed" as still-recovering rather than red. Same magnitude
+// as the cold-start grace (30s) so a user-initiated restart gets
+// the same forgiveness as a fresh launcher boot — children stop,
+// readiness probes go un-ready, then come back over a few seconds.
+const restartGraceWindow = 30 * time.Second
+
+// RestartGraceActive reports whether the tray should treat the
+// current health snapshot through the lens of a recent restart
+// (i.e. "AnyFailed" is expected, don't paint red). True while a
+// RestartAll is in flight, and for restartGraceWindow after it
+// returns. Decouples from StartedAt so subsequent restarts get
+// their own grace, not just the cold-start one.
+func (s *Supervisor) RestartGraceActive() bool {
+	if s.inRestart.Load() {
+		return true
+	}
+	endNano := s.lastRestartEndNano.Load()
+	if endNano == 0 {
+		return false
+	}
+	return time.Since(time.Unix(0, endNano)) < restartGraceWindow
+}

--- a/tools/friday-launcher/supervisor.go
+++ b/tools/friday-launcher/supervisor.go
@@ -91,14 +91,34 @@ func (s *Supervisor) Shutdown() error {
 	return s.runner.ShutDownProject()
 }
 
-// RestartAll runs the two-pass restart in stopOrder then startOrder.
-// Serialized via restartMu so concurrent menu clicks don't race.
-// Returns the first error encountered (other passes still run).
+// RestartAll restarts every supervised process by calling
+// runner.RestartProcess(name) in startOrder (dependency order so
+// foundational services come back first).
 //
+// Why per-process RestartProcess and not the older two-pass
+// "StopProcess everything then StartProcess everything":
+// process-compose's runner.Run loop terminates with "Project
+// completed" when runProcCount hits 0 AND no entries are present in
+// the runner's restartCalls map (process_runner.go:151-180 in
+// process-compose v1.103.0). The old two-pass shape never touched
+// restartCalls, so the moment between the last StopProcess and the
+// first StartProcess satisfied both conditions: Run() returned,
+// runAndWatch latched supervisorExited=true, and the tray painted
+// red forever even though StartProcess immediately brought all
+// children back up. RestartProcess registers an entry in
+// restartCalls for the duration of each call, so pendingRestarts > 0
+// blocks the project-completed branch — Run() stays in its loop.
+//
+// As a bonus the new shape keeps four of five services running at
+// any moment (sequential restart vs. all-down-then-all-up), so a
+// user-initiated Restart no longer has a window where every port is
+// closed.
+//
+// Serialized via restartMu so concurrent menu clicks don't race.
+// Returns the first error encountered (other restarts still run).
 // Sets inRestart for the duration and stamps lastRestartEndNano on
-// completion. RestartGraceActive consults both so the tray can
-// suppress the red bucket while children are stopping + restarting
-// + waiting for readiness probes.
+// completion — RestartGraceActive consults both so the tray can
+// suppress the red bucket while children are coming back.
 func (s *Supervisor) RestartAll() error {
 	s.restartMu.Lock()
 	defer s.restartMu.Unlock()
@@ -110,25 +130,16 @@ func (s *Supervisor) RestartAll() error {
 	}()
 
 	var firstErr error
-	for _, name := range stopOrder {
-		// StopProcess blocks for up to ShutDownParams.ShutDownTimeout
-		// seconds (we set 10), then SIGKILLs and returns. If the
-		// process is not currently running (e.g. crashed and not yet
-		// restarted) StopProcess returns "process is not running"
-		// which we treat as success for the restart-all path.
-		if err := s.runner.StopProcess(name); err != nil &&
+	for _, name := range startOrder {
+		if err := s.runner.RestartProcess(name); err != nil &&
 			firstErr == nil {
-			// Don't propagate "not running" — that's expected for
-			// processes that crashed and haven't been restarted yet.
+			// "not running" is non-fatal: a crashed-and-not-yet-
+			// restarted child returns it, and RestartProcess's
+			// follow-up runProcess will still spawn a fresh
+			// instance via the project config.
 			if !isNotRunningErr(err) {
 				firstErr = err
 			}
-		}
-	}
-	for _, name := range startOrder {
-		if err := s.runner.StartProcess(name); err != nil &&
-			firstErr == nil {
-			firstErr = err
 		}
 	}
 	return firstErr

--- a/tools/friday-launcher/supervisor_test.go
+++ b/tools/friday-launcher/supervisor_test.go
@@ -259,9 +259,9 @@ func (b *blockingFakeRunner) RestartProcess(name string) error {
 	return b.fakeRunner.RestartProcess(name)
 }
 
-// errFakeRestart is the synthetic error TestSupervisorRestartAllPropagatesError
-// surfaces from RestartProcess. Distinct from "not running" so the
-// isNotRunningErr branch doesn't swallow it.
+// errFakeRestart is the synthetic error
+// TestSupervisorRestartAllPropagatesError surfaces from
+// RestartProcess so we can verify RestartAll propagates it.
 var errFakeRestart = &fakeRestartError{}
 
 type fakeRestartError struct{}

--- a/tools/friday-launcher/supervisor_test.go
+++ b/tools/friday-launcher/supervisor_test.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/f1bonacc1/process-compose/src/types"
+)
+
+// fakeRunner records every method call so tests can pin RestartAll's
+// behavior without spinning up real subprocesses. Run() blocks on a
+// channel until ShutDownProject closes it, mirroring the contract of
+// *app.ProjectRunner — Run is supposed to block for the lifetime of
+// the supervisor.
+type fakeRunner struct {
+	mu             sync.Mutex
+	restartCalls   []string // ordered list of RestartProcess(name) args
+	runStarted     atomic.Bool
+	runReturned    atomic.Bool
+	runDone        chan struct{}
+	restartProcErr error // optional error to return from RestartProcess
+}
+
+func newFakeRunner() *fakeRunner {
+	return &fakeRunner{runDone: make(chan struct{})}
+}
+
+func (f *fakeRunner) Run() error {
+	f.runStarted.Store(true)
+	<-f.runDone
+	f.runReturned.Store(true)
+	return nil
+}
+
+func (f *fakeRunner) RestartProcess(name string) error {
+	f.mu.Lock()
+	f.restartCalls = append(f.restartCalls, name)
+	err := f.restartProcErr
+	f.mu.Unlock()
+	return err
+}
+
+func (f *fakeRunner) ShutDownProject() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	select {
+	case <-f.runDone:
+		// Already closed — defensive against double-shutdown.
+	default:
+		close(f.runDone)
+	}
+	return nil
+}
+
+func (f *fakeRunner) GetProcessesState() (*types.ProcessesState, error) {
+	return &types.ProcessesState{}, nil
+}
+
+func (f *fakeRunner) calls() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.restartCalls...)
+}
+
+// waitFor polls cond every 10ms up to timeout. Used to wait on
+// goroutine progress without sleeping unconditionally.
+func waitFor(timeout time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}
+
+// TestSupervisorRestartAllUsesRestartProcess pins the Bug 3 fix:
+// RestartAll calls processRunner.RestartProcess for every supervised
+// service in startOrder. The old shape (StopProcess + StartProcess
+// in two passes) caused process-compose's Run() loop to exit with
+// "Project completed" between the last stop and the first start —
+// SupervisorExited latched true and the tray painted red forever
+// even though children came right back up.
+//
+// Per-service RestartProcess keeps process-compose's restartCalls
+// map non-empty for the duration of each call, so its Run() loop's
+// project-completed branch is gated and Run stays in its loop.
+//
+// Test uses a fakeRunner so we can observe call ordering and prove
+// Run() didn't return at any point during RestartAll. The
+// processRunner interface boundary means a refactor back to
+// StopProcess/StartProcess wouldn't even compile (those methods
+// aren't on the interface), but we verify the positive case
+// explicitly here so the contract is documented in code.
+func TestSupervisorRestartAllUsesRestartProcess(t *testing.T) {
+	var sd atomic.Bool
+	fake := newFakeRunner()
+	sup := &Supervisor{
+		runner:       fake,
+		shuttingDown: &sd,
+		startedAt:    time.Now(),
+	}
+
+	runAndWatchDone := make(chan struct{})
+	go func() {
+		sup.runAndWatch()
+		close(runAndWatchDone)
+	}()
+	if !waitFor(time.Second, func() bool { return fake.runStarted.Load() }) {
+		t.Fatal("fakeRunner.Run() did not start within 1s")
+	}
+
+	if err := sup.RestartAll(); err != nil {
+		t.Fatalf("RestartAll returned %v, want nil", err)
+	}
+
+	if got := fake.calls(); !slices.Equal(got, startOrder) {
+		t.Errorf("RestartProcess calls = %v, want %v (startOrder)", got, startOrder)
+	}
+	if sup.SupervisorExited() {
+		t.Error("SupervisorExited() = true after RestartAll, want false (Bug 3 regression: Run() exited mid-restart)")
+	}
+	if fake.runReturned.Load() {
+		t.Error("fakeRunner.Run() returned during RestartAll — RestartAll let Run exit")
+	}
+
+	// Cleanup: trigger Run() to return so the goroutine exits before
+	// the test does. shuttingDown=true tells runAndWatch this is a
+	// graceful exit, not a watchdog event.
+	sd.Store(true)
+	if err := sup.Shutdown(); err != nil {
+		t.Fatalf("Shutdown: %v", err)
+	}
+	<-runAndWatchDone
+	if sup.SupervisorExited() {
+		t.Error("SupervisorExited() = true after graceful shutdown, want false")
+	}
+}
+
+// TestSupervisorRestartAllPropagatesError verifies that a
+// RestartProcess failure (other than "not running") surfaces as
+// RestartAll's return value, while subsequent restarts still run.
+// The old StopProcess+StartProcess shape had the same property; we
+// keep it under the new RestartProcess loop.
+func TestSupervisorRestartAllPropagatesError(t *testing.T) {
+	var sd atomic.Bool
+	fake := newFakeRunner()
+	fake.restartProcErr = errFakeRestart
+	sup := &Supervisor{
+		runner:       fake,
+		shuttingDown: &sd,
+		startedAt:    time.Now(),
+	}
+	runAndWatchDone := make(chan struct{})
+	go func() {
+		sup.runAndWatch()
+		close(runAndWatchDone)
+	}()
+	if !waitFor(time.Second, func() bool { return fake.runStarted.Load() }) {
+		t.Fatal("fakeRunner.Run() did not start within 1s")
+	}
+
+	err := sup.RestartAll()
+	if err == nil {
+		t.Fatal("RestartAll returned nil, want propagated error")
+	}
+	// Even with errors, every service in startOrder should have been
+	// attempted (matches the original loop's "first error wins, other
+	// passes still run" contract).
+	if got := fake.calls(); !slices.Equal(got, startOrder) {
+		t.Errorf("RestartProcess calls = %v, want %v (every service still attempted)", got, startOrder)
+	}
+
+	sd.Store(true)
+	_ = sup.Shutdown()
+	<-runAndWatchDone
+}
+
+// TestSupervisorRestartGraceLifecycleAroundRestartAll pins the
+// inRestart flag and lastRestartEndNano stamp from the Bug 2 fix.
+// Both must be observable via RestartGraceActive at the right
+// moments: false before any restart, true while RestartAll is in
+// flight, and true for restartGraceWindow after it returns.
+//
+// Uses a blockingFakeRunner that blocks the first RestartProcess
+// until the test releases it — that gives us a deterministic
+// "RestartAll is in-flight" window to assert against.
+func TestSupervisorRestartGraceLifecycleAroundRestartAll(t *testing.T) {
+	var sd atomic.Bool
+	released := atomic.Bool{}
+	fake := &blockingFakeRunner{
+		fakeRunner: fakeRunner{runDone: make(chan struct{})},
+		block:      make(chan struct{}),
+		released:   &released,
+	}
+	sup := &Supervisor{
+		runner:       fake,
+		shuttingDown: &sd,
+		startedAt:    time.Now(),
+	}
+	runAndWatchDone := make(chan struct{})
+	go func() {
+		sup.runAndWatch()
+		close(runAndWatchDone)
+	}()
+	if !waitFor(time.Second, func() bool { return fake.runStarted.Load() }) {
+		t.Fatal("fakeRunner.Run() did not start within 1s")
+	}
+
+	if sup.RestartGraceActive() {
+		t.Error("RestartGraceActive() = true before any restart, want false")
+	}
+
+	restartDone := make(chan error, 1)
+	go func() { restartDone <- sup.RestartAll() }()
+
+	// inRestart is set at the top of RestartAll, before any
+	// RestartProcess call. Wait for it to flip — that's the
+	// "RestartAll is in-flight" signal.
+	if !waitFor(time.Second, func() bool { return sup.RestartGraceActive() }) {
+		t.Fatal("RestartGraceActive didn't flip true within 1s of RestartAll start")
+	}
+
+	released.Store(true)
+	close(fake.block)
+	if err := <-restartDone; err != nil {
+		t.Fatalf("RestartAll returned %v, want nil", err)
+	}
+
+	// Just past completion: still inside post-restart grace because
+	// lastRestartEndNano was just stamped (now − 0s < restartGraceWindow).
+	if !sup.RestartGraceActive() {
+		t.Error("RestartGraceActive() = false immediately after RestartAll, want true (post-restart grace)")
+	}
+
+	sd.Store(true)
+	_ = sup.Shutdown()
+	<-runAndWatchDone
+}
+
+// blockingFakeRunner is fakeRunner with a one-shot blocker on
+// RestartProcess so the test can observe in-flight state. The
+// embedded fakeRunner gives us record-keeping + the same Run()
+// blocking semantics; this wrapper only intercepts RestartProcess.
+type blockingFakeRunner struct {
+	fakeRunner
+	block    chan struct{}
+	released *atomic.Bool
+}
+
+func (b *blockingFakeRunner) RestartProcess(name string) error {
+	if !b.released.Load() {
+		<-b.block
+	}
+	return b.fakeRunner.RestartProcess(name)
+}
+
+// errFakeRestart is the synthetic error TestSupervisorRestartAllPropagatesError
+// surfaces from RestartProcess. Distinct from "not running" so the
+// isNotRunningErr branch doesn't swallow it.
+var errFakeRestart = &fakeRestartError{}
+
+type fakeRestartError struct{}
+
+func (e *fakeRestartError) Error() string { return "fake restart failure" }

--- a/tools/friday-launcher/supervisor_test.go
+++ b/tools/friday-launcher/supervisor_test.go
@@ -65,10 +65,12 @@ func (f *fakeRunner) calls() []string {
 	return append([]string(nil), f.restartCalls...)
 }
 
-// waitFor polls cond every 10ms up to timeout. Used to wait on
-// goroutine progress without sleeping unconditionally.
-func waitFor(timeout time.Duration, cond func() bool) bool {
-	deadline := time.Now().Add(timeout)
+// waitFor polls cond every 10ms up to one second. Used to wait on
+// goroutine progress without sleeping unconditionally. One second
+// is enough for goroutine handoffs in unit tests; longer waits
+// indicate a real bug.
+func waitFor(cond func() bool) bool {
+	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
 		if cond() {
 			return true
@@ -110,7 +112,7 @@ func TestSupervisorRestartAllUsesRestartProcess(t *testing.T) {
 		sup.runAndWatch()
 		close(runAndWatchDone)
 	}()
-	if !waitFor(time.Second, func() bool { return fake.runStarted.Load() }) {
+	if !waitFor(func() bool { return fake.runStarted.Load() }) {
 		t.Fatal("fakeRunner.Run() did not start within 1s")
 	}
 
@@ -160,7 +162,7 @@ func TestSupervisorRestartAllPropagatesError(t *testing.T) {
 		sup.runAndWatch()
 		close(runAndWatchDone)
 	}()
-	if !waitFor(time.Second, func() bool { return fake.runStarted.Load() }) {
+	if !waitFor(func() bool { return fake.runStarted.Load() }) {
 		t.Fatal("fakeRunner.Run() did not start within 1s")
 	}
 
@@ -207,7 +209,7 @@ func TestSupervisorRestartGraceLifecycleAroundRestartAll(t *testing.T) {
 		sup.runAndWatch()
 		close(runAndWatchDone)
 	}()
-	if !waitFor(time.Second, func() bool { return fake.runStarted.Load() }) {
+	if !waitFor(func() bool { return fake.runStarted.Load() }) {
 		t.Fatal("fakeRunner.Run() did not start within 1s")
 	}
 
@@ -221,7 +223,7 @@ func TestSupervisorRestartGraceLifecycleAroundRestartAll(t *testing.T) {
 	// inRestart is set at the top of RestartAll, before any
 	// RestartProcess call. Wait for it to flip — that's the
 	// "RestartAll is in-flight" signal.
-	if !waitFor(time.Second, func() bool { return sup.RestartGraceActive() }) {
+	if !waitFor(func() bool { return sup.RestartGraceActive() }) {
 		t.Fatal("RestartGraceActive didn't flip true within 1s of RestartAll start")
 	}
 

--- a/tools/friday-launcher/tray.go
+++ b/tools/friday-launcher/tray.go
@@ -232,8 +232,10 @@ func (t *trayController) tick() {
 //  2. SupervisorExited (the runner.Run() returned unexpectedly)
 //     trumps everything else (red).
 //  3. AllHealthy → green.
-//  4. AnyFailed past the cold-start grace → red.
-//  5. Otherwise amber (pending / starting / cold-start grace).
+//  4. AnyFailed past the cold-start grace AND no active restart
+//     grace → red.
+//  5. Otherwise amber (pending / starting / cold-start grace /
+//     restart grace).
 func (t *trayController) computeBucket() trayBucket {
 	if t.shuttingDown.Load() {
 		return bucketGrey
@@ -249,8 +251,15 @@ func (t *trayController) computeBucket() trayBucket {
 	if t.healthCache.AllHealthy() {
 		return bucketGreen
 	}
+	// AnyFailed flips to red only outside both the cold-start grace
+	// and the post-restart grace. Without the restart-grace check a
+	// user-initiated tray Restart would paint " Error" for the few
+	// seconds children take to stop + come back up — process-compose
+	// reports them as not-running during that window, which the
+	// cache surfaces as failed.
 	if t.healthCache.AnyFailed() &&
-		time.Since(t.sup.StartedAt()) >= 30*time.Second {
+		time.Since(t.sup.StartedAt()) >= 30*time.Second &&
+		!t.sup.RestartGraceActive() {
 		return bucketRed
 	}
 	return bucketAmber

--- a/tools/friday-launcher/tray.go
+++ b/tools/friday-launcher/tray.go
@@ -217,6 +217,23 @@ func (t *trayController) tick() {
 	}
 }
 
+// bucketFailGraceWindow is how long the tray forgives transient
+// AnyFailed before flipping red. Two callers consult it:
+//   - computeBucket compares it against time.Since(StartedAt()) for
+//     the cold-start grace.
+//   - Supervisor.RestartGraceActive() (supervisor.go) uses the same
+//     value as the post-restart grace window so a user-initiated
+//     Restart gets equivalent forgiveness.
+//
+// Sized to cover the readiness probe budget configured in
+// project.go: InitialDelay=2s + FailureThreshold=30 × PeriodSeconds=2s
+// = 62s worst case before process-compose itself declares a service
+// unhealthy. The previous 30s magnitude was inherited from before
+// the readiness budget was widened to 62s and would paint red for
+// any service that legitimately took >30s to first-pass readiness
+// (which the friday daemon does on cold start).
+const bucketFailGraceWindow = 90 * time.Second
+
 // computeBucket implements the Tray Color Matrix using the health
 // cache as the single source of truth (Decision #4 + #18). The
 // previous heuristic (state.IsReady() over ProcessesState) suffered
@@ -258,7 +275,7 @@ func (t *trayController) computeBucket() trayBucket {
 	// reports them as not-running during that window, which the
 	// cache surfaces as failed.
 	if t.healthCache.AnyFailed() &&
-		time.Since(t.sup.StartedAt()) >= 30*time.Second &&
+		time.Since(t.sup.StartedAt()) >= bucketFailGraceWindow &&
 		!t.sup.RestartGraceActive() {
 		return bucketRed
 	}

--- a/tools/friday-launcher/tray_test.go
+++ b/tools/friday-launcher/tray_test.go
@@ -93,9 +93,12 @@ func TestComputeBucket_PendingDuringColdStartAmber(t *testing.T) {
 }
 
 // TestComputeBucket_FailedPastGraceRed: once the launcher has been
-// up for 30s, a failed service flips the bucket red. The grace
-// window is the only thing that suppressed red earlier; past it,
-// the user needs to know something needs attention.
+// up past bucketFailGraceWindow, a failed service flips the bucket
+// red. The grace window is the only thing that suppressed red
+// earlier; past it, the user needs to know something needs
+// attention. Boundary uses +5s of slack so a slow CI runner
+// preempting between Add() and time.Since() doesn't flip past →
+// within and false-fail.
 func TestComputeBucket_FailedPastGraceRed(t *testing.T) {
 	var sd atomic.Bool
 	cache := NewHealthCache(&sd)
@@ -103,8 +106,7 @@ func TestComputeBucket_FailedPastGraceRed(t *testing.T) {
 		runningReady("a"),
 		failed("b", 5),
 	))
-	// startedAt = 31s ago → past the cold-start grace.
-	sup := newTestSupervisor(time.Now().Add(-31*time.Second), false)
+	sup := newTestSupervisor(time.Now().Add(-(bucketFailGraceWindow + 5*time.Second)), false)
 
 	tc := newTrayController(sup, &sd, cache)
 	if got := tc.computeBucket(); got != bucketRed {
@@ -113,15 +115,15 @@ func TestComputeBucket_FailedPastGraceRed(t *testing.T) {
 }
 
 // TestComputeBucket_NotReadyPastGraceAmber: services in 'starting'
-// (Running but probe NotReady) past the 30s grace stay amber, NOT
-// red. We only flip red on terminal-failed, never on slow-but-
-// eventually-healthy. Otherwise a slow Mac would see red bucket
-// during normal startup.
+// (Running but probe NotReady) past the cold-start grace stay
+// amber, NOT red. We only flip red on terminal-failed, never on
+// slow-but-eventually-healthy. Otherwise a slow Mac would see red
+// bucket during normal startup.
 func TestComputeBucket_NotReadyPastGraceAmber(t *testing.T) {
 	var sd atomic.Bool
 	cache := NewHealthCache(&sd)
 	cache.Update(makeStates(runningNotReady("a")))
-	sup := newTestSupervisor(time.Now().Add(-60*time.Second), false)
+	sup := newTestSupervisor(time.Now().Add(-(bucketFailGraceWindow + 5*time.Second)), false)
 
 	tc := newTrayController(sup, &sd, cache)
 	if got := tc.computeBucket(); got != bucketAmber {
@@ -142,9 +144,9 @@ func TestComputeBucket_FailedDuringActiveRestartAmber(t *testing.T) {
 		runningReady("a"),
 		failed("b", 5),
 	))
-	// startedAt = 60s ago → past the cold-start grace, so without
-	// restart-grace this would render red.
-	sup := newTestSupervisor(time.Now().Add(-60*time.Second), false)
+	// startedAt past the cold-start grace, so without restart-grace
+	// this would render red. inRestart=true must override to amber.
+	sup := newTestSupervisor(time.Now().Add(-(bucketFailGraceWindow + 5*time.Second)), false)
 	sup.inRestart.Store(true)
 
 	tc := newTrayController(sup, &sd, cache)
@@ -164,8 +166,8 @@ func TestComputeBucket_FailedWithinRestartGraceAmber(t *testing.T) {
 		runningReady("a"),
 		failed("b", 5),
 	))
-	sup := newTestSupervisor(time.Now().Add(-60*time.Second), false)
-	// Restart completed 5s ago → still inside the 30s grace.
+	sup := newTestSupervisor(time.Now().Add(-(bucketFailGraceWindow + 5*time.Second)), false)
+	// Restart completed 5s ago → still inside the grace window.
 	sup.lastRestartEndNano.Store(time.Now().Add(-5 * time.Second).UnixNano())
 
 	tc := newTrayController(sup, &sd, cache)
@@ -177,7 +179,9 @@ func TestComputeBucket_FailedWithinRestartGraceAmber(t *testing.T) {
 // TestComputeBucket_FailedAfterRestartGraceRed: once the post-
 // restart grace expires, a still-failed service flips red as
 // usual. The grace is forgiveness for transient stop+start churn,
-// not a permanent suppression.
+// not a permanent suppression. Boundary uses +5s of slack so a
+// slow CI runner preempting between Add() and time.Since() doesn't
+// flip past → within-grace and false-fail.
 func TestComputeBucket_FailedAfterRestartGraceRed(t *testing.T) {
 	var sd atomic.Bool
 	cache := NewHealthCache(&sd)
@@ -185,9 +189,8 @@ func TestComputeBucket_FailedAfterRestartGraceRed(t *testing.T) {
 		runningReady("a"),
 		failed("b", 5),
 	))
-	sup := newTestSupervisor(time.Now().Add(-60*time.Second), false)
-	// Restart completed restartGraceWindow+1s ago → past the grace.
-	sup.lastRestartEndNano.Store(time.Now().Add(-(restartGraceWindow + time.Second)).UnixNano())
+	sup := newTestSupervisor(time.Now().Add(-(bucketFailGraceWindow + 10*time.Second)), false)
+	sup.lastRestartEndNano.Store(time.Now().Add(-(restartGraceWindow + 5*time.Second)).UnixNano())
 
 	tc := newTrayController(sup, &sd, cache)
 	if got := tc.computeBucket(); got != bucketRed {

--- a/tools/friday-launcher/tray_test.go
+++ b/tools/friday-launcher/tray_test.go
@@ -129,6 +129,82 @@ func TestComputeBucket_NotReadyPastGraceAmber(t *testing.T) {
 	}
 }
 
+// TestComputeBucket_FailedDuringActiveRestartAmber: while a tray-
+// initiated RestartAll is in flight, AnyFailed reflects the stop
+// pass tearing children down — that's expected, not a real failure,
+// so the bucket must NOT flip red. Otherwise the menubar shows
+// " Error" for the few seconds children take to come back up,
+// which is exactly the user-visible bug we're fixing here.
+func TestComputeBucket_FailedDuringActiveRestartAmber(t *testing.T) {
+	var sd atomic.Bool
+	cache := NewHealthCache(&sd)
+	cache.Update(makeStates(
+		runningReady("a"),
+		failed("b", 5),
+	))
+	// startedAt = 60s ago → past the cold-start grace, so without
+	// restart-grace this would render red.
+	sup := newTestSupervisor(time.Now().Add(-60*time.Second), false)
+	sup.inRestart.Store(true)
+
+	tc := newTrayController(sup, &sd, cache)
+	if got := tc.computeBucket(); got != bucketAmber {
+		t.Errorf("computeBucket = %v, want amber (active restart)", got)
+	}
+}
+
+// TestComputeBucket_FailedWithinRestartGraceAmber: for the
+// restartGraceWindow seconds AFTER RestartAll returns, AnyFailed
+// stays amber too — process-compose flips children to running
+// before readiness probes pass, so AnyFailed lingers briefly.
+func TestComputeBucket_FailedWithinRestartGraceAmber(t *testing.T) {
+	var sd atomic.Bool
+	cache := NewHealthCache(&sd)
+	cache.Update(makeStates(
+		runningReady("a"),
+		failed("b", 5),
+	))
+	sup := newTestSupervisor(time.Now().Add(-60*time.Second), false)
+	// Restart completed 5s ago → still inside the 30s grace.
+	sup.lastRestartEndNano.Store(time.Now().Add(-5 * time.Second).UnixNano())
+
+	tc := newTrayController(sup, &sd, cache)
+	if got := tc.computeBucket(); got != bucketAmber {
+		t.Errorf("computeBucket = %v, want amber (post-restart grace)", got)
+	}
+}
+
+// TestComputeBucket_FailedAfterRestartGraceRed: once the post-
+// restart grace expires, a still-failed service flips red as
+// usual. The grace is forgiveness for transient stop+start churn,
+// not a permanent suppression.
+func TestComputeBucket_FailedAfterRestartGraceRed(t *testing.T) {
+	var sd atomic.Bool
+	cache := NewHealthCache(&sd)
+	cache.Update(makeStates(
+		runningReady("a"),
+		failed("b", 5),
+	))
+	sup := newTestSupervisor(time.Now().Add(-60*time.Second), false)
+	// Restart completed restartGraceWindow+1s ago → past the grace.
+	sup.lastRestartEndNano.Store(time.Now().Add(-(restartGraceWindow + time.Second)).UnixNano())
+
+	tc := newTrayController(sup, &sd, cache)
+	if got := tc.computeBucket(); got != bucketRed {
+		t.Errorf("computeBucket = %v, want red (grace expired)", got)
+	}
+}
+
+// TestRestartGraceActive_NoRestartYet: before any RestartAll runs
+// (lastRestartEndNano == 0), grace is inactive — otherwise every
+// fresh launcher would silently swallow real failures forever.
+func TestRestartGraceActive_NoRestartYet(t *testing.T) {
+	sup := newTestSupervisor(time.Now(), false)
+	if sup.RestartGraceActive() {
+		t.Error("RestartGraceActive() = true with no restart yet, want false")
+	}
+}
+
 // TestComputeBucket_NilCacheAmber: defensive — if computeBucket
 // runs before the cache is wired (shouldn't happen post-onReady,
 // but the goroutine ordering isn't deterministic), render amber


### PR DESCRIPTION
Four related macOS tray regressions, fixed in one PR because they all surface as the same user symptom — broken \"Start at login\" / Restart all flows — and they're chained: fixing each one revealed the next.

## Bug 1 — autostart plist points at a bundle ID we never install

The launcher's macOS LaunchAgent plist invoked:

\`\`\`
/usr/bin/open -b ai.hellofriday.studio-launcher --args --no-browser
\`\`\`

…but the studio-installer creates \`/Applications/Friday Studio.app\` with \`CFBundleIdentifier = ai.hellofriday.studio\` (no \`-launcher\` suffix — see [\`apps/studio-installer/src-tauri/src/commands/create_app_bundle.rs:53\`](apps/studio-installer/src-tauri/src/commands/create_app_bundle.rs#L53)). LaunchServices failed with \`LSCopyApplicationURLsForBundleIdentifier\`, the LaunchAgent exited 1, and login-time autostart never reached the tray.

**Fix:** align \`launcherBundleID\` in [\`tools/friday-launcher/paths.go\`](tools/friday-launcher/paths.go) with the value the installer actually writes. \`isAutostartStale()\` already detects ID mismatch, so existing broken installs auto-repair their plist on next launcher startup — no migration tooling needed.

The previous code's comment justified the suffix as *\"NOT the same as launchAgentLabel — Apple recommends distinct values to avoid LaunchServices treating the LaunchAgent as the .app's daemon.\"* That concern only applies when the LaunchAgent's \`Program\` **is** the .app's executable. Here \`Program\` is \`/usr/bin/open\` (a separate process), so label == bundle ID is fine.

## Bug 2 — bucket grace window doesn't cover user-initiated restarts

\`computeBucket\`'s grace window is anchored to the launcher's start time, not the latest restart:

\`\`\`go
if t.healthCache.AnyFailed() &&
    time.Since(t.sup.StartedAt()) >= 30*time.Second {
    return bucketRed
}
\`\`\`

A user-initiated tray Restart (or any transient \`AnyFailed\` past the cold-start grace) flips the bucket red even though process-compose's \`RestartPolicyAlways\` will bring services back.

**Fix:** track restart lifecycle on the supervisor and give each restart its own grace window:

- \`Supervisor.inRestart\` (atomic.Bool) — true between \`RestartAll\`'s start and end.
- \`Supervisor.lastRestartEndNano\` (atomic.Int64) — stamped on \`RestartAll\` return.
- \`Supervisor.RestartGraceActive()\` — true while \`inRestart\` OR within \`restartGraceWindow\` (30s, same magnitude as cold-start grace) of the last restart end.
- \`computeBucket\` adds \`&& !t.sup.RestartGraceActive()\` to the AnyFailed branch.

## Bug 3 — Restart all caused runner.Run() to exit, latching supervisorExited forever

After Bugs 1 + 2, manual testing on the VM still produced a permanent \" Error\" badge after every tray Restart click. Live captures with a 200 ms-cadence health monitor showed every service status was \`starting\` or \`healthy\` throughout the restart (never \`failed\`), so neither grace was even relevant. The only path in \`computeBucket\` that paints red without consulting \`AllHealthy\` is the \`SupervisorExited\` check.

Tracing into [\`process-compose@v1.103.0/src/app/project_runner.go:151-180\`](https://github.com/F1bonacc1/process-compose/blob/v1.103.0/src/app/project_runner.go#L151-L180), the \`Run()\` loop exits with \"Project completed\" the moment \`runProcCount == 0\` AND its \`restartCalls\` map is empty. The old \`RestartAll\` shape — \`StopProcess\` every supervised service, then \`StartProcess\` them in startOrder — never touched \`restartCalls\`, so the moment between the last stop and the first start satisfied both conditions:

1. \`Run()\` returns
2. \`runAndWatch\` latches \`supervisorExited = true\`
3. \`computeBucket\` paints red
4. The immediate \`StartProcess\` pass brings every child back up healthy, but \`supervisorExited\` is never cleared → bucket stays red forever

**Fix:** switch \`RestartAll\` to call \`runner.RestartProcess(name)\` for each service in startOrder. \`RestartProcess\` registers an entry in \`restartCalls\` for the duration of each call, so \`pendingRestarts > 0\` blocks the project-completed branch and \`Run()\` stays in its loop. As a side benefit the new shape keeps four of five services running at any instant rather than going all-down-then-all-up. Live verification on Apple Silicon VM showed end-to-end restart taking 12 s with at least one healthy service at every 200 ms sample, no \"Project completed\" in process-compose's logs, and the bucket returning cleanly to green.

## Bug 4 — \"Start at login\" silently re-enables itself across launcher restarts

After verifying autostart-on-fresh-install and autostart-disabled-via-tray + reboot both worked, one more failure mode emerged: unchecking \"Start at login\" then **relaunching the launcher** (without rebooting) re-checked the box. The plist file came back. The user's preference survived exactly one launcher restart before being silently overridden.

\`autostartSelfRegister\`'s case-2 staleness-repair branch calls \`enableAutostart\` whenever \`isAutostartStale()\` returns true. On darwin, \`isAutostartStale\` was:

\`\`\`go
func isAutostartStale() bool {
    registered := currentAutostartBundleID()
    return registered != launcherBundleID
}
\`\`\`

When the plist is absent, \`currentAutostartBundleID\` returns \`\"\"\`, and \`\"\" != launcherBundleID\` → stale → rewrite. That meant: any time the user disabled autostart via the tray (which removes the plist), the next launcher start re-enabled it. The Windows version (\`autostart_windows.go:104-111\`) already did this correctly with a \`registered != \"\"\` guard. Decision #36's stated intent — *\"a deliberately-disabled plist stays disabled across upgrades\"* — was undocumented in code as a contract. The existing test \`TestCurrentAutostartBundleID_AbsentReturnsEmpty\`'s comment even already documented the intended behavior; the implementation just didn't match.

**Fix:** add the \`registered != \"\"\` guard on darwin to mirror Windows. The new behavior matches the spec exactly:

| State | After fix |
|---|---|
| Fresh install (`state.AutostartInitialized=false`) | Case 1 fires → plist written + flag set |
| User unchecks tray, restarts launcher | Case 2 → \`isAutostartStale=false\` for absent plist → no rewrite. Disabled stays disabled. |
| User re-checks, restarts launcher | Plist present + ID matches → no rewrite. Enabled stays enabled. |
| Plist exists with old/wrong bundle ID | Case 2 → \`isAutostartStale=true\` for ID mismatch → rewrite. Migration still works. |

Pin behavior with \`TestIsAutostartStale_AbsentReturnsFalse\` referencing Decision #36 so a future refactor can't quietly regress it.

## Test plan

- [x] \`go build ./tools/friday-launcher/\` clean
- [x] \`go test -short ./tools/friday-launcher/\` passes (full short suite)
- [x] \`go vet\` clean, \`gofmt\` clean
- [x] New unit tests cover: active-restart amber, within-grace amber, post-grace-expiry red, grace inactive before first restart, isAutostartStale-absent-returns-false
- [x] Manual on Apple Silicon VM:
  - **Bug 1**: \`open -b ai.hellofriday.studio --args --no-browser\` from shell exits 0; rebooting with autostart enabled brings up the tray automatically
  - **Bug 2**: 200 ms-cadence monitor across a tray Restart shows transient \`starting\` states, no \" Error\" flash
  - **Bug 3**: same monitor confirms sequential per-service \`starting\` → \`healthy\` transitions, no all-down window, no \"Project completed\" in \`launcher-stdout.log\`, bucket returns cleanly to green
  - **Bug 4**: simulate user uncheck (rm plist) → kill + relaunch launcher → plist stays absent, \`state.json.autostart_initialized\` stays \`true\`, no \"autostart entry stale; rewriting\" log line for the new boot

## Notes

- Existing v0.0.x installs with the broken plist self-heal on first launcher run after upgrading.
- The four fixes are bundled because they all touch the autostart / restart code paths and share the same user-facing surface area. Separating them would force a user who upgrades only halfway to keep seeing one of the four symptoms.
- \`stopOrder\` is left in place for now — the integration test still asserts its value, and removing it is unrelated cleanup.