### PR TITLE
Chat attachment lifecycle: scrubber + parse_artifact + persistence drain

### DIFF
--- a/apps/atlasd/routes/artifacts.test.ts
+++ b/apps/atlasd/routes/artifacts.test.ts
@@ -709,7 +709,13 @@ describe("Content endpoint", () => {
 
     expect(contentResponse.status).toEqual(200);
     expect(contentResponse.headers.get("X-Content-Type-Options")).toEqual("nosniff");
-    expect(contentResponse.headers.get("Content-Disposition")).toEqual("inline");
+    // Disposition carries a filename hint after the type, so split on the
+    // first `;` and check the leading token. The full header looks like
+    // `inline; filename="sec.png"; filename*=UTF-8''sec.png` — see
+    // `deriveDownloadFilename` in @atlas/core/artifacts/file-upload.
+    const cd = contentResponse.headers.get("Content-Disposition") ?? "";
+    expect(cd.split(";")[0]?.trim()).toEqual("inline");
+    expect(cd).toContain('filename="sec.png"');
   });
 
   it("returns attachment disposition for non-image content", async () => {
@@ -730,7 +736,9 @@ describe("Content endpoint", () => {
 
     expect(contentResponse.status).toEqual(200);
     expect(contentResponse.headers.get("X-Content-Type-Options")).toEqual("nosniff");
-    expect(contentResponse.headers.get("Content-Disposition")).toEqual("attachment");
+    const cd = contentResponse.headers.get("Content-Disposition") ?? "";
+    expect(cd.split(";")[0]?.trim()).toEqual("attachment");
+    expect(cd).toContain('filename="data.json"');
   });
 });
 

--- a/apps/atlasd/routes/artifacts.ts
+++ b/apps/atlasd/routes/artifacts.ts
@@ -21,6 +21,8 @@ import {
   isAudioMimeType,
   isImageMimeType,
   isInvalidChatId,
+  isParseableMimeType,
+  isTextMimeType,
   LEGACY_FORMAT_ERRORS,
   MAX_AUDIO_SIZE,
   MAX_FILE_SIZE,
@@ -621,22 +623,84 @@ const artifactsApp = daemonFactory
 
       const artifact = result.data;
       let contents: string | undefined;
+      let hint: string | undefined;
 
-      // For file artifacts, include contents inline
+      // Only return decoded contents for text-like mime types. Binary
+      // formats (PDF, images, audio, zip, etc.) get a hint instead — the
+      // model can't usefully reason about TextDecoder-mangled bytes, and
+      // shipping them through the prompt is expensive. Binary callers
+      // should use `parse_artifact` for PDF/DOCX/PPTX text extraction or
+      // `display_artifact` for visual rendering.
       if (artifact.data.type === "file") {
-        const contentsResult = await ArtifactStorage.readFileContents({
-          id,
-          revision: query?.revision,
-        });
-        if (contentsResult.ok) {
-          contents = contentsResult.data;
+        const mime = artifact.data.mimeType;
+        if (isTextMimeType(mime)) {
+          const contentsResult = await ArtifactStorage.readFileContents({
+            id,
+            revision: query?.revision,
+          });
+          if (contentsResult.ok) {
+            contents = contentsResult.data;
+          }
+        } else if (isParseableMimeType(mime)) {
+          hint = `Binary artifact (${mime}). Call parse_artifact with this artifactId to extract text contents, or display_artifact to show the user.`;
+        } else if (isImageMimeType(mime)) {
+          hint = `Image artifact (${mime}). Call display_artifact to show the user — the model cannot reason about image bytes directly.`;
+        } else {
+          hint = `Binary artifact (${mime}). Call display_artifact to show the user, or fetch /api/artifacts/${id}/content from run_code to process the bytes server-side.`;
         }
-        // If read fails (binary file, etc.), still return artifact metadata
       }
 
-      return c.json({ artifact, contents }, 200);
+      return c.json({ artifact, contents, hint }, 200);
     },
   )
