### PR TITLE
fix(atlasd): retire legacy SESSIONS JetStream stream

### DIFF
--- a/apps/atlasd/routes/sessions/sessions.test.ts
+++ b/apps/atlasd/routes/sessions/sessions.test.ts
@@ -39,7 +39,7 @@ function mockNatsConnection(): NatsConnection {
   const jsMock = {
     publish: vi
       .fn<() => Promise<{ stream: string; seq: number }>>()
-      .mockResolvedValue({ stream: "SESSIONS", seq: 1 }),
+      .mockResolvedValue({ stream: "SESSION_EVENTS", seq: 1 }),
   };
   return {
     jetstream: vi.fn<() => typeof jsMock>().mockReturnValue(jsMock),

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -47,7 +47,7 @@ import { StreamableHTTPTransport } from "@hono/mcp";
 import type { Context, Next } from "hono";
 import { cors } from "hono/cors";
 import { type RunMigrationsResult, readJetStreamConfig, runMigrations } from "jetstream";
-import { type NatsConnection, RetentionPolicy, StorageType } from "nats";
+import type { NatsConnection } from "nats";
 import { agents as agentsRoutes } from "../routes/agents/index.ts";
 import { artifactsApp } from "../routes/artifacts.ts";
 import chatRoutes from "../routes/chat.ts";
@@ -403,12 +403,6 @@ export class AtlasDaemon {
     // SIGNALS land in the same log surface. Wildcard matches every
     // (stream, consumer) pair.
     this.subscribeMaxDeliveriesAdvisory(nc);
-
-    // Ensure the SESSIONS JetStream stream exists (durable session event store).
-    // For NEW installs this creates File + 30d directly; for upgraded installs
-    // the matching migration entry (`m_a6ab40b_sessions_stream_upgrade`) does
-    // the streams.update / Memory-storage warning.
-    await this.ensureSessionsStream(nc);
 
     // Ensure the SIGNALS JetStream stream exists. Triggers (HTTP, cron, chat,
     // future cross-cascade emits) can publish onto this for durable, redeliver-
@@ -978,31 +972,6 @@ export class AtlasDaemon {
   /** Get the ProcessAgentExecutor (available after NATS initializes). */
   public getProcessAgentExecutor(): ProcessAgentExecutor | null {
     return this.processAgentExecutor;
-  }
-
-  /**
-   * Create the SESSIONS JetStream stream if missing. New installs get
-   * File storage + 30d retention. Existing installs are upgraded by the
-   * `m_a6ab40b_sessions_stream_upgrade` migration entry, which adds
-   * `max_age` to streams created without one and warns if storage is
-   * still Memory (storage type can't be changed via update).
-   */
-  private async ensureSessionsStream(nc: NatsConnection): Promise<void> {
-    const jsm = await nc.jetstreamManager();
-    const THIRTY_DAYS_NS = 30 * 24 * 60 * 60 * 1_000_000_000;
-    try {
-      await jsm.streams.info("SESSIONS");
-      // Already exists — leave it. Upgrade path is the migration entry.
-    } catch {
-      await jsm.streams.add({
-        name: "SESSIONS",
-        subjects: ["sessions.*.events"],
-        retention: RetentionPolicy.Limits,
-        storage: StorageType.File,
-        max_age: THIRTY_DAYS_NS,
-      });
-      logger.info("Created SESSIONS JetStream stream (file storage, 30d retention)");
-    }
   }
 
   /**

--- a/apps/atlasd/src/migrations/m_20260503_110250_remove_legacy_sessions_stream.test.ts
+++ b/apps/atlasd/src/migrations/m_20260503_110250_remove_legacy_sessions_stream.test.ts
@@ -8,10 +8,18 @@
  * one record per published event.
  */
 
-import { startNatsTestServer, type TestNatsServer } from "@atlas/core/test-utils/nats-test-server";
+import {
+  startNatsTestServer,
+  type TestNatsServer,
+} from "@atlas/core/test-utils/nats-test-server";
 import type { Logger } from "@atlas/logger";
 import { createJetStreamFacade, enc } from "jetstream";
-import { connect, type NatsConnection, RetentionPolicy, StorageType } from "nats";
+import {
+  connect,
+  type NatsConnection,
+  RetentionPolicy,
+  StorageType,
+} from "nats";
 import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -73,19 +81,37 @@ async function createLegacySessionsStream(): Promise<void> {
   });
 }
 
-async function publishLegacy(sessionId: string, payload: unknown): Promise<void> {
+async function publishLegacy(
+  sessionId: string,
+  payload: unknown,
+): Promise<void> {
   await nc
     .jetstream()
-    .publish(`sessions.${sessionId}.events`, enc.encode(JSON.stringify(payload)));
+    .publish(
+      `sessions.${sessionId}.events`,
+      enc.encode(JSON.stringify(payload)),
+    );
 }
 
 describe("m_20260503_110250_remove_legacy_sessions_stream", () => {
   it("dumps messages to a JSONL backup, then deletes the stream", async () => {
     const home = await freshHome();
     await createLegacySessionsStream();
-    await publishLegacy("alpha", { type: "session:start", sessionId: "alpha", n: 1 });
-    await publishLegacy("alpha", { type: "step:start", sessionId: "alpha", n: 2 });
-    await publishLegacy("beta", { type: "session:start", sessionId: "beta", n: 3 });
+    await publishLegacy("alpha", {
+      type: "session:start",
+      sessionId: "alpha",
+      n: 1,
+    });
+    await publishLegacy("alpha", {
+      type: "step:start",
+      sessionId: "alpha",
+      n: 2,
+    });
+    await publishLegacy("beta", {
+      type: "session:start",
+      sessionId: "beta",
+      n: 3,
+    });
 
     const facade = createJetStreamFacade(nc);
     await migration.run({ nc, js: facade, logger: noopLogger });
@@ -109,7 +135,9 @@ describe("m_20260503_110250_remove_legacy_sessions_stream", () => {
       expect(typeof r.data).toBe("string");
       expect(typeof r.time).toBe("string");
       expect(r.time).toMatch(/Z$/);
-      expect(JSON.parse(r.data as string)).toMatchObject({ sessionId: expect.any(String) });
+      expect(JSON.parse(r.data as string)).toMatchObject({
+        sessionId: expect.any(String),
+      });
     }
   });
 
@@ -129,7 +157,11 @@ describe("m_20260503_110250_remove_legacy_sessions_stream", () => {
   it("preserves an existing same-day backup file by suffixing the new one", async () => {
     const home = await freshHome();
     await createLegacySessionsStream();
-    await publishLegacy("gamma", { type: "session:start", sessionId: "gamma", n: 1 });
+    await publishLegacy("gamma", {
+      type: "session:start",
+      sessionId: "gamma",
+      n: 1,
+    });
 
     // Plant a prior backup at the canonical path — simulates a rerun
     // after a previous crash between backup-write and stream-delete.
@@ -147,7 +179,8 @@ describe("m_20260503_110250_remove_legacy_sessions_stream", () => {
     const files = await readdir(home);
     const suffixed = files.filter(
       (f) =>
-        f.startsWith(`legacy-sessions-backup-${isoDate}-`) && f.endsWith(".jsonl"),
+        f.startsWith(`legacy-sessions-backup-${isoDate}-`) &&
+        f.endsWith(".jsonl"),
     );
     expect(suffixed).toHaveLength(1);
 

--- a/apps/atlasd/src/migrations/m_20260503_110250_remove_legacy_sessions_stream.test.ts
+++ b/apps/atlasd/src/migrations/m_20260503_110250_remove_legacy_sessions_stream.test.ts
@@ -8,22 +8,14 @@
  * one record per published event.
  */
 
-import {
-  startNatsTestServer,
-  type TestNatsServer,
-} from "@atlas/core/test-utils/nats-test-server";
-import type { Logger } from "@atlas/logger";
-import { createJetStreamFacade, enc } from "jetstream";
-import {
-  connect,
-  type NatsConnection,
-  RetentionPolicy,
-  StorageType,
-} from "nats";
 import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
+import { startNatsTestServer, type TestNatsServer } from "@atlas/core/test-utils/nats-test-server";
+import type { Logger } from "@atlas/logger";
+import { createJetStreamFacade, enc } from "jetstream";
+import { connect, type NatsConnection, RetentionPolicy, StorageType } from "nats";
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { migration } from "./m_20260503_110250_remove_legacy_sessions_stream.ts";
 
@@ -81,37 +73,17 @@ async function createLegacySessionsStream(): Promise<void> {
   });
 }
 
-async function publishLegacy(
-  sessionId: string,
-  payload: unknown,
-): Promise<void> {
-  await nc
-    .jetstream()
-    .publish(
-      `sessions.${sessionId}.events`,
-      enc.encode(JSON.stringify(payload)),
-    );
+async function publishLegacy(sessionId: string, payload: unknown): Promise<void> {
+  await nc.jetstream().publish(`sessions.${sessionId}.events`, enc.encode(JSON.stringify(payload)));
 }
 
 describe("m_20260503_110250_remove_legacy_sessions_stream", () => {
   it("dumps messages to a JSONL backup, then deletes the stream", async () => {
     const home = await freshHome();
     await createLegacySessionsStream();
-    await publishLegacy("alpha", {
-      type: "session:start",
-      sessionId: "alpha",
-      n: 1,
-    });
-    await publishLegacy("alpha", {
-      type: "step:start",
-      sessionId: "alpha",
-      n: 2,
-    });
-    await publishLegacy("beta", {
-      type: "session:start",
-      sessionId: "beta",
-      n: 3,
-    });
+    await publishLegacy("alpha", { type: "session:start", sessionId: "alpha", n: 1 });
+    await publishLegacy("alpha", { type: "step:start", sessionId: "alpha", n: 2 });
+    await publishLegacy("beta", { type: "session:start", sessionId: "beta", n: 3 });
 
     const facade = createJetStreamFacade(nc);
     await migration.run({ nc, js: facade, logger: noopLogger });
@@ -135,9 +107,7 @@ describe("m_20260503_110250_remove_legacy_sessions_stream", () => {
       expect(typeof r.data).toBe("string");
       expect(typeof r.time).toBe("string");
       expect(r.time).toMatch(/Z$/);
-      expect(JSON.parse(r.data as string)).toMatchObject({
-        sessionId: expect.any(String),
-      });
+      expect(JSON.parse(r.data as string)).toMatchObject({ sessionId: expect.any(String) });
     }
   });
 
@@ -145,9 +115,7 @@ describe("m_20260503_110250_remove_legacy_sessions_stream", () => {
     const home = await freshHome();
     const facade = createJetStreamFacade(nc);
 
-    await expect(
-      migration.run({ nc, js: facade, logger: noopLogger }),
-    ).resolves.toBeUndefined();
+    await expect(migration.run({ nc, js: facade, logger: noopLogger })).resolves.toBeUndefined();
 
     const isoDate = new Date().toISOString().slice(0, 10);
     const backupPath = join(home, `legacy-sessions-backup-${isoDate}.jsonl`);
@@ -157,11 +125,7 @@ describe("m_20260503_110250_remove_legacy_sessions_stream", () => {
   it("preserves an existing same-day backup file by suffixing the new one", async () => {
     const home = await freshHome();
     await createLegacySessionsStream();
-    await publishLegacy("gamma", {
-      type: "session:start",
-      sessionId: "gamma",
-      n: 1,
-    });
+    await publishLegacy("gamma", { type: "session:start", sessionId: "gamma", n: 1 });
 
     // Plant a prior backup at the canonical path — simulates a rerun
     // after a previous crash between backup-write and stream-delete.
@@ -178,9 +142,7 @@ describe("m_20260503_110250_remove_legacy_sessions_stream", () => {
     // A second backup file written with an epoch suffix.
     const files = await readdir(home);
     const suffixed = files.filter(
-      (f) =>
-        f.startsWith(`legacy-sessions-backup-${isoDate}-`) &&
-        f.endsWith(".jsonl"),
+      (f) => f.startsWith(`legacy-sessions-backup-${isoDate}-`) && f.endsWith(".jsonl"),
     );
     expect(suffixed).toHaveLength(1);
 

--- a/apps/atlasd/src/migrations/m_20260503_110250_remove_legacy_sessions_stream.test.ts
+++ b/apps/atlasd/src/migrations/m_20260503_110250_remove_legacy_sessions_stream.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Integration test: legacy SESSIONS-stream retirement migration.
+ *
+ * Spins up a real NATS test server, primes a `SESSIONS` stream with
+ * the pre-PR-#164 shape (subjects `sessions.*.events`), publishes a
+ * handful of events, runs the migration, and asserts (a) the stream
+ * is gone, (b) a JSONL backup file exists at the expected path with
+ * one record per published event.
+ */
+
+import { startNatsTestServer, type TestNatsServer } from "@atlas/core/test-utils/nats-test-server";
+import type { Logger } from "@atlas/logger";
+import { createJetStreamFacade, enc } from "jetstream";
+import { connect, type NatsConnection, RetentionPolicy, StorageType } from "nats";
+import { mkdtemp, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { migration } from "./m_20260503_110250_remove_legacy_sessions_stream.ts";
+
+let server: TestNatsServer;
+let nc: NatsConnection;
+let tmpHome: string;
+let originalHome: string | undefined;
+
+const noopLogger: Logger = {
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+  child: () => noopLogger,
+};
+
+beforeAll(async () => {
+  server = await startNatsTestServer();
+  nc = await connect({ servers: server.url });
+  originalHome = process.env.FRIDAY_HOME;
+}, 30_000);
+
+afterAll(async () => {
+  await nc.drain();
+  await server.stop();
+  if (originalHome === undefined) delete process.env.FRIDAY_HOME;
+  else process.env.FRIDAY_HOME = originalHome;
+});
+
+afterEach(async () => {
+  // Tear down whatever the migration / a test left behind so each
+  // case starts from a clean broker state.
+  const facade = createJetStreamFacade(nc);
+  await facade.stream.delete("SESSIONS");
+  if (tmpHome) {
+    await rm(tmpHome, { recursive: true, force: true });
+  }
+});
+
+async function freshHome(): Promise<string> {
+  tmpHome = await mkdtemp(join(tmpdir(), "atlas-legacy-sessions-"));
+  process.env.FRIDAY_HOME = tmpHome;
+  return tmpHome;
+}
+
+async function createLegacySessionsStream(): Promise<void> {
+  const jsm = await nc.jetstreamManager();
+  await jsm.streams.add({
+    name: "SESSIONS",
+    subjects: ["sessions.*.events"],
+    retention: RetentionPolicy.Limits,
+    storage: StorageType.File,
+  });
+}
+
+async function publishLegacy(sessionId: string, payload: unknown): Promise<void> {
+  await nc
+    .jetstream()
+    .publish(`sessions.${sessionId}.events`, enc.encode(JSON.stringify(payload)));
+}
+
+describe("m_20260503_110250_remove_legacy_sessions_stream", () => {
+  it("dumps messages to a JSONL backup, then deletes the stream", async () => {
+    const home = await freshHome();
+    await createLegacySessionsStream();
+    await publishLegacy("alpha", { type: "session:start", sessionId: "alpha", n: 1 });
+    await publishLegacy("alpha", { type: "step:start", sessionId: "alpha", n: 2 });
+    await publishLegacy("beta", { type: "session:start", sessionId: "beta", n: 3 });
+
+    const facade = createJetStreamFacade(nc);
+    await migration.run({ nc, js: facade, logger: noopLogger });
+
+    expect(await facade.stream.info("SESSIONS")).toBeNull();
+
+    const isoDate = new Date().toISOString().slice(0, 10);
+    const backupPath = join(home, `legacy-sessions-backup-${isoDate}.jsonl`);
+    const body = await readFile(backupPath, "utf-8");
+    const lines = body.trim().split("\n");
+    expect(lines).toHaveLength(3);
+
+    const records = lines.map((l) => JSON.parse(l) as Record<string, unknown>);
+    expect(records.map((r) => r.subject)).toEqual([
+      "sessions.alpha.events",
+      "sessions.alpha.events",
+      "sessions.beta.events",
+    ]);
+    expect(records.map((r) => r.seq)).toEqual([1, 2, 3]);
+    for (const r of records) {
+      expect(typeof r.data).toBe("string");
+      expect(typeof r.time).toBe("string");
+      expect(r.time).toMatch(/Z$/);
+      expect(JSON.parse(r.data as string)).toMatchObject({ sessionId: expect.any(String) });
+    }
+  });
+
+  it("is a no-op when SESSIONS does not exist", async () => {
+    const home = await freshHome();
+    const facade = createJetStreamFacade(nc);
+
+    await expect(
+      migration.run({ nc, js: facade, logger: noopLogger }),
+    ).resolves.toBeUndefined();
+
+    const isoDate = new Date().toISOString().slice(0, 10);
+    const backupPath = join(home, `legacy-sessions-backup-${isoDate}.jsonl`);
+    await expect(readFile(backupPath, "utf-8")).rejects.toThrow();
+  });
+
+  it("preserves an existing same-day backup file by suffixing the new one", async () => {
+    const home = await freshHome();
+    await createLegacySessionsStream();
+    await publishLegacy("gamma", { type: "session:start", sessionId: "gamma", n: 1 });
+
+    // Plant a prior backup at the canonical path — simulates a rerun
+    // after a previous crash between backup-write and stream-delete.
+    const isoDate = new Date().toISOString().slice(0, 10);
+    const canonicalPath = join(home, `legacy-sessions-backup-${isoDate}.jsonl`);
+    await writeFile(canonicalPath, "PRIOR_BACKUP\n", { encoding: "utf-8" });
+
+    const facade = createJetStreamFacade(nc);
+    await migration.run({ nc, js: facade, logger: noopLogger });
+
+    // Prior file untouched.
+    expect(await readFile(canonicalPath, "utf-8")).toBe("PRIOR_BACKUP\n");
+
+    // A second backup file written with an epoch suffix.
+    const files = await readdir(home);
+    const suffixed = files.filter(
+      (f) =>
+        f.startsWith(`legacy-sessions-backup-${isoDate}-`) && f.endsWith(".jsonl"),
+    );
+    expect(suffixed).toHaveLength(1);
+
+    expect(await facade.stream.info("SESSIONS")).toBeNull();
+  });
+});

--- a/apps/atlasd/src/migrations/m_20260503_110250_remove_legacy_sessions_stream.ts
+++ b/apps/atlasd/src/migrations/m_20260503_110250_remove_legacy_sessions_stream.ts
@@ -65,7 +65,10 @@ export const migration: Migration = {
     }
 
     const isoDate = new Date().toISOString().slice(0, 10);
-    const baseBackupPath = join(getFridayHome(), `legacy-sessions-backup-${isoDate}.jsonl`);
+    const baseBackupPath = join(
+      getFridayHome(),
+      `legacy-sessions-backup-${isoDate}.jsonl`,
+    );
     const backupPath = await uniqueBackupPath(baseBackupPath);
     const tmpPath = `${backupPath}.tmp`;
 
@@ -114,16 +117,20 @@ export const migration: Migration = {
       try {
         await jsm.consumers.delete(STREAM_NAME, consumerName);
       } catch (err) {
-        logger.warn("Failed to delete backup consumer; relying on inactive_threshold", {
-          consumerName,
-          error: stringifyError(err),
-        });
+        logger.warn(
+          "Failed to delete backup consumer; relying on inactive_threshold",
+          {
+            consumerName,
+            error: stringifyError(err),
+          },
+        );
       }
     }
 
     // Atomic-ish write: dump to .tmp then rename, so a crash mid-write
     // never leaves a partial file standing in for a successful backup.
-    const body = records.map((r) => JSON.stringify(r)).join("\n") + (records.length > 0 ? "\n" : "");
+    const body = records.map((r) => JSON.stringify(r)).join("\n") +
+      (records.length > 0 ? "\n" : "");
     await writeFile(tmpPath, body, { encoding: "utf-8" });
     await rename(tmpPath, backupPath);
 

--- a/apps/atlasd/src/migrations/m_20260503_110250_remove_legacy_sessions_stream.ts
+++ b/apps/atlasd/src/migrations/m_20260503_110250_remove_legacy_sessions_stream.ts
@@ -1,0 +1,137 @@
+/**
+ * Migration: delete the legacy `SESSIONS` JetStream stream after dumping
+ * its contents to a JSONL backup at
+ * `~/.atlas/legacy-sessions-backup-<YYYY-MM-DD>.jsonl`.
+ *
+ * Background: PR #164 (2026-05-04) introduced `SESSION_EVENTS` with
+ * subjects `sessions.>`, but left the legacy `SESSIONS` stream
+ * (subjects `sessions.*.events`) in place. JetStream rejects the v2
+ * stream creation at runtime because `sessions.*.events` ⊂ `sessions.>`
+ * — subjects overlap. This migration retires the legacy stream so the
+ * sibling `m_20260503_110300_sessions_v2_to_jetstream` migration (which
+ * sorts immediately after this one) can create `SESSION_EVENTS`.
+ *
+ * Idempotent:
+ *   - If `SESSIONS` doesn't exist, no-op (fresh installs, or reruns
+ *     after success).
+ *   - If a backup file at the chosen path already exists (rerun after
+ *     a crash between backup-write and stream-delete), append a
+ *     millisecond suffix so the prior backup is preserved.
+ */
+
+import { stringifyError } from "@atlas/utils";
+import { getFridayHome } from "@atlas/utils/paths.server";
+import { dec } from "jetstream";
+import type { Migration } from "jetstream";
+import { AckPolicy, DeliverPolicy } from "nats";
+import { rename, stat, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+
+const STREAM_NAME = "SESSIONS";
+const FETCH_BATCH = 500;
+/** Auto-clean ephemeral consumer if we crash mid-fetch. */
+const CONSUMER_INACTIVE_NS = 5_000_000_000;
+
+interface BackupRecord {
+  subject: string;
+  seq: number;
+  data: string;
+  time: string;
+}
+
+async function uniqueBackupPath(base: string): Promise<string> {
+  try {
+    await stat(base);
+  } catch {
+    return base;
+  }
+  return `${base.replace(/\.jsonl$/, "")}-${Date.now()}.jsonl`;
+}
+
+export const migration: Migration = {
+  id: "20260503_110250_remove_legacy_sessions_stream",
+  name: "delete legacy SESSIONS stream (with JSONL backup)",
+  description:
+    "Drop the pre-PR-#164 SESSIONS stream (subjects sessions.*.events) " +
+    "after dumping its contents to ~/.atlas/legacy-sessions-backup-" +
+    "<YYYY-MM-DD>.jsonl. The retained subject namespace overlaps with " +
+    "SESSION_EVENTS (subjects sessions.>) and blocks v2 stream creation. " +
+    "Idempotent: no-op when SESSIONS is absent.",
+  async run({ nc, js, logger }) {
+    const info = await js.stream.info(STREAM_NAME);
+    if (!info) {
+      logger.debug("Legacy SESSIONS stream not present — nothing to retire");
+      return;
+    }
+
+    const isoDate = new Date().toISOString().slice(0, 10);
+    const baseBackupPath = join(getFridayHome(), `legacy-sessions-backup-${isoDate}.jsonl`);
+    const backupPath = await uniqueBackupPath(baseBackupPath);
+    const tmpPath = `${backupPath}.tmp`;
+
+    const jsm = await nc.jetstreamManager();
+    const consumerName = `legacy-sessions-backup-${Date.now()}`;
+    await jsm.consumers.add(STREAM_NAME, {
+      name: consumerName,
+      deliver_policy: DeliverPolicy.All,
+      ack_policy: AckPolicy.None,
+      inactive_threshold: CONSUMER_INACTIVE_NS,
+    });
+
+    const records: BackupRecord[] = [];
+    try {
+      const jsClient = nc.jetstream();
+      const consumer = await jsClient.consumers.get(STREAM_NAME, consumerName);
+      const consumerInfo = await consumer.info();
+      const total = Number(consumerInfo.num_pending);
+      let received = 0;
+      while (received < total) {
+        const batch = await consumer.fetch({
+          max_messages: Math.min(FETCH_BATCH, total - received),
+          expires: 1000,
+        });
+        for await (const msg of batch) {
+          received++;
+          let data: string;
+          try {
+            data = dec.decode(msg.data);
+          } catch {
+            // Lossless fallback: encode raw bytes as base64 with a marker
+            // prefix so a reader can distinguish from a UTF-8 payload.
+            const b64 = btoa(String.fromCharCode(...msg.data));
+            data = `__base64__:${b64}`;
+          }
+          const ms = Math.floor(Number(msg.info.timestampNanos) / 1_000_000);
+          records.push({
+            subject: msg.subject,
+            seq: Number(msg.seq),
+            data,
+            time: new Date(ms).toISOString(),
+          });
+        }
+      }
+    } finally {
+      try {
+        await jsm.consumers.delete(STREAM_NAME, consumerName);
+      } catch (err) {
+        logger.warn("Failed to delete backup consumer; relying on inactive_threshold", {
+          consumerName,
+          error: stringifyError(err),
+        });
+      }
+    }
+
+    // Atomic-ish write: dump to .tmp then rename, so a crash mid-write
+    // never leaves a partial file standing in for a successful backup.
+    const body = records.map((r) => JSON.stringify(r)).join("\n") + (records.length > 0 ? "\n" : "");
+    await writeFile(tmpPath, body, { encoding: "utf-8" });
+    await rename(tmpPath, backupPath);
+
+    await js.stream.delete(STREAM_NAME);
+
+    logger.info("Retired legacy SESSIONS stream", {
+      backupPath,
+      messagesBackedUp: records.length,
+    });
+  },
+};

--- a/apps/atlasd/src/migrations/m_20260503_110250_remove_legacy_sessions_stream.ts
+++ b/apps/atlasd/src/migrations/m_20260503_110250_remove_legacy_sessions_stream.ts
@@ -19,13 +19,13 @@
  *     millisecond suffix so the prior backup is preserved.
  */
 
-import { stringifyError } from "@atlas/utils";
-import { getFridayHome } from "@atlas/utils/paths.server";
-import { dec } from "jetstream";
-import type { Migration } from "jetstream";
-import { AckPolicy, DeliverPolicy } from "nats";
 import { rename, stat, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import { stringifyError } from "@atlas/utils";
+import { getFridayHome } from "@atlas/utils/paths.server";
+import type { Migration } from "jetstream";
+import { dec } from "jetstream";
+import { AckPolicy, DeliverPolicy } from "nats";
 
 const STREAM_NAME = "SESSIONS";
 const FETCH_BATCH = 500;
@@ -65,10 +65,7 @@ export const migration: Migration = {
     }
 
     const isoDate = new Date().toISOString().slice(0, 10);
-    const baseBackupPath = join(
-      getFridayHome(),
-      `legacy-sessions-backup-${isoDate}.jsonl`,
-    );
+    const baseBackupPath = join(getFridayHome(), `legacy-sessions-backup-${isoDate}.jsonl`);
     const backupPath = await uniqueBackupPath(baseBackupPath);
     const tmpPath = `${backupPath}.tmp`;
 
@@ -117,28 +114,22 @@ export const migration: Migration = {
       try {
         await jsm.consumers.delete(STREAM_NAME, consumerName);
       } catch (err) {
-        logger.warn(
-          "Failed to delete backup consumer; relying on inactive_threshold",
-          {
-            consumerName,
-            error: stringifyError(err),
-          },
-        );
+        logger.warn("Failed to delete backup consumer; relying on inactive_threshold", {
+          consumerName,
+          error: stringifyError(err),
+        });
       }
     }
 
     // Atomic-ish write: dump to .tmp then rename, so a crash mid-write
     // never leaves a partial file standing in for a successful backup.
-    const body = records.map((r) => JSON.stringify(r)).join("\n") +
-      (records.length > 0 ? "\n" : "");
+    const body =
+      records.map((r) => JSON.stringify(r)).join("\n") + (records.length > 0 ? "\n" : "");
     await writeFile(tmpPath, body, { encoding: "utf-8" });
     await rename(tmpPath, backupPath);
 
     await js.stream.delete(STREAM_NAME);
 
-    logger.info("Retired legacy SESSIONS stream", {
-      backupPath,
-      messagesBackedUp: records.length,
-    });
+    logger.info("Retired legacy SESSIONS stream", { backupPath, messagesBackedUp: records.length });
   },
 };

--- a/apps/atlasd/src/nats-session-stream.ts
+++ b/apps/atlasd/src/nats-session-stream.ts
@@ -1,13 +1,13 @@
 /**
- * NATS JetStream-backed session event stream.
+ * NATS-backed session event stream.
  *
- * Publishes durable events to the SESSIONS JetStream stream so they survive
- * daemon restarts and are replayable by SSE subscribers. Also maintains an
- * in-memory buffer for fast access (list/get endpoints) and persists events
- * via the disk adapter.
+ * Persists durable events through the JetStream-backed history adapter
+ * (which publishes them to the SESSION_EVENTS stream with per-event
+ * `Nats-Msg-Id` dedup). Also maintains an in-memory buffer for fast
+ * access by list/get endpoints.
  *
- * Ephemeral chunks (streaming LLM tokens) go to a NATS core subject — live
- * only, no persistence, no replay.
+ * Ephemeral chunks (streaming LLM tokens) go to a NATS core subject —
+ * live only, no persistence, no replay.
  *
  * @module
  */
@@ -19,38 +19,26 @@ import type {
   SessionSummary,
 } from "@atlas/core";
 import { logger } from "@atlas/logger";
-import type { JetStreamClient, NatsConnection } from "nats";
+import type { NatsConnection } from "nats";
 
 export class NatsSessionStream {
   private readonly events: SessionStreamEvent[] = [];
   private active = true;
   private pendingWriteCount = 0;
   private readonly flushResolvers: Array<() => void> = [];
-  private readonly js: JetStreamClient;
 
   constructor(
     private readonly sessionId: string,
     private readonly adapter: SessionHistoryAdapter,
     private readonly nc: NatsConnection,
-  ) {
-    this.js = nc.jetstream();
-  }
+  ) {}
 
   /**
-   * Emit a durable event: buffer it, publish to JetStream, and persist to disk.
+   * Emit a durable event: buffer it and persist via the history adapter.
    */
   emit(event: SessionStreamEvent): void {
     this.events.push(event);
 
-    // Publish to JetStream (durable, replayable by SSE subscribers on reconnect)
-    this.js.publish(`sessions.${this.sessionId}.events`, JSON.stringify(event)).catch((err) => {
-      logger.warn("Failed to publish session event to NATS", {
-        sessionId: this.sessionId,
-        error: String(err),
-      });
-    });
-
-    // Persist to disk adapter
     this.pendingWriteCount++;
     this.adapter
       .appendEvent(this.sessionId, event)

--- a/apps/atlasd/src/session-stream-registry.test.ts
+++ b/apps/atlasd/src/session-stream-registry.test.ts
@@ -23,7 +23,7 @@ function mockNatsConnection(): NatsConnection {
   const jsMock = {
     publish: vi
       .fn<() => Promise<{ stream: string; seq: number }>>()
-      .mockResolvedValue({ stream: "SESSIONS", seq: 1 }),
+      .mockResolvedValue({ stream: "SESSION_EVENTS", seq: 1 }),
   };
   return {
     jetstream: vi.fn<() => typeof jsMock>().mockReturnValue(jsMock),


### PR DESCRIPTION
## Summary

- Decommissions the legacy `SESSIONS` JetStream stream (subjects `sessions.*.events`) left in place by #164. The new `SESSION_EVENTS` stream (subjects `sessions.>`) couldn't be lazily created at runtime because subjects overlap → 98+ `Failed to persist session event` warnings per chat session and HTTP 500 on every `GET /api/sessions/<id>`.
- New idempotent migration `m_20260503_110250_remove_legacy_sessions_stream.ts` dumps the legacy stream to JSONL (`~/.atlas/legacy-sessions-backup-<YYYY-MM-DD>.jsonl`) before `streams.delete("SESSIONS")`. Slug `_110250` sorts immediately before the v2 creation migration `_110300` so existing PR #164 deployments are repaired on next boot — no operator action.
- Removes `ensureSessionsStream()` (which kept recreating the legacy stream every boot) and the direct `js.publish` in `NatsSessionStream.emit()` (which was double-publishing alongside `adapter.appendEvent`). All three changes are interlocking — they MUST land together. Commit 1 alone would leave `ensureSessionsStream` recreating `SESSIONS` on next boot; commit 2 alone wouldn't clean up existing brokers.

## Test Plan

- [x] `deno check` clean for all 6 changed files
- [x] `deno task test apps/atlasd` → 4951 passed / 26 skipped / 0 failed
- [x] New migration integration test (real NATS test server per #164's convention) — 3/3 scenarios passing:
  - Happy path: pre-populated `SESSIONS` → JSONL backup written + stream deleted
  - No-op: SESSIONS absent → resolves cleanly, no backup file created
  - Rerun safety: existing same-day backup → epoch-suffixed new file written, prior backup untouched
- [x] **Dogfood verification on a real broker that had the bug:**
  - Migration applied at 14:18:30Z, audit entry recorded as `success`
  - Backup written: `~/.atlas/legacy-sessions-backup-2026-05-04.jsonl`, 80 events, valid JSONL with full schema (subject/seq/data/time)
  - `SESSIONS` stream gone; `SESSION_EVENTS` lazy-created with subjects `sessions.>` on first session event
  - Zero `subjects overlap` errors and zero `Failed to persist session event` warns since the post-fix daemon boot
  - `GET /api/sessions/<fresh-id>` returns HTTP 200 with full session JSON (was 500 pre-fix)
  - `GET /api/sessions/<orphaned-pre-fix-id>` returns HTTP 410 "outdated storage format" — graceful degradation for sessions whose events lived in the now-deleted legacy stream (was 500)

## Notes for review

- The migration's base64 fallback uses `String.fromCharCode(...msg.data)`, which can stack-overflow on very large messages. `SessionStreamEvent` payloads are KB-scale JSON so practically fine, but a future consistency pass could swap to `Buffer.from(...).toString("base64")` or a chunked loop.
- File I/O uses `node:fs/promises`; `m_20260503_110300` uses `Deno.*`. Both work, codebase mixes them — not in this PR's scope.
- `m_20260502_140000_sessions_stream_upgrade.ts` is **intentionally left in place**. It's already idempotent (early-returns when `SESSIONS` is absent) so it becomes a harmless no-op once retired. Touching it would mean reconciling the `_FRIDAY_MIGRATIONS` audit row — out of scope.