### PR TITLE
fix(atlasd): clean up leaked Chrome processes from web agent

### DIFF
--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -109,6 +109,7 @@ import {
 } from "./signal-stream.ts";
 import { initScratchpadStorage } from "./storage/scratchpad.ts";
 import { StreamRegistry } from "./stream-registry.ts";
+import { sweepOrphanedAgentBrowserSessions } from "./sweep-agent-browser-sessions.ts";
 import { callTool, registerToolWorker, type ToolWorker } from "./tool-dispatch.ts";
 import { AtlasMetrics } from "./utils/metrics.ts";
 import { getAtlasDaemonUrl } from "./utils.ts";
@@ -334,6 +335,15 @@ export class AtlasDaemon {
     if (this.isInitialized) return;
 
     logger.info("Initializing Atlas daemon...");
+
+    // Sweep orphaned `agent-browser` daemons left by a previous atlasd that
+    // died without running the bundled web agent's stopSession cleanup
+    // (SIGKILL, crash, OOM, host reboot). Scoped to the atlas-web-<uuid>
+    // namespace, so user-launched agent-browser sessions are untouched.
+    // Pre-NATS so a sweep failure can't poison anything important.
+    await sweepOrphanedAgentBrowserSessions(logger).catch((error) => {
+      logger.warn("agent-browser session sweep failed", { error: String(error) });
+    });
 
     // Load platform model configuration (friday.yml) and construct the resolver.
     // Runs eager validation — throws on malformed config or missing credentials.
@@ -2365,6 +2375,16 @@ export class AtlasDaemon {
       }
       this.signalConsumer = null;
     }