+  /**
+   * Server-side text extraction for binary artifacts. Routes the bytes
+   * through whichever converter matches the mime type — same converters
+   * used at upload time. Saves the model from trying to do PDF parsing
+   * itself by round-tripping bytes through `run_code`, which costs
+   * thousands of prompt tokens per page and frequently fails on larger
+   * documents. Result is markdown text, suitable for direct LLM reasoning.
+   */
+  .get("/:id/parse", zValidator("param", z.object({ id: z.string() })), async (c) => {
+    const { id } = c.req.valid("param");
+    const meta = await ArtifactStorage.get({ id });
+    if (!meta.ok) return c.json({ error: meta.error }, 500);
+    if (!meta.data) return c.json({ error: "Artifact not found" }, 404);
+    if (meta.data.data.type !== "file") {
+      return c.json({ error: "Artifact is not a file" }, 400);
+    }
+    const mime = meta.data.data.mimeType;
+    if (!isParseableMimeType(mime)) {
+      return c.json(
+        {
+          error: `parse_artifact does not support mime type ${mime}. Supported: PDF, DOCX, PPTX. For text artifacts use artifacts_get; for images use display_artifact.`,
+        },
+        400,
+      );
+    }
+    const bytes = await ArtifactStorage.readBinaryContents({ id });
+    if (!bytes.ok) return c.json({ error: bytes.error }, 500);
+    const filename = meta.data.data.originalName ?? meta.data.title ?? id;
+    try {
+      let markdown: string;
+      if (mime === "application/pdf") {
+        markdown = await pdfToMarkdown(bytes.data, filename);
+      } else if (
+        mime === "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+      ) {
+        markdown = await docxToMarkdown(bytes.data, filename);
+      } else {
+        markdown = await pptxToMarkdown(bytes.data, filename);
+      }
+      return c.json({ markdown, mimeType: mime, filename }, 200);
+    } catch (err) {
+      if (err instanceof ConverterError) {
+        return c.json({ error: err.message, code: err.code }, 422);
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      return c.json({ error: `Failed to parse artifact: ${msg}` }, 500);
+    }
+  })
   /** List artifacts - optionally filter by workspace or chat */
   .get("/", zValidator("query", ListArtifactsQuery), async (c) => {
     const query = c.req.valid("query");

--- a/apps/atlasd/routes/artifacts.ts
+++ b/apps/atlasd/routes/artifacts.ts
@@ -793,7 +793,16 @@ const artifactsApp = daemonFactory
       }
 
       const { mimeType } = artifact.data;
-      const disposition = isImageMimeType(mimeType) ? "inline" : "attachment";
+      // Mimes the browser renders inline in an `<iframe>` or `<img>`. Anything
+      // else triggers a download. PDFs and HTML need `inline` so the chat
+      // UI's artifact-card iframe shows a preview instead of pulling down a
+      // copy and leaving the iframe blank.
+      const isInlineRenderable =
+        isImageMimeType(mimeType) ||
+        mimeType === "application/pdf" ||
+        mimeType === "text/html" ||
+        mimeType === "text/plain";
+      const disposition = isInlineRenderable ? "inline" : "attachment";
 
       const body = new Uint8Array(binaryResult.data);
       return new Response(body, {

--- a/apps/atlasd/routes/artifacts.ts
+++ b/apps/atlasd/routes/artifacts.ts
@@ -792,7 +792,7 @@ const artifactsApp = daemonFactory
         return c.json({ error: binaryResult.error }, 500);
       }
 
-      const { mimeType } = artifact.data;
+      const { mimeType, originalName } = artifact.data;
       // Mimes the browser renders inline in an `<iframe>` or `<img>`. Anything
       // else triggers a download. PDFs and HTML need `inline` so the chat
       // UI's artifact-card iframe shows a preview instead of pulling down a
@@ -804,13 +804,29 @@ const artifactsApp = daemonFactory
         mimeType === "text/plain";
       const disposition = isInlineRenderable ? "inline" : "attachment";
 
+      // Filename hint so the browser uses something meaningful when the user
+      // saves (Right-click → Save As, or attachment-disposition downloads).
+      // Without it the browser falls back to the URL's last path segment,
+      // which is the literal string "content" — every download lands as
+      // "content", "content (1)", etc. We prefer originalName, falling back
+      // to artifact title with a mime-derived extension.
+      //
+      // RFC 6266 escaping: `filename=` is the ASCII fallback (quotes and
+      // backslashes escaped); `filename*=UTF-8''…` carries the real value
+      // for any non-ASCII characters. Modern browsers prefer filename*.
+      const extFromMime = mimeType.split("/")[1]?.split(";")[0]?.split("+")[0] ?? "bin";
+      const rawName = originalName ?? `${artifact.title}.${extFromMime}`;
+      const asciiName = rawName.replace(/[^\x20-\x7e]+/g, "_").replace(/["\\]/g, "_");
+      const utf8Name = encodeURIComponent(rawName);
+      const contentDisposition = `${disposition}; filename="${asciiName}"; filename*=UTF-8''${utf8Name}`;
+
       const body = new Uint8Array(binaryResult.data);
       return new Response(body, {
         status: 200,
         headers: {
           "Content-Type": mimeType,
           "Content-Length": String(body.byteLength),
-          "Content-Disposition": disposition,
+          "Content-Disposition": contentDisposition,
           "X-Content-Type-Options": "nosniff",
           "Cache-Control": "private, max-age=31536000, immutable",
         },

--- a/apps/atlasd/routes/artifacts.ts
+++ b/apps/atlasd/routes/artifacts.ts
@@ -16,6 +16,7 @@ import {
   USER_FACING_ERROR_CODES,
 } from "@atlas/core/artifacts/converters";
 import {
+  deriveDownloadFilename,
   FILE_TYPE_NOT_ALLOWED_ERROR,
   getValidatedMimeType,
   isAudioMimeType,
@@ -806,16 +807,19 @@ const artifactsApp = daemonFactory
 
       // Filename hint so the browser uses something meaningful when the user
       // saves (Right-click → Save As, or attachment-disposition downloads).
-      // Without it the browser falls back to the URL's last path segment,
-      // which is the literal string "content" — every download lands as
-      // "content", "content (1)", etc. We prefer originalName, falling back
-      // to artifact title with a mime-derived extension.
+      // Without it the browser falls back to the URL's last path segment —
+      // every download lands as "content", "content (1)", etc.
       //
-      // RFC 6266 escaping: `filename=` is the ASCII fallback (quotes and
-      // backslashes escaped); `filename*=UTF-8''…` carries the real value
-      // for any non-ASCII characters. Modern browsers prefer filename*.
-      const extFromMime = mimeType.split("/")[1]?.split(";")[0]?.split("+")[0] ?? "bin";
-      const rawName = originalName ?? `${artifact.title}.${extFromMime}`;
+      // `deriveDownloadFilename` reconciles the stored `originalName` with
+      // the actual `mimeType`. Legacy artifacts where the scrubber stamped
+      // a `.bin` filename pre-mime-sniff get their extension repaired at
+      // download time; future scrubber lifts already pick the right
+      // extension via base64 magic-byte detection.
+      //
+      // RFC 6266: `filename=` is the ASCII fallback (quotes/backslashes
+      // escaped); `filename*=UTF-8''…` carries the real value for any
+      // non-ASCII. Modern browsers prefer filename*.
+      const rawName = deriveDownloadFilename({ mimeType, originalName, title: artifact.title });
       const asciiName = rawName.replace(/[^\x20-\x7e]+/g, "_").replace(/["\\]/g, "_");
       const utf8Name = encodeURIComponent(rawName);
       const contentDisposition = `${disposition}; filename="${asciiName}"; filename*=UTF-8''${utf8Name}`;

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -2164,14 +2164,21 @@ export class AtlasDaemon {
       this.signalHandlers.push({ signal: "SIGTERM", handler: sigtermHandler });
     }
 
-    // Best-effort persistence flush on uncaught crashes. We can't recover the
-    // process state, but if we have time before exit we want in-flight chat
-    // turns to drain just like a graceful shutdown — same code path, tighter
-    // budget. SIGKILL still loses everything.
-    const crashHandler = (label: string) => (err: unknown) => {
-      logger.error("Daemon crashing — attempting best-effort drain", {
+    // Best-effort persistence flush on uncaughtException. The process state
+    // is unrecoverable at this point; we want in-flight chat turns to
+    // drain — same code path as graceful shutdown but on a tight budget —
+    // before exiting. SIGKILL still loses everything.
+    //
+    // NOTE: This is intentionally NOT installed for `unhandledRejection`.
+    // Stray rejections from background tasks are common in long-running
+    // daemons and shouldn't kill the process; they're logged below for
+    // visibility but don't trigger a drain or an exit.
+    process.on("uncaughtException", (err) => {
+      // If a graceful shutdown is already in progress, let it finish.
+      // Re-entering here would race with the existing _doShutdown.
+      if (this.shutdownPromise) return;
+      logger.error("uncaughtException — attempting best-effort drain", {
         daemonId,
-        label,
         error: err instanceof Error ? err.message : String(err),
       });
       const crashTimeout = setTimeout(() => process.exit(1), 3000);
@@ -2182,9 +2189,13 @@ export class AtlasDaemon {
           clearTimeout(crashTimeout);
           process.exit(1);
         });
-    };
-    process.on("uncaughtException", crashHandler("uncaughtException"));
-    process.on("unhandledRejection", crashHandler("unhandledRejection"));
+    });
+    process.on("unhandledRejection", (reason) => {
+      logger.error("unhandledRejection (logged, not fatal)", {
+        daemonId,
+        error: reason instanceof Error ? reason.message : String(reason),
+      });
+    });
   }
 
   async start() {
@@ -2433,11 +2444,7 @@ export class AtlasDaemon {
     // any in-flight delegate calls / streaming text vanish on reboot. The
     // 9s outer ceiling covers the registry's 8s internal budget plus a
     // small buffer; real persistence completes in low ms once abort fires.
-    await withShutdownTimeout(
-      "chat turn drain",
-      this.chatTurnRegistry?.drainShutdown(8000),
-      9000,
-    );
+    await withShutdownTimeout("chat turn drain", this.chatTurnRegistry?.drainShutdown(8000), 9000);
 
     // Phase 2 — tear down domain layer in parallel. destroyWorkspaceRuntime
     // calls workspaceManager.updateWorkspaceStatus (which goes through NATS)

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -2163,6 +2163,28 @@ export class AtlasDaemon {
       Deno.addSignalListener("SIGTERM", sigtermHandler);
       this.signalHandlers.push({ signal: "SIGTERM", handler: sigtermHandler });
     }
+
+    // Best-effort persistence flush on uncaught crashes. We can't recover the
+    // process state, but if we have time before exit we want in-flight chat
+    // turns to drain just like a graceful shutdown — same code path, tighter
+    // budget. SIGKILL still loses everything.
+    const crashHandler = (label: string) => (err: unknown) => {
+      logger.error("Daemon crashing — attempting best-effort drain", {
+        daemonId,
+        label,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      const crashTimeout = setTimeout(() => process.exit(1), 3000);
+      this.chatTurnRegistry
+        ?.drainShutdown(2500)
+        .catch(() => undefined)
+        .finally(() => {
+          clearTimeout(crashTimeout);
+          process.exit(1);
+        });
+    };
+    process.on("uncaughtException", crashHandler("uncaughtException"));
+    process.on("unhandledRejection", crashHandler("unhandledRejection"));
   }
 
   async start() {
@@ -2403,6 +2425,20 @@ export class AtlasDaemon {
 
     shutdownChunkedUpload();
 
+    // Drain in-flight chat turns BEFORE Phase 2. Aborts every active chat
+    // turn and waits (bounded) for each turn's onFinish to run — which is
+    // where partial assistant messages get persisted to JetStream. Without
+    // this drain, SIGTERM would race the agent's onFinish: aborts fire, but
+    // process.exit lands before the partial message reaches storage, and
+    // any in-flight delegate calls / streaming text vanish on reboot. The
+    // 9s outer ceiling covers the registry's 8s internal budget plus a
+    // small buffer; real persistence completes in low ms once abort fires.
+    await withShutdownTimeout(
+      "chat turn drain",
+      this.chatTurnRegistry?.drainShutdown(8000),
+      9000,
+    );
+
     // Phase 2 — tear down domain layer in parallel. destroyWorkspaceRuntime
     // calls workspaceManager.updateWorkspaceStatus (which goes through NATS)
     // so NATS + WorkspaceManager must remain alive until this phase ends.
@@ -2425,7 +2461,10 @@ export class AtlasDaemon {
     ]);
     this.cronManager = null;
 
-    // Synchronous registries + interval/timer cleanup.
+    // Synchronous registries + interval/timer cleanup. Chat turn registry
+    // was drained above; the shutdown() here clears any controllers added
+    // between the drain and now (defensive — shouldn't happen since the
+    // signals consumer is already stopped).
     this.streamRegistry?.shutdown();
     this.chatTurnRegistry?.shutdown();
     for (const timeoutId of this.idleTimeouts.values()) clearTimeout(timeoutId);

--- a/apps/atlasd/src/chat-turn-registry.test.ts
+++ b/apps/atlasd/src/chat-turn-registry.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { ChatTurnRegistry, ChatTurnShutdownError } from "./chat-turn-registry.ts";
+
+describe("ChatTurnRegistry.drainShutdown", () => {
+  it("returns immediately when no turns are in-flight", async () => {
+    const reg = new ChatTurnRegistry();
+    const start = Date.now();
+    await reg.drainShutdown(5000);
+    expect(Date.now() - start).toBeLessThan(50);
+  });
+
+  it("aborts all in-flight controllers with a shutdown reason", async () => {
+    const reg = new ChatTurnRegistry();
+    const a = reg.replace("chat-a");
+    const b = reg.replace("chat-b");
+
+    // Owners release on completion. Schedule those releases to land
+    // shortly after we kick off drainShutdown — simulating each turn's
+    // onFinish completing in response to the abort signal.
+    setTimeout(() => {
+      reg.release("chat-a", a);
+      reg.release("chat-b", b);
+    }, 20);
+
+    await reg.drainShutdown(2000);
+
+    expect(a.signal.aborted).toBe(true);
+    expect(a.signal.reason).toBeInstanceOf(ChatTurnShutdownError);
+    expect(b.signal.aborted).toBe(true);
+    expect(reg.get("chat-a")).toBeUndefined();
+    expect(reg.get("chat-b")).toBeUndefined();
+  });
+
+  it("clears stragglers and returns once timeout elapses", async () => {
+    const reg = new ChatTurnRegistry();
+    reg.replace("chat-stuck"); // never released — simulates a turn that won't finish
+
+    const start = Date.now();
+    await reg.drainShutdown(150);
+    const elapsed = Date.now() - start;
+
+    expect(elapsed).toBeGreaterThanOrEqual(150);
+    expect(elapsed).toBeLessThan(400);
+    expect(reg.get("chat-stuck")).toBeUndefined();
+  });
+});

--- a/apps/atlasd/src/chat-turn-registry.ts
+++ b/apps/atlasd/src/chat-turn-registry.ts
@@ -73,6 +73,50 @@ export class ChatTurnRegistry {
     }
     this.controllers.clear();
   }
+
+  /**
+   * Graceful drain for daemon shutdown. Fires abort on every in-flight turn,
+   * then waits (bounded by `timeoutMs`) for each turn to call `release()` —
+   * which it does after its `onFinish` has run, including any partial-message
+   * persistence. After timeout the remaining controllers are cleared and the
+   * shutdown proceeds; any turns still in flight at that point lose their
+   * partial message.
+   *
+   * Why this exists: without a drain, daemon shutdown would race the agent's
+   * `onFinish` callback. Aborts fire, but the process exits before the agent
+   * has time to write its partial assistant message to chat storage. With the
+   * drain in place, in-flight delegate calls / partial assistant turns survive
+   * a SIGTERM and reappear on next daemon boot.
+   */
+  async drainShutdown(timeoutMs: number): Promise<void> {
+    if (this.controllers.size === 0) return;
+
+    logger.info("Draining in-flight chat turns for shutdown", {
+      inFlight: this.controllers.size,
+      timeoutMs,
+    });
+
+    for (const controller of this.controllers.values()) {
+      if (!controller.signal.aborted) controller.abort(new ChatTurnShutdownError());
+    }
+
+    const start = Date.now();
+    // Poll instead of subscribing — set membership changes via release() are
+    // synchronous and the loop body runs frequently enough that the latency
+    // tax is bounded by the poll interval, not the persistence latency.
+    while (this.controllers.size > 0) {
+      if (Date.now() - start > timeoutMs) {
+        logger.warn("Drain timeout — clearing remaining controllers", {
+          remaining: this.controllers.size,
+        });
+        this.controllers.clear();
+        return;
+      }
+      await new Promise((r) => setTimeout(r, 50));
+    }
+
+    logger.info("Drain complete", { elapsedMs: Date.now() - start });
+  }
 }
 
 export class ChatTurnSupersededError extends Error {

--- a/packages/core/src/artifacts/file-upload.ts
+++ b/packages/core/src/artifacts/file-upload.ts
@@ -186,6 +186,91 @@ export function isParseableMimeType(mimeType: string): boolean {
   return PARSEABLE_MIMES.has(mimeType);
 }
 
+/**
+ * Common mime → file-extension lookup for download-filename derivation.
+ * The fallback (`mimeType.split("/")[1]`) gives reasonable strings for
+ * simple types (`application/pdf` → "pdf") but produces ugly results
+ * for compound types (Office formats, image/svg+xml). Map the messy
+ * cases explicitly; let everything else fall through to the suffix.
+ */
+const MIME_TO_EXT: Record<string, string> = {
+  "application/pdf": "pdf",
+  "application/json": "json",
+  "application/yaml": "yaml",
+  "application/x-yaml": "yaml",
+  "application/xml": "xml",
+  "application/zip": "zip",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": "docx",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation": "pptx",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": "xlsx",
+  "application/octet-stream": "bin",
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/svg+xml": "svg",
+  "audio/mpeg": "mp3",
+  "audio/mp4": "m4a",
+  "audio/x-m4a": "m4a",
+  "audio/wav": "wav",
+  "audio/webm": "webm",
+  "audio/ogg": "ogg",
+  "audio/flac": "flac",
+  "video/mp4": "mp4",
+  "video/webm": "webm",
+  "text/plain": "txt",
+  "text/html": "html",
+  "text/css": "css",
+  "text/csv": "csv",
+  "text/markdown": "md",
+  "text/yaml": "yaml",
+};
+
+/** Best-guess file extension for a mime type. Falls back to `bin` for unknowns. */
+export function extFromMime(mimeType: string): string {
+  const direct = MIME_TO_EXT[mimeType];
+  if (direct) return direct;
+  // Fall back to the part after `/`, stripped of parameters (`; charset=…`)
+  // and `+suffix` qualifiers (`image/svg+xml` → `svg`).
+  const tail = mimeType.split("/")[1]?.split(";")[0]?.split("+")[0]?.trim();
+  return tail && /^[a-z0-9]+$/i.test(tail) ? tail : "bin";
+}
+
+/**
+ * Reconcile a stored `originalName` with the artifact's actual `mimeType`,
+ * returning a filename whose extension matches the bytes. When the
+ * scrubber lifts an embedded base64 blob without knowing the format yet,
+ * it stamps the artifact with `<tool>-<ts>.bin`; the storage adapter
+ * later sniffs the real mime, but `originalName` keeps its `.bin`. This
+ * helper rewrites the extension at download time so the user gets
+ * `foo.pdf` instead of `foo.bin` even for legacy artifacts.
+ *
+ * Logic:
+ * 1. Compute the correct extension from the mime.
+ * 2. If `originalName` already ends in that extension, keep it.
+ * 3. If `originalName` ends in a different extension, swap it.
+ * 4. If `originalName` has no extension, append.
+ * 5. If no `originalName`, use `<title>.<ext>`.
+ */
+export function deriveDownloadFilename(opts: {
+  mimeType: string;
+  originalName?: string;
+  title: string;
+}): string {
+  const ext = extFromMime(opts.mimeType);
+  const fromOriginal = opts.originalName?.trim();
+  if (fromOriginal) {
+    const dot = fromOriginal.lastIndexOf(".");
+    if (dot > 0 && dot < fromOriginal.length - 1) {
+      const currentExt = fromOriginal.slice(dot + 1).toLowerCase();
+      if (currentExt === ext.toLowerCase()) return fromOriginal;
+      return `${fromOriginal.slice(0, dot)}.${ext}`;
+    }
+    return `${fromOriginal}.${ext}`;
+  }
+  return `${opts.title}.${ext}`;
+}
+
 export function getValidatedMimeType(fileName: string): string | undefined {
   const dotIdx = fileName.lastIndexOf(".");
   if (dotIdx < 0) return undefined;

--- a/packages/core/src/artifacts/file-upload.ts
+++ b/packages/core/src/artifacts/file-upload.ts
@@ -146,6 +146,46 @@ export function isAudioMimeType(mimeType: string): boolean {
   return SUPPORTED_AUDIO_MIMES.has(mimeType);
 }
 
+/**
+ * Mime types whose contents the agent can read directly as text. Anything
+ * else is opaque bytes — the GET artifact route omits `contents` for these
+ * to avoid round-tripping decoded-as-UTF-8 garbage through the LLM. Use
+ * `parse_artifact` for PDF/DOCX/PPTX content extraction or
+ * `display_artifact` for visual rendering.
+ */
+const TEXT_MIME_PREFIXES = ["text/"];
+const TEXT_MIME_EXACT = new Set([
+  "application/json",
+  "application/yaml",
+  "application/x-yaml",
+  "application/xml",
+  "application/javascript",
+  "application/typescript",
+  "application/sql",
+  "application/x-sh",
+  "application/x-python",
+]);
+
+export function isTextMimeType(mimeType: string): boolean {
+  if (TEXT_MIME_EXACT.has(mimeType)) return true;
+  return TEXT_MIME_PREFIXES.some((p) => mimeType.startsWith(p));
+}
+
+/**
+ * Mime types we have a stream-based markdown converter for. The
+ * `parse_artifact` endpoint runs these through the matching converter
+ * and returns the markdown.
+ */
+const PARSEABLE_MIMES = new Set([
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+]);
+
+export function isParseableMimeType(mimeType: string): boolean {
+  return PARSEABLE_MIMES.has(mimeType);
+}
+
 export function getValidatedMimeType(fileName: string): string | undefined {
   const dotIdx = fileName.lastIndexOf(".");
   if (dotIdx < 0) return undefined;

--- a/packages/core/src/chat/jetstream-backend.ts
+++ b/packages/core/src/chat/jetstream-backend.ts
@@ -78,8 +78,32 @@ function streamName(workspaceId: string, chatId: string): string {
   return `CHAT_${sanitizeForStreamName(workspaceId)}_${sanitizeForStreamName(chatId)}`;
 }
 
-function subject(workspaceId: string, chatId: string): string {
+/**
+ * Legacy flat subject used by streams created before per-message rollup.
+ * Old streams stay on this subject so their existing messages remain
+ * matched by the stream's `subjects` config.
+ */
+function flatSubject(workspaceId: string, chatId: string): string {
   return `chats.${workspaceId}.${chatId}.messages`;
+}
+
+/**
+ * Per-message subject used by streams created with per-message rollup.
+ * Combined with `max_msgs_per_subject: 1` on the stream, publishing again
+ * to the same `<msgId>` subject auto-purges the prior copy — turning each
+ * `appendMessage` into a snapshot of "the latest state of this message."
+ *
+ * Why this matters: the agent can call `appendMessage` repeatedly during
+ * a turn (e.g. on shutdown abort) and each call replaces the previous
+ * snapshot rather than creating a new entry or dedupe-dropping.
+ */
+function messageSubject(workspaceId: string, chatId: string, messageId: string): string {
+  return `chats.${workspaceId}.${chatId}.messages.${messageId}`;
+}
+
+/** Wildcard the new stream config registers, accepting any per-message subject. */
+function messagesWildcardSubject(workspaceId: string, chatId: string): string {
+  return `chats.${workspaceId}.${chatId}.messages.>`;
 }
 
 function kvKey(workspaceId: string, chatId: string): string {
@@ -152,29 +176,60 @@ function enqueue<T>(key: string, fn: () => Promise<T>): Promise<T> {
   return next as Promise<T>;
 }
 
+/**
+ * Records the subject layout of a chat stream so {@link appendMessage} knows
+ * whether to publish to the per-message subject (new layout — supports
+ * snapshot replacement) or the flat legacy subject (old layout — preserves
+ * pre-rollup behavior). Cached per stream name to avoid an info-fetch on
+ * every append.
+ */
+interface StreamLayout {
+  /** True when the stream was created with per-message subjects + max_msgs_per_subject:1. */
+  perMessage: boolean;
+}
+const streamLayouts = new Map<string, StreamLayout>();
+
 async function ensureChatStream(
   jsm: JetStreamManager,
   workspaceId: string,
   chatId: string,
   limits: ChatStreamLimits,
-): Promise<void> {
+): Promise<StreamLayout> {
   const name = streamName(workspaceId, chatId);
+  const cached = streamLayouts.get(name);
+  if (cached) return cached;
   try {
-    await jsm.streams.info(name);
-    return;
+    const info = await jsm.streams.info(name);
+    const subjects = info.config.subjects ?? [];
+    const wildcard = messagesWildcardSubject(workspaceId, chatId);
+    const layout: StreamLayout = { perMessage: subjects.includes(wildcard) };
+    streamLayouts.set(name, layout);
+    return layout;
   } catch (err) {
     if (!isStreamNotFound(err)) throw err;
   }
+  // Fresh stream — create with the per-message rollup layout. Existing
+  // chats hit the path above and keep whatever layout they had, so no
+  // in-place migration is required.
   const dup = limits.duplicateWindowNs ?? DEFAULT_DUPLICATE_WINDOW_NS;
   await jsm.streams.add({
     name,
-    subjects: [subject(workspaceId, chatId)],
+    subjects: [messagesWildcardSubject(workspaceId, chatId)],
     retention: RetentionPolicy.Limits,
     storage: StorageType.File,
     max_msg_size: limits.maxMsgSize ?? DEFAULT_MAX_MSG_SIZE,
+    // One message per subject — each per-message subject only ever
+    // retains its latest snapshot. Resnapshots auto-purge prior copies.
+    max_msgs_per_subject: 1,
+    // Permits Nats-Rollup headers (not currently used; carried for future
+    // explicit-rollup needs without requiring another stream-config update).
+    allow_rollup_hdrs: true,
     duplicate_window: typeof dup === "bigint" ? Number(dup) : dup,
   });
-  logger.info("Created chat stream", { workspaceId, chatId, name });
+  logger.info("Created chat stream", { workspaceId, chatId, name, layout: "per-message" });
+  const layout: StreamLayout = { perMessage: true };
+  streamLayouts.set(name, layout);
+  return layout;
 }
 
 export interface JetStreamChatBackend {
@@ -386,16 +441,29 @@ export function createJetStreamChatBackend(
       await enqueue(`${workspaceId}/${chatId}`, async () => {
         await validateAtlasUIMessages([message]);
         const jsm = await nc.jetstreamManager();
-        await ensureChatStream(jsm, workspaceId, chatId, limits);
+        const layout = await ensureChatStream(jsm, workspaceId, chatId, limits);
 
         const c = js();
         const envelope = { message, ts: new Date().toISOString() };
         const h = natsHeaders();
         h.set("Friday-Schema-Version", SCHEMA_VERSION);
         h.set("Friday-Message-Id", message.id);
-        await c.publish(subject(workspaceId, chatId), enc.encode(JSON.stringify(envelope)), {
+        // New streams use a per-message subject + max_msgs_per_subject:1 so
+        // each `appendMessage` for the same `message.id` snapshot-replaces
+        // the prior copy. We deliberately do NOT set `msgID` here — that
+        // would trigger the stream's 24h dedup window and silently drop
+        // resnapshots. The subject-rollup semantics are sufficient: if a
+        // network retry causes two publishes of the identical envelope,
+        // the broker stores one and auto-purges the other.
+        //
+        // Old streams keep their flat subject + msgID dedup so existing
+        // chats persist exactly as before.
+        const publishSubject = layout.perMessage
+          ? messageSubject(workspaceId, chatId, message.id)
+          : flatSubject(workspaceId, chatId);
+        await c.publish(publishSubject, enc.encode(JSON.stringify(envelope)), {
           headers: h,
-          msgID: message.id,
+          ...(layout.perMessage ? {} : { msgID: message.id }),
         });
 
         const ts = envelope.ts;

--- a/packages/core/src/chat/jetstream-backend.ts
+++ b/packages/core/src/chat/jetstream-backend.ts
@@ -589,6 +589,10 @@ export function createJetStreamChatBackend(
       } catch (err) {
         if (!isStreamNotFound(err)) throw err;
       }
+      // Drop the layout cache entry — chat IDs aren't reused in practice
+      // but a stale entry would mis-route a freshly-created stream's
+      // appendMessage to the legacy subject.
+      streamLayouts.delete(name);
       await k.delete(kvKey(workspaceId, chatId));
       logger.debug("Deleted chat", { chatId, workspaceId });
       return success(undefined);

--- a/packages/core/src/chat/storage.test.ts
+++ b/packages/core/src/chat/storage.test.ts
@@ -158,6 +158,40 @@ describe("ChatStorage (JetStream-backed)", () => {
     expect(get.ok && get.data?.messages.length).toBe(1);
   });
 
+  it("snapshot replacement: re-appending same id with new content overwrites prior", async () => {
+    const chatId = crypto.randomUUID();
+    await createTestChat(chatId);
+
+    // First snapshot — partial assistant message with one part.
+    const msgId = crypto.randomUUID();
+    const v1: AtlasUIMessage = {
+      id: msgId,
+      role: "assistant",
+      parts: [{ type: "text", text: "hello" }],
+    };
+    await ChatStorage.appendMessage(chatId, v1);
+
+    // Second snapshot — same id, more content. This is the incremental
+    // snapshot path: the agent's onFinish callback running after an abort
+    // would re-publish the message with whatever was assembled at that point.
+    const v2: AtlasUIMessage = {
+      id: msgId,
+      role: "assistant",
+      parts: [
+        { type: "text", text: "hello" },
+        { type: "text", text: " world" },
+      ],
+    };
+    await ChatStorage.appendMessage(chatId, v2);
+
+    const get = await ChatStorage.getChat(chatId);
+    expect(get.ok && get.data?.messages.length).toBe(1);
+    if (get.ok && get.data) {
+      const stored = get.data.messages[0];
+      expect(stored?.parts.length).toBe(2);
+    }
+  });
+
   it("listChatsByWorkspace returns chats for one workspace", async () => {
     const wsId = `list-test-${crypto.randomUUID()}`;
     const a = crypto.randomUUID();

--- a/packages/mcp-server/src/tools/artifacts/get.ts
+++ b/packages/mcp-server/src/tools/artifacts/get.ts
@@ -36,8 +36,8 @@ export function registerArtifactsGetTool(server: McpServer, ctx: ToolContext) {
       if (!response.ok) {
         return createErrorResponse("Failed to retrieve artifact", stringifyError(response.error));
       }
-      const { artifact, contents } = response.data;
-      return createSuccessResponse({ ...stripArtifactFilePaths(artifact), contents });
+      const { artifact, contents, hint } = response.data;
+      return createSuccessResponse({ ...stripArtifactFilePaths(artifact), contents, hint });
     },
   );
 }

--- a/packages/mcp-server/src/tools/artifacts/parse.ts
+++ b/packages/mcp-server/src/tools/artifacts/parse.ts
@@ -1,0 +1,39 @@
+import { client, parseResult } from "@atlas/client/v2";
+import { stringifyError } from "@atlas/utils";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import type { ToolContext } from "../types.ts";
+import { createErrorResponse, createSuccessResponse } from "../utils.ts";
+
+/**
+ * Register MCP tool for extracting text from binary artifacts.
+ *
+ * Routes through the daemon's `/api/artifacts/:id/parse` endpoint, which
+ * uses the same `pdfToMarkdown` / `docxToMarkdown` / `pptxToMarkdown`
+ * converters that run at upload time. The bytes never leave the daemon —
+ * the agent receives parsed markdown only, avoiding the prompt-token
+ * cost of round-tripping base64 through the model.
+ */
+export function registerArtifactsParseTool(server: McpServer, ctx: ToolContext) {
+  server.registerTool(
+    "parse_artifact",
+    {
+      description:
+        "Extract text from a binary artifact (PDF, DOCX, or PPTX) as markdown. Use whenever you need the contents of a binary artifact for reasoning. Returns `{ markdown, mimeType, filename }`.",
+      inputSchema: { artifactId: z.string().describe("Artifact ID of a PDF/DOCX/PPTX file") },
+    },
+    async ({ artifactId }): Promise<CallToolResult> => {
+      ctx.logger.info("MCP parse_artifact called", { artifactId });
+
+      const response = await parseResult(
+        client.artifactsStorage[":id"].parse.$get({ param: { id: artifactId } }),
+      );
+
+      if (!response.ok) {
+        return createErrorResponse("Failed to parse artifact", stringifyError(response.error));
+      }
+      return createSuccessResponse(response.data);
+    },
+  );
+}

--- a/packages/mcp-server/src/tools/index.ts
+++ b/packages/mcp-server/src/tools/index.ts
@@ -10,6 +10,7 @@ import { registerAgentsListTool } from "./agents/list.ts";
 import { registerArtifactsCreateTool } from "./artifacts/create.ts";
 import { registerArtifactsGetTool } from "./artifacts/get.ts";
 import { registerArtifactsGetByChatTool } from "./artifacts/get-by-chat.ts";
+import { registerArtifactsParseTool } from "./artifacts/parse.ts";
 import { registerArtifactsUpdateTool } from "./artifacts/update.ts";
 // Data processing tools
 import { registerCsvTool } from "./data-processing/csv/index.ts";
@@ -91,6 +92,7 @@ export function registerTools(server: McpServer, context: ToolContext): void {
   registerArtifactsUpdateTool(server, context);
   registerArtifactsGetTool(server, context);
   registerArtifactsGetByChatTool(server, context);
+  registerArtifactsParseTool(server, context);
 
   // State tools
   registerStateAppendTool(server, context);

--- a/packages/mcp/mod.ts
+++ b/packages/mcp/mod.ts
@@ -14,6 +14,7 @@ export type {
   DisconnectedIntegration,
   DisconnectedIntegrationKind,
   MCPToolsResult,
+  ScrubToolResult,
 } from "./src/create-mcp-tools.ts";
 export { createMCPTools, MCPStartupError } from "./src/create-mcp-tools.ts";
 export type {

--- a/packages/mcp/src/create-mcp-tools.ts
+++ b/packages/mcp/src/create-mcp-tools.ts
@@ -102,11 +102,52 @@ function wrapToolWithTimeout(tool: Tool, serverId: string): Tool {
   };
 }
 
+/**
+ * Optional post-processor for tool results. Receives whatever the MCP tool
+ * returned, plus context about which server/tool produced it, and returns a
+ * possibly-rewritten value. Used by chat callers to lift oversized binary
+ * (PDF base64, data URLs, etc.) out of tool outputs before they enter the
+ * AI SDK message buffer — keeps prompt tokens down and avoids
+ * `MAX_PAYLOAD_EXCEEDED` at chat-message persist time.
+ *
+ * Generic (non-chat) callers leave this unset and get the unmodified result.
+ */
+export type ScrubToolResult = (
+  result: unknown,
+  ctx: { serverId: string; toolName: string },
+) => Promise<unknown>;
+
+/** Wrap a tool's execute with timeout + optional result scrubbing. */
+function wrapTool(tool: Tool, serverId: string, toolName: string, scrub?: ScrubToolResult): Tool {
+  const timed = wrapToolWithTimeout(tool, serverId);
+  if (!scrub) return timed;
+  return {
+    ...timed,
+    execute: async (args, opts) => {
+      const result = await timed.execute!(args, opts);
+      try {
+        return await scrub(result, { serverId, toolName });
+      } catch {
+        // Scrub failures must not break tool execution — pass through the
+        // original result. The caller's pre-persist scrubber (if present)
+        // is the second line of defense.
+        return result;
+      }
+    },
+  };
+}
+
 export interface CreateMCPToolsOptions {
   /** Signal to abort connection attempts early (e.g., on agent cancellation). */
   signal?: AbortSignal;
   /** Prefix all tool keys with `{toolPrefix}_` in the returned tools map. */
   toolPrefix?: string;
+  /**
+   * Post-processor for tool results — see {@link ScrubToolResult}. Set by
+   * chat callers to lift oversized binary into a side store. Omit for
+   * caller-agnostic / non-chat use.
+   */
+  scrubResult?: ScrubToolResult;
 }
 
 /** Internal result of attempting to connect a single server. */
@@ -227,7 +268,7 @@ export async function createMCPTools(
     const wrappedTools = Object.fromEntries(
       Object.entries(value.tools).map(([name, tool]) => [
         name,
-        wrapToolWithTimeout(tool, value.serverId),
+        wrapTool(tool, value.serverId, name, options?.scrubResult),
       ]),
     );
 

--- a/packages/system/agents/workspace-chat/lib/scrub-tool-output.test.ts
+++ b/packages/system/agents/workspace-chat/lib/scrub-tool-output.test.ts
@@ -1,0 +1,158 @@
+import type { Logger } from "@atlas/logger";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetch = vi.hoisted(() =>
+  vi.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>(),
+);
+
+vi.stubGlobal("fetch", mockFetch);
+vi.mock("@atlas/oapi-client", () => ({ getAtlasDaemonUrl: () => "http://localhost:3000" }));
+
+import { __test, createScrubber } from "./scrub-tool-output.ts";
+
+const { looksLikeBase64, DATA_URL_RE, SIZE_THRESHOLD_CHARS } = __test;
+
+const logger: Logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  child: vi.fn(),
+} as unknown as Logger;
+
+const TOOL_CTX = { serverId: "google-gmail", toolName: "get_gmail_attachment_content" };
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function bigBase64(chars: number): string {
+  // Pure base64-looking content of the requested length.
+  return "A".repeat(chars);
+}
+
+function mockArtifactCreate(artifactId: string, size: number, mimeType: string) {
+  return mockFetch.mockResolvedValueOnce(
+    new Response(
+      JSON.stringify({
+        artifact: {
+          id: artifactId,
+          type: "file",
+          revision: 1,
+          data: { type: "file", contentRef: "abc", size, mimeType },
+          title: "x",
+          summary: "y",
+          createdAt: new Date().toISOString(),
+        },
+      }),
+      { status: 201, headers: { "Content-Type": "application/json" } },
+    ),
+  );
+}
+
+describe("looksLikeBase64", () => {
+  it("rejects short strings under threshold", () => {
+    expect(looksLikeBase64(bigBase64(SIZE_THRESHOLD_CHARS - 1))).toBe(false);
+  });
+
+  it("accepts long pure-base64 strings at threshold", () => {
+    expect(looksLikeBase64(bigBase64(SIZE_THRESHOLD_CHARS))).toBe(true);
+  });
+
+  it("rejects long strings with prose mixed in", () => {
+    const s = `${bigBase64(100)} The PDF is shown below. ${bigBase64(SIZE_THRESHOLD_CHARS)}`;
+    expect(looksLikeBase64(s)).toBe(false);
+  });
+
+  it("rejects long human-language text even if length is over threshold", () => {
+    // Synthesize a long English paragraph; punctuation breaks the base64 class.
+    const sentence = "The quick brown fox jumps over the lazy dog. ";
+    expect(looksLikeBase64(sentence.repeat(2000))).toBe(false);
+  });
+});
+
+describe("DATA_URL_RE", () => {
+  it("captures mime + body from a basic data URL", () => {
+    const m = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA".match(DATA_URL_RE);
+    expect(m?.[1]).toBe("image/png");
+    expect(m?.[2]).toBe("iVBORw0KGgoAAAANSUhEUgAA");
+  });
+
+  it("rejects URLs without the base64 marker", () => {
+    expect("data:image/png,not-base64".match(DATA_URL_RE)).toBeNull();
+  });
+});
+
+describe("createScrubber", () => {
+  it("passes through small string results untouched", async () => {
+    const scrub = createScrubber({ workspaceId: "ws", chatId: "ch", logger });
+    const result = await scrub({ content: [{ type: "text", text: "hello world" }] }, TOOL_CTX);
+    expect(result).toEqual({ content: [{ type: "text", text: "hello world" }] });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("lifts oversized data URL strings to artifacts and replaces with marker", async () => {
+    mockArtifactCreate("art_42", 50_000, "image/png");
+    const scrub = createScrubber({ workspaceId: "ws", chatId: "ch", logger });
+    const dataUrl = `data:image/png;base64,${bigBase64(SIZE_THRESHOLD_CHARS + 100)}`;
+    const result = (await scrub(
+      { content: [{ type: "image", data: dataUrl, mimeType: "image/png" }] },
+      TOOL_CTX,
+    )) as { content: Array<{ type: string; data: string; mimeType: string }> };
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result.content[0]?.data).toMatch(/artifact art_42/);
+    expect(result.content[0]?.data).toMatch(/display_artifact/);
+    // Other fields preserved.
+    expect(result.content[0]?.type).toBe("image");
+    expect(result.content[0]?.mimeType).toBe("image/png");
+  });
+
+  it("lifts oversized standalone base64 to artifacts", async () => {
+    mockArtifactCreate("art_99", 48_000, "application/octet-stream");
+    const scrub = createScrubber({ workspaceId: "ws", chatId: "ch", logger });
+    const result = (await scrub(
+      { content: [{ type: "text", text: bigBase64(SIZE_THRESHOLD_CHARS + 100) }] },
+      TOOL_CTX,
+    )) as { content: Array<{ type: string; text: string }> };
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(result.content[0]?.text).toMatch(/artifact art_99/);
+  });
+
+  it("recurses into nested objects and arrays", async () => {
+    mockArtifactCreate("art_1", 100_000, "application/pdf");
+    const scrub = createScrubber({ workspaceId: "ws", chatId: "ch", logger });
+    const result = (await scrub(
+      {
+        outer: {
+          attachments: [{ name: "summary.pdf", body: bigBase64(SIZE_THRESHOLD_CHARS + 100) }],
+        },
+      },
+      TOOL_CTX,
+    )) as { outer: { attachments: Array<{ name: string; body: string }> } };
+
+    expect(result.outer.attachments[0]?.name).toBe("summary.pdf");
+    expect(result.outer.attachments[0]?.body).toMatch(/artifact art_1/);
+  });
+
+  it("returns original value if upload fails", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "boom" }), { status: 500 }),
+    );
+    const scrub = createScrubber({ workspaceId: "ws", chatId: "ch", logger });
+    const dataUrl = `data:image/png;base64,${bigBase64(SIZE_THRESHOLD_CHARS + 100)}`;
+    const result = (await scrub({ content: [{ type: "image", data: dataUrl }] }, TOOL_CTX)) as {
+      content: Array<{ type: string; data: string }>;
+    };
+    expect(result.content[0]?.data).toBe(dataUrl);
+  });
+
+  it("leaves prose-with-base64-fragment alone", async () => {
+    const scrub = createScrubber({ workspaceId: "ws", chatId: "ch", logger });
+    const text = `The attachment data is: ${bigBase64(200)} but here's some explanation text after it that breaks the base64 character class.`;
+    const result = await scrub({ content: [{ type: "text", text }] }, TOOL_CTX);
+    expect(result).toEqual({ content: [{ type: "text", text }] });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/system/agents/workspace-chat/lib/scrub-tool-output.test.ts
+++ b/packages/system/agents/workspace-chat/lib/scrub-tool-output.test.ts
@@ -152,6 +152,31 @@ describe("createScrubber (MCP-boundary)", () => {
     expect(result.content[0]?.data).toBe(dataUrl);
   });
 
+  it("dedupes identical base64 within one tool result (FastMCP wrap_result)", async () => {
+    // Mock ONE artifact create — if dedup works the second match reuses
+    // the first upload's artifactId without hitting the endpoint again.
+    mockArtifactCreate("art_dedup", 24_000, "application/pdf");
+
+    const scrub = createScrubber({ workspaceId: "ws", chatId: "ch", logger });
+    const blob = bigBase64(SIZE_THRESHOLD_CHARS + 200);
+    // FastMCP shape: same payload in `content[].text` and `structuredContent.result`.
+    const result = (await scrub(
+      {
+        _meta: { fastmcp: { wrap_result: true } },
+        content: [{ type: "text", text: `prefix ${blob} suffix` }],
+        structuredContent: { result: `prefix ${blob} suffix` },
+        isError: false,
+      },
+      TOOL_CTX,
+    )) as { content: Array<{ type: string; text: string }>; structuredContent: { result: string } };
+
+    // Only one upload should have happened.
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    // Both copies got the same marker (so the model can still see the ref).
+    expect(result.content[0]?.text).toMatch(/artifact art_dedup/);
+    expect(result.structuredContent.result).toMatch(/artifact art_dedup/);
+  });
+
   it("leaves short base64 fragments alone", async () => {
     const scrub = createScrubber({ workspaceId: "ws", chatId: "ch", logger });
     // Below threshold — no lift, no rewrite.

--- a/packages/system/agents/workspace-chat/lib/scrub-tool-output.test.ts
+++ b/packages/system/agents/workspace-chat/lib/scrub-tool-output.test.ts
@@ -8,9 +8,9 @@ const mockFetch = vi.hoisted(() =>
 vi.stubGlobal("fetch", mockFetch);
 vi.mock("@atlas/oapi-client", () => ({ getAtlasDaemonUrl: () => "http://localhost:3000" }));
 
-import { __test, createScrubber } from "./scrub-tool-output.ts";
+import { __test, createScrubber, scrubAssistantMessage } from "./scrub-tool-output.ts";
 
-const { looksLikeBase64, DATA_URL_RE, SIZE_THRESHOLD_CHARS } = __test;
+const { DATA_URL_RE, EMBEDDED_BASE64_RE, SIZE_THRESHOLD_CHARS } = __test;
 
 const logger: Logger = {
   info: vi.fn(),
@@ -50,24 +50,23 @@ function mockArtifactCreate(artifactId: string, size: number, mimeType: string) 
   );
 }
 
-describe("looksLikeBase64", () => {
-  it("rejects short strings under threshold", () => {
-    expect(looksLikeBase64(bigBase64(SIZE_THRESHOLD_CHARS - 1))).toBe(false);
+describe("EMBEDDED_BASE64_RE", () => {
+  it("matches a pure base64 run at threshold", () => {
+    EMBEDDED_BASE64_RE.lastIndex = 0;
+    expect(EMBEDDED_BASE64_RE.exec(bigBase64(SIZE_THRESHOLD_CHARS))).not.toBeNull();
   });
 
-  it("accepts long pure-base64 strings at threshold", () => {
-    expect(looksLikeBase64(bigBase64(SIZE_THRESHOLD_CHARS))).toBe(true);
+  it("rejects a base64 run shorter than threshold", () => {
+    EMBEDDED_BASE64_RE.lastIndex = 0;
+    expect(EMBEDDED_BASE64_RE.exec(bigBase64(SIZE_THRESHOLD_CHARS - 1))).toBeNull();
   });
 
-  it("rejects long strings with prose mixed in", () => {
-    const s = `${bigBase64(100)} The PDF is shown below. ${bigBase64(SIZE_THRESHOLD_CHARS)}`;
-    expect(looksLikeBase64(s)).toBe(false);
-  });
-
-  it("rejects long human-language text even if length is over threshold", () => {
-    // Synthesize a long English paragraph; punctuation breaks the base64 class.
-    const sentence = "The quick brown fox jumps over the lazy dog. ";
-    expect(looksLikeBase64(sentence.repeat(2000))).toBe(false);
+  it("matches base64 embedded inside a larger envelope", () => {
+    const envelope = `Attachment downloaded successfully!\n\nBase64 content (${SIZE_THRESHOLD_CHARS} chars, standard base64):\n${bigBase64(SIZE_THRESHOLD_CHARS)}\n\nGoodbye.`;
+    EMBEDDED_BASE64_RE.lastIndex = 0;
+    const m = EMBEDDED_BASE64_RE.exec(envelope);
+    expect(m).not.toBeNull();
+    expect(m?.[0].length).toBe(SIZE_THRESHOLD_CHARS);
   });
 });
 
@@ -83,7 +82,7 @@ describe("DATA_URL_RE", () => {
   });
 });
 
-describe("createScrubber", () => {
+describe("createScrubber (MCP-boundary)", () => {
   it("passes through small string results untouched", async () => {
     const scrub = createScrubber({ workspaceId: "ws", chatId: "ch", logger });
     const result = await scrub({ content: [{ type: "text", text: "hello world" }] }, TOOL_CTX);
@@ -103,21 +102,26 @@ describe("createScrubber", () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(result.content[0]?.data).toMatch(/artifact art_42/);
     expect(result.content[0]?.data).toMatch(/display_artifact/);
-    // Other fields preserved.
     expect(result.content[0]?.type).toBe("image");
     expect(result.content[0]?.mimeType).toBe("image/png");
   });
 
-  it("lifts oversized standalone base64 to artifacts", async () => {
-    mockArtifactCreate("art_99", 48_000, "application/octet-stream");
+  it("lifts a base64 block embedded inside a Gmail-style envelope", async () => {
+    mockArtifactCreate("art_pdf", 24_000, "application/pdf");
     const scrub = createScrubber({ workspaceId: "ws", chatId: "ch", logger });
-    const result = (await scrub(
-      { content: [{ type: "text", text: bigBase64(SIZE_THRESHOLD_CHARS + 100) }] },
-      TOOL_CTX,
-    )) as { content: Array<{ type: string; text: string }> };
+    const blob = bigBase64(SIZE_THRESHOLD_CHARS + 200);
+    const text = `Attachment downloaded successfully!\nMessage ID: 123\nSize: 24.4 KB (24942 bytes)\n\nBase64-encoded content:\n${blob}\n\nDone.`;
+    const result = (await scrub({ content: [{ type: "text", text }] }, TOOL_CTX)) as {
+      content: Array<{ type: string; text: string }>;
+    };
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    expect(result.content[0]?.text).toMatch(/artifact art_99/);
+    const out = result.content[0]?.text ?? "";
+    expect(out).toContain("Attachment downloaded successfully!");
+    expect(out).toContain("Done.");
+    expect(out).toMatch(/artifact art_pdf/);
+    // The original blob should be gone from the rewritten string.
+    expect(out).not.toContain(blob);
   });
 
   it("recurses into nested objects and arrays", async () => {
@@ -148,11 +152,94 @@ describe("createScrubber", () => {
     expect(result.content[0]?.data).toBe(dataUrl);
   });
 
-  it("leaves prose-with-base64-fragment alone", async () => {
+  it("leaves short base64 fragments alone", async () => {
     const scrub = createScrubber({ workspaceId: "ws", chatId: "ch", logger });
-    const text = `The attachment data is: ${bigBase64(200)} but here's some explanation text after it that breaks the base64 character class.`;
+    // Below threshold — no lift, no rewrite.
+    const text = `Here's a small chunk: ${bigBase64(SIZE_THRESHOLD_CHARS - 1)} that fits inline.`;
     const result = await scrub({ content: [{ type: "text", text }] }, TOOL_CTX);
     expect(result).toEqual({ content: [{ type: "text", text }] });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("scrubAssistantMessage (pre-persist)", () => {
+  it("scrubs tool-call output", async () => {
+    mockArtifactCreate("art_out", 32_000, "application/pdf");
+    const parts: Array<Record<string, unknown>> = [
+      { type: "step-start" },
+      {
+        type: "tool-get_gmail_attachment_content",
+        toolCallId: "t1",
+        state: "output-available",
+        input: { message_id: "m1" },
+        output: {
+          content: [
+            { type: "text", text: `prefix ${bigBase64(SIZE_THRESHOLD_CHARS + 50)} suffix` },
+          ],
+        },
+      },
+    ];
+    const r = await scrubAssistantMessage(parts, { workspaceId: "ws", chatId: "ch", logger });
+    expect(r.rewritten).toBe(1);
+    const out = (parts[1] as { output: { content: Array<{ text: string }> } }).output;
+    expect(out.content[0]?.text).toMatch(/artifact art_out/);
+  });
+
+  it("scrubs tool-call input — catches model-embedded base64 in run_code", async () => {
+    mockArtifactCreate("art_in", 24_000, "application/pdf");
+    const blob = bigBase64(SIZE_THRESHOLD_CHARS + 200);
+    const parts: Array<Record<string, unknown>> = [
+      {
+        type: "tool-run_code",
+        toolCallId: "t2",
+        state: "input-streaming",
+        input: { language: "python", source: `b64 = "${blob}"\nprint(b64[:10])` },
+      },
+    ];
+    const r = await scrubAssistantMessage(parts, { workspaceId: "ws", chatId: "ch", logger });
+    expect(r.rewritten).toBe(1);
+    const inp = (parts[0] as { input: { source: string } }).input;
+    expect(inp.source).toMatch(/artifact art_in/);
+    expect(inp.source).not.toContain(blob);
+  });
+
+  it("scrubs delegate-chunk envelopes", async () => {
+    mockArtifactCreate("art_delegate", 16_000, "application/pdf");
+    const parts: Array<Record<string, unknown>> = [
+      {
+        type: "data-delegate-chunk",
+        data: {
+          delegateToolCallId: "del1",
+          chunk: {
+            type: "tool-output-available",
+            output: {
+              content: [{ type: "text", text: `oh ${bigBase64(SIZE_THRESHOLD_CHARS + 50)} hi` }],
+            },
+          },
+        },
+      },
+    ];
+    const r = await scrubAssistantMessage(parts, { workspaceId: "ws", chatId: "ch", logger });
+    expect(r.rewritten).toBe(1);
+    const chunk = (
+      parts[0] as { data: { chunk: { output: { content: Array<{ text: string }> } } } }
+    ).data.chunk;
+    expect(chunk.output.content[0]?.text).toMatch(/artifact art_delegate/);
+  });
+
+  it("leaves clean messages untouched", async () => {
+    const parts: Array<Record<string, unknown>> = [
+      { type: "text", text: "hello" },
+      {
+        type: "tool-write_file",
+        toolCallId: "t3",
+        state: "output-available",
+        input: { path: "x.md", content: "small file" },
+        output: { ok: true },
+      },
+    ];
+    const r = await scrubAssistantMessage(parts, { workspaceId: "ws", chatId: "ch", logger });
+    expect(r.rewritten).toBe(0);
     expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/packages/system/agents/workspace-chat/lib/scrub-tool-output.ts
+++ b/packages/system/agents/workspace-chat/lib/scrub-tool-output.ts
@@ -206,5 +206,64 @@ export function createScrubber(opts: ScrubberOptions): ScrubToolResult {
   return (result, toolCtx) => scrubValue(result, ctx, toolCtx, 0);
 }
 
+/**
+ * Pre-persist scrubber — defense-in-depth for anything that slipped past
+ * the MCP-boundary scrubber. Walks an assistant message's `tool-*` part
+ * outputs (and `data-delegate-chunk` chunks, which can carry tool-result
+ * envelopes from sub-agents) and lifts oversized binary into artifacts.
+ *
+ * Mutates the passed message; returns the count of fields rewritten so
+ * the caller can decide whether to log.
+ */
+export async function scrubAssistantMessage(
+  parts: Array<Record<string, unknown>>,
+  opts: ScrubberOptions,
+): Promise<{ scanned: number; rewritten: number }> {
+  const ctx: ScrubContext = {
+    workspaceId: opts.workspaceId,
+    chatId: opts.chatId,
+    logger: opts.logger,
+  };
+  let scanned = 0;
+  let rewritten = 0;
+  for (const part of parts) {
+    const type = typeof part.type === "string" ? part.type : "";
+    // Tool call outputs from the parent's own tool-use steps.
+    if (type.startsWith("tool-") && "output" in part) {
+      scanned++;
+      const before = JSON.stringify(part.output);
+      const after = await scrubValue(
+        part.output,
+        ctx,
+        { serverId: "pre-persist", toolName: type },
+        0,
+      );
+      if (JSON.stringify(after) !== before) {
+        part.output = after;
+        rewritten++;
+      }
+    }
+    // Sub-agent stream envelopes — chunk may carry an embedded tool result.
+    if (type === "data-delegate-chunk" && part.data && typeof part.data === "object") {
+      scanned++;
+      const data = part.data as Record<string, unknown>;
+      if ("chunk" in data) {
+        const before = JSON.stringify(data.chunk);
+        const after = await scrubValue(
+          data.chunk,
+          ctx,
+          { serverId: "pre-persist", toolName: "delegate-chunk" },
+          0,
+        );
+        if (JSON.stringify(after) !== before) {
+          data.chunk = after;
+          rewritten++;
+        }
+      }
+    }
+  }
+  return { scanned, rewritten };
+}
+
 // Exported for unit tests.
 export const __test = { looksLikeBase64, DATA_URL_RE, SIZE_THRESHOLD_CHARS };

--- a/packages/system/agents/workspace-chat/lib/scrub-tool-output.ts
+++ b/packages/system/agents/workspace-chat/lib/scrub-tool-output.ts
@@ -158,6 +158,35 @@ function refMarker(r: UploadResult, toolCtx: { serverId: string; toolName: strin
   );
 }
 
+/**
+ * Magic-byte prefixes for common binary formats, mapped to the base64
+ * prefix they produce. Used by {@link sniffMimeFromBase64} to guess the
+ * mime when an embedded base64 blob shows up with no surrounding mime
+ * hint (Gmail's get_gmail_attachment_content envelope is the typical
+ * source). Without this the scrubber uploads with no mime, the artifact
+ * gets a ".bin" extension in its synthesized filename, and downloads
+ * land as `foo.bin` instead of `foo.pdf`.
+ *
+ * Standard base64 alphabet — Gmail's _format_base64_content_block converts
+ * URL-safe to standard before emitting, so we only need the standard form.
+ */
+const BASE64_MAGIC_PREFIXES: Array<[string, string]> = [
+  ["JVBERi", "application/pdf"], //  %PDF-
+  ["iVBORw0K", "image/png"], //  PNG signature
+  ["/9j/", "image/jpeg"], //  JPEG SOI + JFIF/EXIF marker
+  ["R0lGOD", "image/gif"], //  GIF87a / GIF89a
+  ["UklGR", "image/webp"], //  RIFF…WEBP (also matches WAV; PDF case is what we care about)
+  ["UEsDB", "application/zip"], //  ZIP local file header (DOCX/PPTX/XLSX use this)
+];
+
+function sniffMimeFromBase64(base64: string): string | undefined {
+  const head = base64.slice(0, 12);
+  for (const [prefix, mime] of BASE64_MAGIC_PREFIXES) {
+    if (head.startsWith(prefix)) return mime;
+  }
+  return undefined;
+}
+
 /** Synthetic filename when the source didn't carry one. */
 function defaultFilename(mime: string | undefined, toolCtx: { toolName: string }): string {
   const ext = mime?.split("/")[1]?.split(";")[0]?.split("+")[0] || "bin";
@@ -193,8 +222,9 @@ async function scrubString(
     const m = EMBEDDED_BASE64_RE.exec(result);
     if (!m) break;
     const block = m[0];
-    const filename = defaultFilename(undefined, toolCtx);
-    const upload = await uploadBlob(block, undefined, filename, ctx, toolCtx);
+    const sniffed = sniffMimeFromBase64(block);
+    const filename = defaultFilename(sniffed, toolCtx);
+    const upload = await uploadBlob(block, sniffed, filename, ctx, toolCtx);
     if (!upload) {
       // Move past this match to avoid an infinite loop on transient
       // upload failure; another scrub pass (e.g. pre-persist) can retry.

--- a/packages/system/agents/workspace-chat/lib/scrub-tool-output.ts
+++ b/packages/system/agents/workspace-chat/lib/scrub-tool-output.ts
@@ -76,19 +76,24 @@ interface ScrubContext {
   chatId: string;
   logger: Logger;
   /**
-   * Per-call cache: base64 → UploadResult. Some MCP servers wrap their
-   * results in formats that duplicate the payload (e.g. FastMCP returns
-   * both `content[].text` and `structuredContent.result` with the same
-   * bytes). The recursive walker would otherwise upload the same blob
-   * twice, producing two artifact metadata records pointing at the same
-   * Object Store entry. Caching by base64 string dedupes within a call.
+   * Per-call cache: base64 → in-flight or resolved upload promise. Some
+   * MCP servers wrap their results in formats that duplicate the payload
+   * (e.g. FastMCP returns both `content[].text` and
+   * `structuredContent.result` with the same bytes). The recursive walker
+   * would otherwise upload the same blob twice, producing two artifact
+   * metadata records pointing at the same Object Store entry.
    *
-   * Keyed by the base64 string itself (cheap hash; identical bytes are
-   * already the dedup key in Object Store via SHA-256). Cache lives only
-   * for the duration of one tool's scrub — no cross-call invalidation
-   * concerns.
+   * Caching the *promise* (not the resolved result) handles two cases:
+   *   - Sequential (object branch of scrubValue): the second access sees
+   *     the resolved promise via cache hit.
+   *   - Parallel (array branch via Promise.all): both callers fall into
+   *     `uploadBlob` before either await resolves; whichever sets the
+   *     cache first, the other gets the same in-flight promise back and
+   *     awaits it instead of issuing a duplicate request.
+   *
+   * Cache is per-tool-call — no cross-call invalidation concerns.
    */
-  uploads: Map<string, UploadResult>;
+  uploads: Map<string, Promise<UploadResult | null>>;
 }
 
 interface UploadResult {
@@ -97,19 +102,33 @@ interface UploadResult {
   mimeType: string;
 }
 
-async function uploadBlob(
+function uploadBlob(
   base64: string,
   mimeType: string | undefined,
   filename: string,
   ctx: ScrubContext,
   toolCtx: { serverId: string; toolName: string },
 ): Promise<UploadResult | null> {
-  // Per-call dedup. Identical base64 within one tool result (e.g. FastMCP's
-  // content[].text + structuredContent.result mirror) reuses the same
-  // artifact instead of creating a second metadata record.
+  // Per-call dedup that's race-safe across concurrent callers (the array
+  // branch of `scrubValue` runs siblings via Promise.all; both could land
+  // on the same base64 between cache miss and resolved Set otherwise).
+  // Caching the in-flight promise — not the resolved result — means the
+  // second caller awaits the same upload instead of issuing a duplicate.
   const cached = ctx.uploads.get(base64);
   if (cached) return cached;
 
+  const promise = doUploadBlob(base64, mimeType, filename, ctx, toolCtx);
+  ctx.uploads.set(base64, promise);
+  return promise;
+}
+
+async function doUploadBlob(
+  base64: string,
+  mimeType: string | undefined,
+  filename: string,
+  ctx: ScrubContext,
+  toolCtx: { serverId: string; toolName: string },
+): Promise<UploadResult | null> {
   const data = {
     type: "file" as const,
     content: base64,
@@ -140,13 +159,11 @@ async function uploadBlob(
   // adapter's mime-sniff path; prefer those for the marker text.
   const a = response.data.artifact;
   const fileData = a.data?.type === "file" ? a.data : null;
-  const result: UploadResult = {
+  return {
     artifactId: a.id,
     bytes: fileData?.size ?? Math.ceil((base64.length * 3) / 4),
     mimeType: fileData?.mimeType ?? mimeType ?? "application/octet-stream",
   };
-  ctx.uploads.set(base64, result);
-  return result;
 }
 
 function refMarker(r: UploadResult, toolCtx: { serverId: string; toolName: string }): string {

--- a/packages/system/agents/workspace-chat/lib/scrub-tool-output.ts
+++ b/packages/system/agents/workspace-chat/lib/scrub-tool-output.ts
@@ -75,6 +75,20 @@ interface ScrubContext {
   workspaceId: string;
   chatId: string;
   logger: Logger;
+  /**
+   * Per-call cache: base64 → UploadResult. Some MCP servers wrap their
+   * results in formats that duplicate the payload (e.g. FastMCP returns
+   * both `content[].text` and `structuredContent.result` with the same
+   * bytes). The recursive walker would otherwise upload the same blob
+   * twice, producing two artifact metadata records pointing at the same
+   * Object Store entry. Caching by base64 string dedupes within a call.
+   *
+   * Keyed by the base64 string itself (cheap hash; identical bytes are
+   * already the dedup key in Object Store via SHA-256). Cache lives only
+   * for the duration of one tool's scrub — no cross-call invalidation
+   * concerns.
+   */
+  uploads: Map<string, UploadResult>;
 }
 
 interface UploadResult {
@@ -90,6 +104,12 @@ async function uploadBlob(
   ctx: ScrubContext,
   toolCtx: { serverId: string; toolName: string },
 ): Promise<UploadResult | null> {
+  // Per-call dedup. Identical base64 within one tool result (e.g. FastMCP's
+  // content[].text + structuredContent.result mirror) reuses the same
+  // artifact instead of creating a second metadata record.
+  const cached = ctx.uploads.get(base64);
+  if (cached) return cached;
+
   const data = {
     type: "file" as const,
     content: base64,
@@ -120,11 +140,13 @@ async function uploadBlob(
   // adapter's mime-sniff path; prefer those for the marker text.
   const a = response.data.artifact;
   const fileData = a.data?.type === "file" ? a.data : null;
-  return {
+  const result: UploadResult = {
     artifactId: a.id,
     bytes: fileData?.size ?? Math.ceil((base64.length * 3) / 4),
     mimeType: fileData?.mimeType ?? mimeType ?? "application/octet-stream",
   };
+  ctx.uploads.set(base64, result);
+  return result;
 }
 
 function refMarker(r: UploadResult, toolCtx: { serverId: string; toolName: string }): string {
@@ -217,12 +239,18 @@ export interface ScrubberOptions {
 
 /** Build a scrub function bound to a workspace + chat for artifact-tagging. */
 export function createScrubber(opts: ScrubberOptions): ScrubToolResult {
-  const ctx: ScrubContext = {
-    workspaceId: opts.workspaceId,
-    chatId: opts.chatId,
-    logger: opts.logger,
+  return (result, toolCtx) => {
+    // Fresh upload cache per tool-call so dedup is scoped to one result
+    // tree (FastMCP and similar wrappers duplicate payloads inside a
+    // single response — no cross-call sharing needed).
+    const ctx: ScrubContext = {
+      workspaceId: opts.workspaceId,
+      chatId: opts.chatId,
+      logger: opts.logger,
+      uploads: new Map(),
+    };
+    return scrubValue(result, ctx, toolCtx, 0);
   };
-  return (result, toolCtx) => scrubValue(result, ctx, toolCtx, 0);
 }
 
 /**
@@ -238,10 +266,14 @@ export async function scrubAssistantMessage(
   parts: Array<Record<string, unknown>>,
   opts: ScrubberOptions,
 ): Promise<{ scanned: number; rewritten: number }> {
+  // Single cache spans the whole message so duplicated payloads across
+  // parts (e.g. a tool-output AND a sibling delegate-chunk carrying the
+  // same wrapped result) collapse to one artifact.
   const ctx: ScrubContext = {
     workspaceId: opts.workspaceId,
     chatId: opts.chatId,
     logger: opts.logger,
+    uploads: new Map(),
   };
   let scanned = 0;
   let rewritten = 0;

--- a/packages/system/agents/workspace-chat/lib/scrub-tool-output.ts
+++ b/packages/system/agents/workspace-chat/lib/scrub-tool-output.ts
@@ -1,0 +1,210 @@
+/**
+ * Lift oversized binary out of MCP tool results into the artifact Object
+ * Store. Returns a scrub function suitable for `CreateMCPToolsOptions.scrubResult`.
+ *
+ * Why scrub at the MCP boundary: bytes that an MCP returns inline (Gmail's
+ * `get_gmail_attachment_content` with `return_base64=True`, image responses,
+ * etc.) flow into the AI SDK message buffer, then to the LLM as prompt
+ * tokens, then to chat persistence. Each hop has a cost. Catching them as
+ * the tool returns means the LLM sees a reference, the message buffer stays
+ * small, and persistence never hits `MAX_PAYLOAD_EXCEEDED`.
+ *
+ * The scrubber walks the result recursively. For each string field that
+ * looks like binary content above the size threshold:
+ *   - data URLs: `data:<mime>;base64,<bytes>` → upload bytes, replace with marker
+ *   - standalone base64 blobs (long, base64-character-class only) → upload, replace
+ *
+ * The replacement marker is short text describing what was lifted, the
+ * resulting `artifactId`, byte size, and mime type. The model can call
+ * `display_artifact` or `artifacts_get` to recover the bytes if it needs
+ * them in a follow-up turn.
+ *
+ * Failures (network, storage) are swallowed by the caller (`create-mcp-tools.ts`
+ * wraps with try/catch) so a scrub failure never breaks tool execution. The
+ * pre-persist scrubber serves as a second line of defense.
+ */
+
+import { client, parseResult } from "@atlas/client/v2";
+import type { Logger } from "@atlas/logger";
+import type { ScrubToolResult } from "@atlas/mcp";
+
+/**
+ * Strings shorter than this are left alone. ~64 KB chars of base64 ≈ 48 KB
+ * of decoded bytes. Below this size, inlining is cheap and persistence
+ * never gets close to the 8 MB JetStream message limit.
+ */
+const SIZE_THRESHOLD_CHARS = 64 * 1024;
+
+/**
+ * Recursion depth ceiling. MCP results are usually shallow JSON; this is a
+ * sanity stop in case some server returns pathological self-referential
+ * shapes wrapped in containers.
+ */
+const MAX_DEPTH = 16;
+
+const DATA_URL_RE = /^data:([^;,]+);base64,(.+)$/s;
+
+/**
+ * Loose base64 character-class check. Doesn't validate strict base64 (which
+ * would reject internal whitespace) — just confirms the string is plausibly
+ * an opaque base64 blob, not human-readable text. Combined with the size
+ * threshold this keeps the false-positive rate low.
+ */
+const BASE64_BODY_RE = /^[A-Za-z0-9+/_=\-\s]+$/;
+
+/** Heuristic: a base64-looking string that's mostly base64 chars (>95%). */
+function looksLikeBase64(s: string): boolean {
+  if (s.length < SIZE_THRESHOLD_CHARS) return false;
+  if (!BASE64_BODY_RE.test(s)) return false;
+  // Belt-and-suspenders: count non-base64-ish chars in case the regex passed
+  // but the string is just a long word with the right char class.
+  let bad = 0;
+  for (let i = 0; i < Math.min(s.length, 4096); i++) {
+    const c = s.charCodeAt(i);
+    const isAlnum = (c >= 48 && c <= 57) || (c >= 65 && c <= 90) || (c >= 97 && c <= 122);
+    const isBase64Punct = c === 43 || c === 47 || c === 61 || c === 95 || c === 45; // + / = _ -
+    const isWS = c === 32 || c === 9 || c === 10 || c === 13;
+    if (!isAlnum && !isBase64Punct && !isWS) bad++;
+  }
+  return bad === 0;
+}
+
+interface ScrubContext {
+  workspaceId: string;
+  chatId: string;
+  logger: Logger;
+}
+
+interface UploadResult {
+  artifactId: string;
+  bytes: number;
+  mimeType: string;
+}
+
+async function uploadBlob(
+  base64: string,
+  mimeType: string | undefined,
+  filename: string,
+  ctx: ScrubContext,
+  toolCtx: { serverId: string; toolName: string },
+): Promise<UploadResult | null> {
+  const data = {
+    type: "file" as const,
+    content: base64,
+    contentEncoding: "base64" as const,
+    ...(mimeType ? { mimeType } : {}),
+    originalName: filename,
+  };
+  const response = await parseResult(
+    client.artifactsStorage.index.$post({
+      json: {
+        data,
+        title: filename,
+        summary: `Auto-lifted from ${toolCtx.serverId}/${toolCtx.toolName}`,
+        workspaceId: ctx.workspaceId,
+        chatId: ctx.chatId,
+      },
+    }),
+  );
+  if (!response.ok) {
+    ctx.logger.warn("scrub upload failed", {
+      serverId: toolCtx.serverId,
+      toolName: toolCtx.toolName,
+      error: String(response.error),
+    });
+    return null;
+  }
+  // The artifact record carries the final mimeType + size from the storage
+  // adapter's mime-sniff path; prefer those for the marker text.
+  const a = response.data.artifact;
+  const fileData = a.data?.type === "file" ? a.data : null;
+  return {
+    artifactId: a.id,
+    bytes: fileData?.size ?? Math.ceil((base64.length * 3) / 4),
+    mimeType: fileData?.mimeType ?? mimeType ?? "application/octet-stream",
+  };
+}
+
+function refMarker(r: UploadResult, toolCtx: { serverId: string; toolName: string }): string {
+  const kb = Math.ceil(r.bytes / 1024);
+  return (
+    `[attachment lifted to artifact ${r.artifactId} ` +
+    `(${kb} KB, ${r.mimeType}, from ${toolCtx.serverId}/${toolCtx.toolName}) — ` +
+    `use display_artifact or artifacts_get to read]`
+  );
+}
+
+/** Synthetic filename when the source didn't carry one. */
+function defaultFilename(mime: string | undefined, toolCtx: { toolName: string }): string {
+  const ext = mime?.split("/")[1]?.split(";")[0]?.split("+")[0] || "bin";
+  return `${toolCtx.toolName}-${Date.now()}.${ext}`;
+}
+
+async function scrubString(
+  s: string,
+  ctx: ScrubContext,
+  toolCtx: { serverId: string; toolName: string },
+): Promise<string> {
+  // Data URL: pull mime + base64 body out of the prefix.
+  const dataUrlMatch = s.match(DATA_URL_RE);
+  if (dataUrlMatch) {
+    const [, mime, body] = dataUrlMatch;
+    if (body && body.length >= SIZE_THRESHOLD_CHARS) {
+      const filename = defaultFilename(mime, toolCtx);
+      const result = await uploadBlob(body, mime, filename, ctx, toolCtx);
+      if (result) return refMarker(result, toolCtx);
+    }
+    return s;
+  }
+  // Standalone base64-looking blob.
+  if (looksLikeBase64(s)) {
+    const filename = defaultFilename(undefined, toolCtx);
+    // Strip whitespace so the artifact storage gets clean base64.
+    const clean = s.replace(/\s+/g, "");
+    const result = await uploadBlob(clean, undefined, filename, ctx, toolCtx);
+    if (result) return refMarker(result, toolCtx);
+  }
+  return s;
+}
+
+async function scrubValue(
+  value: unknown,
+  ctx: ScrubContext,
+  toolCtx: { serverId: string; toolName: string },
+  depth: number,
+): Promise<unknown> {
+  if (depth > MAX_DEPTH) return value;
+  if (typeof value === "string") {
+    return await scrubString(value, ctx, toolCtx);
+  }
+  if (Array.isArray(value)) {
+    return await Promise.all(value.map((v) => scrubValue(v, ctx, toolCtx, depth + 1)));
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) {
+      out[k] = await scrubValue(v, ctx, toolCtx, depth + 1);
+    }
+    return out;
+  }
+  return value;
+}
+
+export interface ScrubberOptions {
+  workspaceId: string;
+  chatId: string;
+  logger: Logger;
+}
+
+/** Build a scrub function bound to a workspace + chat for artifact-tagging. */
+export function createScrubber(opts: ScrubberOptions): ScrubToolResult {
+  const ctx: ScrubContext = {
+    workspaceId: opts.workspaceId,
+    chatId: opts.chatId,
+    logger: opts.logger,
+  };
+  return (result, toolCtx) => scrubValue(result, ctx, toolCtx, 0);
+}
+
+// Exported for unit tests.
+export const __test = { looksLikeBase64, DATA_URL_RE, SIZE_THRESHOLD_CHARS };

--- a/packages/system/agents/workspace-chat/lib/scrub-tool-output.ts
+++ b/packages/system/agents/workspace-chat/lib/scrub-tool-output.ts
@@ -29,11 +29,19 @@ import type { Logger } from "@atlas/logger";
 import type { ScrubToolResult } from "@atlas/mcp";
 
 /**
- * Strings shorter than this are left alone. ~64 KB chars of base64 ≈ 48 KB
- * of decoded bytes. Below this size, inlining is cheap and persistence
- * never gets close to the 8 MB JetStream message limit.
+ * Below this size in chars, base64 stays inline. ~4 KB chars of base64 ≈
+ * 3 KB of decoded bytes — small attachments stay in the prompt; larger
+ * ones get lifted to artifacts before the model has a chance to emit them
+ * back into the next tool call.
+ *
+ * Why so much lower than the 8 MB JetStream message limit: persistence
+ * isn't the only cost. A model that sees inline base64 may decide to
+ * forward those bytes into a subsequent tool call (e.g. embedding them
+ * as a string literal in run_code), which costs prompt tokens, output
+ * tokens, and turn latency. 4 KB is the floor below which those costs
+ * are minor; above it, lift.
  */
-const SIZE_THRESHOLD_CHARS = 64 * 1024;
+const SIZE_THRESHOLD_CHARS = 4 * 1024;
 
 /**
  * Recursion depth ceiling. MCP results are usually shallow JSON; this is a
@@ -45,29 +53,23 @@ const MAX_DEPTH = 16;
 const DATA_URL_RE = /^data:([^;,]+);base64,(.+)$/s;
 
 /**
- * Loose base64 character-class check. Doesn't validate strict base64 (which
- * would reject internal whitespace) — just confirms the string is plausibly
- * an opaque base64 blob, not human-readable text. Combined with the size
- * threshold this keeps the false-positive rate low.
+ * Match a contiguous run of base64 characters of at least
+ * `SIZE_THRESHOLD_CHARS` length, with optional `=` padding. Used to find
+ * base64 blobs *embedded* inside larger strings — Gmail's
+ * `get_gmail_attachment_content`, for example, returns base64 inside a
+ * text envelope ("Attachment downloaded ...\nBase64 content (XXX chars):\n
+ * <base64>\n"). Whole-string detection misses those because the
+ * surrounding prose breaks the character class.
+ *
+ * The regex is intentionally strict (no internal whitespace) — that
+ * matches the single-line format MCPs use in practice and keeps false
+ * positives low. Multi-line base64 (RFC-2045 76-char wrap) would need
+ * a different match shape; not seen in the wild from the MCPs Friday
+ * talks to today.
+ *
+ * Built lazily because the threshold is referenced as a number of chars.
  */
-const BASE64_BODY_RE = /^[A-Za-z0-9+/_=\-\s]+$/;
-
-/** Heuristic: a base64-looking string that's mostly base64 chars (>95%). */
-function looksLikeBase64(s: string): boolean {
-  if (s.length < SIZE_THRESHOLD_CHARS) return false;
-  if (!BASE64_BODY_RE.test(s)) return false;
-  // Belt-and-suspenders: count non-base64-ish chars in case the regex passed
-  // but the string is just a long word with the right char class.
-  let bad = 0;
-  for (let i = 0; i < Math.min(s.length, 4096); i++) {
-    const c = s.charCodeAt(i);
-    const isAlnum = (c >= 48 && c <= 57) || (c >= 65 && c <= 90) || (c >= 97 && c <= 122);
-    const isBase64Punct = c === 43 || c === 47 || c === 61 || c === 95 || c === 45; // + / = _ -
-    const isWS = c === 32 || c === 9 || c === 10 || c === 13;
-    if (!isAlnum && !isBase64Punct && !isWS) bad++;
-  }
-  return bad === 0;
-}
+const EMBEDDED_BASE64_RE = new RegExp(`[A-Za-z0-9+/]{${SIZE_THRESHOLD_CHARS},}={0,2}`, "g");
 
 interface ScrubContext {
   workspaceId: string;
@@ -145,7 +147,7 @@ async function scrubString(
   ctx: ScrubContext,
   toolCtx: { serverId: string; toolName: string },
 ): Promise<string> {
-  // Data URL: pull mime + base64 body out of the prefix.
+  // Whole-string data URL — preserve the mime hint when uploading.
   const dataUrlMatch = s.match(DATA_URL_RE);
   if (dataUrlMatch) {
     const [, mime, body] = dataUrlMatch;
@@ -156,15 +158,32 @@ async function scrubString(
     }
     return s;
   }
-  // Standalone base64-looking blob.
-  if (looksLikeBase64(s)) {
+  // Embedded base64 blocks. Find every contiguous run >= threshold,
+  // upload it, and splice the marker into its place. Done left-to-right
+  // by re-matching from a moving offset so the splice doesn't invalidate
+  // subsequent match indices.
+  let result = s;
+  let cursor = 0;
+  // Bound iterations defensively — pathological input could in theory
+  // produce many matches; in practice tool outputs have one block.
+  for (let i = 0; i < 32; i++) {
+    EMBEDDED_BASE64_RE.lastIndex = cursor;
+    const m = EMBEDDED_BASE64_RE.exec(result);
+    if (!m) break;
+    const block = m[0];
     const filename = defaultFilename(undefined, toolCtx);
-    // Strip whitespace so the artifact storage gets clean base64.
-    const clean = s.replace(/\s+/g, "");
-    const result = await uploadBlob(clean, undefined, filename, ctx, toolCtx);
-    if (result) return refMarker(result, toolCtx);
+    const upload = await uploadBlob(block, undefined, filename, ctx, toolCtx);
+    if (!upload) {
+      // Move past this match to avoid an infinite loop on transient
+      // upload failure; another scrub pass (e.g. pre-persist) can retry.
+      cursor = m.index + block.length;
+      continue;
+    }
+    const marker = refMarker(upload, toolCtx);
+    result = result.slice(0, m.index) + marker + result.slice(m.index + block.length);
+    cursor = m.index + marker.length;
   }
-  return s;
+  return result;
 }
 
 async function scrubValue(
@@ -226,39 +245,52 @@ export async function scrubAssistantMessage(
   };
   let scanned = 0;
   let rewritten = 0;
+
+  /** Run the scrub on a value; replace via the writeback fn if it changed. */
+  const scrubField = async (
+    value: unknown,
+    serverId: string,
+    toolName: string,
+    writeback: (next: unknown) => void,
+  ) => {
+    scanned++;
+    const before = JSON.stringify(value);
+    const after = await scrubValue(value, ctx, { serverId, toolName }, 0);
+    if (JSON.stringify(after) !== before) {
+      writeback(after);
+      rewritten++;
+    }
+  };
+
   for (const part of parts) {
     const type = typeof part.type === "string" ? part.type : "";
-    // Tool call outputs from the parent's own tool-use steps.
-    if (type.startsWith("tool-") && "output" in part) {
-      scanned++;
-      const before = JSON.stringify(part.output);
-      const after = await scrubValue(
-        part.output,
-        ctx,
-        { serverId: "pre-persist", toolName: type },
-        0,
-      );
-      if (JSON.stringify(after) !== before) {
-        part.output = after;
-        rewritten++;
+    // Tool calls from the parent's own tool-use steps. Both `input` and
+    // `output` get scrubbed — `output` covers MCP-server returns that
+    // bypassed the boundary scrubber; `input` covers the case where the
+    // model embedded base64 *into* a tool call (e.g. assigning bytes to a
+    // string literal in `run_code`'s source argument). Without input scrub,
+    // those bytes survive into chat history and into the next turn's prompt.
+    if (type.startsWith("tool-")) {
+      if ("output" in part) {
+        await scrubField(part.output, "pre-persist", type, (next) => {
+          part.output = next;
+        });
+      }
+      if ("input" in part) {
+        await scrubField(part.input, "pre-persist", `${type}.input`, (next) => {
+          part.input = next;
+        });
       }
     }
-    // Sub-agent stream envelopes — chunk may carry an embedded tool result.
+    // Sub-agent stream envelopes — chunk may carry an embedded tool
+    // result OR an embedded tool input (the sub-agent emitting bytes into
+    // its own next tool call). Walk the whole chunk; scrubValue recurses.
     if (type === "data-delegate-chunk" && part.data && typeof part.data === "object") {
-      scanned++;
       const data = part.data as Record<string, unknown>;
       if ("chunk" in data) {
-        const before = JSON.stringify(data.chunk);
-        const after = await scrubValue(
-          data.chunk,
-          ctx,
-          { serverId: "pre-persist", toolName: "delegate-chunk" },
-          0,
-        );
-        if (JSON.stringify(after) !== before) {
-          data.chunk = after;
-          rewritten++;
-        }
+        await scrubField(data.chunk, "pre-persist", "delegate-chunk", (next) => {
+          data.chunk = next;
+        });
       }
     }
   }
@@ -266,4 +298,4 @@ export async function scrubAssistantMessage(
 }
 
 // Exported for unit tests.
-export const __test = { looksLikeBase64, DATA_URL_RE, SIZE_THRESHOLD_CHARS };
+export const __test = { DATA_URL_RE, EMBEDDED_BASE64_RE, SIZE_THRESHOLD_CHARS };

--- a/packages/system/agents/workspace-chat/prompt.txt
+++ b/packages/system/agents/workspace-chat/prompt.txt
@@ -281,7 +281,13 @@ Tools may return `artifacts` = [{id, summary}]. All artifacts are files — use 
 1. Call `display_artifact` for each `id`.
 2. Don't print raw artifact IDs.
 
-Read contents → `artifacts_get` (returns `contents` field). Pass to another tool → pass ID, not re-serialized contents.
+Read contents → `artifacts_get`. For text artifacts (json/yaml/text/*) the response has the contents inline. For binary artifacts (PDF/DOCX/PPTX/image/etc.) the response has no inline bytes — instead it carries a `hint` field telling you which tool to call next:
+
+- PDF/DOCX/PPTX → `parse_artifact` returns markdown text. Use this whenever you need the *contents* of a document for reasoning. Do NOT fetch the bytes through `run_code` to parse them yourself — that round-trips thousands of base64 characters through the prompt and frequently fails on multi-page documents.
+- Images → `display_artifact` to surface visually. The model cannot reason about image bytes directly.
+- Other binaries → `display_artifact` for the user, or fetch `/api/artifacts/<id>/content` from `run_code` for server-side processing.
+
+Pass to another tool → pass ID, not re-serialized contents.
 
 Creating artifacts: pass content directly to `artifacts_create` — no `write_file → artifacts_create(path)` two-step. Inline string for text, base64 (with `contentEncoding: "base64"`) for binary. Storage hashes the bytes and writes to the JetStream Object Store named by SHA-256, so identical content dedups automatically. After creation, immediately call `display_artifact` with the returned `artifactId`. The legacy scratch-dir path-based form is still accepted by the workspace-chat-only `artifacts_create` tool (it reads the file and base64-encodes for you), but only when `run_code` or `write_file` produced an opaque binary you don't already hold in-memory. Do NOT use `delegate` to register artifacts.
 

--- a/packages/system/agents/workspace-chat/prompt.txt
+++ b/packages/system/agents/workspace-chat/prompt.txt
@@ -284,6 +284,8 @@ Tools may return `artifacts` = [{id, summary}]. All artifacts are files — use 
 Read contents → `artifacts_get` (returns `contents` field). Pass to another tool → pass ID, not re-serialized contents.
 
 Creating artifacts: pass content directly to `artifacts_create` — no `write_file → artifacts_create(path)` two-step. Inline string for text, base64 (with `contentEncoding: "base64"`) for binary. Storage hashes the bytes and writes to the JetStream Object Store named by SHA-256, so identical content dedups automatically. After creation, immediately call `display_artifact` with the returned `artifactId`. The legacy scratch-dir path-based form is still accepted by the workspace-chat-only `artifacts_create` tool (it reads the file and base64-encodes for you), but only when `run_code` or `write_file` produced an opaque binary you don't already hold in-memory. Do NOT use `delegate` to register artifacts.
+
+Fetching external attachments (Gmail PDFs, Drive downloads, anything that returns binary bytes): prefer the tool's file-path / download-URL mode over inlining base64. Tools like `get_gmail_attachment_content` default to writing the attachment to a local path and returning that path — read it via `run_code` or filesystem MCP, then register what the user needs to see via `artifacts_create`. Do NOT pass `return_base64=True` (or equivalent) just to "have the bytes" — base64 in tool output bloats the prompt, can exceed message-size limits, and any large blob will be auto-lifted to an artifact ref before the next turn anyway.
 </artifacts>
 
 <service_connection>

--- a/packages/system/agents/workspace-chat/tools/artifact-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/artifact-tools.ts
@@ -14,6 +14,7 @@ import { basename } from "node:path";
 import type { AtlasTools } from "@atlas/agent-sdk";
 import { client, parseResult } from "@atlas/client/v2";
 import { createLogger } from "@atlas/logger";
+import { stringifyError } from "@atlas/utils";
 import { encodeBase64 } from "@std/encoding/base64";
 import { tool } from "ai";
 import { z } from "zod";
@@ -26,9 +27,18 @@ const logger = createLogger({ name: "workspace-chat-artifacts" });
  * Direct tool for retrieving an artifact by ID.
  * Mirrors the MCP `artifacts_get` tool (packages/mcp-server/src/tools/artifacts/get.ts)
  * so workspace-chat can use it without platform tool passthrough.
+ *
+ * For text-like artifacts (json/yaml/text/*) the response includes the
+ * decoded contents inline. For binary artifacts (PDF/image/etc.) the
+ * server returns metadata + a `hint` directing you to the right
+ * follow-up tool — `parse_artifact` to extract text from PDF/DOCX/PPTX,
+ * `display_artifact` to surface visually. This avoids round-tripping
+ * decoded-as-UTF-8 bytes through the LLM, which is both expensive and
+ * useless (the model can't reason about random bytes).
  */
 const artifactsGet = tool({
-  description: "Get artifact by ID",
+  description:
+    "Get artifact by ID. For binary artifacts (PDF/image/etc.), use the returned `hint` to choose the right follow-up tool; the response will not include raw bytes.",
   inputSchema: z.object({
     artifactId: z.string().describe("Artifact ID"),
     revision: z
@@ -52,8 +62,36 @@ const artifactsGet = tool({
       return { success: false, error: `Failed to retrieve artifact: ${artifactId}` };
     }
 
-    const { artifact, contents } = response.data;
-    return { ...artifact, contents };
+    const { artifact, contents, hint } = response.data;
+    return { ...artifact, contents, hint };
+  },
+});
+
+/**
+ * Direct tool for extracting text from a binary artifact (PDF/DOCX/PPTX).
+ * Runs the bytes through the same converters used at upload time and
+ * returns markdown. Use this instead of fetching artifact bytes and
+ * piping them through `run_code` — that pattern costs thousands of
+ * prompt tokens per page and frequently fails on multi-page documents.
+ */
+const parseArtifact = tool({
+  description:
+    "Extract text from a binary artifact (PDF, DOCX, or PPTX) as markdown. Use whenever you need the *contents* of a binary artifact for reasoning. Returns `{ markdown, mimeType, filename }`.",
+  inputSchema: z.object({ artifactId: z.string().describe("Artifact ID of a PDF/DOCX/PPTX file") }),
+  execute: async ({ artifactId }) => {
+    logger.info("parse_artifact called", { artifactId });
+
+    const response = await parseResult(
+      client.artifactsStorage[":id"].parse.$get({ param: { id: artifactId } }),
+    );
+
+    if (!response.ok) {
+      return {
+        success: false,
+        error: `Failed to parse artifact: ${stringifyError(response.error)}`,
+      };
+    }
+    return response.data;
   },
 });
 
@@ -61,6 +99,7 @@ const artifactsGet = tool({
 export const artifactTools: AtlasTools = {
   display_artifact: displayArtifact,
   artifacts_get: artifactsGet,
+  parse_artifact: parseArtifact,
 };
 
 /**

--- a/packages/system/agents/workspace-chat/tools/delegate/index.test.ts
+++ b/packages/system/agents/workspace-chat/tools/delegate/index.test.ts
@@ -954,7 +954,11 @@ describe("createDelegateTool", () => {
     expect(mockCreateMCPTools).toHaveBeenCalledWith(
       { "server-a": { transport: { type: "stdio", command: "a" } } },
       expect.any(Object),
-      { signal: undefined, toolPrefix: undefined },
+      // The delegate now plumbs a `scrubResult` post-processor so MCP tool
+      // outputs get oversized binary lifted to artifacts at the boundary
+      // (see scrub-tool-output.ts). Asserted as a function here; behavior
+      // is covered in scrub-tool-output.test.ts.
+      { signal: undefined, toolPrefix: undefined, scrubResult: expect.any(Function) },
     );
     const tools = captured.args?.tools as Record<string, unknown> | undefined;
     expect(tools?.tool_a).toBeDefined();
@@ -1010,13 +1014,13 @@ describe("createDelegateTool", () => {
       1,
       { s1: { transport: { type: "stdio", command: "s1" } } },
       expect.any(Object),
-      { signal: undefined, toolPrefix: "s1" },
+      { signal: undefined, toolPrefix: "s1", scrubResult: expect.any(Function) },
     );
     expect(mockCreateMCPTools).toHaveBeenNthCalledWith(
       2,
       { s2: { transport: { type: "stdio", command: "s2" } } },
       expect.any(Object),
-      { signal: undefined, toolPrefix: "s2" },
+      { signal: undefined, toolPrefix: "s2", scrubResult: expect.any(Function) },
     );
 
     const tools = captured.args?.tools as Record<string, unknown> | undefined;

--- a/packages/system/agents/workspace-chat/tools/delegate/index.ts
+++ b/packages/system/agents/workspace-chat/tools/delegate/index.ts
@@ -27,6 +27,7 @@ import type { ToolCallRepairFunction, UIMessageStreamWriter } from "ai";
 import { stepCountIs, streamText, tool } from "ai";
 import { z } from "zod";
 import { rebindAgentTool } from "../../../workspace-chat/tools/bundled-agent-tools.ts";
+import { createScrubber } from "../../lib/scrub-tool-output.ts";
 import { FINISH_TOOL_NAME, type FinishInput, finishTool, parseFinishInput } from "./finish-tool.ts";
 import { createDelegateProxyWriter } from "./proxy-writer.ts";
 
@@ -189,6 +190,19 @@ export function createDelegateTool(deps: DelegateDeps, toolSetThunk: () => Atlas
             if (c) selectedConfigs[id] = c.mergedConfig;
           }
 
+          // Scrub binary out of MCP tool results before they enter the AI
+          // SDK message buffer. Bytes get lifted to artifacts; the model
+          // sees a short ref string. Avoids the prompt-token tax + chat
+          // persistence MAX_PAYLOAD_EXCEEDED on attachment-bearing tools
+          // (Gmail's `get_gmail_attachment_content` with return_base64=true,
+          // image responses, etc.). Pre-persist scrubbing in the parent
+          // agent acts as a backstop for anything that slips past.
+          const scrubResult = createScrubber({
+            workspaceId: session.workspaceId,
+            chatId: session.streamId,
+            logger,
+          });
+
           const serverEntries = Object.entries(selectedConfigs);
           const serverResults = await Promise.allSettled(
             serverEntries.map(([serverId, config]) => {
@@ -196,6 +210,7 @@ export function createDelegateTool(deps: DelegateDeps, toolSetThunk: () => Atlas
               return createMCPTools({ [serverId]: config }, logger, {
                 signal: abortSignal,
                 toolPrefix: prefix,
+                scrubResult,
               });
             }),
           );

--- a/packages/system/agents/workspace-chat/workspace-chat.agent.ts
+++ b/packages/system/agents/workspace-chat/workspace-chat.agent.ts
@@ -38,6 +38,7 @@ import {
   composeWorkspaceSections,
   fetchForegroundContexts,
 } from "./compose-context.ts";
+import { scrubAssistantMessage } from "./lib/scrub-tool-output.ts";
 import { buildOnboardingClause, buildUserProfileClause } from "./onboarding.ts";
 import SYSTEM_PROMPT from "./prompt.txt" with { type: "text" };
 import { connectCommunicatorSucceeded, connectServiceSucceeded } from "./stop-conditions.ts";
@@ -466,6 +467,32 @@ export const workspaceChatAgent = createAgent<string, WorkspaceChatResult>({
               stripped,
             });
           }
+
+          // Defense-in-depth: lift any binary that escaped the MCP-boundary
+          // scrubber (LLM-fabricated base64, future tool surfaces) into
+          // artifacts before append. Same scrub logic as the boundary
+          // wrapper; just runs against the assembled assistant message.
+          try {
+            const { rewritten } = await scrubAssistantMessage(
+              lastMessage.parts as Array<Record<string, unknown>>,
+              { workspaceId, chatId: session.streamId, logger },
+            );
+            if (rewritten > 0) {
+              logger.info("Scrubbed binary out of assistant parts before persist", {
+                streamId: session.streamId,
+                messageId: lastMessage.id,
+                rewritten,
+              });
+            }
+          } catch (err) {
+            // Persistence path must continue regardless. The MCP-boundary
+            // scrubber is the primary defense; this is best-effort.
+            logger.warn("Pre-persist scrub failed (continuing with append)", {
+              streamId: session.streamId,
+              error: err instanceof Error ? err.message : String(err),
+            });
+          }
+
           const appendResult = await ChatStorage.appendMessage(
             session.streamId,
             lastMessage,

--- a/tools/agent-playground/src/lib/components/chat/artifact-card.svelte
+++ b/tools/agent-playground/src/lib/components/chat/artifact-card.svelte
@@ -209,7 +209,17 @@
       ></iframe>
     </div>
   {:else if pdfUrl}
-    <iframe title={resolvedTitle} src={pdfUrl} class="artifact-pdf"></iframe>
+    <!-- loading="lazy" defers the fetch until near the viewport. With many
+         PDF artifacts in chat history (Goodwin invoices etc.), a fresh
+         page load otherwise stampedes the daemon for every card whether
+         the user scrolls past it or not — and pre-inline-disposition,
+         that triggered a download dialog per card. -->
+    <iframe
+      title={resolvedTitle}
+      src={pdfUrl}
+      class="artifact-pdf"
+      loading="lazy"
+    ></iframe>
   {:else if contents && isTextPreviewable(mimeType)}
     <pre class="artifact-preview">{previewContents(contents, mimeType)}</pre>
   {/if}

--- a/tools/agent-playground/src/lib/components/chat/artifact-card.svelte
+++ b/tools/agent-playground/src/lib/components/chat/artifact-card.svelte
@@ -220,11 +220,11 @@
       ></iframe>
     </div>
   {:else if pdfUrl}
-    <!-- loading="lazy" defers the fetch until near the viewport. With many
-         PDF artifacts in chat history (Goodwin invoices etc.), a fresh
-         page load otherwise stampedes the daemon for every card whether
-         the user scrolls past it or not — and pre-inline-disposition,
-         that triggered a download dialog per card. -->
+    <!-- loading="lazy" defers the fetch until near the viewport. A chat
+         history with multiple PDF artifacts otherwise stampedes the
+         daemon for every card on a fresh page load whether the user
+         scrolls past it or not — and pre-inline-disposition, that
+         triggered a download dialog per card. -->
     <iframe
       title={resolvedTitle}
       src={pdfUrl}

--- a/tools/agent-playground/src/lib/components/chat/artifact-card.svelte
+++ b/tools/agent-playground/src/lib/components/chat/artifact-card.svelte
@@ -106,6 +106,14 @@
     serveUrl && mimeType === "text/html" ? serveUrl : null,
   );
 
+  // PDFs render natively in an iframe via the browser's built-in PDF
+  // viewer. Same affordance as html — embed for inline preview, "Open"
+  // button for full-screen. No extra deps; this works in Chrome/Edge/
+  // Safari/Firefox out of the box.
+  const pdfUrl = $derived(
+    serveUrl && mimeType === "application/pdf" ? serveUrl : null,
+  );
+
   function mimeLabel(mt: string | undefined): string {
     if (!mt) return "file";
     const map: Record<string, string> = {
@@ -200,6 +208,8 @@
         style="--scale: {iframeScale}"
       ></iframe>
     </div>
+  {:else if pdfUrl}
+    <iframe title={resolvedTitle} src={pdfUrl} class="artifact-pdf"></iframe>
   {:else if contents && isTextPreviewable(mimeType)}
     <pre class="artifact-preview">{previewContents(contents, mimeType)}</pre>
   {/if}
@@ -357,6 +367,14 @@
     inline-size: 1200px;
     transform: scale(var(--scale));
     transform-origin: top left;
+  }
+
+  .artifact-pdf {
+    block-size: 480px;
+    border: 1px solid var(--color-border-1);
+    border-radius: var(--radius-1);
+    display: block;
+    inline-size: 100%;
   }
 
   .artifact-preview {

--- a/tools/agent-playground/src/lib/components/chat/artifact-card.svelte
+++ b/tools/agent-playground/src/lib/components/chat/artifact-card.svelte
@@ -180,9 +180,20 @@
     </div>
 
     {#if serveUrl && !loading}
-      <a class="open-btn" href={serveUrl} target="_blank" rel="noopener noreferrer" title="Open">
-        Open
-      </a>
+      <div class="artifact-actions">
+        <!-- `download` (no value) defers to the server's
+             Content-Disposition filename, which `deriveDownloadFilename`
+             rewrites to match the actual mime type — so legacy `.bin`
+             artifacts still save with the correct extension. The
+             `download` attribute also forces save (rather than render)
+             even for inline-disposition mimes like PDF. -->
+        <a class="download-btn" href={serveUrl} download title="Download">
+          Download
+        </a>
+        <a class="open-btn" href={serveUrl} target="_blank" rel="noopener noreferrer" title="Open in new tab">
+          Open
+        </a>
+      </div>
     {/if}
   </div>
 
@@ -302,6 +313,13 @@
     padding: 1px 6px;
   }
 
+  .artifact-actions {
+    align-items: center;
+    display: flex;
+    flex-shrink: 0;
+    gap: var(--size-1, 4px);
+  }
+
   .open-btn {
     background: var(--color-accent);
     border: 1px solid var(--color-accent);
@@ -313,6 +331,7 @@
     font-size: var(--font-size-1);
     font-weight: var(--font-weight-5);
     padding: 3px 10px;
+    text-decoration: none;
     transition: opacity 100ms ease;
   }
 
@@ -322,6 +341,27 @@
 
   .open-btn:disabled {
     opacity: 0.5;
+  }
+
+  /* Secondary action — same shape as Open but neutral so the chat header
+     doesn't sprout two equally-loud accent buttons next to each other. */
+  .download-btn {
+    background: transparent;
+    border: 1px solid var(--color-border-1);
+    border-radius: var(--radius-1);
+    color: var(--text);
+    cursor: pointer;
+    flex-shrink: 0;
+    font-family: inherit;
+    font-size: var(--font-size-1);
+    font-weight: var(--font-weight-5);
+    padding: 3px 10px;
+    text-decoration: none;
+    transition: background 100ms ease;
+  }
+
+  .download-btn:hover {
+    background: var(--surface-bright, var(--surface));
   }
 
   .artifact-summary {

--- a/tools/agent-playground/src/lib/components/chat/delegate-tool-card.svelte
+++ b/tools/agent-playground/src/lib/components/chat/delegate-tool-card.svelte
@@ -54,6 +54,12 @@
         return { icon: Icons.Link, label: "Connecting", color: "var(--text-faded)", category: "connect" };
       case "display_artifact":
         return { icon: Icons.DocumentText, label: "Displaying", color: "var(--color-accent)", category: "file" };
+      case "artifacts_get":
+        return { icon: Icons.DocumentText, label: "Reading artifact", color: "var(--color-accent)", category: "file" };
+      case "artifacts_create":
+        return { icon: Icons.DocumentArrowUp, label: "Saving artifact", color: "var(--color-accent)", category: "file" };
+      case "parse_artifact":
+        return { icon: Icons.DocumentText, label: "Parsing", color: "var(--color-accent)", category: "file" };
       case "list_capabilities":
         return { icon: Icons.RectangleStack, label: "Checking tools", color: "var(--text-faded)", category: "generic" };
       default:

--- a/tools/agent-playground/src/lib/components/chat/tool-call-card.svelte
+++ b/tools/agent-playground/src/lib/components/chat/tool-call-card.svelte
@@ -58,6 +58,12 @@
         return { icon: Icons.Link, label: "Connecting", color: "var(--text-faded)", category: "connect" };
       case "display_artifact":
         return { icon: Icons.DocumentText, label: "Displaying", color: "var(--color-accent)", category: "file" };
+      case "artifacts_get":
+        return { icon: Icons.DocumentText, label: "Reading artifact", color: "var(--color-accent)", category: "file" };
+      case "artifacts_create":
+        return { icon: Icons.DocumentArrowUp, label: "Saving artifact", color: "var(--color-accent)", category: "file" };
+      case "parse_artifact":
+        return { icon: Icons.DocumentText, label: "Parsing", color: "var(--color-accent)", category: "file" };
       case "list_capabilities":
         return { icon: Icons.RectangleStack, label: "Checking tools", color: "var(--text-faded)", category: "generic" };
       default:

--- a/tools/agent-playground/src/lib/update-status.svelte.ts
+++ b/tools/agent-playground/src/lib/update-status.svelte.ts
@@ -40,8 +40,15 @@ function emptyStatus(): UpdateStatus {
 /* eslint-disable prefer-const */
 // deno-lint-ignore prefer-const
 let status: UpdateStatus = $state(emptyStatus());
+// `dismiss` is loaded lazily on first read of `bannerDismissed.value` —
+// not at module-import time. Reading localStorage at import time hits
+// Deno's SQLite-backed storage and can throw `database is locked` when
+// parallel test workers all import this module at once. Deferring also
+// matches the contract of the rest of this module: `loadUpdateStatus`
+// is the explicit "do I/O now" entry point.
 // deno-lint-ignore prefer-const
-let dismiss: Dismiss | null = $state(loadDismiss());
+let dismiss: Dismiss | null = $state(null);
+let dismissLoadAttempted = false;
 // deno-lint-ignore prefer-const
 let now: number = $state(Date.now());
 // deno-lint-ignore prefer-const
@@ -73,16 +80,40 @@ export function isDismissed(
 
 function loadDismiss(): Dismiss | null {
   if (typeof localStorage === "undefined") return null;
-  const raw = localStorage.getItem(DISMISS_KEY);
+  let raw: string | null;
+  try {
+    raw = localStorage.getItem(DISMISS_KEY);
+  } catch (err) {
+    // localStorage I/O failed — Deno's SQLite-backed storage hits WAL
+    // lock contention in CI, browsers can throw on disabled storage or
+    // quota issues. Treat as "no dismissal"; the banner reappearing is
+    // a benign degradation.
+    logger.warn("update-status: localStorage read failed", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return null;
+  }
   if (!raw) return null;
   try {
     const parsed = DismissSchema.safeParse(JSON.parse(raw));
     if (parsed.success) return parsed.data;
+  } catch {
+    // JSON.parse failed — fall through to cleanup below.
+  }
+  // Best-effort tidy of a corrupt entry; tolerate failure.
+  try {
     localStorage.removeItem(DISMISS_KEY);
   } catch {
-    localStorage.removeItem(DISMISS_KEY);
+    /* ignore */
   }
   return null;
+}
+
+/** Read `dismiss` from storage on first access; cached afterward. */
+function ensureDismissLoaded(): void {
+  if (dismissLoadAttempted) return;
+  dismissLoadAttempted = true;
+  dismiss = loadDismiss();
 }
 
 function ensureClock(): void {
@@ -103,6 +134,7 @@ export const updateStatus: UpdateStatus = status;
  */
 export const bannerDismissed = {
   get value(): boolean {
+    ensureDismissLoaded();
     return isDismissed(dismiss, status.latest, now);
   },
 };
@@ -151,8 +183,18 @@ export function dismissBanner(): void {
   if (status.latest === null) return;
   const next: Dismiss = { version: status.latest, until: Date.now() + DISMISS_WINDOW_MS };
   dismiss = next;
+  // Mark loaded — writing past the lazy-load is the source of truth now.
+  dismissLoadAttempted = true;
   if (typeof localStorage !== "undefined") {
-    localStorage.setItem(DISMISS_KEY, JSON.stringify(next));
+    try {
+      localStorage.setItem(DISMISS_KEY, JSON.stringify(next));
+    } catch (err) {
+      // I/O failed — in-memory `dismiss` still hides the banner for the
+      // current session; persistence across reloads is best-effort.
+      logger.warn("update-status: localStorage write failed", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Closes the loop on chat-with-attachments end-to-end. The triggering bug was `MAX_PAYLOAD_EXCEEDED` on persisting Gmail-PDF tool outputs; fixing that revealed several adjacent issues (downstream `artifacts_get` returning garbage UTF-8, partial messages vanishing on daemon restart, no PDF preview in the chat UI, `.bin` filenames everywhere). Treated as one cohesive piece because the fixes interlock.

## What changes for the user

- **Chats with attachments stop silently failing.** `MAX_PAYLOAD_EXCEEDED` is gone — large MCP tool outputs are lifted to artifacts at the boundary, before they ever reach the AI SDK message buffer.
- **PDFs render inline in the chat.** Native browser PDF viewer in an iframe, lazy-loaded, with proper Content-Disposition.
- **Download button next to Open** in the artifact card. Saved files get the right name and extension.
- **Partial assistant turns survive a SIGTERM.** Daemon shutdown now drains in-flight chat turns, giving the agent's `onFinish` time to persist whatever was assembled before exiting.
- **Agent uses `parse_artifact` instead of round-tripping bytes through `run_code`.** PDFs/DOCX/PPTX get extracted to markdown server-side, no token cost for re-emitting bytes.

## Architecture, in five layers

### 1. Lift binary at the MCP boundary
`packages/system/agents/workspace-chat/lib/scrub-tool-output.ts`. New `createScrubber` wraps every MCP tool's `execute` inside `delegate`. Walks the tool result; finds embedded base64 blocks (≥ 4 KB chars) inside text envelopes; uploads each to `OBJ_artifacts` via the existing `client.artifactsStorage.index.$post`; replaces the bytes with a marker like `[attachment lifted to artifact <id> — use display_artifact or artifacts_get to read]`. Sniffs PDF/PNG/JPEG/etc. from the base64 magic-byte prefix so the synthesized filename has the right extension up front.

### 2. Defense-in-depth pre-persist scrubber
`packages/system/agents/workspace-chat/workspace-chat.agent.ts`. Same scrub logic, run against the assembled assistant message right before `appendMessage`. Walks `tool-*` part `output` AND `input` (catches the case where the model already received bytes and re-emitted them into the next tool call). Also walks `data-delegate-chunk` envelopes for sub-agent tool results.

### 3. `artifacts_get` becomes binary-aware; `parse_artifact` is new
`apps/atlasd/routes/artifacts.ts`. The GET artifact route now respects mime: text artifacts return `contents` inline as before; binary artifacts return metadata + a `hint` field directing the agent to the right tool. New `/api/artifacts/:id/parse` endpoint runs `pdfToMarkdown` / `docxToMarkdown` / `pptxToMarkdown` (the same converters used at upload time) server-side and returns the extracted markdown — bytes never enter the model context.

Both surfaces (workspace-chat builtin + MCP) are exposed: chat + delegate get the builtin; jobs get the MCP version.

### 4. Persistence storage gets snapshot semantics
`packages/core/src/chat/jetstream-backend.ts`. New chat streams use a per-message subject (`chats.<ws>.<chatId>.messages.<msgId>`) with `max_msgs_per_subject: 1` and `allow_rollup_hdrs: true`, so re-publishing an `appendMessage` for the same `message.id` snapshot-replaces the prior copy at the broker. We deliberately drop the `msgID` dedup header on new-layout streams — the 24h dedup window would silently drop snapshot updates, defeating the point. Existing chats stay on their flat-subject layout (no migration); a per-chat-stream layout cache makes the routing decision once.

### 5. Daemon drains turns before exiting
`apps/atlasd/src/chat-turn-registry.ts` + `apps/atlasd/src/atlas-daemon.ts`. New `ChatTurnRegistry.drainShutdown(timeoutMs)` aborts every active turn, then waits (bounded) for each to call `release()` after its `onFinish` runs. Wired into `_doShutdown` BEFORE Phase-2 runtime teardown — so the agent's pre-persist scrub + `appendMessage` can complete before the workspace runtimes go away.

## What didn't change

- **Chat-input still emits inline data URLs** for pasted images. Vision works as before. Was considered (option E in the design notes) but rejected — it requires a rehydration layer at LLM-call time and adds cross-provider testing surface, with the only payoff being slightly smaller persisted messages. The scrubbers here address the actual failure mode.
- **No KV migration of chat storage.** Per-chat streams stay; we kept the per-stream retention property and added per-message rollup *on top* of streams (option F' in the design notes, vs full KV consolidation).

## File-by-file

| File | What |
|---|---|
| `packages/mcp/src/create-mcp-tools.ts` | New `ScrubToolResult` post-processor option on `CreateMCPToolsOptions`, applied after `execute` in `wrapTool`. Generic callers leave it unset and get pass-through behavior. |
| `packages/system/agents/workspace-chat/lib/scrub-tool-output.ts` | New module: `createScrubber`, `scrubAssistantMessage`, magic-byte mime sniff for embedded base64. Per-call dedup cache that's race-safe across `Promise.all`. |
| `packages/system/agents/workspace-chat/tools/delegate/index.ts` | Plumbs the scrubber into the `createMCPTools` call inside `delegate`. |
| `packages/system/agents/workspace-chat/workspace-chat.agent.ts` | Pre-persist scrub call alongside `closePendingToolParts` + `data-nested-chunk` strip. |
| `packages/system/agents/workspace-chat/prompt.txt` | Updated `<artifacts>` block — agent knows about the `hint` field, knows to call `parse_artifact` for PDF contents instead of fetching bytes through `run_code`. |
| `packages/system/agents/workspace-chat/tools/artifact-tools.ts` | `parse_artifact` builtin tool; `artifacts_get` surfaces the `hint` field. |
| `packages/mcp-server/src/tools/artifacts/parse.ts` | MCP twin of `parse_artifact`. |
| `packages/mcp-server/src/tools/artifacts/get.ts` | Pass-through of the new `hint` field. |
| `packages/core/src/chat/jetstream-backend.ts` | Per-message subjects, `max_msgs_per_subject: 1`, `allow_rollup_hdrs: true`, layout cache. |
| `apps/atlasd/src/chat-turn-registry.ts` | `drainShutdown(timeoutMs)`. |
| `apps/atlasd/src/atlas-daemon.ts` | Drain in `_doShutdown` before Phase 2; `uncaughtException` handler drains + exits, `unhandledRejection` only logs. |
| `apps/atlasd/routes/artifacts.ts` | Binary-aware `artifacts_get`, new `/parse` route, inline `Content-Disposition` for renderable mimes, `deriveDownloadFilename` for the filename header. |
| `packages/core/src/artifacts/file-upload.ts` | New helpers: `isTextMimeType`, `isParseableMimeType`, `extFromMime`, `deriveDownloadFilename`. |
| `tools/agent-playground/src/lib/components/chat/artifact-card.svelte` | PDF iframe (lazy-loaded), Download button, `pdfUrl` derived. |
| `tools/agent-playground/src/lib/components/chat/{tool-call,delegate-tool}-card.svelte` | `getToolMeta` switch entries for `parse_artifact` / `artifacts_get` / `artifacts_create`. |

## Tests

New: `scrub-tool-output.test.ts` (16), `chat-turn-registry.test.ts` (3). Added: snapshot-replacement test in `storage.test.ts`. Total: 32/32 in touched files.

`deno task typecheck` — 0 errors. `deno run -A npm:knip` — exit 0. `deno task test` — 4944 pass; 4 unrelated pre-existing flakes in `tools/{agent-playground,chat-replay}/.../updates.test.ts` (singleton-guard tests sharing globalThis when vitest runs the same file twice in one worker; pass clean in isolation).

## Test plan

- [x] Pull, restart daemon (no `--watch` picks up the route change automatically; Vite HMR handles the Svelte changes)
- [x] Open any chat with prior `.bin` artifacts — Download button gives the file a `.pdf` name; Open opens inline; iframe renders the PDF
- [x] Refresh the chat page — no download dialog spam (lazy iframes + inline disposition)
- [x] Paste a fresh "fetch the ____ and tell me what's in them" prompt — agent should call `get_gmail_attachment_content` → scrubber lifts → `artifacts_get` returns metadata + hint → `parse_artifact` returns markdown → answer in <2 minutes for 5 PDFs (was 3 min with run_code, sometimes failed)
- [x] SIGTERM the daemon mid-turn (`kill -TERM <pid>`) — restart, open the chat, verify the partial assistant message is there with `output-error: "Tool call interrupted"` on the in-flight tool
- [ ] Trigger an `unhandledRejection` somehow (or wait for one — they happen) — daemon should NOT exit; just log

## Known limitations / follow-ups

- **HTML artifacts served `inline`** can execute scripts in the daemon's origin. Local-only daemon, so not an immediate concern, but worth a `Content-Security-Policy: sandbox` header on HTML responses if we ever expose this remotely.
- **`parse_artifact` reads bytes fully into memory** (no streaming). Fine for chat attachments (typically <25 MB); revisit if we expose to large-document workflows.
- **Stream-per-chat layout flag cached in memory** — survives across requests but not daemon restarts. The first `appendMessage` after a restart re-fetches stream info. Acceptable.