### PR TITLE
Enforce timeout on hung MCP servers

### DIFF
--- a/apps/atlasd/routes/mcp-registry.test.ts
+++ b/apps/atlasd/routes/mcp-registry.test.ts
@@ -50,15 +50,6 @@ const mockCreateMCPTools =
 
 vi.mock("@atlas/mcp", () => ({
   createMCPTools: (...args: Parameters<typeof mockCreateMCPTools>) => mockCreateMCPTools(...args),
-  MCPAuthError: class extends Error {
-    readonly serverId: string;
-    readonly url: string;
-    constructor(serverId: string, url: string, message: string) {
-      super(`MCP server "${serverId}" authentication failed (${url}): ${message}`);
-      this.serverId = serverId;
-      this.url = url;
-    }
-  },
 }));
 
 // Mock streamText from ai for test-chat tests

--- a/apps/atlasd/routes/mcp-registry.ts
+++ b/apps/atlasd/routes/mcp-registry.ts
@@ -23,7 +23,7 @@ import {
 } from "@atlas/core/mcp-registry/translator";
 import { MCPUpstreamClient } from "@atlas/core/mcp-registry/upstream-client";
 import { createLogger } from "@atlas/logger";
-import { createMCPTools, MCPAuthError } from "@atlas/mcp";
+import { createMCPTools } from "@atlas/mcp";
 import { zValidator } from "@hono/zod-validator";
 import { RetryError } from "@std/async/retry";
 import { stepCountIs, streamText } from "ai";
@@ -75,10 +75,6 @@ function classifyProbeError(error: unknown): {
       return { error: inner.message, phase: "dns" };
     }
     return { error: inner.message, phase: "connect" };
-  }
-
-  if (inner instanceof MCPAuthError) {
-    return { error: inner.message, phase: "auth" };
   }
 
   if (inner instanceof Error) {

--- a/deno.lock
+++ b/deno.lock
@@ -6301,7 +6301,6 @@
         "packageJson": {
           "dependencies": [
             "npm:@ai-sdk/mcp@^1.0.36",
-            "npm:@jsr/std__async@^1.0.14",
             "npm:@modelcontextprotocol/sdk@1.28",
             "npm:ai@^6.0.168",
             "npm:vitest@^4.1.0",

--- a/packages/core/src/agent-context/index.ts
+++ b/packages/core/src/agent-context/index.ts
@@ -83,10 +83,9 @@ export function createAgentContextBuilder(deps: AgentContextBuilderDeps) {
         disconnectedCount: disconnectedIntegrations.length,
       });
     } catch (error) {
-      // Credential errors are now handled per-server inside createMCPTools and
-      // surfaced via `disconnected`; only non-credential failures (transport,
-      // startup, etc.) still throw. Continue with empty tools so the agent can
-      // at least respond rather than aborting the session.
+      // Unexpected fatal error (e.g. signal abort). Per-server transport,
+      // startup, and timeout failures are silently dropped inside
+      // createMCPTools so the chat continues with whatever connected.
       agentLogger.error("Failed to pre-fetch tools", { error });
       allTools = {};
     }

--- a/packages/mcp/mod.ts
+++ b/packages/mcp/mod.ts
@@ -15,7 +15,7 @@ export type {
   DisconnectedIntegrationKind,
   MCPToolsResult,
 } from "./src/create-mcp-tools.ts";
-export { createMCPTools, MCPAuthError, MCPStartupError } from "./src/create-mcp-tools.ts";
+export { createMCPTools, MCPStartupError } from "./src/create-mcp-tools.ts";
 export type {
   ProcessRegistry,
   ProcessRegistryDeps,

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -8,7 +8,6 @@
     "@ai-sdk/mcp": "^1.0.36",
     "@atlas/config": "workspace:*",
     "@atlas/logger": "workspace:*",
-    "@std/async": "npm:@jsr/std__async@^1.0.14",
     "@modelcontextprotocol/sdk": "~1.28.0",
     "ai": "^6.0.168"
   },

--- a/packages/mcp/src/create-mcp-tools-startup.test.ts
+++ b/packages/mcp/src/create-mcp-tools-startup.test.ts
@@ -14,9 +14,6 @@ vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
   StreamableHTTPClientTransport: MockHTTPTransport,
 }));
 
-// Strip retry backoff — retry logic is @std/async's responsibility, not ours.
-vi.mock("@std/async/retry", () => ({ retry: (fn: () => Promise<unknown>) => fn() }));
-
 // Import after mocks
 const { connectHttp, MCPStartupError } = await import("./create-mcp-tools.ts");
 const { sharedMCPProcesses } = await import("./process-registry.ts");

--- a/packages/mcp/src/create-mcp-tools.test.ts
+++ b/packages/mcp/src/create-mcp-tools.test.ts
@@ -381,8 +381,6 @@ describe("createMCPTools", () => {
     expect(result.disconnected[0]?.message).toContain("my-github-server");
   });
 