+
+    // Reap orphaned agent-browser daemons. Done early in shutdown — after
+    // the SIGNALS consumer stops (no new agent invocations can start) but
+    // before runtime/MCP teardown (which can hang past the 30s shutdown
+    // budget). Force-closes any in-flight web sessions; the bundled agents
+    // were about to be SIGTERM'd anyway, and the next-startup sweep
+    // (layer 2) is the long-stop for anything that slips through here.
+    await sweepOrphanedAgentBrowserSessions(logger).catch((error) => {
+      logger.warn("agent-browser session sweep failed at shutdown", { error: String(error) });
+    });
 
     // Stop chunked upload cleanup
     shutdownChunkedUpload();

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -185,7 +185,7 @@ export class AtlasDaemon {
     new Map();
   // Private properties
   private idleTimeouts: Map<string, ReturnType<typeof setTimeout>> = new Map();
-  private isShuttingDown = false;
+  private shutdownPromise: Promise<void> | null = null;
   private server: Deno.HttpServer | null = null;
   private signalHandlers: Array<{ signal: Deno.Signal; handler: () => void }> = [];
   private isInitialized = false;
@@ -2082,8 +2082,12 @@ export class AtlasDaemon {
     const daemonId = crypto.randomUUID().slice(0, 8);
 
     const handleShutdown = (signal: string) => {
-      if (this.isShuttingDown) return;
-      this.isShuttingDown = true;
+      // Re-entry guard — the same handler can fire twice in quick succession.
+      // Guarded by `shutdownPromise` (set inside shutdown()) so that any
+      // other caller racing this path (e.g. the CLI's own SIGTERM handler in
+      // apps/atlas-cli/src/commands/daemon/start.tsx) awaits the same
+      // in-flight work instead of calling process.exit(0) on top of it.
+      if (this.shutdownPromise) return;
 
       logger.info("Daemon received signal, shutting down gracefully", { daemonId, signal });
 
@@ -2311,10 +2315,17 @@ export class AtlasDaemon {
     return { botToken, publicKey, applicationId };
   }
 
-  async shutdown(): Promise<void> {
-    if (this.isShuttingDown) return;
-    this.isShuttingDown = true;
+  shutdown(): Promise<void> {
+    // Memoize so concurrent callers (signal handlers in this file and in
+    // apps/atlas-cli/src/commands/daemon/start.tsx, plus any tests/HTTP
+    // routes) await the same in-flight teardown instead of racing on
+    // process.exit(0) and tearing down work mid-flight.
+    if (this.shutdownPromise) return this.shutdownPromise;
+    this.shutdownPromise = this._doShutdown();
+    return this.shutdownPromise;
+  }
 
+  private async _doShutdown(): Promise<void> {
     logger.info("Shutting down Atlas daemon...");
 
     // Stop the Discord Gateway service FIRST so the WebSocket closes cleanly

--- a/apps/atlasd/src/sweep-agent-browser-sessions.test.ts
+++ b/apps/atlasd/src/sweep-agent-browser-sessions.test.ts
@@ -1,0 +1,186 @@
+import { mkdir, mkdtemp, readdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { sweepOrphanedAgentBrowserSessions } from "./sweep-agent-browser-sessions.ts";
+
+const NOOP_LOGGER = { info: vi.fn(), warn: vi.fn() };
+
+const VALID_UUID = "11111111-2222-3333-4444-555555555555";
+const VALID_UUID_2 = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+async function writeSessionFiles(dir: string, session: string, pid: number) {
+  for (const ext of ["pid", "sock", "engine", "stream", "version"]) {
+    await writeFile(join(dir, `${session}.${ext}`), ext === "pid" ? String(pid) : "x");
+  }
+}
+
+describe("sweepOrphanedAgentBrowserSessions", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "atlas-sweep-"));
+    NOOP_LOGGER.info.mockReset();
+    NOOP_LOGGER.warn.mockReset();
+  });
+
+  afterEach(async () => {
+    // mkdtemp cleanup is best-effort — tests don't rely on it
+  });
+
+  it("returns empty result when directory does not exist", async () => {
+    const missing = join(dir, "does-not-exist");
+    const result = await sweepOrphanedAgentBrowserSessions(NOOP_LOGGER, { dir: missing });
+    expect(result).toEqual({ scanned: 0, closed: 0, killed: 0, staleFilesOnly: 0, errors: [] });
+  });
+
+  it("ignores non-Friday session names", async () => {
+    // User-launched flat-name sessions must not be touched
+    for (const ext of ["pid", "sock"]) {
+      await writeFile(join(dir, `amazon.${ext}`), "1234");
+      await writeFile(join(dir, `default.${ext}`), "1234");
+      await writeFile(join(dir, `bh2.${ext}`), "1234");
+    }
+    // Also ignore atlas-web-* without proper UUID shape
+    await writeFile(join(dir, "atlas-web-not-a-uuid.pid"), "1234");
+
+    const result = await sweepOrphanedAgentBrowserSessions(NOOP_LOGGER, {
+      dir,
+      isPidAlive: () => true,
+      closeSession: vi.fn(),
+      killByPid: vi.fn(),
+    });
+
+    expect(result.scanned).toBe(0);
+    // Files still there
+    const remaining = await readdir(dir);
+    expect(remaining).toContain("amazon.pid");
+    expect(remaining).toContain("default.sock");
+    expect(remaining).toContain("atlas-web-not-a-uuid.pid");
+  });
+
+  it("removes stale files for dead PIDs without calling close/kill", async () => {
+    await writeSessionFiles(dir, `atlas-web-${VALID_UUID}`, 99999);
+    const closeSession = vi.fn();
+    const killByPid = vi.fn();
+
+    const result = await sweepOrphanedAgentBrowserSessions(NOOP_LOGGER, {
+      dir,
+      isPidAlive: () => false,
+      closeSession,
+      killByPid,
+    });
+
+    expect(result).toMatchObject({ scanned: 1, closed: 0, killed: 0, staleFilesOnly: 1 });
+    expect(closeSession).not.toHaveBeenCalled();
+    expect(killByPid).not.toHaveBeenCalled();
+
+    const remaining = await readdir(dir);
+    expect(remaining.filter((e) => e.startsWith("atlas-web-"))).toEqual([]);
+  });
+
+  it("calls close for live daemons and removes files", async () => {
+    await writeSessionFiles(dir, `atlas-web-${VALID_UUID}`, 12345);
+    const closeSession = vi.fn().mockResolvedValue(undefined);
+    const killByPid = vi.fn();
+
+    const result = await sweepOrphanedAgentBrowserSessions(NOOP_LOGGER, {
+      dir,
+      isPidAlive: (pid) => pid === 12345,
+      closeSession,
+      killByPid,
+    });
+
+    expect(result).toMatchObject({ scanned: 1, closed: 1, killed: 0, staleFilesOnly: 0 });
+    expect(closeSession).toHaveBeenCalledWith(`atlas-web-${VALID_UUID}`);
+    expect(killByPid).not.toHaveBeenCalled();
+
+    const remaining = await readdir(dir);
+    expect(remaining).toEqual([]);
+  });
+
+  it("falls back to killByPid when close fails", async () => {
+    await writeSessionFiles(dir, `atlas-web-${VALID_UUID}`, 12345);
+    const closeSession = vi.fn().mockRejectedValue(new Error("ENOENT"));
+    const killByPid = vi.fn().mockResolvedValue(true);
+
+    const result = await sweepOrphanedAgentBrowserSessions(NOOP_LOGGER, {
+      dir,
+      isPidAlive: (pid) => pid === 12345,
+      closeSession,
+      killByPid,
+    });
+
+    expect(result).toMatchObject({ scanned: 1, closed: 0, killed: 1, staleFilesOnly: 0 });
+    expect(killByPid).toHaveBeenCalledWith(12345);
+  });
+
+  it("records error when neither close nor kill succeeds", async () => {
+    await writeSessionFiles(dir, `atlas-web-${VALID_UUID}`, 12345);
+    const closeSession = vi.fn().mockRejectedValue(new Error("close failed"));
+    const killByPid = vi.fn().mockResolvedValue(false);
+
+    const result = await sweepOrphanedAgentBrowserSessions(NOOP_LOGGER, {
+      dir,
+      isPidAlive: () => true,
+      closeSession,
+      killByPid,
+    });
+
+    expect(result.scanned).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]?.session).toBe(`atlas-web-${VALID_UUID}`);
+  });
+
+  it("processes multiple sessions independently", async () => {
+    await writeSessionFiles(dir, `atlas-web-${VALID_UUID}`, 12345); // alive
+    await writeSessionFiles(dir, `atlas-web-${VALID_UUID_2}`, 99999); // dead
+    await writeFile(join(dir, "amazon.pid"), "777"); // user, ignore
+
+    const closeSession = vi.fn().mockResolvedValue(undefined);
+    const result = await sweepOrphanedAgentBrowserSessions(NOOP_LOGGER, {
+      dir,
+      isPidAlive: (pid) => pid === 12345,
+      closeSession,
+      killByPid: vi.fn(),
+    });
+
+    expect(result).toMatchObject({ scanned: 2, closed: 1, staleFilesOnly: 1 });
+    expect(closeSession).toHaveBeenCalledTimes(1);
+    expect(closeSession).toHaveBeenCalledWith(`atlas-web-${VALID_UUID}`);
+
+    const remaining = await readdir(dir);
+    expect(remaining).toEqual(["amazon.pid"]);
+  });
+
+  it("handles missing or unreadable pid file as 'not alive'", async () => {
+    // Create only sock + version, no pid file
+    await writeFile(join(dir, `atlas-web-${VALID_UUID}.sock`), "x");
+    await writeFile(join(dir, `atlas-web-${VALID_UUID}.version`), "x");
+    // But the regex matches only on .pid presence, so this entry is ignored.
+    const result = await sweepOrphanedAgentBrowserSessions(NOOP_LOGGER, {
+      dir,
+      isPidAlive: () => true,
+      closeSession: vi.fn(),
+      killByPid: vi.fn(),
+    });
+    expect(result.scanned).toBe(0);
+    // Now add a pid file with garbage contents
+    await writeFile(join(dir, `atlas-web-${VALID_UUID}.pid`), "not-a-number");
+    const result2 = await sweepOrphanedAgentBrowserSessions(NOOP_LOGGER, {
+      dir,
+      isPidAlive: () => true, // would be true if asked
+      closeSession: vi.fn(),
+      killByPid: vi.fn(),
+    });
+    expect(result2.scanned).toBe(1);
+    expect(result2.staleFilesOnly).toBe(1); // unreadable pid → treated as not alive
+  });
+
+  it("does not log when nothing was scanned", async () => {
+    await mkdir(dir, { recursive: true });
+    await sweepOrphanedAgentBrowserSessions(NOOP_LOGGER, { dir });
+    expect(NOOP_LOGGER.info).not.toHaveBeenCalled();
+  });
+});

