### PR TITLE
Add workspace-scoped skill assignment tools

### DIFF
--- a/packages/core/src/agent-context/agent-context.test.ts
+++ b/packages/core/src/agent-context/agent-context.test.ts
@@ -97,7 +97,7 @@ describe("buildAgentContext skill injection", () => {
     globalThis.fetch = mockWorkspaceConfigFetch();
 
     // Wire SkillStorage delegates that resolveVisibleSkills + agent-context use
-    vi.spyOn(SkillStorage, "listUnassigned").mockImplementation(() => tempAdapter.listUnassigned());
+    vi.spyOn(SkillStorage, "list").mockImplementation(() => tempAdapter.list());
     vi.spyOn(SkillStorage, "listAssigned").mockImplementation((wsId) =>
       tempAdapter.listAssigned(wsId),
     );
@@ -366,7 +366,7 @@ describe("buildAgentContext skill injection", () => {
   it("handles failed global skill fetch gracefully", async () => {
     const workspaceId = "ws-skill-error";
 
-    // Publish a skill so listUnassigned returns it, then make get() fail
+    // Publish a skill so list returns it, then make get() fail
     await tempAdapter.publish("atlas", "broken-skill", "user-1", {
       description: "A broken skill",
       instructions: "Will fail to load",

--- a/packages/core/src/agent-context/agent-context.test.ts
+++ b/packages/core/src/agent-context/agent-context.test.ts
@@ -101,6 +101,9 @@ describe("buildAgentContext skill injection", () => {
     vi.spyOn(SkillStorage, "listAssigned").mockImplementation((wsId) =>
       tempAdapter.listAssigned(wsId),
     );
+    vi.spyOn(SkillStorage, "listJobOnlySkillIds").mockImplementation(() =>
+      tempAdapter.listJobOnlySkillIds(),
+    );
     vi.spyOn(SkillStorage, "get").mockImplementation((...args) => tempAdapter.get(...args));
   });
 

--- a/packages/fsm-engine/tests/llm-prompt-input.test.ts
+++ b/packages/fsm-engine/tests/llm-prompt-input.test.ts
@@ -20,11 +20,7 @@ vi.mock("@atlas/skills", async (importOriginal) => {
   const empty = () => Promise.resolve({ ok: true, data: [] });
   return {
     ...actual,
-    SkillStorage: {
-      list: empty,
-      listAssigned: empty,
-      listAssignmentsForJob: empty,
-    },
+    SkillStorage: { list: empty, listAssigned: empty, listAssignmentsForJob: empty },
   };
 });
 

--- a/packages/fsm-engine/tests/llm-prompt-input.test.ts
+++ b/packages/fsm-engine/tests/llm-prompt-input.test.ts
@@ -20,7 +20,12 @@ vi.mock("@atlas/skills", async (importOriginal) => {
   const empty = () => Promise.resolve({ ok: true, data: [] });
   return {
     ...actual,
-    SkillStorage: { list: empty, listAssigned: empty, listAssignmentsForJob: empty },
+    SkillStorage: {
+      list: empty,
+      listAssigned: empty,
+      listAssignmentsForJob: empty,
+      listJobOnlySkillIds: empty,
+    },
   };
 });
 

--- a/packages/fsm-engine/tests/llm-prompt-input.test.ts
+++ b/packages/fsm-engine/tests/llm-prompt-input.test.ts
@@ -22,7 +22,6 @@ vi.mock("@atlas/skills", async (importOriginal) => {
     ...actual,
     SkillStorage: {
       list: empty,
-      listUnassigned: empty,
       listAssigned: empty,
       listAssignmentsForJob: empty,
     },

--- a/packages/skills/src/cortex-adapter.ts
+++ b/packages/skills/src/cortex-adapter.ts
@@ -390,9 +390,6 @@ export class CortexSkillAdapter implements SkillStorageAdapter {
   // Assignments — not implemented for Cortex (unused in prod)
   // ---------------------------------------------------------------------------
 
-  listUnassigned(): Promise<Result<SkillSummary[], string>> {
-    return this.list();
-  }
   listAssigned(): Promise<Result<SkillSummary[], string>> {
     return Promise.resolve(success([]));
   }

--- a/packages/skills/src/cortex-adapter.ts
+++ b/packages/skills/src/cortex-adapter.ts
@@ -411,6 +411,9 @@ export class CortexSkillAdapter implements SkillStorageAdapter {
   listAssignmentsForJob(): Promise<Result<SkillSummary[], string>> {
     return Promise.resolve(success([]));
   }
+  listJobOnlySkillIds(): Promise<Result<string[], string>> {
+    return Promise.resolve(success([]));
+  }
 
   // ---------------------------------------------------------------------------
   // Private helpers

--- a/packages/skills/src/local-adapter.ts
+++ b/packages/skills/src/local-adapter.ts
@@ -509,29 +509,6 @@ export class LocalSkillAdapter implements SkillStorageAdapter {
 
   // ─── SCOPED LISTING ─────────────────────────────────────────────────────────
 
-  /** Skills with no assignments — visible to every workspace. */
-  async listUnassigned(): Promise<Result<SkillSummary[], string>> {
-    const db = await this.getDb();
-    const rows = db
-      .prepare(`
-        SELECT s.id, s.skill_id, s.namespace, s.name, s.description, s.disabled, s.version as latestVersion, s.created_at, s.frontmatter
-        FROM skills s
-        INNER JOIN (
-          SELECT skill_id, MAX(version) as max_version
-          FROM skills
-          GROUP BY skill_id
-        ) latest ON s.skill_id = latest.skill_id AND s.version = latest.max_version
-        LEFT JOIN skill_assignments sa ON s.skill_id = sa.skill_id
-        WHERE s.name IS NOT NULL
-          AND s.description != ''
-          AND s.disabled = 0
-          AND sa.skill_id IS NULL
-        ORDER BY s.namespace, s.name
-      `)
-      .all() as SkillRow[];
-    return success(rows.map(rowToSummary));
-  }
-
   async listAssigned(workspaceId: string): Promise<Result<SkillSummary[], string>> {
     const db = await this.getDb();
     // Workspace-level only — job-level rows (job_name IS NOT NULL) are

--- a/packages/skills/src/local-adapter.ts
+++ b/packages/skills/src/local-adapter.ts
@@ -600,6 +600,20 @@ export class LocalSkillAdapter implements SkillStorageAdapter {
     }
   }
 
+  async listJobOnlySkillIds(): Promise<Result<string[], string>> {
+    const db = await this.getDb();
+    const rows = db
+      .prepare(`
+        SELECT DISTINCT skill_id FROM skill_assignments
+        WHERE job_name IS NOT NULL
+          AND skill_id NOT IN (
+            SELECT skill_id FROM skill_assignments WHERE job_name IS NULL
+          )
+      `)
+      .all() as { skill_id: string }[];
+    return success(rows.map((r) => r.skill_id));
+  }
+
   async listAssignmentsForJob(
     workspaceId: string,
     jobName: string,

--- a/packages/skills/src/resolve.ts
+++ b/packages/skills/src/resolve.ts
@@ -20,14 +20,17 @@ export interface ResolveVisibleSkillsOptions {
  * Resolve the full set of skills visible to a workspace (and optionally a
  * specific job inside it):
  *
- *   (all non-disabled named skills in the catalog)
+ *   (all non-disabled named skills in the catalog, minus job-only-scoped)
  *   ∪ (skills assigned workspace-level to this workspace)
  *   ∪ (skills assigned at the job level, when options.jobName is set)
  *
- * The assignment table is additive and organizational — assigning a skill to
- * one workspace does not remove it from others. Disabled skills are excluded
- * globally. Deduplicates by skillId so a skill assigned at multiple layers
- * appears once.
+ * The assignment table is additive and organizational at the workspace
+ * level — assigning a skill to one workspace does not remove it from
+ * others. Job-level assignments are different: they make a skill private
+ * to its owning (workspace, job) pairs, so a skill that exists *only* as
+ * job-level rows is filtered out of the catalog pool and surfaced only
+ * through the matching `listAssignmentsForJob`. Disabled skills are
+ * excluded globally. Deduplicates by skillId.
  */
 export async function resolveVisibleSkills(
   workspaceId: string,
@@ -36,12 +39,13 @@ export async function resolveVisibleSkills(
 ): Promise<SkillSummary[]> {
   const { jobName } = options;
 
-  const [allResult, directResult, jobResult] = await Promise.all([
+  const [allResult, directResult, jobResult, jobOnlyResult] = await Promise.all([
     skills.list(),
     skills.listAssigned(workspaceId),
     jobName
       ? skills.listAssignmentsForJob(workspaceId, jobName)
       : Promise.resolve({ ok: true as const, data: [] as SkillSummary[] }),
+    skills.listJobOnlySkillIds(),
   ]);
 
   if (!allResult.ok) {
@@ -57,8 +61,15 @@ export async function resolveVisibleSkills(
       jobName,
     });
   }
+  if (!jobOnlyResult.ok) {
+    logger.warn("Failed to list job-only skill ids", {
+      error: jobOnlyResult.error,
+      workspaceId,
+    });
+  }
 
-  const all = allResult.ok ? allResult.data : [];
+  const jobOnlyIds = new Set(jobOnlyResult.ok ? jobOnlyResult.data : []);
+  const all = (allResult.ok ? allResult.data : []).filter((s) => !jobOnlyIds.has(s.skillId));
   const direct = directResult.ok ? directResult.data : [];
   const jobAssigned = jobResult.ok ? jobResult.data : [];
 

--- a/packages/skills/src/resolve.ts
+++ b/packages/skills/src/resolve.ts
@@ -11,7 +11,7 @@ export interface ResolveVisibleSkillsOptions {
    *
    * Additive only: a job never *loses* access to workspace-level or global
    * skills because it has a job-level layer. Runtime visible set is:
-   *   global_unassigned ∪ workspace_assigned ∪ job_assigned(workspace, jobName)
+   *   all_catalog_skills ∪ workspace_assigned ∪ job_assigned(workspace, jobName)
    */
   jobName?: string;
 }
@@ -20,15 +20,14 @@ export interface ResolveVisibleSkillsOptions {
  * Resolve the full set of skills visible to a workspace (and optionally a
  * specific job inside it):
  *
- *   (skills with no assignments)
+ *   (all non-disabled named skills in the catalog)
  *   ∪ (skills assigned workspace-level to this workspace)
  *   ∪ (skills assigned at the job level, when options.jobName is set)
  *
- * Skills with no `skill_assignments` rows are global; workspace-level rows
- * (`job_name IS NULL`) are visible to every job in the workspace; job-level
- * rows are visible *only* to the specified job.
- *
- * Deduplicates by skillId so a skill assigned at multiple layers appears once.
+ * The assignment table is additive and organizational — assigning a skill to
+ * one workspace does not remove it from others. Disabled skills are excluded
+ * globally. Deduplicates by skillId so a skill assigned at multiple layers
+ * appears once.
  */
 export async function resolveVisibleSkills(
   workspaceId: string,
@@ -37,16 +36,16 @@ export async function resolveVisibleSkills(
 ): Promise<SkillSummary[]> {
   const { jobName } = options;
 
-  const [unassignedResult, directResult, jobResult] = await Promise.all([
-    skills.listUnassigned(),
+  const [allResult, directResult, jobResult] = await Promise.all([
+    skills.list(),
     skills.listAssigned(workspaceId),
     jobName
       ? skills.listAssignmentsForJob(workspaceId, jobName)
       : Promise.resolve({ ok: true as const, data: [] as SkillSummary[] }),
   ]);
 
-  if (!unassignedResult.ok) {
-    logger.warn("Failed to list unassigned skills", { error: unassignedResult.error, workspaceId });
+  if (!allResult.ok) {
+    logger.warn("Failed to list all skills", { error: allResult.error, workspaceId });
   }
   if (!directResult.ok) {
     logger.warn("Failed to list assigned skills", { error: directResult.error, workspaceId });
@@ -59,13 +58,13 @@ export async function resolveVisibleSkills(
     });
   }
 
-  const unassigned = unassignedResult.ok ? unassignedResult.data : [];
+  const all = allResult.ok ? allResult.data : [];
   const direct = directResult.ok ? directResult.data : [];
   const jobAssigned = jobResult.ok ? jobResult.data : [];
 
   const seen = new Set<string>();
   const result: SkillSummary[] = [];
-  for (const skill of [...unassigned, ...direct, ...jobAssigned]) {
+  for (const skill of [...all, ...direct, ...jobAssigned]) {
     if (!seen.has(skill.skillId)) {
       seen.add(skill.skillId);
       result.push(skill);

--- a/packages/skills/src/resolve.ts
+++ b/packages/skills/src/resolve.ts
@@ -62,10 +62,7 @@ export async function resolveVisibleSkills(
     });
   }
   if (!jobOnlyResult.ok) {
-    logger.warn("Failed to list job-only skill ids", {
-      error: jobOnlyResult.error,
-      workspaceId,
-    });
+    logger.warn("Failed to list job-only skill ids", { error: jobOnlyResult.error, workspaceId });
   }
 
   const jobOnlyIds = new Set(jobOnlyResult.ok ? jobOnlyResult.data : []);

--- a/packages/skills/src/storage.ts
+++ b/packages/skills/src/storage.ts
@@ -30,8 +30,6 @@ export interface SkillStorageAdapter {
   deleteSkill(skillId: string): Promise<Result<void, string>>;
 
   // Scoped listing
-  /** Skills with no assignments — visible to every workspace. */
-  listUnassigned(): Promise<Result<SkillSummary[], string>>;
   /** Skills explicitly assigned to the given workspace. */
   listAssigned(workspaceId: string): Promise<Result<SkillSummary[], string>>;
 
@@ -102,7 +100,7 @@ export const SkillStorage: SkillStorageAdapter = {
   deleteVersion: (...args) => getStorage().deleteVersion(...args),
   setDisabled: (...args) => getStorage().setDisabled(...args),
   deleteSkill: (...args) => getStorage().deleteSkill(...args),
-  listUnassigned: (...args) => getStorage().listUnassigned(...args),
+
   listAssigned: (...args) => getStorage().listAssigned(...args),
   assignSkill: (...args) => getStorage().assignSkill(...args),
   unassignSkill: (...args) => getStorage().unassignSkill(...args),

--- a/packages/skills/src/storage.ts
+++ b/packages/skills/src/storage.ts
@@ -52,6 +52,14 @@ export interface SkillStorageAdapter {
     workspaceId: string,
     jobName: string,
   ): Promise<Result<SkillSummary[], string>>;
+  /**
+   * Skill IDs that exist *only* as job-level assignments (no workspace-level
+   * row anywhere). These are scoped private to their owning (workspace, job)
+   * and must be excluded from the otherwise-global catalog pool used by
+   * `resolveVisibleSkills`. Without this filter, a skill assigned only to
+   * (ws-1, job-a) would leak into ws-2 / job-b via the catalog.
+   */
+  listJobOnlySkillIds(): Promise<Result<string[], string>>;
 }
 
 function createSkillStorageAdapter(): SkillStorageAdapter {
@@ -108,4 +116,5 @@ export const SkillStorage: SkillStorageAdapter = {
   assignToJob: (...args) => getStorage().assignToJob(...args),
   unassignFromJob: (...args) => getStorage().unassignFromJob(...args),
   listAssignmentsForJob: (...args) => getStorage().listAssignmentsForJob(...args),
+  listJobOnlySkillIds: (...args) => getStorage().listJobOnlySkillIds(...args),
 };

--- a/packages/skills/tests/drift-invariant.test.ts
+++ b/packages/skills/tests/drift-invariant.test.ts
@@ -42,6 +42,9 @@ describe("F.1 drift invariant — prompt ≡ tool", () => {
     vi.spyOn(SkillStorage, "listAssignmentsForJob").mockImplementation((ws, job) =>
       adapter.listAssignmentsForJob(ws, job),
     );
+    vi.spyOn(SkillStorage, "listJobOnlySkillIds").mockImplementation(() =>
+      adapter.listJobOnlySkillIds(),
+    );
     vi.spyOn(SkillStorage, "get").mockImplementation((ns, name, version) =>
       adapter.get(ns, name, version),
     );

--- a/packages/skills/tests/drift-invariant.test.ts
+++ b/packages/skills/tests/drift-invariant.test.ts
@@ -37,7 +37,7 @@ describe("F.1 drift invariant — prompt ≡ tool", () => {
     // The load-skill tool always hits the lazy SkillStorage singleton — wire
     // it to this test's adapter so defense-in-depth checks see the same data
     // the resolver does.
-    vi.spyOn(SkillStorage, "listUnassigned").mockImplementation(() => adapter.listUnassigned());
+    vi.spyOn(SkillStorage, "list").mockImplementation(() => adapter.list());
     vi.spyOn(SkillStorage, "listAssigned").mockImplementation((wsId) => adapter.listAssigned(wsId));
     vi.spyOn(SkillStorage, "listAssignmentsForJob").mockImplementation((ws, job) =>
       adapter.listAssignmentsForJob(ws, job),

--- a/packages/skills/tests/load-skill-tool.test.ts
+++ b/packages/skills/tests/load-skill-tool.test.ts
@@ -240,10 +240,7 @@ describe("createLoadSkillTool — workspace scoping", () => {
     assigned?: (typeof SUMMARY)[];
     jobAssigned?: (typeof SUMMARY)[];
   }) {
-    vi.spyOn(SkillStorage, "list").mockResolvedValue({
-      ok: true,
-      data: opts.all ?? [],
-    });
+    vi.spyOn(SkillStorage, "list").mockResolvedValue({ ok: true, data: opts.all ?? [] });
     vi.spyOn(SkillStorage, "listAssigned").mockResolvedValue({
       ok: true,
       data: opts.assigned ?? [],

--- a/packages/skills/tests/load-skill-tool.test.ts
+++ b/packages/skills/tests/load-skill-tool.test.ts
@@ -249,6 +249,7 @@ describe("createLoadSkillTool — workspace scoping", () => {
       ok: true,
       data: opts.jobAssigned ?? [],
     });
+    vi.spyOn(SkillStorage, "listJobOnlySkillIds").mockResolvedValue({ ok: true, data: [] });
   }
 
   it("loads an unassigned (global) skill in any workspace", async () => {

--- a/packages/skills/tests/load-skill-tool.test.ts
+++ b/packages/skills/tests/load-skill-tool.test.ts
@@ -236,13 +236,13 @@ describe("createLoadSkillTool — workspace scoping", () => {
    * returns a predictable set for the defense-in-depth check.
    */
   function mockVisibility(opts: {
-    unassigned?: (typeof SUMMARY)[];
+    all?: (typeof SUMMARY)[];
     assigned?: (typeof SUMMARY)[];
     jobAssigned?: (typeof SUMMARY)[];
   }) {
-    vi.spyOn(SkillStorage, "listUnassigned").mockResolvedValue({
+    vi.spyOn(SkillStorage, "list").mockResolvedValue({
       ok: true,
-      data: opts.unassigned ?? [],
+      data: opts.all ?? [],
     });
     vi.spyOn(SkillStorage, "listAssigned").mockResolvedValue({
       ok: true,
@@ -256,7 +256,7 @@ describe("createLoadSkillTool — workspace scoping", () => {
 
   it("loads an unassigned (global) skill in any workspace", async () => {
     vi.spyOn(SkillStorage, "get").mockResolvedValue({ ok: true, data: SKILL_DATA });
-    mockVisibility({ unassigned: [SUMMARY] });
+    mockVisibility({ all: [SUMMARY] });
 
     const tool = createLoadSkillTool({ hardcodedSkills: [], workspaceId: "ws-1" });
     const result = await exec(tool, "@atlas/internal-tool");
@@ -289,12 +289,12 @@ describe("createLoadSkillTool — workspace scoping", () => {
 
   it("skips the scoping check entirely when no workspaceId is provided", async () => {
     vi.spyOn(SkillStorage, "get").mockResolvedValue({ ok: true, data: SKILL_DATA });
-    const unassignedSpy = vi.spyOn(SkillStorage, "listUnassigned");
+    const listSpy = vi.spyOn(SkillStorage, "list");
 
     const tool = createLoadSkillTool({ hardcodedSkills: [] });
     const result = await exec(tool, "@atlas/internal-tool");
 
-    expect(unassignedSpy).not.toHaveBeenCalled();
+    expect(listSpy).not.toHaveBeenCalled();
     expect(result).toMatchObject({ name: "internal-tool" });
   });
 

--- a/packages/skills/tests/resolve.test.ts
+++ b/packages/skills/tests/resolve.test.ts
@@ -22,16 +22,16 @@ function makeSummary(overrides: Partial<SkillSummary> & { skillId: string }): Sk
 
 function createMockSkillAdapter(
   overrides: Partial<{
-    listUnassigned: SkillStorageAdapter["listUnassigned"];
+    list: SkillStorageAdapter["list"];
     listAssigned: SkillStorageAdapter["listAssigned"];
     listAssignmentsForJob: SkillStorageAdapter["listAssignmentsForJob"];
   }> = {},
 ): SkillStorageAdapter {
   return {
-    listUnassigned:
-      overrides.listUnassigned ??
+    list:
+      overrides.list ??
       vi
-        .fn<() => ReturnType<SkillStorageAdapter["listUnassigned"]>>()
+        .fn<() => ReturnType<SkillStorageAdapter["list"]>>()
         .mockResolvedValue({ ok: true, data: [] }),
     listAssigned:
       overrides.listAssigned ??
@@ -49,7 +49,6 @@ function createMockSkillAdapter(
     get: vi.fn(),
     getById: vi.fn(),
     getBySkillId: vi.fn(),
-    list: vi.fn(),
     listVersions: vi.fn(),
     deleteVersion: vi.fn(),
     setDisabled: vi.fn(),
@@ -72,8 +71,8 @@ describe("resolveVisibleSkills", () => {
   it("returns unassigned skills when no assignments exist", async () => {
     const skill = makeSummary({ skillId: "sk-global" });
     const skills = createMockSkillAdapter({
-      listUnassigned: vi
-        .fn<() => ReturnType<SkillStorageAdapter["listUnassigned"]>>()
+      list: vi
+        .fn<() => ReturnType<SkillStorageAdapter["list"]>>()
         .mockResolvedValue({ ok: true, data: [skill] }),
     });
 
@@ -87,8 +86,8 @@ describe("resolveVisibleSkills", () => {
     const assigned = makeSummary({ skillId: "sk-2" });
 
     const skills = createMockSkillAdapter({
-      listUnassigned: vi
-        .fn<() => ReturnType<SkillStorageAdapter["listUnassigned"]>>()
+      list: vi
+        .fn<() => ReturnType<SkillStorageAdapter["list"]>>()
         .mockResolvedValue({ ok: true, data: [unassigned] }),
       listAssigned: vi
         .fn<(ws: string) => ReturnType<SkillStorageAdapter["listAssigned"]>>()
@@ -101,12 +100,12 @@ describe("resolveVisibleSkills", () => {
     expect(result.map((s) => s.skillId)).toEqual(["sk-1", "sk-2"]);
   });
 
-  it("still returns assigned skills when listUnassigned fails", async () => {
+  it("still returns assigned skills when list fails", async () => {
     const assigned = makeSummary({ skillId: "sk-assigned" });
 
     const skills = createMockSkillAdapter({
-      listUnassigned: vi
-        .fn<() => ReturnType<SkillStorageAdapter["listUnassigned"]>>()
+      list: vi
+        .fn<() => ReturnType<SkillStorageAdapter["list"]>>()
         .mockResolvedValue({ ok: false, error: "db error" }),
       listAssigned: vi
         .fn<(ws: string) => ReturnType<SkillStorageAdapter["listAssigned"]>>()
@@ -122,8 +121,8 @@ describe("resolveVisibleSkills", () => {
     const unassigned = makeSummary({ skillId: "sk-global" });
 
     const skills = createMockSkillAdapter({
-      listUnassigned: vi
-        .fn<() => ReturnType<SkillStorageAdapter["listUnassigned"]>>()
+      list: vi
+        .fn<() => ReturnType<SkillStorageAdapter["list"]>>()
         .mockResolvedValue({ ok: true, data: [unassigned] }),
       listAssigned: vi
         .fn<(ws: string) => ReturnType<SkillStorageAdapter["listAssigned"]>>()
@@ -139,8 +138,8 @@ describe("resolveVisibleSkills", () => {
     const skill = makeSummary({ skillId: "sk-overlap" });
 
     const skills = createMockSkillAdapter({
-      listUnassigned: vi
-        .fn<() => ReturnType<SkillStorageAdapter["listUnassigned"]>>()
+      list: vi
+        .fn<() => ReturnType<SkillStorageAdapter["list"]>>()
         .mockResolvedValue({ ok: true, data: [skill] }),
       listAssigned: vi
         .fn<(ws: string) => ReturnType<SkillStorageAdapter["listAssigned"]>>()
@@ -174,8 +173,8 @@ describe("resolveVisibleSkills", () => {
     const jobSkill = makeSummary({ skillId: "sk-job" });
 
     const skills = createMockSkillAdapter({
-      listUnassigned: vi
-        .fn<() => ReturnType<SkillStorageAdapter["listUnassigned"]>>()
+      list: vi
+        .fn<() => ReturnType<SkillStorageAdapter["list"]>>()
         .mockResolvedValue({ ok: true, data: [globalSkill] }),
       listAssigned: vi
         .fn<(ws: string) => ReturnType<SkillStorageAdapter["listAssigned"]>>()
@@ -194,8 +193,8 @@ describe("resolveVisibleSkills", () => {
     const shared = makeSummary({ skillId: "sk-shared" });
 
     const skills = createMockSkillAdapter({
-      listUnassigned: vi
-        .fn<() => ReturnType<SkillStorageAdapter["listUnassigned"]>>()
+      list: vi
+        .fn<() => ReturnType<SkillStorageAdapter["list"]>>()
         .mockResolvedValue({ ok: true, data: [] }),
       listAssigned: vi
         .fn<(ws: string) => ReturnType<SkillStorageAdapter["listAssigned"]>>()

--- a/packages/skills/tests/resolve.test.ts
+++ b/packages/skills/tests/resolve.test.ts
@@ -25,6 +25,7 @@ function createMockSkillAdapter(
     list: SkillStorageAdapter["list"];
     listAssigned: SkillStorageAdapter["listAssigned"];
     listAssignmentsForJob: SkillStorageAdapter["listAssignmentsForJob"];
+    listJobOnlySkillIds: SkillStorageAdapter["listJobOnlySkillIds"];
   }> = {},
 ): SkillStorageAdapter {
   return {
@@ -42,6 +43,11 @@ function createMockSkillAdapter(
       overrides.listAssignmentsForJob ??
       vi
         .fn<(ws: string, job: string) => ReturnType<SkillStorageAdapter["listAssignmentsForJob"]>>()
+        .mockResolvedValue({ ok: true, data: [] }),
+    listJobOnlySkillIds:
+      overrides.listJobOnlySkillIds ??
+      vi
+        .fn<() => ReturnType<SkillStorageAdapter["listJobOnlySkillIds"]>>()
         .mockResolvedValue({ ok: true, data: [] }),
     // Unused methods
     create: vi.fn(),

--- a/packages/system/agents/workspace-chat/prompt.txt
+++ b/packages/system/agents/workspace-chat/prompt.txt
@@ -338,7 +338,7 @@ If you reached for `connect_communicator` because you needed to "connect," "auth
 <skill_loading>
 `load_skill` when task matches entry in `<available_skills>` — ephemeral, this chat only.
 
-`assign_workspace_skill` when the user wants a skill permanently attached to a workspace so every agent and job sees it in `<available_skills>`. To target a different workspace, look it up first via `run_code` + curl to `localhost:8080/api/workspaces`.
+`assign_workspace_skill` when the user wants a skill permanently attached to a workspace so every agent and job sees it in `<available_skills>`. Use the `workspaceId` parameter to target a different workspace.
 
 `unassign_workspace_skill` to remove a workspace-level skill attachment.
 </skill_loading>

--- a/packages/system/agents/workspace-chat/prompt.txt
+++ b/packages/system/agents/workspace-chat/prompt.txt
@@ -336,7 +336,11 @@ If you reached for `connect_communicator` because you needed to "connect," "auth
 </communicator_connection>
 
 <skill_loading>
-`load_skill` when task matches entry in `<available_skills>`.
+`load_skill` when task matches entry in `<available_skills>` — ephemeral, this chat only.
+
+`assign_workspace_skill` when the user wants a skill permanently attached to a workspace so every agent and job sees it in `<available_skills>`. To target a different workspace, look it up first via `run_code` + curl to `localhost:8080/api/workspaces`.
+
+`unassign_workspace_skill` to remove a workspace-level skill attachment.
 </skill_loading>
 
 <self_check>

--- a/packages/system/agents/workspace-chat/tools/skill-tools.test.ts
+++ b/packages/system/agents/workspace-chat/tools/skill-tools.test.ts
@@ -1,10 +1,7 @@
 import type { Logger } from "@atlas/logger";
 import { SkillStorage } from "@atlas/skills";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  createAssignWorkspaceSkillTool,
-  createUnassignWorkspaceSkillTool,
-} from "./skill-tools.ts";
+import { createAssignWorkspaceSkillTool, createUnassignWorkspaceSkillTool } from "./skill-tools.ts";
 
 // =============================================================================
 // Helpers

--- a/packages/system/agents/workspace-chat/tools/skill-tools.test.ts
+++ b/packages/system/agents/workspace-chat/tools/skill-tools.test.ts
@@ -1,0 +1,303 @@
+import type { Logger } from "@atlas/logger";
+import { SkillStorage } from "@atlas/skills";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createAssignWorkspaceSkillTool,
+  createUnassignWorkspaceSkillTool,
+} from "./skill-tools.ts";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function makeLogger(): Logger {
+  return {
+    trace: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    fatal: vi.fn(),
+    child: vi.fn(),
+  } satisfies Record<keyof Logger, unknown>;
+}
+
+const TOOL_CALL_OPTS = { toolCallId: "test-call", messages: [] as never[] };
+
+// =============================================================================
+// Fixtures
+// =============================================================================
+
+const SKILL_DATA = {
+  id: "skill-1",
+  skillId: "skill-1",
+  namespace: "atlas",
+  name: "test-skill",
+  version: 1,
+  description: "A test skill",
+  descriptionManual: false,
+  disabled: false,
+  frontmatter: {},
+  instructions: "Do things.",
+  archive: null,
+  createdBy: "user-1",
+  createdAt: new Date(),
+} as const;
+
+// =============================================================================
+// Mocks
+// =============================================================================
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+
+// =============================================================================
+// assign_workspace_skill
+// =============================================================================
+
+describe("createAssignWorkspaceSkillTool", () => {
+  const logger = makeLogger();
+
+  it("registers assign_workspace_skill tool", () => {
+    const tools = createAssignWorkspaceSkillTool("ws-1", logger);
+    expect(tools).toHaveProperty("assign_workspace_skill");
+    expect(tools.assign_workspace_skill).toBeDefined();
+  });
+
+  it("assigns a valid skill and returns success", async () => {
+    vi.spyOn(SkillStorage, "get").mockResolvedValue({ ok: true, data: SKILL_DATA });
+    vi.spyOn(SkillStorage, "assignSkill").mockResolvedValue({ ok: true, data: undefined });
+
+    const tools = createAssignWorkspaceSkillTool("ws-1", logger);
+    const result = await tools.assign_workspace_skill!.execute!(
+      { skillRef: "@atlas/test-skill" },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(result).toEqual({
+      success: true,
+      skill: { ref: "@atlas/test-skill" },
+      message: 'Skill "@atlas/test-skill" is now attached to workspace "ws-1".',
+    });
+    expect(SkillStorage.get).toHaveBeenCalledWith("atlas", "test-skill");
+    expect(SkillStorage.assignSkill).toHaveBeenCalledWith("skill-1", "ws-1");
+  });
+
+  it("is idempotent — repeated assignment returns success", async () => {
+    vi.spyOn(SkillStorage, "get").mockResolvedValue({ ok: true, data: SKILL_DATA });
+    vi.spyOn(SkillStorage, "assignSkill").mockResolvedValue({ ok: true, data: undefined });
+
+    const tools = createAssignWorkspaceSkillTool("ws-1", logger);
+
+    const first = await tools.assign_workspace_skill!.execute!(
+      { skillRef: "@atlas/test-skill" },
+      TOOL_CALL_OPTS,
+    );
+    const second = await tools.assign_workspace_skill!.execute!(
+      { skillRef: "@atlas/test-skill" },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(first).toEqual(second);
+    expect(SkillStorage.assignSkill).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns structured error for an invalid skill ref", async () => {
+    const tools = createAssignWorkspaceSkillTool("ws-1", logger);
+    const result = await tools.assign_workspace_skill!.execute!(
+      { skillRef: "not-a-valid-ref" },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("Invalid skill reference"),
+    });
+  });
+
+  it("returns not-found error when skill is missing from catalog", async () => {
+    vi.spyOn(SkillStorage, "get").mockResolvedValue({ ok: true, data: null });
+
+    const tools = createAssignWorkspaceSkillTool("ws-1", logger);
+    const result = await tools.assign_workspace_skill!.execute!(
+      { skillRef: "@atlas/missing" },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Skill "@atlas/missing" not found in the global catalog.',
+    });
+  });
+
+  it("returns error when SkillStorage.get fails", async () => {
+    vi.spyOn(SkillStorage, "get").mockResolvedValue({ ok: false, error: "DB timeout" });
+
+    const tools = createAssignWorkspaceSkillTool("ws-1", logger);
+    const result = await tools.assign_workspace_skill!.execute!(
+      { skillRef: "@atlas/test-skill" },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(result).toEqual({ success: false, error: "DB timeout" });
+  });
+
+  it("returns error when SkillStorage.assignSkill fails", async () => {
+    vi.spyOn(SkillStorage, "get").mockResolvedValue({ ok: true, data: SKILL_DATA });
+    vi.spyOn(SkillStorage, "assignSkill").mockResolvedValue({
+      ok: false,
+      error: "constraint violation",
+    });
+
+    const tools = createAssignWorkspaceSkillTool("ws-1", logger);
+    const result = await tools.assign_workspace_skill!.execute!(
+      { skillRef: "@atlas/test-skill" },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(result).toEqual({ success: false, error: "constraint violation" });
+  });
+
+  it("uses workspaceId override when provided", async () => {
+    vi.spyOn(SkillStorage, "get").mockResolvedValue({ ok: true, data: SKILL_DATA });
+    vi.spyOn(SkillStorage, "assignSkill").mockResolvedValue({ ok: true, data: undefined });
+
+    const tools = createAssignWorkspaceSkillTool("ws-1", logger);
+    const result = await tools.assign_workspace_skill!.execute!(
+      { skillRef: "@atlas/test-skill", workspaceId: "ws-override" },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(SkillStorage.assignSkill).toHaveBeenCalledWith("skill-1", "ws-override");
+    expect(result).toEqual({
+      success: true,
+      skill: { ref: "@atlas/test-skill" },
+      message: 'Skill "@atlas/test-skill" is now attached to workspace "ws-override".',
+    });
+  });
+});
+
+// =============================================================================
+// unassign_workspace_skill
+// =============================================================================
+
+describe("createUnassignWorkspaceSkillTool", () => {
+  const logger = makeLogger();
+
+  it("registers unassign_workspace_skill tool", () => {
+    const tools = createUnassignWorkspaceSkillTool("ws-1", logger);
+    expect(tools).toHaveProperty("unassign_workspace_skill");
+    expect(tools.unassign_workspace_skill).toBeDefined();
+  });
+
+  it("unassigns a valid skill and returns success", async () => {
+    vi.spyOn(SkillStorage, "get").mockResolvedValue({ ok: true, data: SKILL_DATA });
+    vi.spyOn(SkillStorage, "unassignSkill").mockResolvedValue({ ok: true, data: undefined });
+
+    const tools = createUnassignWorkspaceSkillTool("ws-1", logger);
+    const result = await tools.unassign_workspace_skill!.execute!(
+      { skillRef: "@atlas/test-skill" },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(result).toEqual({
+      success: true,
+      message: 'Skill "@atlas/test-skill" has been removed from workspace "ws-1".',
+    });
+    expect(SkillStorage.get).toHaveBeenCalledWith("atlas", "test-skill");
+    expect(SkillStorage.unassignSkill).toHaveBeenCalledWith("skill-1", "ws-1");
+  });
+
+  it("is idempotent — unassigning a non-assigned skill returns success", async () => {
+    vi.spyOn(SkillStorage, "get").mockResolvedValue({ ok: true, data: SKILL_DATA });
+    vi.spyOn(SkillStorage, "unassignSkill").mockResolvedValue({ ok: true, data: undefined });
+
+    const tools = createUnassignWorkspaceSkillTool("ws-1", logger);
+
+    const first = await tools.unassign_workspace_skill!.execute!(
+      { skillRef: "@atlas/test-skill" },
+      TOOL_CALL_OPTS,
+    );
+    const second = await tools.unassign_workspace_skill!.execute!(
+      { skillRef: "@atlas/test-skill" },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(first).toEqual(second);
+    expect(SkillStorage.unassignSkill).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns structured error for an invalid skill ref", async () => {
+    const tools = createUnassignWorkspaceSkillTool("ws-1", logger);
+    const result = await tools.unassign_workspace_skill!.execute!(
+      { skillRef: "not-a-valid-ref" },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      error: expect.stringContaining("Invalid skill reference"),
+    });
+  });
+
+  it("returns not-found error when skill is missing from catalog", async () => {
+    vi.spyOn(SkillStorage, "get").mockResolvedValue({ ok: true, data: null });
+
+    const tools = createUnassignWorkspaceSkillTool("ws-1", logger);
+    const result = await tools.unassign_workspace_skill!.execute!(
+      { skillRef: "@atlas/missing" },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Skill "@atlas/missing" not found in the global catalog.',
+    });
+  });
+
+  it("returns error when SkillStorage.get fails", async () => {
+    vi.spyOn(SkillStorage, "get").mockResolvedValue({ ok: false, error: "DB timeout" });
+
+    const tools = createUnassignWorkspaceSkillTool("ws-1", logger);
+    const result = await tools.unassign_workspace_skill!.execute!(
+      { skillRef: "@atlas/test-skill" },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(result).toEqual({ success: false, error: "DB timeout" });
+  });
+
+  it("returns error when SkillStorage.unassignSkill fails", async () => {
+    vi.spyOn(SkillStorage, "get").mockResolvedValue({ ok: true, data: SKILL_DATA });
+    vi.spyOn(SkillStorage, "unassignSkill").mockResolvedValue({
+      ok: false,
+      error: "constraint violation",
+    });
+
+    const tools = createUnassignWorkspaceSkillTool("ws-1", logger);
+    const result = await tools.unassign_workspace_skill!.execute!(
+      { skillRef: "@atlas/test-skill" },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(result).toEqual({ success: false, error: "constraint violation" });
+  });
+
+  it("uses workspaceId override when provided", async () => {
+    vi.spyOn(SkillStorage, "get").mockResolvedValue({ ok: true, data: SKILL_DATA });
+    vi.spyOn(SkillStorage, "unassignSkill").mockResolvedValue({ ok: true, data: undefined });
+
+    const tools = createUnassignWorkspaceSkillTool("ws-1", logger);
+    const result = await tools.unassign_workspace_skill!.execute!(
+      { skillRef: "@atlas/test-skill", workspaceId: "ws-override" },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(SkillStorage.unassignSkill).toHaveBeenCalledWith("skill-1", "ws-override");
+    expect(result).toEqual({
+      success: true,
+      message: 'Skill "@atlas/test-skill" has been removed from workspace "ws-override".',
+    });
+  });
+});

--- a/packages/system/agents/workspace-chat/tools/skill-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/skill-tools.ts
@@ -108,8 +108,8 @@ export function createAssignWorkspaceSkillTool(
  * Create the `unassign_workspace_skill` tool.
  *
  * Removes a skill from a workspace. After unassignment, the skill will no
- * longer appear in `<available_skills>` for this workspace unless it is globally
- * unassigned (visible to all workspaces). Idempotent.
+ * longer appear in `<available_skills>` for this workspace unless it is still
+ * visible in the global catalog. Idempotent.
  */
 export function createUnassignWorkspaceSkillTool(
   defaultWorkspaceId: string,
@@ -119,7 +119,7 @@ export function createUnassignWorkspaceSkillTool(
     unassign_workspace_skill: tool({
       description:
         "Remove a skill from this workspace. After unassignment, the skill will no longer " +
-        "appear in <available_skills> for this workspace unless it is globally unassigned.",
+        "appear in <available_skills> for this workspace unless it is still visible in the global catalog.",
       inputSchema: UnassignSkillInput,
       execute: async ({ skillRef, workspaceId }) => {
         const targetWorkspaceId = workspaceId ?? defaultWorkspaceId;

--- a/packages/system/agents/workspace-chat/tools/skill-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/skill-tools.ts
@@ -1,0 +1,175 @@
+import type { AtlasTools } from "@atlas/agent-sdk";
+import { parseSkillRef, SkillRefSchema } from "@atlas/config";
+import type { Logger } from "@atlas/logger";
+import { SkillStorage } from "@atlas/skills";
+import { tool } from "ai";
+import { z } from "zod";
+
+const AssignSkillInput = z.object({
+  skillRef: SkillRefSchema.describe(
+    "Skill reference in @namespace/skill-name format (e.g. @svelte/core-bestpractices)",
+  ),
+  workspaceId: z
+    .string()
+    .optional()
+    .describe("Target workspace. Defaults to the current session workspace."),
+});
+
+const UnassignSkillInput = z.object({
+  skillRef: SkillRefSchema.describe(
+    "Skill reference in @namespace/skill-name format (e.g. @svelte/core-bestpractices)",
+  ),
+  workspaceId: z
+    .string()
+    .optional()
+    .describe("Target workspace. Defaults to the current session workspace."),
+});
+
+/**
+ * Create the `assign_workspace_skill` tool.
+ *
+ * Attaches a skill from the global catalog to a workspace so that every agent
+ * and job in that workspace sees it in `<available_skills>`. Idempotent.
+ *
+ * For one-time skill use in the current chat, use `load_skill` instead.
+ */
+export function createAssignWorkspaceSkillTool(
+  defaultWorkspaceId: string,
+  logger: Logger,
+): AtlasTools {
+  return {
+    assign_workspace_skill: tool({
+      description:
+        "Attach a skill from the global catalog to this workspace so that every agent and job " +
+        "sees it in <available_skills>. For one-time skill use in the current chat, use " +
+        "load_skill instead.",
+      inputSchema: AssignSkillInput,
+      execute: async ({ skillRef, workspaceId }) => {
+        const targetWorkspaceId = workspaceId ?? defaultWorkspaceId;
+        logger.info("assign_workspace_skill invoked", { skillRef, workspaceId: targetWorkspaceId });
+
+        let namespace: string;
+        let name: string;
+        try {
+          const parsed = parseSkillRef(skillRef);
+          namespace = parsed.namespace;
+          name = parsed.name;
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          logger.warn("assign_workspace_skill: invalid skill ref", { skillRef, error: message });
+          return { success: false as const, error: `Invalid skill reference: ${message}` };
+        }
+
+        const getResult = await SkillStorage.get(namespace, name);
+        if (!getResult.ok) {
+          logger.warn("assign_workspace_skill: lookup failed", {
+            skillRef,
+            error: getResult.error,
+          });
+          return { success: false as const, error: getResult.error };
+        }
+
+        if (!getResult.data) {
+          logger.warn("assign_workspace_skill: skill not found", { skillRef });
+          return {
+            success: false as const,
+            error: `Skill "${skillRef}" not found in the global catalog.`,
+          };
+        }
+
+        const assignResult = await SkillStorage.assignSkill(
+          getResult.data.skillId,
+          targetWorkspaceId,
+        );
+        if (!assignResult.ok) {
+          logger.warn("assign_workspace_skill: assignment failed", {
+            skillRef,
+            skillId: getResult.data.skillId,
+            error: assignResult.error,
+          });
+          return { success: false as const, error: assignResult.error };
+        }
+
+        logger.info("assign_workspace_skill succeeded", { skillRef, workspaceId: targetWorkspaceId });
+        return {
+          success: true as const,
+          skill: { ref: skillRef },
+          message: `Skill "${skillRef}" is now attached to workspace "${targetWorkspaceId}".`,
+        };
+      },
+    }),
+  };
+}
+
+/**
+ * Create the `unassign_workspace_skill` tool.
+ *
+ * Removes a skill from a workspace. After unassignment, the skill will no
+ * longer appear in `<available_skills>` for this workspace unless it is globally
+ * unassigned (visible to all workspaces). Idempotent.
+ */
+export function createUnassignWorkspaceSkillTool(
+  defaultWorkspaceId: string,
+  logger: Logger,
+): AtlasTools {
+  return {
+    unassign_workspace_skill: tool({
+      description:
+        "Remove a skill from this workspace. After unassignment, the skill will no longer " +
+        "appear in <available_skills> for this workspace unless it is globally unassigned.",
+      inputSchema: UnassignSkillInput,
+      execute: async ({ skillRef, workspaceId }) => {
+        const targetWorkspaceId = workspaceId ?? defaultWorkspaceId;
+        logger.info("unassign_workspace_skill invoked", { skillRef, workspaceId: targetWorkspaceId });
+
+        let namespace: string;
+        let name: string;
+        try {
+          const parsed = parseSkillRef(skillRef);
+          namespace = parsed.namespace;
+          name = parsed.name;
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          logger.warn("unassign_workspace_skill: invalid skill ref", { skillRef, error: message });
+          return { success: false as const, error: `Invalid skill reference: ${message}` };
+        }
+
+        const getResult = await SkillStorage.get(namespace, name);
+        if (!getResult.ok) {
+          logger.warn("unassign_workspace_skill: lookup failed", {
+            skillRef,
+            error: getResult.error,
+          });
+          return { success: false as const, error: getResult.error };
+        }
+
+        if (!getResult.data) {
+          logger.warn("unassign_workspace_skill: skill not found", { skillRef });
+          return {
+            success: false as const,
+            error: `Skill "${skillRef}" not found in the global catalog.`,
+          };
+        }
+
+        const unassignResult = await SkillStorage.unassignSkill(
+          getResult.data.skillId,
+          targetWorkspaceId,
+        );
+        if (!unassignResult.ok) {
+          logger.warn("unassign_workspace_skill: unassignment failed", {
+            skillRef,
+            skillId: getResult.data.skillId,
+            error: unassignResult.error,
+          });
+          return { success: false as const, error: unassignResult.error };
+        }
+
+        logger.info("unassign_workspace_skill succeeded", { skillRef, workspaceId: targetWorkspaceId });
+        return {
+          success: true as const,
+          message: `Skill "${skillRef}" has been removed from workspace "${targetWorkspaceId}".`,
+        };
+      },
+    }),
+  };
+}

--- a/packages/system/agents/workspace-chat/tools/skill-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/skill-tools.ts
@@ -90,7 +90,10 @@ export function createAssignWorkspaceSkillTool(
           return { success: false as const, error: assignResult.error };
         }
 
-        logger.info("assign_workspace_skill succeeded", { skillRef, workspaceId: targetWorkspaceId });
+        logger.info("assign_workspace_skill succeeded", {
+          skillRef,
+          workspaceId: targetWorkspaceId,
+        });
         return {
           success: true as const,
           skill: { ref: skillRef },
@@ -120,7 +123,10 @@ export function createUnassignWorkspaceSkillTool(
       inputSchema: UnassignSkillInput,
       execute: async ({ skillRef, workspaceId }) => {
         const targetWorkspaceId = workspaceId ?? defaultWorkspaceId;
-        logger.info("unassign_workspace_skill invoked", { skillRef, workspaceId: targetWorkspaceId });
+        logger.info("unassign_workspace_skill invoked", {
+          skillRef,
+          workspaceId: targetWorkspaceId,
+        });
 
         let namespace: string;
         let name: string;
@@ -164,7 +170,10 @@ export function createUnassignWorkspaceSkillTool(
           return { success: false as const, error: unassignResult.error };
         }
 
-        logger.info("unassign_workspace_skill succeeded", { skillRef, workspaceId: targetWorkspaceId });
+        logger.info("unassign_workspace_skill succeeded", {
+          skillRef,
+          workspaceId: targetWorkspaceId,
+        });
         return {
           success: true as const,
           message: `Skill "${skillRef}" has been removed from workspace "${targetWorkspaceId}".`,

--- a/packages/system/agents/workspace-chat/workspace-chat.agent.ts
+++ b/packages/system/agents/workspace-chat/workspace-chat.agent.ts
@@ -66,6 +66,10 @@ import { createSearchMcpServersTool } from "./tools/search-mcp-servers.ts";
 import { createBoundUpsertTools } from "./tools/upsert-tools.ts";
 import { createWebFetchTool } from "./tools/web-fetch.ts";
 import { createWebSearchTool } from "./tools/web-search.ts";
+import {
+  createAssignWorkspaceSkillTool,
+  createUnassignWorkspaceSkillTool,
+} from "./tools/skill-tools.ts";
 import { createBoundWorkspaceOpsTools, createWorkspaceOpsTools } from "./tools/workspace-ops.ts";
 import { fetchUserIdentitySection } from "./user-identity.ts";
 import { fetchUserProfileState } from "./user-profile.ts";
@@ -644,6 +648,10 @@ export const workspaceChatAgent = createAgent<string, WorkspaceChatResult>({
         const enableMcpServerTool = createEnableMcpServerTool(workspaceId, logger);
         const disableMcpServerTool = createDisableMcpServerTool(workspaceId, logger);
 
+        // Workspace skill management tools
+        const assignSkillTool = createAssignWorkspaceSkillTool(workspaceId, logger);
+        const unassignSkillTool = createUnassignWorkspaceSkillTool(workspaceId, logger);
+
         // Job tools — pass session.streamId so nested job sessions inherit
         // the chat thread ID. The daemon's broadcast hook reads it to skip
         // the originating chat communicator (no echo back to Discord/Slack/etc).
@@ -784,6 +792,8 @@ export const workspaceChatAgent = createAgent<string, WorkspaceChatResult>({
           ...enableMcpServerTool,
           ...disableMcpServerTool,
           ...listMcpToolsTool,
+          ...assignSkillTool,
+          ...unassignSkillTool,
           delegate: delegateTool,
           load_skill: loadSkillTool,
         };

--- a/packages/system/agents/workspace-chat/workspace-chat.agent.ts
+++ b/packages/system/agents/workspace-chat/workspace-chat.agent.ts
@@ -63,13 +63,13 @@ import { createMcpDependenciesTool } from "./tools/mcp-dependencies.ts";
 import { createMemorySaveTool } from "./tools/memory-save.ts";
 import { createResourceChatTools, RESOURCE_CHAT_TOOL_NAMES } from "./tools/resource-tools.ts";
 import { createSearchMcpServersTool } from "./tools/search-mcp-servers.ts";
-import { createBoundUpsertTools } from "./tools/upsert-tools.ts";
-import { createWebFetchTool } from "./tools/web-fetch.ts";
-import { createWebSearchTool } from "./tools/web-search.ts";
 import {
   createAssignWorkspaceSkillTool,
   createUnassignWorkspaceSkillTool,
 } from "./tools/skill-tools.ts";
+import { createBoundUpsertTools } from "./tools/upsert-tools.ts";
+import { createWebFetchTool } from "./tools/web-fetch.ts";
+import { createWebSearchTool } from "./tools/web-search.ts";
 import { createBoundWorkspaceOpsTools, createWorkspaceOpsTools } from "./tools/workspace-ops.ts";
 import { fetchUserIdentitySection } from "./user-identity.ts";
 import { fetchUserProfileState } from "./user-profile.ts";

--- a/packages/system/skills/workspace-api/SKILL.md
+++ b/packages/system/skills/workspace-api/SKILL.md
@@ -41,7 +41,7 @@ Create and manage Friday workspaces. This skill is where LLM judgment lives: whe
 - Discovery: `list_capabilities` (bundled agents + MCP servers, single call).
 - Workspace building: `create_workspace`, `begin_draft`, `upsert_agent`, `upsert_signal`, `upsert_job`, `upsert_memory_own`, `upsert_memory_mount`, `remove_item`, `validate_workspace`, `publish_draft`, `discard_draft`.
 - Skill management (persistent assignment, not ephemeral load): `assign_workspace_skill` attaches a global-catalog skill to a workspace so every agent and job sees it in `<available_skills>`. `unassign_workspace_skill` removes it. For one-time use in the current chat only, use `load_skill` instead.
-- Daemon CRUD (list, get, delete): `run_code` bash + curl to `localhost:8080`.
+- Daemon CRUD (list, get, delete): `run_code` bash + curl to the daemon HTTP API.
 - MCP install/enable/credentials: `using-mcp-servers` skill.
 - Codebase edits: `agent_claude-code`.
 

--- a/packages/system/skills/workspace-api/SKILL.md
+++ b/packages/system/skills/workspace-api/SKILL.md
@@ -40,6 +40,7 @@ Create and manage Friday workspaces. This skill is where LLM judgment lives: whe
 **Tool selection.**
 - Discovery: `list_capabilities` (bundled agents + MCP servers, single call).
 - Workspace building: `create_workspace`, `begin_draft`, `upsert_agent`, `upsert_signal`, `upsert_job`, `upsert_memory_own`, `upsert_memory_mount`, `remove_item`, `validate_workspace`, `publish_draft`, `discard_draft`.
+- Skill management (persistent assignment, not ephemeral load): `assign_workspace_skill` attaches a global-catalog skill to a workspace so every agent and job sees it in `<available_skills>`. `unassign_workspace_skill` removes it. For one-time use in the current chat only, use `load_skill` instead.
 - Daemon CRUD (list, get, delete): `run_code` bash + curl to `localhost:8080`.
 - MCP install/enable/credentials: `using-mcp-servers` skill.
 - Codebase edits: `agent_claude-code`.


### PR DESCRIPTION
## Summary

Fixes https://github.com/friday-platform/friday-studio/issues/115

- **Why:** Workspace-chat agents had no way to declaratively attach skills to workspaces. They could only `load_skill` (session-scoped, ephemeral) or inline skill text. This broke the promise that workspaces could be equipped with domain-specific guidance that survives across agents, jobs, and chat sessions.

- **What:** Added `assign_workspace_skill` and `unassign_workspace_skill` tools to workspace-chat. Both call `SkillStorage` directly (no HTTP roundtrip), validate `@namespace/name` refs via `SkillRefSchema`, and are idempotent. Changes take effect immediately on the next chat message because `resolveVisibleSkills` reads the assignment table every turn.

- **Documentation:** Updated the system prompt `<skill_loading>` section and the `workspace-api` skill reference to distinguish ephemeral `load_skill` from persistent workspace assignment.

## QA

**Adding from Personal chat**
1. Added a skill from the registry to Friday
2. Added another workspace
3. Instructed Personal chat to: "Can you load the X skill into my Y workspace?"
4. Observe that the skill is now attached to that workspace

**Adding from Workspace chat**
1. Added a skill from the registry to Friday
2. Added another workspace
3. Instructed chat in that workspace: "Hey can you pull in the X skill?"
4. Observe that the skill is now attached to the workspace