-
-
   it("keeps already-connected clients alive when a later server has a credential error", async () => {
     const closeA = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
 
@@ -502,8 +500,6 @@ describe("createMCPTools", () => {
     expect(closeA).toHaveBeenCalledTimes(1);
     expect(closeB).toHaveBeenCalledTimes(1);
   });
-
-
 
   it("warns on tool name collision when two servers export same tool", async () => {
     mockCreateMCPClient
@@ -705,7 +701,9 @@ describe("createMCPTools", () => {
     expect(result.tools).toHaveProperty("strava_get-activity");
     expect(result.tools).toHaveProperty("strava_list-activities");
     expect(result.tools["strava_get-activity"]).toMatchObject({ description: "Fetch an activity" });
-    expect(result.tools["strava_list-activities"]).toMatchObject({ description: "List activities" });
+    expect(result.tools["strava_list-activities"]).toMatchObject({
+      description: "List activities",
+    });
 
     await result.dispose();
   });
@@ -786,7 +784,9 @@ describe("createMCPTools", () => {
       const promise = createMCPTools(configs, fakeLogger);
 
       // Advance past the 20s listTools timeout (async variant flushes microtasks)
-      await (vi as unknown as { advanceTimersByTimeAsync: (ms: number) => Promise<void> }).advanceTimersByTimeAsync(21_000);
+      await (
+        vi as unknown as { advanceTimersByTimeAsync: (ms: number) => Promise<void> }
+      ).advanceTimersByTimeAsync(21_000);
 
       const result = await promise;
 
@@ -807,9 +807,9 @@ describe("createMCPTools", () => {
       const hangExecute = vi.fn().mockImplementation(() => new Promise(() => {}));
 
       mockCreateMCPClient.mockResolvedValue({
-        tools: vi.fn().mockResolvedValue({
-          "hang-tool": { description: "hangs", execute: hangExecute },
-        }),
+        tools: vi
+          .fn()
+          .mockResolvedValue({ "hang-tool": { description: "hangs", execute: hangExecute } }),
         close: vi.fn().mockResolvedValue(undefined),
       });
 

--- a/packages/mcp/src/create-mcp-tools.test.ts
+++ b/packages/mcp/src/create-mcp-tools.test.ts
@@ -799,6 +799,7 @@ describe("createMCPTools", () => {
           serverId: "server-slow",
           phase: "list_tools",
           timeoutMs: 20_000,
+          durationMs: expect.any(Number),
         }),
       );
     });

--- a/packages/mcp/src/create-mcp-tools.test.ts
+++ b/packages/mcp/src/create-mcp-tools.test.ts
@@ -74,7 +74,7 @@ vi.mock("@std/async/retry", () => {
 });
 
 // Import after mocks
-const { createMCPTools } = await import("./create-mcp-tools.ts");
+const { createMCPTools, MCPTimeoutError } = await import("./create-mcp-tools.ts");
 
 // Fake logger
 const fakeLogger = {
@@ -120,18 +120,20 @@ describe("createMCPTools", () => {
     expect(mockClose).toHaveBeenCalledTimes(1);
   });
 
-  it("throws when a server fails to connect instead of continuing", async () => {
+  it("skips server that fails to connect and returns empty tools", async () => {
     mockCreateMCPClient.mockRejectedValue(new Error("spawn failed"));
 
     const configs: Record<string, MCPServerConfig> = {
       "broken-server": { transport: { type: "stdio", command: "nonexistent", args: [] } },
     };
 
-    const error = await createMCPTools(configs, fakeLogger).catch((e: unknown) => e);
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain("broken-server");
-    expect((error as Error).message).toContain("nonexistent");
-    expect((error as Error).message).toContain("spawn failed");
+    const result = await createMCPTools(configs, fakeLogger);
+    expect(Object.keys(result.tools)).toHaveLength(0);
+    expect(result.disconnected).toHaveLength(0);
+    expect(fakeLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("connection error"),
+      expect.anything(),
+    );
   });
 
   it("skips server with LinkCredentialNotFoundError and continues", async () => {
@@ -379,87 +381,7 @@ describe("createMCPTools", () => {
     expect(result.disconnected[0]?.message).toContain("my-github-server");
   });
 
-  it("retries stdio connection that fails then succeeds", async () => {
-    const fakeTool = { description: "retry tool" };
-    let attempt = 0;
-    mockCreateMCPClient.mockImplementation(() => {
-      attempt++;
-      if (attempt === 1) {
-        return Promise.reject(new Error("ECONNREFUSED"));
-      }
-      return Promise.resolve({
-        tools: vi.fn().mockResolvedValue({ "retry-tool": fakeTool }),
-        close: vi.fn().mockResolvedValue(undefined),
-      });
-    });
 
-    const configs: Record<string, MCPServerConfig> = {
-      "flaky-server": { transport: { type: "stdio", command: "echo", args: [] } },
-    };
-
-    const result = await createMCPTools(configs, fakeLogger);
-
-    expect(result.tools).toHaveProperty("retry-tool");
-    expect(mockCreateMCPClient).toHaveBeenCalledTimes(2);
-  });
-
-  it("retries when stdio tools() verification fails", async () => {
-    let attempt = 0;
-    mockCreateMCPClient.mockImplementation(() => {
-      attempt++;
-      if (attempt === 1) {
-        // Client connects but tools() fails (server not ready)
-        return Promise.resolve({
-          tools: vi.fn().mockRejectedValue(new Error("not ready")),
-          close: vi.fn().mockResolvedValue(undefined),
-        });
-      }
-      return Promise.resolve({
-        tools: vi.fn().mockResolvedValue({ "verified-tool": { description: "ok" } }),
-        close: vi.fn().mockResolvedValue(undefined),
-      });
-    });
-
-    const configs: Record<string, MCPServerConfig> = {
-      "slow-server": { transport: { type: "stdio", command: "echo", args: [] } },
-    };
-
-    const result = await createMCPTools(configs, fakeLogger);
-
-    expect(result.tools).toHaveProperty("verified-tool");
-    // First attempt: createMCPClient + tools() fail → retry
-    // Second attempt: createMCPClient + tools() succeed
-    expect(mockCreateMCPClient).toHaveBeenCalledTimes(2);
-  });
-
-  it("closes leaked client when stdio tools() verification fails before retry", async () => {
-    const failedClose = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
-    let attempt = 0;
-    mockCreateMCPClient.mockImplementation(() => {
-      attempt++;
-      if (attempt === 1) {
-        // Client connects but tools() fails — subprocess should be closed
-        return Promise.resolve({
-          tools: vi.fn().mockRejectedValue(new Error("not ready")),
-          close: failedClose,
-        });
-      }
-      return Promise.resolve({
-        tools: vi.fn().mockResolvedValue({ "ok-tool": { description: "ok" } }),
-        close: vi.fn().mockResolvedValue(undefined),
-      });
-    });
-
-    const configs: Record<string, MCPServerConfig> = {
-      "flaky-server": { transport: { type: "stdio", command: "echo", args: [] } },
-    };
-
-    const result = await createMCPTools(configs, fakeLogger);
-
-    expect(result.tools).toHaveProperty("ok-tool");
-    // The failed client from attempt 1 must have been closed
-    expect(failedClose).toHaveBeenCalledTimes(1);
-  });
 
   it("keeps already-connected clients alive when a later server has a credential error", async () => {
     const closeA = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
@@ -492,21 +414,23 @@ describe("createMCPTools", () => {
     expect(closeA).toHaveBeenCalledTimes(1);
   });
 
-  it("throws and includes URL when HTTP server fails to connect", async () => {
+  it("skips HTTP server that fails to connect", async () => {
     mockCreateMCPClient.mockRejectedValue(new Error("connection refused"));
 
     const configs: Record<string, MCPServerConfig> = {
       "broken-http": { transport: { type: "http", url: "https://mcp.example.com" } },
     };
 
-    const error = await createMCPTools(configs, fakeLogger).catch((e: unknown) => e);
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain("broken-http");
-    expect((error as Error).message).toContain("https://mcp.example.com");
-    expect((error as Error).message).toContain("connection refused");
+    const result = await createMCPTools(configs, fakeLogger);
+    expect(Object.keys(result.tools)).toHaveLength(0);
+    expect(result.disconnected).toHaveLength(0);
+    expect(fakeLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("connection error"),
+      expect.anything(),
+    );
   });
 
-  it("throws MCPAuthError when HTTP server returns 401", async () => {
+  it("skips HTTP server that returns 401", async () => {
     const { StreamableHTTPError } = await import(
       "@modelcontextprotocol/sdk/client/streamableHttp.js"
     );
@@ -516,14 +440,16 @@ describe("createMCPTools", () => {
       "auth-http": { transport: { type: "http", url: "https://mcp.example.com" } },
     };
 
-    const error = await createMCPTools(configs, fakeLogger).catch((e: unknown) => e);
-    expect(error).toBeInstanceOf((await import("./create-mcp-tools.ts")).MCPAuthError);
-    expect((error as Error).message).toContain("auth-http");
-    expect((error as Error).message).toContain("https://mcp.example.com");
-    expect((error as Error).message).toContain("invalid token");
+    const result = await createMCPTools(configs, fakeLogger);
+    expect(Object.keys(result.tools)).toHaveLength(0);
+    expect(result.disconnected).toHaveLength(0);
+    expect(fakeLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("connection error"),
+      expect.anything(),
+    );
   });
 
-  it("cleans up already-connected clients when a later server fails", async () => {
+  it("keeps already-connected clients when another server fails", async () => {
     const closeA = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
 
     // Server A connects successfully
@@ -532,7 +458,7 @@ describe("createMCPTools", () => {
         tools: vi.fn().mockResolvedValue({ "tool-a": { description: "from A" } }),
         close: closeA,
       })
-      // Server B fails after retries
+      // Server B fails
       .mockRejectedValue(new Error("spawn failed"));
 
     const configs: Record<string, MCPServerConfig> = {
@@ -540,10 +466,12 @@ describe("createMCPTools", () => {
       "server-b": { transport: { type: "stdio", command: "nonexistent", args: [] } },
     };
 
-    const error = await createMCPTools(configs, fakeLogger).catch((e: unknown) => e);
-    expect(error).toBeInstanceOf(Error);
-    expect((error as Error).message).toContain("server-b");
-    // Server A's client must have been cleaned up before throwing
+    const result = await createMCPTools(configs, fakeLogger);
+    expect(result.tools).toHaveProperty("tool-a");
+    expect(Object.keys(result.tools)).toHaveLength(1);
+    // Server A stays alive — only dispose() should close it
+    expect(closeA).not.toHaveBeenCalled();
+    await result.dispose();
     expect(closeA).toHaveBeenCalledTimes(1);
   });
 
@@ -575,32 +503,7 @@ describe("createMCPTools", () => {
     expect(closeB).toHaveBeenCalledTimes(1);
   });
 
-  it("retries HTTP connection when tools() fails transiently", async () => {
-    let attempt = 0;
-    mockCreateMCPClient.mockImplementation(() => {
-      attempt++;
-      if (attempt === 1) {
-        // HTTP client connects but tools() fails (cold start)
-        return Promise.resolve({
-          tools: vi.fn().mockRejectedValue(new Error("service unavailable")),
-          close: vi.fn().mockResolvedValue(undefined),
-        });
-      }
-      return Promise.resolve({
-        tools: vi.fn().mockResolvedValue({ "http-retry-tool": { description: "ok" } }),
-        close: vi.fn().mockResolvedValue(undefined),
-      });
-    });
 
-    const configs: Record<string, MCPServerConfig> = {
-      "flaky-http": { transport: { type: "http", url: "https://mcp.example.com" } },
-    };
-
-    const result = await createMCPTools(configs, fakeLogger);
-
-    expect(result.tools).toHaveProperty("http-retry-tool");
-    expect(mockCreateMCPClient).toHaveBeenCalledTimes(2);
-  });
 
   it("warns on tool name collision when two servers export same tool", async () => {
     mockCreateMCPClient
@@ -631,7 +534,7 @@ describe("createMCPTools", () => {
     const result = await createMCPTools(configs, fakeLogger);
 
     // Later server wins
-    expect(result.tools["shared-tool"]).toEqual({ description: "from B" });
+    expect(result.tools["shared-tool"]).toMatchObject({ description: "from B" });
     expect(result.tools).toHaveProperty("unique-a");
     expect(result.tools).toHaveProperty("unique-b");
     // Collision warning was logged for server-b
@@ -727,13 +630,11 @@ describe("createMCPTools", () => {
     expect(result.disconnected[0]?.message).not.toContain("different-server");
   });
 
-  it("cleans up already-connected clients when signal is aborted before next server", async () => {
+  it("disposes all connected clients when signal aborts mid-connect", async () => {
     const closeA = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
     const controller = new AbortController();
 
-    // Server A connects; abort before server B starts
     mockCreateMCPClient.mockImplementation(() => {
-      // Abort after the first server connects
       controller.abort(new Error("cancelled"));
       return Promise.resolve({
         tools: vi.fn().mockResolvedValue({ "tool-a": { description: "from A" } }),
@@ -751,10 +652,9 @@ describe("createMCPTools", () => {
     );
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toBe("cancelled");
-    // Server A's client must have been cleaned up
-    expect(closeA).toHaveBeenCalledTimes(1);
-    // Server B should never have been attempted
-    expect(mockCreateMCPClient).toHaveBeenCalledTimes(1);
+    // Both parallel mappers created a client; both get disposed in cleanup
+    expect(closeA).toHaveBeenCalledTimes(2);
+    expect(mockCreateMCPClient).toHaveBeenCalledTimes(2);
   });
 
   it("dispose awaits close() — does not resolve before cleanup finishes", async () => {
@@ -804,8 +704,8 @@ describe("createMCPTools", () => {
 
     expect(result.tools).toHaveProperty("strava_get-activity");
     expect(result.tools).toHaveProperty("strava_list-activities");
-    expect(result.tools["strava_get-activity"]).toEqual({ description: "Fetch an activity" });
-    expect(result.tools["strava_list-activities"]).toEqual({ description: "List activities" });
+    expect(result.tools["strava_get-activity"]).toMatchObject({ description: "Fetch an activity" });
+    expect(result.tools["strava_list-activities"]).toMatchObject({ description: "List activities" });
 
     await result.dispose();
   });
@@ -855,6 +755,79 @@ describe("createMCPTools", () => {
 
     await resultA.dispose();
     await resultB.dispose();
+  });
+
+  describe("timeout behaviour", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("listTools timeout isolates the slow server", async () => {
+      // Fast server returns immediately
+      mockCreateMCPClient.mockResolvedValueOnce({
+        tools: vi.fn().mockResolvedValue({ "fast-tool": { description: "fast" } }),
+        close: vi.fn().mockResolvedValue(undefined),
+      });
+
+      // Slow server: createMCPClient resolves, but tools() hangs forever
+      mockCreateMCPClient.mockResolvedValueOnce({
+        tools: vi.fn().mockImplementation(() => new Promise(() => {})),
+        close: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const configs: Record<string, MCPServerConfig> = {
+        "server-fast": { transport: { type: "stdio", command: "echo", args: [] } },
+        "server-slow": { transport: { type: "stdio", command: "echo", args: [] } },
+      };
+
+      const promise = createMCPTools(configs, fakeLogger);
+
+      // Advance past the 20s listTools timeout (async variant flushes microtasks)
+      await (vi as unknown as { advanceTimersByTimeAsync: (ms: number) => Promise<void> }).advanceTimersByTimeAsync(21_000);
+
+      const result = await promise;
+
+      expect(result.tools).toHaveProperty("fast-tool");
+      expect(result.tools).not.toHaveProperty("slow-tool");
+      expect(fakeLogger.warn).toHaveBeenCalledWith(
+        "MCP operation timed out",
+        expect.objectContaining({
+          operation: "mcp_timeout",
+          serverId: "server-slow",
+          phase: "list_tools",
+          timeoutMs: 20_000,
+        }),
+      );
+    });
+
+    it("callTool timeout enforces the 15min ceiling", async () => {
+      const hangExecute = vi.fn().mockImplementation(() => new Promise(() => {}));
+
+      mockCreateMCPClient.mockResolvedValue({
+        tools: vi.fn().mockResolvedValue({
+          "hang-tool": { description: "hangs", execute: hangExecute },
+        }),
+        close: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const configs: Record<string, MCPServerConfig> = {
+        hang: { transport: { type: "stdio", command: "echo", args: [] } },
+      };
+
+      const result = await createMCPTools(configs, fakeLogger);
+      expect(result.tools).toHaveProperty("hang-tool");
+
+      const tool = result.tools["hang-tool"]!;
+      const executePromise = tool.execute!({}, { toolCallId: "tc_1", messages: [] });
+
+      // Advance past the 15-minute ceiling
+      vi.advanceTimersByTime(15 * 60 * 1_000 + 1_000);
+
+      await expect(executePromise).rejects.toBeInstanceOf(MCPTimeoutError);
+    });
   });
 
   describe("stdio arg placeholder expansion", () => {

--- a/packages/mcp/src/create-mcp-tools.test.ts
+++ b/packages/mcp/src/create-mcp-tools.test.ts
@@ -45,34 +45,6 @@ vi.mock("@atlas/core/mcp-registry/credential-resolver", async (importOriginal) =
   return { ...actual, resolveEnvValues: mockResolveEnvValues };
 });
 
-// Strip retry backoff delays — retry logic is @std/async's responsibility, not ours.
-vi.mock("@std/async/retry", () => {
-  class RetryError extends Error {
-    constructor(
-      public override readonly cause: unknown,
-      public readonly attempts: number,
-    ) {
-      super(`Retrying exceeded the maxAttempts (${attempts}).`);
-      this.name = "RetryError";
-    }
-  }
-  return {
-    RetryError,
-    retry: async (fn: () => Promise<unknown>, opts?: { maxAttempts?: number }) => {
-      const maxAttempts = opts?.maxAttempts ?? 3;
-      let lastError: unknown;
-      for (let i = 0; i < maxAttempts; i++) {
-        try {
-          return await fn();
-        } catch (err) {
-          lastError = err;
-        }
-      }
-      throw new RetryError(lastError, maxAttempts);
-    },
-  };
-});
-
 // Import after mocks
 const { createMCPTools, MCPTimeoutError } = await import("./create-mcp-tools.ts");
 

--- a/packages/mcp/src/create-mcp-tools.ts
+++ b/packages/mcp/src/create-mcp-tools.ts
@@ -87,7 +87,8 @@ function wrapToolWithTimeout(tool: Tool, serverId: string): Tool {
       return withTimeout(
         tool.execute!(args, opts),
         CALL_TOOL_TIMEOUT_MS,
-        (actualDurationMs) => new MCPTimeoutError(serverId, "call_tool", CALL_TOOL_TIMEOUT_MS, actualDurationMs),
+        (actualDurationMs) =>
+          new MCPTimeoutError(serverId, "call_tool", CALL_TOOL_TIMEOUT_MS, actualDurationMs),
       );
     },
   };
@@ -333,7 +334,8 @@ function connectServerWithTimeout(
   return withTimeout(
     connectServer(config, resolvedEnv, serverId, logger),
     LIST_TOOLS_TIMEOUT_MS,
-    (actualDurationMs) => new MCPTimeoutError(serverId, "list_tools", LIST_TOOLS_TIMEOUT_MS, actualDurationMs),
+    (actualDurationMs) =>
+      new MCPTimeoutError(serverId, "list_tools", LIST_TOOLS_TIMEOUT_MS, actualDurationMs),
   );
 }
 
@@ -459,7 +461,8 @@ async function isReachable(
     const res = await withTimeout(
       fetchImpl(url, { method: "GET" }),
       REACHABLE_TIMEOUT_MS,
-      (actualDurationMs) => new MCPTimeoutError(serverId, "reachable", REACHABLE_TIMEOUT_MS, actualDurationMs),
+      (actualDurationMs) =>
+        new MCPTimeoutError(serverId, "reachable", REACHABLE_TIMEOUT_MS, actualDurationMs),
     );
     return { ok: true, status: res.status };
   } catch (err) {

--- a/packages/mcp/src/create-mcp-tools.ts
+++ b/packages/mcp/src/create-mcp-tools.ts
@@ -75,17 +75,14 @@ function withTimeout<T>(
   const timeoutPromise = new Promise<never>((_, reject) => {
     timer = setTimeout(() => reject(makeError()), timeoutMs);
   });
-  return Promise.race([
-    promise.finally(() => clearTimeout(timer)),
-    timeoutPromise,
-  ]);
+  return Promise.race([promise.finally(() => clearTimeout(timer)), timeoutPromise]);
 }
 
 /** Add the 15-minute hard ceiling to a single tool's execute. */
 function wrapToolWithTimeout(tool: Tool, serverId: string): Tool {
   return {
     ...tool,
-    execute: async (args, opts) => {
+    execute: (args, opts) => {
       return withTimeout(
         tool.execute!(args, opts),
         CALL_TOOL_TIMEOUT_MS,
@@ -128,37 +125,28 @@ export async function createMCPTools(
   }
 
   const results = await Promise.allSettled(
-    Object.entries(configs).map(
-      async ([serverId, config]): Promise<ServerConnectResult> => {
-        try {
-          const resolvedEnv = config.env
-            ? await resolveEnvValues(config.env, logger)
-            : {};
-          const connected = await connectServerWithTimeout(
-            config,
-            resolvedEnv,
-            serverId,
-            logger,
-          );
-          const filtered = filterTools(connected.tools, config.tools);
-          const prefixed = options?.toolPrefix
-            ? prefixToolKeys(filtered, options.toolPrefix)
-            : filtered;
-          return { status: "success", serverId, client: connected.client, tools: prefixed };
-        } catch (error) {
-          if (
-            error instanceof LinkCredentialNotFoundError ||
-            error instanceof LinkCredentialExpiredError ||
-            error instanceof NoDefaultCredentialError
-          ) {
-            const entry = buildDisconnectedEntry(error, serverId, config);
-            return { status: "disconnected", entry };
-          }
-
-          return { status: "failed", serverId, error };
+    Object.entries(configs).map(async ([serverId, config]): Promise<ServerConnectResult> => {
+      try {
+        const resolvedEnv = config.env ? await resolveEnvValues(config.env, logger) : {};
+        const connected = await connectServerWithTimeout(config, resolvedEnv, serverId, logger);
+        const filtered = filterTools(connected.tools, config.tools);
+        const prefixed = options?.toolPrefix
+          ? prefixToolKeys(filtered, options.toolPrefix)
+          : filtered;
+        return { status: "success", serverId, client: connected.client, tools: prefixed };
+      } catch (error) {
+        if (
+          error instanceof LinkCredentialNotFoundError ||
+          error instanceof LinkCredentialExpiredError ||
+          error instanceof NoDefaultCredentialError
+        ) {
+          const entry = buildDisconnectedEntry(error, serverId, config);
+          return { status: "disconnected", entry };
         }
-      },
-    ),
+
+        return { status: "failed", serverId, error };
+      }
+    }),
   );
 
   // If the parent signal aborted while connections were in flight, clean up
@@ -169,7 +157,11 @@ export async function createMCPTools(
         (r): r is PromiseFulfilledResult<ServerConnectResult> =>
           r.status === "fulfilled" && r.value.status === "success",
       )
-      .map((r) => (r as PromiseFulfilledResult<Extract<ServerConnectResult, { status: "success" }>>).value.client);
+      .map(
+        (r) =>
+          (r as PromiseFulfilledResult<Extract<ServerConnectResult, { status: "success" }>>).value
+            .client,
+      );
     await disposeAll(connectedClients);
     throw signal.reason ?? new Error("Aborted");
   }
@@ -230,14 +222,11 @@ export async function createMCPTools(
 
     const clobbered = Object.keys(wrappedTools).filter((name) => name in allTools);
     if (clobbered.length > 0) {
-      logger.warn(
-        `MCP tool name collision: server "${value.serverId}" overwrites existing tools`,
-        {
-          operation: "mcp_connect",
-          serverId: value.serverId,
-          clobberedTools: clobbered,
-        },
-      );
+      logger.warn(`MCP tool name collision: server "${value.serverId}" overwrites existing tools`, {
+        operation: "mcp_connect",
+        serverId: value.serverId,
+        clobberedTools: clobbered,
+      });
     }
     Object.assign(allTools, wrappedTools);
     clients.push(value.client);
@@ -269,10 +258,7 @@ export async function createMCPTools(
  * enrichment).
  */
 function buildDisconnectedEntry(
-  error:
-    | LinkCredentialNotFoundError
-    | LinkCredentialExpiredError
-    | NoDefaultCredentialError,
+  error: LinkCredentialNotFoundError | LinkCredentialExpiredError | NoDefaultCredentialError,
   serverId: string,
   config: MCPServerConfig,
 ): DisconnectedIntegration {
@@ -302,9 +288,7 @@ function buildDisconnectedEntry(
     serverId,
     provider: extractProviderFromConfig(config),
     kind:
-      error.status === "expired_no_refresh"
-        ? "credential_expired"
-        : "credential_refresh_failed",
+      error.status === "expired_no_refresh" ? "credential_expired" : "credential_refresh_failed",
     message: enriched.message,
   };
 }
@@ -339,7 +323,7 @@ interface ConnectedServer {
  * Connect a single MCP server with a hard timeout on the full handshake +
  * listTools sequence. No retry — a hung server is not a transient failure.
  */
-async function connectServerWithTimeout(
+function connectServerWithTimeout(
   config: MCPServerConfig,
   resolvedEnv: Record<string, string>,
   serverId: string,
@@ -452,10 +436,7 @@ async function connectStdio(
     throw err;
   }
 
-  logger.debug(`MCP stdio connected for "${serverId}"`, {
-    operation: "mcp_connect",
-    serverId,
-  });
+  logger.debug(`MCP stdio connected for "${serverId}"`, { operation: "mcp_connect", serverId });
 
   return { client, tools };
 }
@@ -605,11 +586,7 @@ async function connectHttpClient(
     throw err;
   }
 
-  logger.debug(`MCP HTTP connected for "${serverId}"`, {
-    operation: "mcp_connect",
-    serverId,
-    url,
-  });
+  logger.debug(`MCP HTTP connected for "${serverId}"`, { operation: "mcp_connect", serverId, url });
 
   return { client, tools };
 }
@@ -649,10 +626,7 @@ function filterTools(
 }
 
 /** Prefix every key in a tools map with `{prefix}_`. Descriptions are unmodified. */
-function prefixToolKeys(
-  tools: Record<string, Tool>,
-  prefix: string,
-): Record<string, Tool> {
+function prefixToolKeys(tools: Record<string, Tool>, prefix: string): Record<string, Tool> {
   const prefixed: Record<string, Tool> = {};
   for (const [name, tool] of Object.entries(tools)) {
     prefixed[`${prefix}_${name}`] = tool;

--- a/packages/mcp/src/create-mcp-tools.ts
+++ b/packages/mcp/src/create-mcp-tools.ts
@@ -40,7 +40,7 @@ const LIST_TOOLS_TIMEOUT_MS = 20_000;
 /** Hard ceiling for a single MCP tool invocation. */
 const CALL_TOOL_TIMEOUT_MS = 15 * 60 * 1_000;
 
-export { MCPAuthError, MCPStartupError, MCPTimeoutError } from "./errors.ts";
+export { MCPStartupError, MCPTimeoutError } from "./errors.ts";
 
 import { MCPTimeoutError } from "./errors.ts";
 
@@ -69,11 +69,12 @@ export interface MCPToolsResult {
 function withTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,
-  makeError: () => Error,
+  makeError: (actualDurationMs: number) => Error,
 ): Promise<T> {
+  const startedAt = Date.now();
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(makeError()), timeoutMs);
+    timer = setTimeout(() => reject(makeError(Date.now() - startedAt)), timeoutMs);
   });
   return Promise.race([promise.finally(() => clearTimeout(timer)), timeoutPromise]);
 }
@@ -86,7 +87,7 @@ function wrapToolWithTimeout(tool: Tool, serverId: string): Tool {
       return withTimeout(
         tool.execute!(args, opts),
         CALL_TOOL_TIMEOUT_MS,
-        () => new MCPTimeoutError(serverId, "call_tool", CALL_TOOL_TIMEOUT_MS),
+        (actualDurationMs) => new MCPTimeoutError(serverId, "call_tool", CALL_TOOL_TIMEOUT_MS, actualDurationMs),
       );
     },
   };
@@ -199,7 +200,7 @@ export async function createMCPTools(
           serverId: error.serverId,
           phase: error.phase,
           timeoutMs: error.timeoutMs,
-          durationMs: error.timeoutMs,
+          durationMs: error.actualDurationMs,
         });
       } else {
         const message = error instanceof Error ? error.message : String(error);
@@ -332,7 +333,7 @@ function connectServerWithTimeout(
   return withTimeout(
     connectServer(config, resolvedEnv, serverId, logger),
     LIST_TOOLS_TIMEOUT_MS,
-    () => new MCPTimeoutError(serverId, "list_tools", LIST_TOOLS_TIMEOUT_MS),
+    (actualDurationMs) => new MCPTimeoutError(serverId, "list_tools", LIST_TOOLS_TIMEOUT_MS, actualDurationMs),
   );
 }
 
@@ -458,7 +459,7 @@ async function isReachable(
     const res = await withTimeout(
       fetchImpl(url, { method: "GET" }),
       REACHABLE_TIMEOUT_MS,
-      () => new MCPTimeoutError(serverId, "reachable", REACHABLE_TIMEOUT_MS),
+      (actualDurationMs) => new MCPTimeoutError(serverId, "reachable", REACHABLE_TIMEOUT_MS, actualDurationMs),
     );
     return { ok: true, status: res.status };
   } catch (err) {
@@ -468,7 +469,7 @@ async function isReachable(
         serverId: err.serverId,
         phase: err.phase,
         timeoutMs: err.timeoutMs,
-        durationMs: err.timeoutMs,
+        durationMs: err.actualDurationMs,
       });
     }
     return { ok: false };

--- a/packages/mcp/src/create-mcp-tools.ts
+++ b/packages/mcp/src/create-mcp-tools.ts
@@ -24,27 +24,25 @@ import {
 } from "@atlas/core/mcp-registry/credential-resolver";
 import type { Logger } from "@atlas/logger";
 import { getFridayHome } from "@atlas/utils/paths.server";
-import {
-  StreamableHTTPClientTransport,
-  StreamableHTTPError,
-} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import { RetryError, type RetryOptions, retry } from "@std/async/retry";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Tool } from "ai";
 import { type PidFileWriter, sharedMCPProcesses } from "./process-registry.ts";
 
 /** ai doesn't export the MCPClient type, so we infer it. */
 type MCPClient = Awaited<ReturnType<typeof createMCPClient>>;
 
-const RETRY_OPTIONS: RetryOptions = {
-  maxAttempts: 3,
-  multiplier: 1, // constant backoff
-  minTimeout: 1000,
-  maxTimeout: 3000,
-};
+/** Hard timeout for the HTTP reachability probe. */
+const REACHABLE_TIMEOUT_MS = 4_000;
 
-export { MCPAuthError, MCPStartupError } from "./errors.ts";
+/** Hard timeout for `createMCPClient` handshake + `listTools` per server. */
+const LIST_TOOLS_TIMEOUT_MS = 20_000;
 
-import { MCPAuthError, MCPStartupError } from "./errors.ts";
+/** Hard ceiling for a single MCP tool invocation. */
+const CALL_TOOL_TIMEOUT_MS = 15 * 60 * 1_000;
+
+export { MCPAuthError, MCPStartupError, MCPTimeoutError } from "./errors.ts";
+
+import { MCPTimeoutError } from "./errors.ts";
 
 export type DisconnectedIntegrationKind =
   | "credential_not_found"
@@ -67,12 +65,34 @@ export interface MCPToolsResult {
   disconnected: DisconnectedIntegration[];
 }
 
-/** Unwrap a RetryError so the real underlying error is surfaced. */
-function unwrapError(error: unknown): unknown {
-  if (error instanceof RetryError && error.cause) {
-    return error.cause;
-  }
-  return error;
+/** Race a promise against a timeout, clearing the timer when the promise settles. */
+function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  makeError: () => Error,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(makeError()), timeoutMs);
+  });
+  return Promise.race([
+    promise.finally(() => clearTimeout(timer)),
+    timeoutPromise,
+  ]);
+}
+
+/** Add the 15-minute hard ceiling to a single tool's execute. */
+function wrapToolWithTimeout(tool: Tool, serverId: string): Tool {
+  return {
+    ...tool,
+    execute: async (args, opts) => {
+      return withTimeout(
+        tool.execute!(args, opts),
+        CALL_TOOL_TIMEOUT_MS,
+        () => new MCPTimeoutError(serverId, "call_tool", CALL_TOOL_TIMEOUT_MS),
+      );
+    },
+  };
 }
 
 export interface CreateMCPToolsOptions {
@@ -82,108 +102,154 @@ export interface CreateMCPToolsOptions {
   toolPrefix?: string;
 }
 
+/** Internal result of attempting to connect a single server. */
+type ServerConnectResult =
+  | { status: "success"; serverId: string; client: MCPClient; tools: Record<string, Tool> }
+  | { status: "disconnected"; entry: DisconnectedIntegration }
+  | { status: "failed"; serverId: string; error: unknown };
+
 /**
- * Connect to MCP servers, fetch tools, return a dispose callback.
+ * Connect to MCP servers in parallel, fetch tools, return a dispose callback.
+ *
  * Servers whose Link credentials are missing/expired/un-refreshable are skipped
- * and reported in `disconnected` rather than aborting the whole batch — the
- * caller decides how to surface them to the user. Other failures (transport,
- * startup, etc.) still throw.
+ * and reported in `disconnected`. All other failures (transport, startup,
+ * timeout) silently drop that server — the chat continues with whatever
+ * servers connected. Every timeout emits a structured `warn` log.
  */
 export async function createMCPTools(
   configs: Record<string, MCPServerConfig>,
   logger: Logger,
   options?: CreateMCPToolsOptions,
 ): Promise<MCPToolsResult> {
+  const signal = options?.signal;
+
+  if (signal?.aborted) {
+    throw signal.reason ?? new Error("Aborted");
+  }
+
+  const results = await Promise.allSettled(
+    Object.entries(configs).map(
+      async ([serverId, config]): Promise<ServerConnectResult> => {
+        try {
+          const resolvedEnv = config.env
+            ? await resolveEnvValues(config.env, logger)
+            : {};
+          const connected = await connectServerWithTimeout(
+            config,
+            resolvedEnv,
+            serverId,
+            logger,
+          );
+          const filtered = filterTools(connected.tools, config.tools);
+          const prefixed = options?.toolPrefix
+            ? prefixToolKeys(filtered, options.toolPrefix)
+            : filtered;
+          return { status: "success", serverId, client: connected.client, tools: prefixed };
+        } catch (error) {
+          if (
+            error instanceof LinkCredentialNotFoundError ||
+            error instanceof LinkCredentialExpiredError ||
+            error instanceof NoDefaultCredentialError
+          ) {
+            const entry = buildDisconnectedEntry(error, serverId, config);
+            return { status: "disconnected", entry };
+          }
+
+          return { status: "failed", serverId, error };
+        }
+      },
+    ),
+  );
+
+  // If the parent signal aborted while connections were in flight, clean up
+  // anything that managed to connect and re-throw.
+  if (signal?.aborted) {
+    const connectedClients = results
+      .filter(
+        (r): r is PromiseFulfilledResult<ServerConnectResult> =>
+          r.status === "fulfilled" && r.value.status === "success",
+      )
+      .map((r) => (r as PromiseFulfilledResult<Extract<ServerConnectResult, { status: "success" }>>).value.client);
+    await disposeAll(connectedClients);
+    throw signal.reason ?? new Error("Aborted");
+  }
+
   const clients: MCPClient[] = [];
   const allTools: Record<string, Tool> = {};
   const disconnected: DisconnectedIntegration[] = [];
-  let disposed = false;
 
-  const signal = options?.signal;
-
-  for (const [serverId, config] of Object.entries(configs)) {
-    if (signal?.aborted) {
+  for (const result of results) {
+    if (result.status === "rejected") {
+      // Defensive: shouldn't happen since each mapper catches its own errors.
       await disposeAll(clients);
-      throw signal.reason ?? new Error("Aborted");
+      throw result.reason;
     }
 
-    try {
-      const resolvedEnv = config.env ? await resolveEnvValues(config.env, logger) : {};
+    const value = result.value;
 
-      const connected = await connectServer(config, resolvedEnv, serverId, logger);
-      clients.push(connected.client);
-
-      const filtered = filterTools(connected.tools, config.tools);
-      const prefixed = options?.toolPrefix
-        ? prefixToolKeys(filtered, options.toolPrefix)
-        : filtered;
-
-      const clobbered = Object.keys(prefixed).filter((name) => name in allTools);
-      if (clobbered.length > 0) {
-        logger.warn(`MCP tool name collision: server "${serverId}" overwrites existing tools`, {
-          operation: "mcp_connect",
-          serverId,
-          clobberedTools: clobbered,
-        });
-      }
-
-      Object.assign(allTools, prefixed);
-
-      logger.info(`Connected MCP server: ${serverId}`, {
+    if (value.status === "disconnected") {
+      disconnected.push(value.entry);
+      logger.warn(`MCP server skipped due to credential issue`, {
         operation: "mcp_connect",
-        serverId,
-        toolCount: Object.keys(filtered).length,
+        serverId: value.entry.serverId,
+        kind: value.entry.kind,
+        provider: value.entry.provider,
+        reason: value.entry.message,
       });
-    } catch (error) {
-      if (
-        error instanceof LinkCredentialNotFoundError ||
-        error instanceof LinkCredentialExpiredError ||
-        error instanceof NoDefaultCredentialError
-      ) {
-        const entry = buildDisconnectedEntry(error, serverId, config);
-        disconnected.push(entry);
-        logger.warn(`MCP server skipped due to credential issue`, {
-          operation: "mcp_connect",
-          serverId,
-          kind: entry.kind,
-          provider: entry.provider,
-          reason: entry.message,
-        });
-        continue;
-      }
-
-      // Clean up any already-connected clients before throwing
-      await disposeAll(clients);
-
-      if (error instanceof MCPStartupError) {
-        throw error;
-      }
-
-      const actualError = unwrapError(error);
-
-      // HTTP 401 from the transport is an auth failure, not a connection failure.
-      if (
-        config.transport.type === "http" &&
-        actualError instanceof StreamableHTTPError &&
-        actualError.code === 401
-      ) {
-        throw new MCPAuthError(serverId, config.transport.url, actualError.message);
-      }
-
-      const command =
-        config.transport.type === "stdio"
-          ? `${config.transport.command} ${(config.transport.args ?? []).join(" ")}`.trim()
-          : config.transport.url;
-      const reason = actualError instanceof Error ? actualError.message : String(actualError);
-      // Omit the generic install hint when the reason already contains specific
-      // process output (e.g. ENOENT from a bad root path) — it's misleading there.
-      const hint =
-        reason.includes("\n") || reason.includes("ENOENT") || reason.includes("Error:")
-          ? ""
-          : " Check that the command is installed and available in the container.";
-      throw new Error(`MCP server "${serverId}" failed to start (${command}): ${reason}.${hint}`);
+      continue;
     }
+
+    if (value.status === "failed") {
+      const error = value.error;
+      if (error instanceof MCPTimeoutError) {
+        logger.warn("MCP operation timed out", {
+          operation: "mcp_timeout",
+          serverId: error.serverId,
+          phase: error.phase,
+          timeoutMs: error.timeoutMs,
+          durationMs: error.timeoutMs,
+        });
+      } else {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.warn("MCP server skipped due to connection error", {
+          operation: "mcp_connect",
+          serverId: value.serverId,
+          error: message,
+        });
+      }
+      continue;
+    }
+
+    // status === "success"
+    const wrappedTools = Object.fromEntries(
+      Object.entries(value.tools).map(([name, tool]) => [
+        name,
+        wrapToolWithTimeout(tool, value.serverId),
+      ]),
+    );
+
+    const clobbered = Object.keys(wrappedTools).filter((name) => name in allTools);
+    if (clobbered.length > 0) {
+      logger.warn(
+        `MCP tool name collision: server "${value.serverId}" overwrites existing tools`,
+        {
+          operation: "mcp_connect",
+          serverId: value.serverId,
+          clobberedTools: clobbered,
+        },
+      );
+    }
+    Object.assign(allTools, wrappedTools);
+    clients.push(value.client);
+
+    logger.info(`Connected MCP server`, {
+      operation: "mcp_connect",
+      serverId: value.serverId,
+      toolCount: Object.keys(wrappedTools).length,
+    });
   }
+
+  let disposed = false;
 
   return {
     tools: allTools,
@@ -203,7 +269,10 @@ export async function createMCPTools(
  * enrichment).
  */
 function buildDisconnectedEntry(
-  error: LinkCredentialNotFoundError | LinkCredentialExpiredError | NoDefaultCredentialError,
+  error:
+    | LinkCredentialNotFoundError
+    | LinkCredentialExpiredError
+    | NoDefaultCredentialError,
   serverId: string,
   config: MCPServerConfig,
 ): DisconnectedIntegration {
@@ -233,7 +302,9 @@ function buildDisconnectedEntry(
     serverId,
     provider: extractProviderFromConfig(config),
     kind:
-      error.status === "expired_no_refresh" ? "credential_expired" : "credential_refresh_failed",
+      error.status === "expired_no_refresh"
+        ? "credential_expired"
+        : "credential_refresh_failed",
     message: enriched.message,
   };
 }
@@ -265,9 +336,23 @@ interface ConnectedServer {
 }
 
 /**
- * Connect a single MCP server with retry and fetch tools.
- * Both stdio and HTTP retry the full connect + tools() sequence.
+ * Connect a single MCP server with a hard timeout on the full handshake +
+ * listTools sequence. No retry — a hung server is not a transient failure.
  */
+async function connectServerWithTimeout(
+  config: MCPServerConfig,
+  resolvedEnv: Record<string, string>,
+  serverId: string,
+  logger: Logger,
+): Promise<ConnectedServer> {
+  return withTimeout(
+    connectServer(config, resolvedEnv, serverId, logger),
+    LIST_TOOLS_TIMEOUT_MS,
+    () => new MCPTimeoutError(serverId, "list_tools", LIST_TOOLS_TIMEOUT_MS),
+  );
+}
+
+/** Connect a single MCP server (stdio or HTTP). */
 async function connectServer(
   config: MCPServerConfig,
   resolvedEnv: Record<string, string>,
@@ -317,69 +402,62 @@ async function connectStdio(
   );
   const mergedEnv = { ...parentEnv, ...resolvedEnv };
 
-  let attempt = 0;
-  return await retry(async () => {
-    attempt++;
-    logger.debug(`MCP stdio connection attempt ${attempt} for "${serverId}"`, {
-      operation: "mcp_connect",
-      serverId,
+  logger.debug(`MCP stdio connection attempt for "${serverId}"`, {
+    operation: "mcp_connect",
+    serverId,
+    command,
+    args: expandedArgs,
+  });
+
+  // Capture subprocess stderr so startup errors (e.g. ENOENT on a root path)
+  // are included in the thrown error instead of silently dropped.
+  const stderrChunks: Buffer[] = [];
+  const stderrCapture = new Writable({
+    write(chunk: Buffer, _encoding, callback) {
+      stderrChunks.push(chunk);
+      callback();
+    },
+  });
+
+  const client = await createMCPClient({
+    transport: new StdioMCPTransport({
       command,
       args: expandedArgs,
-      attempt,
-    });
+      env: mergedEnv,
+      stderr: stderrCapture,
+    }),
+  });
 
-    // Capture subprocess stderr so startup errors (e.g. ENOENT on a root path)
-    // are included in the thrown error instead of silently dropped.
-    const stderrChunks: Buffer[] = [];
-    const stderrCapture = new Writable({
-      write(chunk: Buffer, _encoding, callback) {
-        stderrChunks.push(chunk);
-        callback();
-      },
-    });
-
-    const client = await createMCPClient({
-      transport: new StdioMCPTransport({
-        command,
-        args: expandedArgs,
-        env: mergedEnv,
-        stderr: stderrCapture,
-      }),
-    });
-
-    // Verify the subprocess is actually responding AND capture tools in one call.
-    // createMCPClient can succeed for stdio even when the server isn't ready yet.
-    let tools: Record<string, Tool>;
-    try {
-      tools = await client.tools();
-    } catch (err) {
-      // Close the client to kill the orphaned subprocess before retry
-      await client.close().catch(() => {});
-      const stderrOutput = Buffer.concat(stderrChunks).toString("utf8").trim();
-      logger.debug(`MCP stdio tools() failed on attempt ${attempt} for "${serverId}"`, {
-        operation: "mcp_connect",
-        serverId,
-        attempt,
-        error: err instanceof Error ? err.message : String(err),
-        stderrOutput: stderrOutput || undefined,
-      });
-      // Prepend subprocess stderr to the error message so callers see the
-      // actual failure reason (e.g. "ENOENT: no such file or directory")
-      // rather than just the generic "Connection closed" from the transport.
-      if (stderrOutput && err instanceof Error) {
-        err.message = `${stderrOutput} (${err.message})`;
-      }
-      throw err;
-    }
-
-    logger.debug(`MCP stdio connected on attempt ${attempt} for "${serverId}"`, {
+  // Verify the subprocess is actually responding AND capture tools in one call.
+  // createMCPClient can succeed for stdio even when the server isn't ready yet.
+  let tools: Record<string, Tool>;
+  try {
+    tools = await client.tools();
+  } catch (err) {
+    // Close the client to kill the orphaned subprocess before re-throwing
+    await client.close().catch(() => {});
+    const stderrOutput = Buffer.concat(stderrChunks).toString("utf8").trim();
+    logger.debug(`MCP stdio tools() failed for "${serverId}"`, {
       operation: "mcp_connect",
       serverId,
-      attempt,
+      error: err instanceof Error ? err.message : String(err),
+      stderrOutput: stderrOutput || undefined,
     });
+    // Prepend subprocess stderr to the error message so callers see the
+    // actual failure reason (e.g. "ENOENT: no such file or directory")
+    // rather than just the generic "Connection closed" from the transport.
+    if (stderrOutput && err instanceof Error) {
+      err.message = `${stderrOutput} (${err.message})`;
+    }
+    throw err;
+  }
 
-    return { client, tools };
-  }, RETRY_OPTIONS);
+  logger.debug(`MCP stdio connected for "${serverId}"`, {
+    operation: "mcp_connect",
+    serverId,
+  });
+
+  return { client, tools };
 }
 
 /**
@@ -392,11 +470,26 @@ async function connectStdio(
 async function isReachable(
   url: string,
   fetchImpl: typeof fetch,
+  serverId: string,
+  logger: Logger,
 ): Promise<{ ok: boolean; status?: number }> {
   try {
-    const res = await fetchImpl(url, { method: "GET" });
+    const res = await withTimeout(
+      fetchImpl(url, { method: "GET" }),
+      REACHABLE_TIMEOUT_MS,
+      () => new MCPTimeoutError(serverId, "reachable", REACHABLE_TIMEOUT_MS),
+    );
     return { ok: true, status: res.status };
-  } catch {
+  } catch (err) {
+    if (err instanceof MCPTimeoutError) {
+      logger.warn("MCP operation timed out", {
+        operation: "mcp_timeout",
+        serverId: err.serverId,
+        phase: err.phase,
+        timeoutMs: err.timeoutMs,
+        durationMs: err.timeoutMs,
+      });
+    }
     return { ok: false };
   }
 }
@@ -421,7 +514,7 @@ export async function connectHttp(
   const headers = buildAuthHeaders(auth, resolvedEnv);
 
   // If already reachable, connect directly — no spawn needed.
-  const reachable = await isReachable(url, _fetch);
+  const reachable = await isReachable(url, _fetch, serverId, logger);
   logger.debug(`MCP HTTP reachable check for "${serverId}"`, {
     operation: "mcp_connect",
     serverId,
@@ -486,46 +579,39 @@ async function connectHttpClient(
   serverId: string,
   logger: Logger,
 ): Promise<ConnectedServer> {
-  let attempt = 0;
-  return await retry(async () => {
-    attempt++;
-    logger.debug(`MCP HTTP connection attempt ${attempt} for "${serverId}"`, {
+  logger.debug(`MCP HTTP connection attempt for "${serverId}"`, {
+    operation: "mcp_connect",
+    serverId,
+    url,
+  });
+
+  const httpTransport = new StreamableHTTPClientTransport(new URL(url), {
+    requestInit: { headers },
+  });
+
+  const client = await createMCPClient({ transport: httpTransport });
+
+  let tools: Record<string, Tool>;
+  try {
+    tools = await client.tools();
+  } catch (err) {
+    logger.debug(`MCP HTTP tools() failed for "${serverId}"`, {
       operation: "mcp_connect",
       serverId,
       url,
-      attempt,
+      error: err instanceof Error ? err.message : String(err),
     });
+    await client.close().catch(() => {});
+    throw err;
+  }
 
-    const httpTransport = new StreamableHTTPClientTransport(new URL(url), {
-      requestInit: { headers },
-    });
+  logger.debug(`MCP HTTP connected for "${serverId}"`, {
+    operation: "mcp_connect",
+    serverId,
+    url,
+  });
 
-    const client = await createMCPClient({ transport: httpTransport });
-
-    let tools: Record<string, Tool>;
-    try {
-      tools = await client.tools();
-    } catch (err) {
-      logger.debug(`MCP HTTP tools() failed on attempt ${attempt} for "${serverId}"`, {
-        operation: "mcp_connect",
-        serverId,
-        url,
-        attempt,
-        error: err instanceof Error ? err.message : String(err),
-      });
-      await client.close().catch(() => {});
-      throw err;
-    }
-
-    logger.debug(`MCP HTTP connected on attempt ${attempt} for "${serverId}"`, {
-      operation: "mcp_connect",
-      serverId,
-      url,
-      attempt,
-    });
-
-    return { client, tools };
-  }, RETRY_OPTIONS);
+  return { client, tools };
 }
 
 /** Build bearer auth headers from config + resolved env. */
@@ -563,7 +649,10 @@ function filterTools(
 }
 
 /** Prefix every key in a tools map with `{prefix}_`. Descriptions are unmodified. */
-function prefixToolKeys(tools: Record<string, Tool>, prefix: string): Record<string, Tool> {
+function prefixToolKeys(
+  tools: Record<string, Tool>,
+  prefix: string,
+): Record<string, Tool> {
   const prefixed: Record<string, Tool> = {};
   for (const [name, tool] of Object.entries(tools)) {
     prefixed[`${prefix}_${name}`] = tool;

--- a/packages/mcp/src/errors.ts
+++ b/packages/mcp/src/errors.ts
@@ -25,15 +25,3 @@ export class MCPTimeoutError extends Error {
     this.name = "MCPTimeoutError";
   }
 }
-
-/** Error thrown when an MCP HTTP server rejects authentication (401). */
-export class MCPAuthError extends Error {
-  constructor(
-    public readonly serverId: string,
-    public readonly url: string,
-    message: string,
-  ) {
-    super(`MCP server "${serverId}" authentication failed (${url}): ${message}`);
-    this.name = "MCPAuthError";
-  }
-}

--- a/packages/mcp/src/errors.ts
+++ b/packages/mcp/src/errors.ts
@@ -17,8 +17,11 @@ export class MCPTimeoutError extends Error {
     public readonly serverId: string,
     public readonly phase: "reachable" | "list_tools" | "call_tool",
     public readonly timeoutMs: number,
+    public readonly actualDurationMs: number,
   ) {
-    super(`MCP ${phase} timed out for ${serverId} after ${timeoutMs}ms`);
+    super(
+      `MCP ${phase} timed out for ${serverId} after ${actualDurationMs}ms (limit ${timeoutMs}ms)`,
+    );
     this.name = "MCPTimeoutError";
   }
 }

--- a/packages/mcp/src/errors.ts
+++ b/packages/mcp/src/errors.ts
@@ -11,6 +11,18 @@ export class MCPStartupError extends Error {
   }
 }
 
+/** Error thrown when an MCP operation exceeds its hard timeout. */
+export class MCPTimeoutError extends Error {
+  constructor(
+    public readonly serverId: string,
+    public readonly phase: "reachable" | "list_tools" | "call_tool",
+    public readonly timeoutMs: number,
+  ) {
+    super(`MCP ${phase} timed out for ${serverId} after ${timeoutMs}ms`);
+    this.name = "MCPTimeoutError";
+  }
+}
+
 /** Error thrown when an MCP HTTP server rejects authentication (401). */
 export class MCPAuthError extends Error {
   constructor(


### PR DESCRIPTION
## Summary

Fixes https://github.com/friday-platform/friday-studio/issues/112

- **Parallel connection**: `Promise.allSettled` replaces serial `for...of` so one hung MCP server cannot block others.
- **Hard timeouts**: 4s on HTTP reachability probe, 20s on `createMCPClient` + `listTools` handshake, 15min ceiling on `callTool` invocation. A timed-out server is silently dropped; the chat continues with whatever connected.
- **Structured telemetry**: Every timeout logs `operation: "mcp_timeout"` with `serverId`, `phase`, and `durationMs` for future circuit-breaker decisions.
- **Removed retry**: A hung server is not a transient failure. One shot, one timeout, move on.

Fixes the incident where a single dead MCP server blocked all workspace chats from progressing.

## Test Plan

Two new tests cover the timeout behavior:
- `listTools timeout isolates the slow server` — fake timers, fast server connects while slow one hits 20s ceiling
- `callTool timeout enforces the 15min ceiling` — fake timers advance past 15min, execute rejects with `MCPTimeoutError`
