### PR TITLE
fix(skills): unbreak skills.sh autocomplete in Add-skill dialog

### DIFF
--- a/tools/agent-playground/src/lib/components/skills/skills-sh-import.svelte
+++ b/tools/agent-playground/src/lib/components/skills/skills-sh-import.svelte
@@ -42,17 +42,32 @@
     }, 200);
   }
 
+  /**
+   * skills.sh search is free-text over skill names — it doesn't honour
+   * `owner/partial` as a prefix filter, and short suffixes like `c` get
+   * buried by unrelated matches. Once the user types a slash, send the
+   * owner (first segment) to skills.sh so the response is scoped to
+   * that owner, then narrow client-side by the full query prefix.
+   */
+  const segs = $derived(searchQuery.split("/").filter(Boolean));
+  const searchTerm = $derived(segs[0] ?? "");
   const suggestionsQuery = createQuery(() =>
     queryOptions({
-      queryKey: ["skillssh-search", searchQuery] as const,
+      queryKey: ["skillssh-search", searchTerm, segs.length] as const,
       queryFn:
-        searchQuery.length >= 2 && searchQuery.split("/").filter(Boolean).length < 3
-          ? () => searchSkillsSh(searchQuery, 8)
+        searchTerm.length >= 2 && segs.length < 3
+          ? () => searchSkillsSh(searchTerm, segs.length >= 2 ? 50 : 8)
           : skipToken,
       staleTime: 60_000,
     }),
   );
-  const suggestions = $derived(suggestionsQuery.data?.skills ?? []);
+  const suggestions = $derived(
+    segs.length >= 2
+      ? (suggestionsQuery.data?.skills ?? [])
+          .filter((s) => s.id.startsWith(searchQuery))
+          .slice(0, 8)
+      : (suggestionsQuery.data?.skills ?? []),
+  );
   const showSuggestions = $derived(
     focused && source.trim().length >= 2 && suggestions.length > 0,
   );
@@ -120,10 +135,8 @@
             <button
               type="button"
               class="sugg"
-              onmousedown={(e) => {
-                e.preventDefault();
-                pickSuggestion(s.id);
-              }}
+              onmousedown={(e) => e.preventDefault()}
+              onclick={() => pickSuggestion(s.id)}
             >
               <span class="sugg-name">{s.name}</span>
               <span class="sugg-src">{s.source}</span>

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/skills/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/skills/+page.svelte
@@ -78,18 +78,32 @@
    * Autocomplete query over skills.sh. Only fires when the user is actively
    * typing something short enough to be a search term (not already a full
    * `owner/repo/slug`) — once they paste a 3-segment ref, skip search.
+   *
+   * skills.sh search is free-text over skill names — it doesn't honour
+   * `owner/partial` as a prefix filter, and short suffixes get buried by
+   * unrelated matches. Once the user types a slash, send the owner
+   * (first segment) so the response is scoped to that owner, then narrow
+   * client-side by the full query prefix.
    */
+  const segs = $derived(searchQuery.split("/").filter(Boolean));
+  const searchTerm = $derived(segs[0] ?? "");
   const searchSuggestions = createQuery(() =>
     queryOptions({
-      queryKey: ["skillssh-search", searchQuery] as const,
+      queryKey: ["skillssh-search", searchTerm, segs.length] as const,
       queryFn:
-        searchQuery.length >= 2 && searchQuery.split("/").filter(Boolean).length < 3
-          ? () => searchSkillsSh(searchQuery, 8)
+        searchTerm.length >= 2 && segs.length < 3
+          ? () => searchSkillsSh(searchTerm, segs.length >= 2 ? 50 : 8)
           : skipToken,
       staleTime: 60_000,
     }),
   );
-  const suggestions = $derived(searchSuggestions.data?.skills ?? []);
+  const suggestions = $derived(
+    segs.length >= 2
+      ? (searchSuggestions.data?.skills ?? [])
+          .filter((s) => s.id.startsWith(searchQuery))
+          .slice(0, 8)
+      : (searchSuggestions.data?.skills ?? []),
+  );
   const showSuggestions = $derived(
     searchFocused && installSource.trim().length >= 2 && suggestions.length > 0,
   );


### PR DESCRIPTION
## Summary

Two bugs in the skills.sh autocomplete when adding a skill via the Add-skill dialog.

### 1. Clicking a suggestion below the dialog box closed the modal
The `onmousedown` handler ran `pickSuggestion` synchronously, which unmounted the `<ul>` before the user lifted the mouse. `mouseup` then landed on whatever was now under the cursor — for items rendered visually below the dialog, that was an element outside the dialog, and Melt UI's debounced `interactOutside` detection treated it as an outside-click and closed the modal.

**Fix:** split the handler — `onmousedown` only prevents focus loss, `onclick` runs `pickSuggestion`. The original button stays the event target across mousedown/mouseup/click. Once it detaches, Melt's `isValidEvent` short-circuits (target no longer in document) and the dialog stays open.

### 2. Typing `owner/partial` (e.g. `ljagiello/c`) returned no suggestions
skills.sh search is free-text over skill names — it doesn't honour `owner/partial` as a prefix filter, and short suffixes get buried by unrelated matches.

**Fix:** when the query contains a slash, send the owner (first segment) to skills.sh so the response is scoped to that owner, then narrow client-side by the full query prefix.

Same fixes applied to the inline install row on the workspace skills page (`/platform/[workspaceId]/skills`) for consistency.

## Test plan
- [x] `ljagiello` → 8 ctf-skills suggestions appear
- [x] Click bottom item (`solve-challenge`, rendered visually below dialog box) → input populates, modal stays open
- [x] Click any item visually inside dialog box → input populates, modal stays open (no regression)
- [x] `ljagiello/c` → 8 ctf-skills suggestions (single char after slash)
- [x] `ljagiello/x` → empty list (no ljagiello skill matches)
- [x] `ljagiello/ctf-skills/ctf-cry` (3 segments) → no suggestions, treated as direct ref
- [x] All scenarios verified in Chrome against a running daemon at localhost:8080