--- a/apps/atlasd/src/sweep-agent-browser-sessions.ts
+++ b/apps/atlasd/src/sweep-agent-browser-sessions.ts
@@ -1,0 +1,163 @@
+import { execFile } from "node:child_process";
+import { readdir, readFile, unlink } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+// Matches `atlas-web-${randomUUID()}` from packages/bundled-agents/src/web/index.ts.
+// The prefix is Friday's exclusive namespace — user-launched agent-browser
+// sessions use flat names (e.g. "amazon", "default") that cannot collide.
+const SESSION_FILE_RE =
+  /^(atlas-web-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\.pid$/;
+
+const SESSION_FILE_EXTS = ["pid", "sock", "engine", "stream", "version"] as const;
+
+const CLOSE_TIMEOUT_MS = 5_000;
+const SIGTERM_GRACE_MS = 500;
+
+export interface SweepLogger {
+  info: (msg: string, ctx?: Record<string, unknown>) => void;
+  warn: (msg: string, ctx?: Record<string, unknown>) => void;
+}
+
+export interface SweepResult {
+  scanned: number;
+  closed: number;
+  killed: number;
+  staleFilesOnly: number;
+  errors: { session: string; error: string }[];
+}
+
+export interface SweepDeps {
+  /** Directory where agent-browser writes per-session pid/sock files. */
+  dir?: string;
+  /** Returns true if pid is currently alive. */
+  isPidAlive?: (pid: number) => boolean;
+  /** Asks the agent-browser daemon to exit gracefully via the CLI. */
+  closeSession?: (session: string) => Promise<void>;
+  /** Kills a daemon by PID, escalating to SIGKILL if SIGTERM doesn't take. */
+  killByPid?: (pid: number) => Promise<boolean>;
+}
+
+/**
+ * Sweep orphaned `agent-browser` daemons left by a previous atlasd that
+ * died without running the bundled web agent's stopSession cleanup
+ * (SIGKILL, crash, OOM, host reboot). Scoped to the `atlas-web-<uuid>`
+ * namespace owned exclusively by the bundled web agent.
+ *
+ * Safe to call only at daemon startup, before any web-agent invocation —
+ * any matching session in the directory is necessarily orphaned.
+ */
+export async function sweepOrphanedAgentBrowserSessions(
+  logger: SweepLogger,
+  deps: SweepDeps = {},
+): Promise<SweepResult> {
+  const dir = deps.dir ?? join(homedir(), ".agent-browser");
+  const isPidAlive = deps.isPidAlive ?? defaultIsPidAlive;
+  const closeSession = deps.closeSession ?? defaultCloseSession;
+  const killByPid = deps.killByPid ?? ((pid: number) => defaultKillByPid(pid, isPidAlive));
+
+  const result: SweepResult = { scanned: 0, closed: 0, killed: 0, staleFilesOnly: 0, errors: [] };
+
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch {
+    return result;
+  }
+
+  const sessions: string[] = [];
+  for (const entry of entries) {
+    const match = SESSION_FILE_RE.exec(entry);
+    if (match?.[1]) sessions.push(match[1]);
+  }
+  result.scanned = sessions.length;
+  if (sessions.length === 0) return result;
+
+  // Sessions are independent — each owns its own socket/pid set. Run in
+  // parallel so shutdown-time invocations stay within the 30s budget even
+  // with many leftover sessions.
+  const perSession = sessions.map(async (session) => {
+    const pid = await readPid(dir, session);
+    const alive = pid !== null && isPidAlive(pid);
+
+    if (alive && pid !== null) {
+      try {
+        await closeSession(session);
+        result.closed++;
+      } catch {
+        try {
+          const killed = await killByPid(pid);
+          if (killed) {
+            result.killed++;
+          } else {
+            result.errors.push({ session, error: `failed to terminate pid ${pid}` });
+          }
+        } catch (err) {
+          result.errors.push({ session, error: String(err) });
+        }
+      }
+    } else {
+      result.staleFilesOnly++;
+    }
+
+    await removeSessionFiles(dir, session);
+  });
+  await Promise.all(perSession);
+
+  logger.info("Swept orphaned agent-browser sessions", { ...result });
+  return result;
+}
+
+async function readPid(dir: string, session: string): Promise<number | null> {
+  try {
+    const raw = await readFile(join(dir, `${session}.pid`), "utf8");
+    const pid = parseInt(raw.trim(), 10);
+    return Number.isFinite(pid) && pid > 1 ? pid : null;
+  } catch {
+    return null;
+  }
+}
+
+function defaultIsPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function defaultCloseSession(session: string): Promise<void> {
+  await execFileAsync("agent-browser", ["--session", session, "close"], {
+    timeout: CLOSE_TIMEOUT_MS,
+  });
+}
+
+async function defaultKillByPid(
+  pid: number,
+  isPidAlive: (pid: number) => boolean,
+): Promise<boolean> {
+  try {
+    process.kill(pid, "SIGTERM");
+  } catch {
+    return !isPidAlive(pid);
+  }
+  await new Promise((r) => setTimeout(r, SIGTERM_GRACE_MS));
+  if (!isPidAlive(pid)) return true;
+  try {
+    process.kill(pid, "SIGKILL");
+  } catch {
+    // Already dead between checks
+  }
+  return !isPidAlive(pid);
+}
+
+async function removeSessionFiles(dir: string, session: string): Promise<void> {
+  await Promise.all(
+    SESSION_FILE_EXTS.map((ext) => unlink(join(dir, `${session}.${ext}`)).catch(() => {})),
+  );
+}


### PR DESCRIPTION
## Summary

The bundled web agent (`packages/bundled-agents/src/web/`) spawns
`agent-browser` per invocation, which daemonizes itself (detaches to
PPID=1) and launches Chrome. When the agent subprocess is killed before
its `finally { stopSession }` runs — which is the *common* case under
atlasd's SIGTERM→SIGKILL escalation, not the edge case — the daemon and
Chrome live forever. Found 13 leaked browser instances and 9 stale
daemons on my machine; oldest PIDs were from days earlier.

This PR adds a sweep at daemon startup and shutdown, scoped to the
`atlas-web-<uuid>` namespace that's exclusively Friday's. While
implementing the shutdown sweep, I found a pre-existing race in
`shutdown()` that made signal-driven shutdown a no-op (~1s premature
exit), included as a separate first commit.

## Coverage

| Failure mode | Existing `finally` | Startup sweep | Shutdown sweep |
|---|---|---|---|
| Web task completes normally | ✓ | – | – |
| Aborted with finally flush | ✓ | – | ✓ |
| Graceful daemon shutdown (finally skipped) | ✗ | ✓ next start | ✓ same shutdown |
| SIGKILL / crash / OOM / reboot | ✗ | ✓ next start | – (can't run) |

## Test plan

- [x] `deno task test apps/atlasd/src/sweep-agent-browser-sessions.test.ts` — 9 unit tests pass
- [x] `deno task test apps/atlasd/src/atlas-daemon.test.ts` — existing tests still pass
- [x] `deno task typecheck` — 0 errors (8220 files)
- [x] `knip` — clean
- [x] `deno lint` + `biome check` on modified files — clean
- [x] End-to-end: planted live `agent-browser` daemon (PPID=1) + 11 Chrome processes, SIGTERM'd daemon, verified 9s shutdown, sweep ran, 0 leftover processes
- [x] End-to-end: planted dead `atlas-web-*` PID files + a flat-name `manual-test.pid`, started daemon, verified atlas-web files removed and `manual-test.pid` preserved