### PR TITLE
fix(atlasd): flush in-flight writes on SessionStreamRegistry shutdown

### DIFF
--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -2410,7 +2410,7 @@ export class AtlasDaemon {
     this.chatTurnRegistry?.shutdown();
 
     // Shutdown SessionStreamRegistry
-    this.sessionStreamRegistry?.shutdown();
+    await this.sessionStreamRegistry?.shutdown();
 
     // Clear all idle timeouts
     for (const timeoutId of this.idleTimeouts.values()) {

--- a/apps/atlasd/src/session-stream-registry.test.ts
+++ b/apps/atlasd/src/session-stream-registry.test.ts
@@ -42,7 +42,7 @@ aroundEach(async (run) => {
   registry = new SessionStreamRegistry(mockNatsConnection());
   registry.start();
   await run();
-  registry.shutdown();
+  await registry.shutdown();
   vi.useRealTimers();
 });
 
@@ -158,12 +158,12 @@ describe("TTL cleanup", () => {
 // ---------------------------------------------------------------------------
 
 describe("shutdown", () => {
-  test("clears all streams", () => {
+  test("clears all streams", async () => {
     const adapter = mockAdapter();
     registry.create("sess-1", adapter);
     registry.create("sess-2", adapter);
 
-    registry.shutdown();
+    await registry.shutdown();
 
     expect(registry.get("sess-1")).toBeUndefined();
     expect(registry.get("sess-2")).toBeUndefined();

--- a/apps/atlasd/src/session-stream-registry.ts
+++ b/apps/atlasd/src/session-stream-registry.ts
@@ -43,12 +43,14 @@ export class SessionStreamRegistry {
     logger.info("SessionStreamRegistry started");
   }
 
-  /** Shutdown: clear all streams, stop cleanup. */
-  shutdown(): void {
+  /** Shutdown: flush in-flight writes, clear all streams, stop cleanup. */
+  async shutdown(): Promise<void> {
     if (this.cleanupInterval) {
       clearInterval(this.cleanupInterval);
       this.cleanupInterval = null;
     }
+    const pending = Array.from(this.streams.values(), (e) => e.stream.flush());
+    await Promise.all(pending);
     this.streams.clear();
     logger.info("SessionStreamRegistry shutdown");
   }

--- a/apps/atlasd/src/tool-worker-entry.ts
+++ b/apps/atlasd/src/tool-worker-entry.ts
@@ -74,6 +74,10 @@ export async function startToolWorkerProcess(opts?: {
   logger.info("Tool worker connecting", { natsUrl, tools: selected.map((s) => s.toolId) });
   const nc = await connect({ servers: natsUrl });
   const workers = selected.map((s) => registerToolWorker(nc, s.toolId, s.handle));
+  // Wait for all SUB protocol messages to flush before signalling readiness —
+  // otherwise a caller dispatching immediately after this resolves can race
+  // the server-side subscription registration and see NatsError 503.
+  await Promise.all(workers.map((w) => w.ready));
   logger.info("Tool worker registered", { tools: workers.map((w) => w.toolId) });
 
   return {


### PR DESCRIPTION
## Summary
- Fixes the `main` CI flake at `apps/atlasd/routes/sessions/sessions.test.ts > GET / (list) > includes active session summaries from registry` ([failed run](https://github.com/friday-platform/friday-studio/actions/runs/25305699373/job/74181068305)).
- Root cause: `SessionStreamRegistry.shutdown()` was synchronous and cleared the streams map without awaiting `NatsSessionStream`'s in-flight `adapter.appendEvent` writes. `stream.emit()` is fire-and-forget, so the test's `afterEach` `rm(testDir, { recursive: true, force: true })` raced with a write still landing → `ENOTEMPTY: directory not empty, rm`.
- Make `shutdown()` async, await `Promise.all` of every stream's `flush()` before clearing, and await it from `atlas-daemon.shutdown()` and the registry unit tests. The route test was already awaiting the previously-void `shutdown()`, so it picks up the fix automatically.
- Also closes a real prod bug: daemon shutdown previously dropped the last few session events on the floor.

## Test plan
- [x] `deno run -A npm:vitest run apps/atlasd/routes/sessions/sessions.test.ts` × 5 — all green
- [x] `deno run -A npm:vitest run apps/atlasd/src/session-stream-registry.test.ts` — green
- [x] `deno check` on changed files
- [x] `knip` — only pre-existing SvelteKit `$types` warnings in `tools/agent-playground`, unrelated