### PR TITLE
fix(cli): load launcher .env so compiled binary finds daemon on correct port

### DIFF
--- a/apps/atlas-cli/package.json
+++ b/apps/atlas-cli/package.json
@@ -13,6 +13,7 @@
     "@atlas/oapi-client": "workspace:*",
     "@atlas/storage": "workspace:*",
     "@atlas/utils": "workspace:*",
+    "dotenv": "^16.4.7",
     "@inkjs/ui": "^2.0.0",
     "@std/dotenv": "npm:@jsr/std__dotenv@^0.225.5",
     "@std/yaml": "npm:@jsr/std__yaml@^1.0.10",

--- a/apps/atlas-cli/src/cli.ts
+++ b/apps/atlas-cli/src/cli.ts
@@ -1,5 +1,30 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import process from "node:process";
+import dotenv from "dotenv";
 import { stringifyError } from "@atlas/utils";
+
+// Mirror the launcher's importDotEnvIntoProcessEnv() so FRIDAYD_URL,
+// FRIDAY_PORT_*, and other launcher-managed vars are visible to CLI
+// commands when the binary is run directly from a shell. Shell exports
+// win — we only inject vars not already present in process.env.
+(function importLauncherEnv() {
+  const home = process.env.FRIDAY_LAUNCHER_HOME
+    || join(process.env.HOME || process.env.USERPROFILE || "", ".friday", "local");
+  const envPath = join(home, ".env");
+  if (!existsSync(envPath)) return;
+  try {
+    const parsed = dotenv.parse(readFileSync(envPath, "utf-8"));
+    for (const [key, value] of Object.entries(parsed)) {
+      if (process.env[key] === undefined) {
+        process.env[key] = value;
+      }
+    }
+  } catch {
+    // .env is best-effort; absent or unreadable is normal for
+    // dev-mode installs that don't use the launcher.
+  }
+})();
 
 /**
  * CLI entry point — routes between native gunshi commands and legacy yargs commands.

--- a/apps/atlas-cli/src/cli.ts
+++ b/apps/atlas-cli/src/cli.ts
@@ -1,16 +1,17 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import process from "node:process";
-import dotenv from "dotenv";
 import { stringifyError } from "@atlas/utils";
+import dotenv from "dotenv";
 
 // Mirror the launcher's importDotEnvIntoProcessEnv() so FRIDAYD_URL,
 // FRIDAY_PORT_*, and other launcher-managed vars are visible to CLI
 // commands when the binary is run directly from a shell. Shell exports
 // win — we only inject vars not already present in process.env.
 (function importLauncherEnv() {
-  const home = process.env.FRIDAY_LAUNCHER_HOME
-    || join(process.env.HOME || process.env.USERPROFILE || "", ".friday", "local");
+  const home =
+    process.env.FRIDAY_LAUNCHER_HOME ||
+    join(process.env.HOME || process.env.USERPROFILE || "", ".friday", "local");
   const envPath = join(home, ".env");
   if (!existsSync(envPath)) return;
   try {


### PR DESCRIPTION
## What

The compiled `friday` binary (deno-compile'd from `apps/atlas-cli`) starts with a fresh `process.env`. The launcher writes `FRIDAYD_URL=http://localhost:18080` to `~/.friday/local/.env` and imports it into child processes, but a standalone binary launched from the shell never sees those variables. Every command routing through `getAtlasDaemonUrl()` falls back to the hardcoded `:8080`, producing `Connection refused (os error 61)` when the daemon is actually on `:18080`.

## Changes

- `apps/atlas-cli/src/cli.ts`: Load `~/.friday/local/.env` into `process.env` at the entry point, before any command runs. Only injects keys not already present — shell exports still win.
- `apps/atlas-cli/package.json`: Add `dotenv` dependency (replacing `@std/dotenv` per codebase preference).

## Verified

- `deno run ./apps/atlas-cli/src/otel-bootstrap.ts workspace ls` → connects to `:18080`, lists workspaces ✅
- Old installed binary (`~/.friday/local/bin/friday workspace ls`) → still fails on `:8080` ✅ (confirms bug is in the build)
- Compiled binary (`deno compile …`) → works on `:18080` ✅
- Shell export override (`FRIDAYD_URL=http://localhost:9999`) → wins over `.env` ✅

## Files Changed

- `apps/atlas-cli/src/cli.ts`
- `apps/atlas-cli/package.json`
