### PR TITLE
fix(artifacts): persist correct mime for agent-created files

### DIFF
--- a/apps/atlasd/routes/artifacts.test.ts
+++ b/apps/atlasd/routes/artifacts.test.ts
@@ -773,6 +773,39 @@ describe("Content endpoint", () => {
     expect(htmlCsp).toContain("allow-scripts");
   });
 
+  it("sandboxes XHTML artifact content the same as HTML", async () => {
+    // XHTML is rendered as a document and executes `<script>` exactly like
+    // text/html. Without the sandbox the embedded script would run
+    // same-origin against the daemon.
+    const createResponse = await artifactsApp.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "XHTML report",
+        summary: "XHTML report with active content",
+        data: {
+          type: "file",
+          content:
+            '<?xml version="1.0"?><html xmlns="http://www.w3.org/1999/xhtml"><body><script>parent.document.body.dataset.pwned = "true"</script></body></html>',
+          mimeType: "application/xhtml+xml",
+          originalName: "report.xhtml",
+        },
+      }),
+    });
+    expect(createResponse.status).toEqual(201);
+    const { artifact } = ArtifactResponseSchema.parse(await createResponse.json());
+
+    const contentResponse = await artifactsApp.request(`/${artifact.id}/content`, {
+      method: "GET",
+    });
+
+    expect(contentResponse.status).toEqual(200);
+    expect(contentResponse.headers.get("Content-Type")).toEqual("application/xhtml+xml");
+    const xhtmlCsp = contentResponse.headers.get("Content-Security-Policy") ?? "";
+    expect(xhtmlCsp).toContain("sandbox");
+    expect(xhtmlCsp).toContain("allow-scripts");
+  });
+
   it("sandboxes SVG artifact content (X-Content-Type-Options does not stop SVG scripts)", async () => {
     // SVG served same-origin can execute embedded `<script>` regardless
     // of `nosniff`. The CSP sandbox directive is the only thing that

--- a/apps/atlasd/routes/artifacts.test.ts
+++ b/apps/atlasd/routes/artifacts.test.ts
@@ -767,6 +767,37 @@ describe("Content endpoint", () => {
     expect(contentResponse.headers.get("Content-Type")).toEqual("text/html");
     expect(contentResponse.headers.get("Content-Security-Policy")).toContain("sandbox");
   });
+
+  it("sandboxes SVG artifact content (X-Content-Type-Options does not stop SVG scripts)", async () => {
+    // SVG served same-origin can execute embedded `<script>` regardless
+    // of `nosniff`. The CSP sandbox directive is the only thing that
+    // blocks it — ship it on `image/svg+xml` for parity with text/html.
+    const createResponse = await artifactsApp.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "SVG icon",
+        summary: "SVG with embedded script that should be sandboxed",
+        data: {
+          type: "file",
+          content:
+            '<svg xmlns="http://www.w3.org/2000/svg"><script>parent.document.body.dataset.pwned = "true"</script></svg>',
+          mimeType: "image/svg+xml",
+          originalName: "icon.svg",
+        },
+      }),
+    });
+    expect(createResponse.status).toEqual(201);
+    const { artifact } = ArtifactResponseSchema.parse(await createResponse.json());
+
+    const contentResponse = await artifactsApp.request(`/${artifact.id}/content`, {
+      method: "GET",
+    });
+
+    expect(contentResponse.status).toEqual(200);
+    expect(contentResponse.headers.get("Content-Type")).toEqual("image/svg+xml");
+    expect(contentResponse.headers.get("Content-Security-Policy")).toContain("sandbox");
+  });
 });
 
 describe("PDF upload integration", () => {

--- a/apps/atlasd/routes/artifacts.test.ts
+++ b/apps/atlasd/routes/artifacts.test.ts
@@ -765,7 +765,12 @@ describe("Content endpoint", () => {
 
     expect(contentResponse.status).toEqual(200);
     expect(contentResponse.headers.get("Content-Type")).toEqual("text/html");
-    expect(contentResponse.headers.get("Content-Security-Policy")).toContain("sandbox");
+    // HTML gets `allow-scripts` so legit agent-rendered pages (Leaflet,
+    // charts, embedded viewers) can run. The opaque-origin sandbox is
+    // what isolates them from the parent.
+    const htmlCsp = contentResponse.headers.get("Content-Security-Policy") ?? "";
+    expect(htmlCsp).toContain("sandbox");
+    expect(htmlCsp).toContain("allow-scripts");
   });
 
   it("sandboxes SVG artifact content (X-Content-Type-Options does not stop SVG scripts)", async () => {
@@ -796,7 +801,11 @@ describe("Content endpoint", () => {
 
     expect(contentResponse.status).toEqual(200);
     expect(contentResponse.headers.get("Content-Type")).toEqual("image/svg+xml");
-    expect(contentResponse.headers.get("Content-Security-Policy")).toContain("sandbox");
+    // SVG renders as an image — no `<script>` should ever execute.
+    // Sandbox stays on, but `allow-scripts` is intentionally absent.
+    const svgCsp = contentResponse.headers.get("Content-Security-Policy") ?? "";
+    expect(svgCsp).toContain("sandbox");
+    expect(svgCsp).not.toContain("allow-scripts");
   });
 });
 

--- a/apps/atlasd/routes/artifacts.test.ts
+++ b/apps/atlasd/routes/artifacts.test.ts
@@ -740,6 +740,33 @@ describe("Content endpoint", () => {
     expect(cd.split(";")[0]?.trim()).toEqual("attachment");
     expect(cd).toContain('filename="data.json"');
   });
+
+  it("sandboxes inline HTML artifact content", async () => {
+    const createResponse = await artifactsApp.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "HTML report",
+        summary: "HTML report with active content",
+        data: {
+          type: "file",
+          content: "<script>parent.document.body.dataset.pwned = 'true'</script>",
+          mimeType: "text/html",
+          originalName: "report.html",
+        },
+      }),
+    });
+    expect(createResponse.status).toEqual(201);
+    const { artifact } = ArtifactResponseSchema.parse(await createResponse.json());
+
+    const contentResponse = await artifactsApp.request(`/${artifact.id}/content`, {
+      method: "GET",
+    });
+
+    expect(contentResponse.status).toEqual(200);
+    expect(contentResponse.headers.get("Content-Type")).toEqual("text/html");
+    expect(contentResponse.headers.get("Content-Security-Policy")).toContain("sandbox");
+  });
 });
 
 describe("PDF upload integration", () => {

--- a/apps/atlasd/routes/artifacts.test.ts
+++ b/apps/atlasd/routes/artifacts.test.ts
@@ -806,6 +806,78 @@ describe("Content endpoint", () => {
     expect(xhtmlCsp).toContain("allow-scripts");
   });
 
+  it("sandboxes HTML artifact content even when mime carries a charset parameter", async () => {
+    // Storage adapters that round-trip text mimes with a charset (e.g.
+    // `text/html; charset=utf-8`) used to bypass the sandbox because the
+    // route keyed the CSP gate off raw `mimeType` equality. The browser
+    // still parses such responses as HTML, so the sandbox MUST apply.
+    const createResponse = await artifactsApp.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "HTML with charset",
+        summary: "HTML report whose stored mime carries a charset parameter",
+        data: {
+          type: "file",
+          content: "<script>parent.document.body.dataset.pwned = 'true'</script>",
+          mimeType: "text/html; charset=utf-8",
+          originalName: "report.html",
+        },
+      }),
+    });
+    expect(createResponse.status).toEqual(201);
+    const { artifact } = ArtifactResponseSchema.parse(await createResponse.json());
+
+    const contentResponse = await artifactsApp.request(`/${artifact.id}/content`, {
+      method: "GET",
+    });
+
+    expect(contentResponse.status).toEqual(200);
+    // Response Content-Type preserves the charset for the browser.
+    expect(contentResponse.headers.get("Content-Type")).toEqual("text/html; charset=utf-8");
+    const csp = contentResponse.headers.get("Content-Security-Policy") ?? "";
+    expect(csp).toContain("sandbox");
+    expect(csp).toContain("allow-scripts");
+  });
+
+  it("does not set a CSP for benign mimes (PNG)", async () => {
+    // Locks the contract that the CSP sandbox is mime-keyed: ordinary
+    // image/audio/document responses must not inherit the active-content
+    // restrictions, otherwise a future refactor that broadens the gate
+    // would ship without breaking the HTML/SVG tests.
+    const pngBytes = new Uint8Array([
+      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
+      0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f,
+      0x15, 0xc4, 0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x62, 0x00,
+      0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49,
+      0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
+    ]);
+    const createResponse = await artifactsApp.request("/", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        title: "Benign image",
+        summary: "PNG that should not receive a CSP header",
+        data: {
+          type: "file",
+          content: btoa(String.fromCharCode(...pngBytes)),
+          contentEncoding: "base64",
+          mimeType: "image/png",
+          originalName: "tiny.png",
+        },
+      }),
+    });
+    expect(createResponse.status).toEqual(201);
+    const { artifact } = ArtifactResponseSchema.parse(await createResponse.json());
+
+    const contentResponse = await artifactsApp.request(`/${artifact.id}/content`, {
+      method: "GET",
+    });
+
+    expect(contentResponse.status).toEqual(200);
+    expect(contentResponse.headers.get("Content-Security-Policy")).toBeNull();
+  });
+
   it("sandboxes SVG artifact content (X-Content-Type-Options does not stop SVG scripts)", async () => {
     // SVG served same-origin can execute embedded `<script>` regardless
     // of `nosniff`. The CSP sandbox directive is the only thing that

--- a/apps/atlasd/routes/artifacts.test.ts
+++ b/apps/atlasd/routes/artifacts.test.ts
@@ -709,6 +709,10 @@ describe("Content endpoint", () => {
 
     expect(contentResponse.status).toEqual(200);
     expect(contentResponse.headers.get("X-Content-Type-Options")).toEqual("nosniff");
+    // The CSP sandbox is mime-keyed to active-content responses
+    // (HTML/XHTML/SVG). Benign images must NOT inherit the restriction —
+    // a future refactor that broadens the gate would be caught here.
+    expect(contentResponse.headers.get("Content-Security-Policy")).toBeNull();
     // Disposition carries a filename hint after the type, so split on the
     // first `;` and check the leading token. The full header looks like
     // `inline; filename="sec.png"; filename*=UTF-8''sec.png` — see
@@ -736,6 +740,8 @@ describe("Content endpoint", () => {
 
     expect(contentResponse.status).toEqual(200);
     expect(contentResponse.headers.get("X-Content-Type-Options")).toEqual("nosniff");
+    // No CSP for application/json: JSON is not active content.
+    expect(contentResponse.headers.get("Content-Security-Policy")).toBeNull();
     const cd = contentResponse.headers.get("Content-Disposition") ?? "";
     expect(cd.split(";")[0]?.trim()).toEqual("attachment");
     expect(cd).toContain('filename="data.json"');
@@ -838,44 +844,6 @@ describe("Content endpoint", () => {
     const csp = contentResponse.headers.get("Content-Security-Policy") ?? "";
     expect(csp).toContain("sandbox");
     expect(csp).toContain("allow-scripts");
-  });
-
-  it("does not set a CSP for benign mimes (PNG)", async () => {
-    // Locks the contract that the CSP sandbox is mime-keyed: ordinary
-    // image/audio/document responses must not inherit the active-content
-    // restrictions, otherwise a future refactor that broadens the gate
-    // would ship without breaking the HTML/SVG tests.
-    const pngBytes = new Uint8Array([
-      0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44,
-      0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1f,
-      0x15, 0xc4, 0x89, 0x00, 0x00, 0x00, 0x0d, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9c, 0x62, 0x00,
-      0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0d, 0x0a, 0x2d, 0xb4, 0x00, 0x00, 0x00, 0x00, 0x49,
-      0x45, 0x4e, 0x44, 0xae, 0x42, 0x60, 0x82,
-    ]);
-    const createResponse = await artifactsApp.request("/", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        title: "Benign image",
-        summary: "PNG that should not receive a CSP header",
-        data: {
-          type: "file",
-          content: btoa(String.fromCharCode(...pngBytes)),
-          contentEncoding: "base64",
-          mimeType: "image/png",
-          originalName: "tiny.png",
-        },
-      }),
-    });
-    expect(createResponse.status).toEqual(201);
-    const { artifact } = ArtifactResponseSchema.parse(await createResponse.json());
-
-    const contentResponse = await artifactsApp.request(`/${artifact.id}/content`, {
-      method: "GET",
-    });
-
-    expect(contentResponse.status).toEqual(200);
-    expect(contentResponse.headers.get("Content-Security-Policy")).toBeNull();
   });
 
   it("sandboxes SVG artifact content (X-Content-Type-Options does not stop SVG scripts)", async () => {

--- a/apps/atlasd/routes/artifacts.ts
+++ b/apps/atlasd/routes/artifacts.ts
@@ -794,15 +794,22 @@ const artifactsApp = daemonFactory
       }
 
       const { mimeType, originalName } = artifact.data;
+      // Strip mime parameters (`; charset=…`) for predicates. Storage adapters
+      // can round-trip text mimes with a charset attached (e.g.
+      // `text/html; charset=utf-8`); without normalization the equality
+      // checks below silently miss and the CSP sandbox fails to apply on
+      // what the browser still parses as HTML. The response `Content-Type`
+      // keeps the original value so the browser sees the charset.
+      const baseMime = mimeType.split(";")[0]?.trim() || mimeType;
       // Mimes the browser renders inline in an `<iframe>` or `<img>`. Anything
       // else triggers a download. PDFs and HTML need `inline` so the chat
       // UI's artifact-card iframe shows a preview instead of pulling down a
       // copy and leaving the iframe blank.
       const isInlineRenderable =
-        isImageMimeType(mimeType) ||
-        mimeType === "application/pdf" ||
-        mimeType === "text/html" ||
-        mimeType === "text/plain";
+        isImageMimeType(baseMime) ||
+        baseMime === "application/pdf" ||
+        baseMime === "text/html" ||
+        baseMime === "text/plain";
       const disposition = isInlineRenderable ? "inline" : "attachment";
 
       // Filename hint so the browser uses something meaningful when the user
@@ -841,10 +848,10 @@ const artifactsApp = daemonFactory
       // XHTML is rendered as a document and executes `<script>` exactly
       // like text/html, so it gets the same sandbox treatment.
       let contentSecurityPolicy: string | undefined;
-      if (mimeType === "text/html" || mimeType === "application/xhtml+xml") {
+      if (baseMime === "text/html" || baseMime === "application/xhtml+xml") {
         contentSecurityPolicy =
           "sandbox allow-scripts; default-src https: data: blob: 'unsafe-inline' 'unsafe-eval'";
-      } else if (mimeType === "image/svg+xml") {
+      } else if (baseMime === "image/svg+xml") {
         contentSecurityPolicy =
           "sandbox; default-src 'none'; img-src data: blob:; style-src 'unsafe-inline'";
       }

--- a/apps/atlasd/routes/artifacts.ts
+++ b/apps/atlasd/routes/artifacts.ts
@@ -823,10 +823,14 @@ const artifactsApp = daemonFactory
       const asciiName = rawName.replace(/[^\x20-\x7e]+/g, "_").replace(/["\\]/g, "_");
       const utf8Name = encodeURIComponent(rawName);
       const contentDisposition = `${disposition}; filename="${asciiName}"; filename*=UTF-8''${utf8Name}`;
-      const contentSecurityPolicy =
-        mimeType === "text/html"
-          ? "sandbox; default-src 'none'; img-src data: blob:; style-src 'unsafe-inline'"
-          : undefined;
+      // Active-content mimes that the browser will execute scripts for
+      // when fetched same-origin. `X-Content-Type-Options: nosniff` does
+      // NOT stop an SVG `<script>` element from running, so SVG needs
+      // the same CSP sandbox as HTML.
+      const isActiveContentMime = mimeType === "text/html" || mimeType === "image/svg+xml";
+      const contentSecurityPolicy = isActiveContentMime
+        ? "sandbox; default-src 'none'; img-src data: blob:; style-src 'unsafe-inline'"
+        : undefined;
 
       const body = new Uint8Array(binaryResult.data);
       return new Response(body, {

--- a/apps/atlasd/routes/artifacts.ts
+++ b/apps/atlasd/routes/artifacts.ts
@@ -823,6 +823,10 @@ const artifactsApp = daemonFactory
       const asciiName = rawName.replace(/[^\x20-\x7e]+/g, "_").replace(/["\\]/g, "_");
       const utf8Name = encodeURIComponent(rawName);
       const contentDisposition = `${disposition}; filename="${asciiName}"; filename*=UTF-8''${utf8Name}`;
+      const contentSecurityPolicy =
+        mimeType === "text/html"
+          ? "sandbox; default-src 'none'; img-src data: blob:; style-src 'unsafe-inline'"
+          : undefined;
 
       const body = new Uint8Array(binaryResult.data);
       return new Response(body, {
@@ -833,6 +837,7 @@ const artifactsApp = daemonFactory
           "Content-Disposition": contentDisposition,
           "X-Content-Type-Options": "nosniff",
           "Cache-Control": "private, max-age=31536000, immutable",
+          ...(contentSecurityPolicy ? { "Content-Security-Policy": contentSecurityPolicy } : {}),
         },
       });
     },

--- a/apps/atlasd/routes/artifacts.ts
+++ b/apps/atlasd/routes/artifacts.ts
@@ -838,8 +838,10 @@ const artifactsApp = daemonFactory
       //
       // SVG stays scriptless: when a user views what's nominally an
       // image, no `<script>` should ever execute, regardless of source.
+      // XHTML is rendered as a document and executes `<script>` exactly
+      // like text/html, so it gets the same sandbox treatment.
       let contentSecurityPolicy: string | undefined;
-      if (mimeType === "text/html") {
+      if (mimeType === "text/html" || mimeType === "application/xhtml+xml") {
         contentSecurityPolicy =
           "sandbox allow-scripts; default-src https: data: blob: 'unsafe-inline' 'unsafe-eval'";
       } else if (mimeType === "image/svg+xml") {

--- a/apps/atlasd/routes/artifacts.ts
+++ b/apps/atlasd/routes/artifacts.ts
@@ -823,14 +823,29 @@ const artifactsApp = daemonFactory
       const asciiName = rawName.replace(/[^\x20-\x7e]+/g, "_").replace(/["\\]/g, "_");
       const utf8Name = encodeURIComponent(rawName);
       const contentDisposition = `${disposition}; filename="${asciiName}"; filename*=UTF-8''${utf8Name}`;
-      // Active-content mimes that the browser will execute scripts for
-      // when fetched same-origin. `X-Content-Type-Options: nosniff` does
-      // NOT stop an SVG `<script>` element from running, so SVG needs
-      // the same CSP sandbox as HTML.
-      const isActiveContentMime = mimeType === "text/html" || mimeType === "image/svg+xml";
-      const contentSecurityPolicy = isActiveContentMime
-        ? "sandbox; default-src 'none'; img-src data: blob:; style-src 'unsafe-inline'"
-        : undefined;
+      // Sandbox active-content mimes. The CSP `sandbox` directive (and
+      // the matching iframe `sandbox` attribute) drops the document
+      // into an opaque origin, which is the actual security boundary —
+      // scripts in the iframe can't reach the parent's cookies, storage,
+      // or DOM via the same-origin policy.
+      //
+      // HTML opts into `allow-scripts` so legit agent-rendered pages
+      // (Leaflet maps, charts, embedded viewers) actually run. The
+      // opaque-origin sandbox still blocks parent access, so this is
+      // not a regression on the threat model — it just lets the iframe
+      // execute the JS the agent wrote, which is the whole point of
+      // rendering HTML.
+      //
+      // SVG stays scriptless: when a user views what's nominally an
+      // image, no `<script>` should ever execute, regardless of source.
+      let contentSecurityPolicy: string | undefined;
+      if (mimeType === "text/html") {
+        contentSecurityPolicy =
+          "sandbox allow-scripts; default-src https: data: blob: 'unsafe-inline' 'unsafe-eval'";
+      } else if (mimeType === "image/svg+xml") {
+        contentSecurityPolicy =
+          "sandbox; default-src 'none'; img-src data: blob:; style-src 'unsafe-inline'";
+      }
 
       const body = new Uint8Array(binaryResult.data);
       return new Response(body, {

--- a/apps/atlasd/routes/artifacts.ts
+++ b/apps/atlasd/routes/artifacts.ts
@@ -30,6 +30,7 @@ import {
   MAX_IMAGE_SIZE,
   MAX_OFFICE_SIZE,
   MAX_PDF_SIZE,
+  stripMimeParams,
 } from "@atlas/core/artifacts/file-upload";
 import { ArtifactStorage } from "@atlas/core/artifacts/server";
 import { type PlatformModels, smallLLM } from "@atlas/llm";
@@ -800,7 +801,7 @@ const artifactsApp = daemonFactory
       // checks below silently miss and the CSP sandbox fails to apply on
       // what the browser still parses as HTML. The response `Content-Type`
       // keeps the original value so the browser sees the charset.
-      const baseMime = mimeType.split(";")[0]?.trim() || mimeType;
+      const baseMime = stripMimeParams(mimeType);
       // Mimes the browser renders inline in an `<iframe>` or `<img>`. Anything
       // else triggers a download. PDFs and HTML need `inline` so the chat
       // UI's artifact-card iframe shows a preview instead of pulling down a

--- a/packages/core/src/artifacts/file-upload.test.ts
+++ b/packages/core/src/artifacts/file-upload.test.ts
@@ -52,6 +52,42 @@ describe("deriveDownloadFilename", () => {
     expect(result).toBe("misnamed.png");
   });
 
+  it("preserves originalName when stored mime carries a charset parameter", () => {
+    // Storage adapters that normalize text mimes with charset round-trip
+    // them as `text/markdown; charset=utf-8`. The extension comparison
+    // must ignore the parameter — otherwise `notes.md` silently rewrites
+    // to `notes.markdown` because `extFromMime` strips the parameter
+    // while the equality check did not.
+    const result = deriveDownloadFilename({
+      mimeType: "text/markdown; charset=utf-8",
+      originalName: "notes.md",
+      title: "Notes",
+    });
+    expect(result).toBe("notes.md");
+  });
+
+  // Scrubber path with the hyphenated source-code mimes this PR
+  // introduces. Without reverse-map entries, `extFromMime` falls back
+  // to the alnum-only regex, rejects the hyphenated tail, and returns
+  // `bin` — leaving the placeholder unrepaired.
+  it.each([
+    ["text/x-typescript", "ts"],
+    ["text/x-python", "py"],
+    ["text/x-go", "go"],
+    ["text/x-rust", "rs"],
+    ["text/x-shellscript", "sh"],
+    ["text/x-sql", "sql"],
+    ["text/x-toml", "toml"],
+    ["text/tab-separated-values", "tsv"],
+  ])("repairs scrubber-stamped .bin for mime %s → .%s", (mime, ext) => {
+    const result = deriveDownloadFilename({
+      mimeType: mime,
+      originalName: "scrubber_tool-12345.bin",
+      title: "irrelevant",
+    });
+    expect(result).toBe(`scrubber_tool-12345.${ext}`);
+  });
+
   // Round-trip lock: every mime the agent-side inference can stamp on
   // an artifact must result in a download filename that preserves the
   // original extension. This blocks the regression Ken's reviewer

--- a/packages/core/src/artifacts/file-upload.test.ts
+++ b/packages/core/src/artifacts/file-upload.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { deriveDownloadFilename } from "./file-upload.ts";
+import {
+  ALLOWED_EXTENSIONS,
+  deriveDownloadFilename,
+  getValidatedMimeType,
+  inferMimeFromFilename,
+} from "./file-upload.ts";
 
 describe("deriveDownloadFilename", () => {
   it("preserves originalName extension when stored mime is octet-stream and original ext is non-bin", () => {
@@ -24,5 +29,111 @@ describe("deriveDownloadFilename", () => {
       title: "Attachment",
     });
     expect(result).toBe("gmail_get_attachment-1234.png");
+  });
+
+  it("preserves originalName when mime does not round-trip through extFromMime", () => {
+    // text/x-typescript fails extFromMime's `[a-z0-9]+` regex (hyphen),
+    // so the old logic rewrote `script.ts` → `script.bin`. Filenames
+    // should follow originalName when its extension is meaningful.
+    const result = deriveDownloadFilename({
+      mimeType: "text/x-typescript",
+      originalName: "script.ts",
+      title: "Script",
+    });
+    expect(result).toBe("script.ts");
+  });
+
+  // Round-trip lock: every mime the agent-side inference can stamp on
+  // an artifact must result in a download filename that preserves the
+  // original extension. This blocks the regression Ken's reviewer
+  // surfaced — ~12 of 22 inferred mimes failed to round-trip through
+  // extFromMime under the old logic.
+  it.each([
+    ["text/html", "page.html"],
+    ["text/html", "page.htm"],
+    ["application/xml", "feed.xml"],
+    ["image/svg+xml", "icon.svg"],
+    ["text/css", "site.css"],
+    ["text/x-typescript", "script.ts"],
+    ["text/x-typescript", "Component.tsx"],
+    ["text/javascript", "app.js"],
+    ["text/javascript", "Component.jsx"],
+    ["text/javascript", "loader.mjs"],
+    ["text/javascript", "loader.cjs"],
+    ["text/x-python", "main.py"],
+    ["text/x-go", "main.go"],
+    ["text/x-rust", "lib.rs"],
+    ["text/x-shellscript", "deploy.sh"],
+    ["text/x-shellscript", "setup.bash"],
+    ["text/x-sql", "migration.sql"],
+    ["text/x-toml", "Cargo.toml"],
+    ["text/plain", "config.ini"],
+    ["text/plain", "nginx.conf"],
+    ["text/plain", "build.log"],
+    ["text/tab-separated-values", "data.tsv"],
+    ["text/markdown", "SKILL.md"],
+    ["text/csv", "rows.csv"],
+    ["application/json", "package.json"],
+  ])("round-trips %s as %s", (mimeType, originalName) => {
+    expect(deriveDownloadFilename({ mimeType, originalName, title: "irrelevant" })).toBe(
+      originalName,
+    );
+  });
+
+  it("appends mime extension when originalName has no extension", () => {
+    const result = deriveDownloadFilename({
+      mimeType: "application/pdf",
+      originalName: "report",
+      title: "Report",
+    });
+    expect(result).toBe("report.pdf");
+  });
+
+  it("falls back to title.<ext> when originalName is missing", () => {
+    const result = deriveDownloadFilename({ mimeType: "text/markdown", title: "release-notes" });
+    expect(result).toBe("release-notes.md");
+  });
+});
+
+describe("inferMimeFromFilename", () => {
+  it("returns the mime for an upload-allowlisted extension", () => {
+    expect(inferMimeFromFilename("notes.md")).toBe("text/markdown");
+  });
+
+  it("returns the mime for a non-uploadable but inferable extension", () => {
+    expect(inferMimeFromFilename("script.ts")).toBe("text/x-typescript");
+  });
+
+  it("returns undefined for an unknown extension", () => {
+    expect(inferMimeFromFilename("artifact.unknownext")).toBeUndefined();
+  });
+
+  it("returns undefined when the filename has no extension", () => {
+    expect(inferMimeFromFilename("README")).toBeUndefined();
+  });
+});
+
+describe("getValidatedMimeType", () => {
+  it("returns the mime for an uploadable extension", () => {
+    expect(getValidatedMimeType("notes.md")).toBe("text/markdown");
+  });
+
+  it("returns undefined for a non-uploadable extension (gates UI uploads)", () => {
+    // .ts is inferable for agent-side artifact creation but must NOT be
+    // accepted via the UI upload allowlist.
+    expect(getValidatedMimeType("script.ts")).toBeUndefined();
+  });
+});
+
+describe("ALLOWED_EXTENSIONS", () => {
+  it("contains user-uploadable extensions", () => {
+    expect(ALLOWED_EXTENSIONS.has(".md")).toBe(true);
+    expect(ALLOWED_EXTENSIONS.has(".pdf")).toBe(true);
+  });
+
+  it("does not contain agent-only inferred extensions", () => {
+    expect(ALLOWED_EXTENSIONS.has(".ts")).toBe(false);
+    expect(ALLOWED_EXTENSIONS.has(".html")).toBe(false);
+    expect(ALLOWED_EXTENSIONS.has(".sh")).toBe(false);
   });
 });

--- a/packages/core/src/artifacts/file-upload.test.ts
+++ b/packages/core/src/artifacts/file-upload.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { deriveDownloadFilename } from "./file-upload.ts";
+
+describe("deriveDownloadFilename", () => {
+  it("preserves originalName extension when stored mime is octet-stream and original ext is non-bin", () => {
+    // Bug case: agent created an artifact whose mime got defaulted to
+    // octet-stream (e.g. text format with no magic bytes). The original
+    // filename has the correct extension — trust it instead of rewriting
+    // to .bin.
+    const result = deriveDownloadFilename({
+      mimeType: "application/octet-stream",
+      originalName: "report.html",
+      title: "A report",
+    });
+    expect(result).toBe("report.html");
+  });
+
+  it("rewrites a .bin originalName when a real mime is known (scrubber path)", () => {
+    // Scrubber stamps `<tool>-<ts>.bin` before mime is sniffed; once we
+    // know the real mime, the extension should be corrected.
+    const result = deriveDownloadFilename({
+      mimeType: "image/png",
+      originalName: "gmail_get_attachment-1234.bin",
+      title: "Attachment",
+    });
+    expect(result).toBe("gmail_get_attachment-1234.png");
+  });
+});

--- a/packages/core/src/artifacts/file-upload.test.ts
+++ b/packages/core/src/artifacts/file-upload.test.ts
@@ -4,6 +4,7 @@ import {
   deriveDownloadFilename,
   getValidatedMimeType,
   inferMimeFromFilename,
+  stripMimeParams,
 } from "./file-upload.ts";
 
 describe("deriveDownloadFilename", () => {
@@ -180,5 +181,26 @@ describe("ALLOWED_EXTENSIONS", () => {
     expect(ALLOWED_EXTENSIONS.has(".ts")).toBe(false);
     expect(ALLOWED_EXTENSIONS.has(".html")).toBe(false);
     expect(ALLOWED_EXTENSIONS.has(".sh")).toBe(false);
+  });
+});
+
+describe("stripMimeParams", () => {
+  it("returns the canonical type/subtype when a parameter is present", () => {
+    expect(stripMimeParams("text/html; charset=utf-8")).toBe("text/html");
+  });
+
+  it("trims whitespace before the parameter separator", () => {
+    expect(stripMimeParams("text/markdown ; charset=utf-8")).toBe("text/markdown");
+  });
+
+  it("returns the input unchanged when no parameter is present", () => {
+    expect(stripMimeParams("application/pdf")).toBe("application/pdf");
+  });
+
+  it("falls back to the original on a malformed empty-prefix mime", () => {
+    // `;…` has no type/subtype before the separator. Returning the raw
+    // input is the right tradeoff vs. silently producing an empty string
+    // that could match unrelated equality checks downstream.
+    expect(stripMimeParams("; charset=utf-8")).toBe("; charset=utf-8");
   });
 });

--- a/packages/core/src/artifacts/file-upload.test.ts
+++ b/packages/core/src/artifacts/file-upload.test.ts
@@ -43,6 +43,15 @@ describe("deriveDownloadFilename", () => {
     expect(result).toBe("script.ts");
   });
 
+  it("rewrites originalName when stored mime proves the extension is wrong", () => {
+    const result = deriveDownloadFilename({
+      mimeType: "image/png",
+      originalName: "misnamed.txt",
+      title: "Misnamed image",
+    });
+    expect(result).toBe("misnamed.png");
+  });
+
   // Round-trip lock: every mime the agent-side inference can stamp on
   // an artifact must result in a download filename that preserves the
   // original extension. This blocks the regression Ken's reviewer

--- a/packages/core/src/artifacts/file-upload.ts
+++ b/packages/core/src/artifacts/file-upload.ts
@@ -29,37 +29,82 @@ export const LEGACY_FORMAT_ERRORS = new Map([
 ]);
 
 /**
- * Extension to MIME type mapping for allowed file types.
+ * Extension → mime + upload-allowlist flag.
  *
- * Covers text formats (CSV, JSON, TXT, MD, YAML), documents (PDF, DOCX, PPTX),
- * images (PNG, JPEG, WebP, GIF), and audio (MP3, MP4, M4A, WAV, WebM, OGG, FLAC).
- * Images and audio are stored as-is (no conversion).
+ * Single source of truth for both extension-driven mime inference and
+ * the UI upload allowlist. `uploadable: true` entries gate
+ * `getValidatedMimeType` and `ALLOWED_EXTENSIONS`; `uploadable: false`
+ * entries are agent-side inferences only — markup/source/config text
+ * formats that agents commonly write to scratch and register as
+ * artifacts. Adding such an extension here does NOT widen the UI
+ * upload allowlist.
  */
-export const EXTENSION_TO_MIME = new Map([
-  [".csv", "text/csv"],
-  [".json", "application/json"],
-  [".txt", "text/plain"],
-  [".md", "text/markdown"],
-  [".markdown", "text/markdown"],
-  [".yml", "text/yaml"],
-  [".yaml", "text/yaml"],
-  [".pdf", "application/pdf"],
-  [".docx", "application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
-  [".pptx", "application/vnd.openxmlformats-officedocument.presentationml.presentation"],
-  [".png", "image/png"],
-  [".jpg", "image/jpeg"],
-  [".jpeg", "image/jpeg"],
-  [".webp", "image/webp"],
-  [".gif", "image/gif"],
-  [".mp3", "audio/mpeg"],
-  [".mp4", "audio/mp4"],
-  [".m4a", "audio/x-m4a"],
-  [".wav", "audio/wav"],
-  [".webm", "audio/webm"],
-  [".ogg", "audio/ogg"],
-  [".flac", "audio/flac"],
-  [".mpeg", "audio/mpeg"],
-  [".mpga", "audio/mpeg"],
+export const EXTENSION_TO_MIME = new Map<string, { mime: string; uploadable: boolean }>([
+  // Uploadable: text/data
+  [".csv", { mime: "text/csv", uploadable: true }],
+  [".json", { mime: "application/json", uploadable: true }],
+  [".txt", { mime: "text/plain", uploadable: true }],
+  [".md", { mime: "text/markdown", uploadable: true }],
+  [".markdown", { mime: "text/markdown", uploadable: true }],
+  [".yml", { mime: "text/yaml", uploadable: true }],
+  [".yaml", { mime: "text/yaml", uploadable: true }],
+  // Uploadable: documents
+  [".pdf", { mime: "application/pdf", uploadable: true }],
+  [
+    ".docx",
+    {
+      mime: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      uploadable: true,
+    },
+  ],
+  [
+    ".pptx",
+    {
+      mime: "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+      uploadable: true,
+    },
+  ],
+  // Uploadable: images
+  [".png", { mime: "image/png", uploadable: true }],
+  [".jpg", { mime: "image/jpeg", uploadable: true }],
+  [".jpeg", { mime: "image/jpeg", uploadable: true }],
+  [".webp", { mime: "image/webp", uploadable: true }],
+  [".gif", { mime: "image/gif", uploadable: true }],
+  // Uploadable: audio
+  [".mp3", { mime: "audio/mpeg", uploadable: true }],
+  [".mp4", { mime: "audio/mp4", uploadable: true }],
+  [".m4a", { mime: "audio/x-m4a", uploadable: true }],
+  [".wav", { mime: "audio/wav", uploadable: true }],
+  [".webm", { mime: "audio/webm", uploadable: true }],
+  [".ogg", { mime: "audio/ogg", uploadable: true }],
+  [".flac", { mime: "audio/flac", uploadable: true }],
+  [".mpeg", { mime: "audio/mpeg", uploadable: true }],
+  [".mpga", { mime: "audio/mpeg", uploadable: true }],
+  // Agent-inference only: markup
+  [".html", { mime: "text/html", uploadable: false }],
+  [".htm", { mime: "text/html", uploadable: false }],
+  [".xml", { mime: "application/xml", uploadable: false }],
+  [".svg", { mime: "image/svg+xml", uploadable: false }],
+  [".css", { mime: "text/css", uploadable: false }],
+  // Agent-inference only: source code
+  [".ts", { mime: "text/x-typescript", uploadable: false }],
+  [".tsx", { mime: "text/x-typescript", uploadable: false }],
+  [".js", { mime: "text/javascript", uploadable: false }],
+  [".jsx", { mime: "text/javascript", uploadable: false }],
+  [".mjs", { mime: "text/javascript", uploadable: false }],
+  [".cjs", { mime: "text/javascript", uploadable: false }],
+  [".py", { mime: "text/x-python", uploadable: false }],
+  [".go", { mime: "text/x-go", uploadable: false }],
+  [".rs", { mime: "text/x-rust", uploadable: false }],
+  [".sh", { mime: "text/x-shellscript", uploadable: false }],
+  [".bash", { mime: "text/x-shellscript", uploadable: false }],
+  [".sql", { mime: "text/x-sql", uploadable: false }],
+  // Agent-inference only: config/log
+  [".toml", { mime: "text/x-toml", uploadable: false }],
+  [".ini", { mime: "text/plain", uploadable: false }],
+  [".conf", { mime: "text/plain", uploadable: false }],
+  [".log", { mime: "text/plain", uploadable: false }],
+  [".tsv", { mime: "text/tab-separated-values", uploadable: false }],
 ]);
 
 /**
@@ -237,104 +282,70 @@ export function extFromMime(mimeType: string): string {
 }
 
 /**
- * Reconcile a stored `originalName` with the artifact's actual `mimeType`,
- * returning a filename whose extension matches the bytes. When the
- * scrubber lifts an embedded base64 blob without knowing the format yet,
- * it stamps the artifact with `<tool>-<ts>.bin`; the storage adapter
- * later sniffs the real mime, but `originalName` keeps its `.bin`. This
- * helper rewrites the extension at download time so the user gets
- * `foo.pdf` instead of `foo.bin` even for legacy artifacts.
+ * Pick a download filename for an artifact.
  *
- * Logic:
- * 1. Compute the correct extension from the mime.
- * 2. If `originalName` already ends in that extension, keep it.
- * 3. If `originalName` ends in a different extension, swap it.
- * 4. If `originalName` has no extension, append.
- * 5. If no `originalName`, use `<title>.<ext>`.
+ * `originalName` is the source of truth when it carries a usable
+ * extension. The only case where we override it is the scrubber path:
+ * when the scrubber lifts an embedded base64 blob without knowing the
+ * format, it stamps `<tool>-<ts>.bin`; later the real mime is known
+ * and we rewrite the `.bin` to the right extension.
+ *
+ * Trusting `originalName` keeps the contract simple — extensions don't
+ * have to round-trip through `extFromMime` for every mime we ever
+ * choose, which is a contract no extension→mime table can hold without
+ * a perfectly invertible inverse.
  */
 export function deriveDownloadFilename(opts: {
   mimeType: string;
   originalName?: string;
   title: string;
 }): string {
-  const ext = extFromMime(opts.mimeType);
   const fromOriginal = opts.originalName?.trim();
   if (fromOriginal) {
     const dot = fromOriginal.lastIndexOf(".");
-    if (dot > 0 && dot < fromOriginal.length - 1) {
+    const hasExt = dot > 0 && dot < fromOriginal.length - 1;
+    if (hasExt) {
       const currentExt = fromOriginal.slice(dot + 1).toLowerCase();
-      if (currentExt === ext.toLowerCase()) return fromOriginal;
-      // Stored mime is octet-stream but originalName carries a real
-      // extension — the mime is wrong, trust the original. (Scrubber
-      // path goes the other way: bin originalName, real mime → rewrite.)
-      if (opts.mimeType === "application/octet-stream" && currentExt !== "bin") {
-        return fromOriginal;
+      // Scrubber path: `.bin` placeholder → swap to real ext.
+      if (currentExt === "bin") {
+        return `${fromOriginal.slice(0, dot)}.${extFromMime(opts.mimeType)}`;
       }
-      return `${fromOriginal.slice(0, dot)}.${ext}`;
+      return fromOriginal;
     }
-    return `${fromOriginal}.${ext}`;
+    return `${fromOriginal}.${extFromMime(opts.mimeType)}`;
   }
-  return `${opts.title}.${ext}`;
+  return `${opts.title}.${extFromMime(opts.mimeType)}`;
 }
 
-export function getValidatedMimeType(fileName: string): string | undefined {
+function lookupExtension(fileName: string): { mime: string; uploadable: boolean } | undefined {
   const dotIdx = fileName.lastIndexOf(".");
   if (dotIdx < 0) return undefined;
-  const ext = fileName.slice(dotIdx).toLowerCase();
-  return EXTENSION_TO_MIME.get(ext);
+  return EXTENSION_TO_MIME.get(fileName.slice(dotIdx).toLowerCase());
 }
 
-export const ALLOWED_EXTENSIONS = new Set(EXTENSION_TO_MIME.keys());
-export const ALLOWED_EXTENSION_LIST = [...ALLOWED_EXTENSIONS];
-
 /**
- * Additional extension→mime mappings for *agent-side inference only*.
- *
- * Deliberately separate from `EXTENSION_TO_MIME`, which doubles as the
- * UI upload allowlist (`ALLOWED_EXTENSIONS`). Agents commonly write
- * source code, markup, and config files to scratch and register them as
- * artifacts; without an inferred mime they persist as
- * `application/octet-stream` and download as `.bin`.
+ * Mime for a UI-uploadable extension, or `undefined` for any extension
+ * that is unknown or restricted to agent-side inference. Gates the
+ * upload allowlist.
  */
-const INFERRED_TEXT_EXTENSION_TO_MIME = new Map([
-  [".html", "text/html"],
-  [".htm", "text/html"],
-  [".xml", "application/xml"],
-  [".svg", "image/svg+xml"],
-  [".css", "text/css"],
-  [".ts", "text/x-typescript"],
-  [".tsx", "text/x-typescript"],
-  [".js", "text/javascript"],
-  [".jsx", "text/javascript"],
-  [".mjs", "text/javascript"],
-  [".cjs", "text/javascript"],
-  [".py", "text/x-python"],
-  [".go", "text/x-go"],
-  [".rs", "text/x-rust"],
-  [".sh", "text/x-shellscript"],
-  [".bash", "text/x-shellscript"],
-  [".sql", "text/x-sql"],
-  [".toml", "text/x-toml"],
-  [".ini", "text/plain"],
-  [".conf", "text/plain"],
-  [".log", "text/plain"],
-  [".tsv", "text/tab-separated-values"],
-]);
+export function getValidatedMimeType(fileName: string): string | undefined {
+  const entry = lookupExtension(fileName);
+  return entry?.uploadable ? entry.mime : undefined;
+}
 
 /**
- * Infer mime type from a filename for storage purposes. Consults the
- * upload allowlist first, then a broader text-format map. Returns
- * `undefined` for truly unknown extensions — caller should let the
- * storage layer fall back to magic-byte sniff or octet-stream.
- *
- * Distinct from `getValidatedMimeType`, which gates UI uploads against
- * a security-conscious allowlist.
+ * Mime for any known extension, including agent-only ones. Used at
+ * `artifacts_create` time so text/markup/source-code files persist
+ * with a meaningful mime instead of falling through to the storage
+ * layer's binary-only magic-byte sniff and ending up as
+ * `application/octet-stream`. Returns `undefined` for unknown
+ * extensions — caller should let the storage layer decide.
  */
 export function inferMimeFromFilename(fileName: string): string | undefined {
-  const allowlisted = getValidatedMimeType(fileName);
-  if (allowlisted) return allowlisted;
-  const dotIdx = fileName.lastIndexOf(".");
-  if (dotIdx < 0) return undefined;
-  const ext = fileName.slice(dotIdx).toLowerCase();
-  return INFERRED_TEXT_EXTENSION_TO_MIME.get(ext);
+  return lookupExtension(fileName)?.mime;
 }
+
+export const ALLOWED_EXTENSIONS = new Set(
+  [...EXTENSION_TO_MIME].filter(([, v]) => v.uploadable).map(([k]) => k),
+);
+export const ALLOWED_EXTENSION_LIST = [...ALLOWED_EXTENSIONS];

--- a/packages/core/src/artifacts/file-upload.ts
+++ b/packages/core/src/artifacts/file-upload.ts
@@ -264,6 +264,12 @@ export function deriveDownloadFilename(opts: {
     if (dot > 0 && dot < fromOriginal.length - 1) {
       const currentExt = fromOriginal.slice(dot + 1).toLowerCase();
       if (currentExt === ext.toLowerCase()) return fromOriginal;
+      // Stored mime is octet-stream but originalName carries a real
+      // extension — the mime is wrong, trust the original. (Scrubber
+      // path goes the other way: bin originalName, real mime → rewrite.)
+      if (opts.mimeType === "application/octet-stream" && currentExt !== "bin") {
+        return fromOriginal;
+      }
       return `${fromOriginal.slice(0, dot)}.${ext}`;
     }
     return `${fromOriginal}.${ext}`;
@@ -280,3 +286,55 @@ export function getValidatedMimeType(fileName: string): string | undefined {
 
 export const ALLOWED_EXTENSIONS = new Set(EXTENSION_TO_MIME.keys());
 export const ALLOWED_EXTENSION_LIST = [...ALLOWED_EXTENSIONS];
+
+/**
+ * Additional extension→mime mappings for *agent-side inference only*.
+ *
+ * Deliberately separate from `EXTENSION_TO_MIME`, which doubles as the
+ * UI upload allowlist (`ALLOWED_EXTENSIONS`). Agents commonly write
+ * source code, markup, and config files to scratch and register them as
+ * artifacts; without an inferred mime they persist as
+ * `application/octet-stream` and download as `.bin`.
+ */
+const INFERRED_TEXT_EXTENSION_TO_MIME = new Map([
+  [".html", "text/html"],
+  [".htm", "text/html"],
+  [".xml", "application/xml"],
+  [".svg", "image/svg+xml"],
+  [".css", "text/css"],
+  [".ts", "text/x-typescript"],
+  [".tsx", "text/x-typescript"],
+  [".js", "text/javascript"],
+  [".jsx", "text/javascript"],
+  [".mjs", "text/javascript"],
+  [".cjs", "text/javascript"],
+  [".py", "text/x-python"],
+  [".go", "text/x-go"],
+  [".rs", "text/x-rust"],
+  [".sh", "text/x-shellscript"],
+  [".bash", "text/x-shellscript"],
+  [".sql", "text/x-sql"],
+  [".toml", "text/x-toml"],
+  [".ini", "text/plain"],
+  [".conf", "text/plain"],
+  [".log", "text/plain"],
+  [".tsv", "text/tab-separated-values"],
+]);
+
+/**
+ * Infer mime type from a filename for storage purposes. Consults the
+ * upload allowlist first, then a broader text-format map. Returns
+ * `undefined` for truly unknown extensions — caller should let the
+ * storage layer fall back to magic-byte sniff or octet-stream.
+ *
+ * Distinct from `getValidatedMimeType`, which gates UI uploads against
+ * a security-conscious allowlist.
+ */
+export function inferMimeFromFilename(fileName: string): string | undefined {
+  const allowlisted = getValidatedMimeType(fileName);
+  if (allowlisted) return allowlisted;
+  const dotIdx = fileName.lastIndexOf(".");
+  if (dotIdx < 0) return undefined;
+  const ext = fileName.slice(dotIdx).toLowerCase();
+  return INFERRED_TEXT_EXTENSION_TO_MIME.get(ext);
+}

--- a/packages/core/src/artifacts/file-upload.ts
+++ b/packages/core/src/artifacts/file-upload.ts
@@ -224,6 +224,18 @@ export function isTextMimeType(mimeType: string): boolean {
 }
 
 /**
+ * Drop any mime parameters (`; charset=…`, `; boundary=…`) and return the
+ * canonical `type/subtype`. Storage adapters can round-trip text mimes with
+ * a charset attached (`text/markdown; charset=utf-8`); equality checks
+ * against literal mime strings would silently miss the parameterised form.
+ * Use this helper anywhere the mime is gating a security predicate or
+ * routing decision.
+ */
+export function stripMimeParams(mimeType: string): string {
+  return mimeType.split(";")[0]?.trim() || mimeType;
+}
+
+/**
  * Mime types we have a stream-based markdown converter for. The
  * `parse_artifact` endpoint runs these through the matching converter
  * and returns the markdown.
@@ -322,7 +334,7 @@ export function deriveDownloadFilename(opts: {
   // that round-trip text mimes with a charset attached. Without this,
   // `notes.md` + stored `text/markdown; charset=utf-8` silently rewrote
   // to `notes.markdown`.
-  const baseMime = opts.mimeType.split(";")[0]?.trim() || opts.mimeType;
+  const baseMime = stripMimeParams(opts.mimeType);
   const fromOriginal = opts.originalName?.trim();
   if (fromOriginal) {
     const dot = fromOriginal.lastIndexOf(".");

--- a/packages/core/src/artifacts/file-upload.ts
+++ b/packages/core/src/artifacts/file-upload.ts
@@ -285,15 +285,13 @@ export function extFromMime(mimeType: string): string {
  * Pick a download filename for an artifact.
  *
  * `originalName` is the source of truth when it carries a usable
- * extension. The only case where we override it is the scrubber path:
- * when the scrubber lifts an embedded base64 blob without knowing the
- * format, it stamps `<tool>-<ts>.bin`; later the real mime is known
- * and we rewrite the `.bin` to the right extension.
+ * extension that agrees with the stored mime. The scrubber path still
+ * gets repaired: when the scrubber lifts an embedded base64 blob without
+ * knowing the format, it stamps `<tool>-<ts>.bin`; later the real mime
+ * is known and we rewrite the `.bin` to the right extension.
  *
- * Trusting `originalName` keeps the contract simple — extensions don't
- * have to round-trip through `extFromMime` for every mime we ever
- * choose, which is a contract no extension→mime table can hold without
- * a perfectly invertible inverse.
+ * Unknown/octet-stream artifacts keep their original extension because
+ * the stored mime carries no better information.
  */
 export function deriveDownloadFilename(opts: {
   mimeType: string;
@@ -310,7 +308,12 @@ export function deriveDownloadFilename(opts: {
       if (currentExt === "bin") {
         return `${fromOriginal.slice(0, dot)}.${extFromMime(opts.mimeType)}`;
       }
-      return fromOriginal;
+
+      const originalMime = inferMimeFromFilename(fromOriginal);
+      if (opts.mimeType === "application/octet-stream" || originalMime === opts.mimeType) {
+        return fromOriginal;
+      }
+      return `${fromOriginal.slice(0, dot)}.${extFromMime(opts.mimeType)}`;
     }
     return `${fromOriginal}.${extFromMime(opts.mimeType)}`;
   }

--- a/packages/core/src/artifacts/file-upload.ts
+++ b/packages/core/src/artifacts/file-upload.ts
@@ -209,6 +209,13 @@ const TEXT_MIME_EXACT = new Set([
   "application/sql",
   "application/x-sh",
   "application/x-python",
+  // SVG is XML text. Treating it as text means agents stamp the mime
+  // explicitly at artifact-create time, which keeps the daemon's CSP
+  // sandbox firing on the /content route. Without this, .svg falls
+  // through to the binary-byte sniff and stores as octet-stream — at
+  // which point the sandbox key (`mimeType === "image/svg+xml"`) misses
+  // and an SVG `<script>` would execute same-origin.
+  "image/svg+xml",
 ]);
 
 export function isTextMimeType(mimeType: string): boolean {
@@ -269,6 +276,18 @@ const MIME_TO_EXT: Record<string, string> = {
   "text/csv": "csv",
   "text/markdown": "md",
   "text/yaml": "yaml",
+  // Hyphenated source/config mimes the agent-side inference can stamp.
+  // The fallback `tail` regex (`^[a-z0-9]+$`) rejects hyphens and falls
+  // through to `bin`, so without these the scrubber `.bin` repair
+  // produces e.g. `tool-12345.bin` instead of `tool-12345.ts`.
+  "text/x-typescript": "ts",
+  "text/x-python": "py",
+  "text/x-go": "go",
+  "text/x-rust": "rs",
+  "text/x-shellscript": "sh",
+  "text/x-sql": "sql",
+  "text/x-toml": "toml",
+  "text/tab-separated-values": "tsv",
 };
 
 /** Best-guess file extension for a mime type. Falls back to `bin` for unknowns. */
@@ -298,6 +317,12 @@ export function deriveDownloadFilename(opts: {
   originalName?: string;
   title: string;
 }): string {
+  // Strip mime parameters (`; charset=…`) up front so the equality
+  // check against the filename-inferred mime survives storage adapters
+  // that round-trip text mimes with a charset attached. Without this,
+  // `notes.md` + stored `text/markdown; charset=utf-8` silently rewrote
+  // to `notes.markdown`.
+  const baseMime = opts.mimeType.split(";")[0]?.trim() || opts.mimeType;
   const fromOriginal = opts.originalName?.trim();
   if (fromOriginal) {
     const dot = fromOriginal.lastIndexOf(".");
@@ -306,18 +331,18 @@ export function deriveDownloadFilename(opts: {
       const currentExt = fromOriginal.slice(dot + 1).toLowerCase();
       // Scrubber path: `.bin` placeholder → swap to real ext.
       if (currentExt === "bin") {
-        return `${fromOriginal.slice(0, dot)}.${extFromMime(opts.mimeType)}`;
+        return `${fromOriginal.slice(0, dot)}.${extFromMime(baseMime)}`;
       }
 
       const originalMime = inferMimeFromFilename(fromOriginal);
-      if (opts.mimeType === "application/octet-stream" || originalMime === opts.mimeType) {
+      if (baseMime === "application/octet-stream" || originalMime === baseMime) {
         return fromOriginal;
       }
-      return `${fromOriginal.slice(0, dot)}.${extFromMime(opts.mimeType)}`;
+      return `${fromOriginal.slice(0, dot)}.${extFromMime(baseMime)}`;
     }
-    return `${fromOriginal}.${extFromMime(opts.mimeType)}`;
+    return `${fromOriginal}.${extFromMime(baseMime)}`;
   }
-  return `${opts.title}.${extFromMime(opts.mimeType)}`;
+  return `${opts.title}.${extFromMime(baseMime)}`;
 }
 
 function lookupExtension(fileName: string): { mime: string; uploadable: boolean } | undefined {

--- a/packages/system/agents/workspace-chat/tools/artifact-tools.test.ts
+++ b/packages/system/agents/workspace-chat/tools/artifact-tools.test.ts
@@ -5,11 +5,7 @@ const mockArtifactsCreatePost = vi.hoisted(() => vi.fn<(args: unknown) => Promis
 const mockReadFile = vi.hoisted(() => vi.fn<(path: string) => Promise<Uint8Array>>());
 
 vi.mock("@atlas/client/v2", () => ({
-  client: {
-    artifactsStorage: {
-      index: { $post: mockArtifactsCreatePost },
-    },
-  },
+  client: { artifactsStorage: { index: { $post: mockArtifactsCreatePost } } },
   parseResult: async (p: Promise<unknown>) => {
     await p;
     return { ok: true, data: { artifact: { id: "art-1" } } };
@@ -43,7 +39,9 @@ describe("artifacts_create", () => {
     );
 
     expect(mockArtifactsCreatePost).toHaveBeenCalledOnce();
-    const call = mockArtifactsCreatePost.mock.calls[0]?.[0] as { json: { data: { mimeType?: string } } };
+    const call = mockArtifactsCreatePost.mock.calls[0]?.[0] as {
+      json: { data: { mimeType?: string } };
+    };
     expect(call.json.data.mimeType).toBe("text/markdown");
   });
 
@@ -59,7 +57,9 @@ describe("artifacts_create", () => {
       TOOL_CALL_OPTS,
     );
 
-    const call = mockArtifactsCreatePost.mock.calls[0]?.[0] as { json: { data: { mimeType?: string } } };
+    const call = mockArtifactsCreatePost.mock.calls[0]?.[0] as {
+      json: { data: { mimeType?: string } };
+    };
     expect(call.json.data.mimeType).toBe("text/html");
   });
 });

--- a/packages/system/agents/workspace-chat/tools/artifact-tools.test.ts
+++ b/packages/system/agents/workspace-chat/tools/artifact-tools.test.ts
@@ -84,6 +84,30 @@ describe("artifacts_create", () => {
     expect(call?.json.data).not.toHaveProperty("mimeType");
   });
 
+  it("stamps image/svg+xml mimeType for .svg filename so the CSP sandbox applies", async () => {
+    // SVG is text-encoded XML and the daemon CSP keys off mimeType.
+    // Letting storage fall back to octet-stream loses the sandbox —
+    // an attacker-supplied SVG with `<script>` would execute same-origin.
+    const tools = createArtifactsCreateTool({
+      sessionId: "session-1",
+      workspaceId: "ws-1",
+      streamId: undefined,
+    });
+
+    await tools.artifacts_create!.execute!(
+      { path: "icon.svg", title: "An icon", summary: "A test SVG artifact." },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(mockArtifactsCreatePost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        json: expect.objectContaining({
+          data: expect.objectContaining({ mimeType: "image/svg+xml" }),
+        }),
+      }),
+    );
+  });
+
   it("omits mimeType for binary extensions so storage can sniff the bytes", async () => {
     const tools = createArtifactsCreateTool({
       sessionId: "session-1",

--- a/packages/system/agents/workspace-chat/tools/artifact-tools.test.ts
+++ b/packages/system/agents/workspace-chat/tools/artifact-tools.test.ts
@@ -61,9 +61,7 @@ describe("artifacts_create", () => {
 
     expect(mockArtifactsCreatePost).toHaveBeenCalledWith(
       expect.objectContaining({
-        json: expect.objectContaining({
-          data: expect.objectContaining({ mimeType: "text/html" }),
-        }),
+        json: expect.objectContaining({ data: expect.objectContaining({ mimeType: "text/html" }) }),
       }),
     );
   });

--- a/packages/system/agents/workspace-chat/tools/artifact-tools.test.ts
+++ b/packages/system/agents/workspace-chat/tools/artifact-tools.test.ts
@@ -1,0 +1,49 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createArtifactsCreateTool } from "./artifact-tools.ts";
+
+const mockArtifactsCreatePost = vi.hoisted(() => vi.fn<(args: unknown) => Promise<unknown>>());
+const mockReadFile = vi.hoisted(() => vi.fn<(path: string) => Promise<Uint8Array>>());
+
+vi.mock("@atlas/client/v2", () => ({
+  client: {
+    artifactsStorage: {
+      index: { $post: mockArtifactsCreatePost },
+    },
+  },
+  parseResult: async (p: Promise<unknown>) => {
+    await p;
+    return { ok: true, data: { artifact: { id: "art-1" } } };
+  },
+}));
+
+vi.mock("node:fs/promises", async () => {
+  const actual = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
+  return { ...actual, readFile: mockReadFile };
+});
+
+const TOOL_CALL_OPTS = { toolCallId: "test-call", messages: [] as never[] };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockArtifactsCreatePost.mockResolvedValue({});
+  mockReadFile.mockResolvedValue(new TextEncoder().encode("# hello\nmarkdown body"));
+});
+
+describe("artifacts_create", () => {
+  it("infers text/markdown mimeType from .md filename", async () => {
+    const tools = createArtifactsCreateTool({
+      sessionId: "session-1",
+      workspaceId: "ws-1",
+      streamId: undefined,
+    });
+
+    await tools.artifacts_create!.execute!(
+      { path: "SKILL.md", title: "A skill", summary: "A test skill artifact." },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(mockArtifactsCreatePost).toHaveBeenCalledOnce();
+    const call = mockArtifactsCreatePost.mock.calls[0]?.[0] as { json: { data: { mimeType?: string } } };
+    expect(call.json.data.mimeType).toBe("text/markdown");
+  });
+});

--- a/packages/system/agents/workspace-chat/tools/artifact-tools.test.ts
+++ b/packages/system/agents/workspace-chat/tools/artifact-tools.test.ts
@@ -38,11 +38,13 @@ describe("artifacts_create", () => {
       TOOL_CALL_OPTS,
     );
 
-    expect(mockArtifactsCreatePost).toHaveBeenCalledOnce();
-    const call = mockArtifactsCreatePost.mock.calls[0]?.[0] as {
-      json: { data: { mimeType?: string } };
-    };
-    expect(call.json.data.mimeType).toBe("text/markdown");
+    expect(mockArtifactsCreatePost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        json: expect.objectContaining({
+          data: expect.objectContaining({ mimeType: "text/markdown" }),
+        }),
+      }),
+    );
   });
 
   it("infers text/html mimeType from .html filename (extension outside upload allowlist)", async () => {
@@ -57,9 +59,12 @@ describe("artifacts_create", () => {
       TOOL_CALL_OPTS,
     );
 
-    const call = mockArtifactsCreatePost.mock.calls[0]?.[0] as {
-      json: { data: { mimeType?: string } };
-    };
-    expect(call.json.data.mimeType).toBe("text/html");
+    expect(mockArtifactsCreatePost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        json: expect.objectContaining({
+          data: expect.objectContaining({ mimeType: "text/html" }),
+        }),
+      }),
+    );
   });
 });

--- a/packages/system/agents/workspace-chat/tools/artifact-tools.test.ts
+++ b/packages/system/agents/workspace-chat/tools/artifact-tools.test.ts
@@ -83,4 +83,22 @@ describe("artifacts_create", () => {
       | undefined;
     expect(call?.json.data).not.toHaveProperty("mimeType");
   });
+
+  it("omits mimeType for binary extensions so storage can sniff the bytes", async () => {
+    const tools = createArtifactsCreateTool({
+      sessionId: "session-1",
+      workspaceId: "ws-1",
+      streamId: undefined,
+    });
+
+    await tools.artifacts_create!.execute!(
+      { path: "image.png", title: "An image", summary: "A test image artifact." },
+      TOOL_CALL_OPTS,
+    );
+
+    const call = mockArtifactsCreatePost.mock.calls[0]?.[0] as
+      | { json: { data: Record<string, unknown> } }
+      | undefined;
+    expect(call?.json.data).not.toHaveProperty("mimeType");
+  });
 });

--- a/packages/system/agents/workspace-chat/tools/artifact-tools.test.ts
+++ b/packages/system/agents/workspace-chat/tools/artifact-tools.test.ts
@@ -65,4 +65,22 @@ describe("artifacts_create", () => {
       }),
     );
   });
+
+  it("omits mimeType for unknown extensions (storage layer falls back to magic-byte sniff)", async () => {
+    const tools = createArtifactsCreateTool({
+      sessionId: "session-1",
+      workspaceId: "ws-1",
+      streamId: undefined,
+    });
+
+    await tools.artifacts_create!.execute!(
+      { path: "data.weirdext", title: "A blob", summary: "A test artifact with unknown ext." },
+      TOOL_CALL_OPTS,
+    );
+
+    const call = mockArtifactsCreatePost.mock.calls[0]?.[0] as
+      | { json: { data: Record<string, unknown> } }
+      | undefined;
+    expect(call?.json.data).not.toHaveProperty("mimeType");
+  });
 });

--- a/packages/system/agents/workspace-chat/tools/artifact-tools.test.ts
+++ b/packages/system/agents/workspace-chat/tools/artifact-tools.test.ts
@@ -46,4 +46,20 @@ describe("artifacts_create", () => {
     const call = mockArtifactsCreatePost.mock.calls[0]?.[0] as { json: { data: { mimeType?: string } } };
     expect(call.json.data.mimeType).toBe("text/markdown");
   });
+
+  it("infers text/html mimeType from .html filename (extension outside upload allowlist)", async () => {
+    const tools = createArtifactsCreateTool({
+      sessionId: "session-1",
+      workspaceId: "ws-1",
+      streamId: undefined,
+    });
+
+    await tools.artifacts_create!.execute!(
+      { path: "report.html", title: "A report", summary: "A test HTML artifact." },
+      TOOL_CALL_OPTS,
+    );
+
+    const call = mockArtifactsCreatePost.mock.calls[0]?.[0] as { json: { data: { mimeType?: string } } };
+    expect(call.json.data.mimeType).toBe("text/html");
+  });
 });

--- a/packages/system/agents/workspace-chat/tools/artifact-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/artifact-tools.ts
@@ -13,7 +13,7 @@ import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
 import type { AtlasTools } from "@atlas/agent-sdk";
 import { client, parseResult } from "@atlas/client/v2";
-import { inferMimeFromFilename } from "@atlas/core/artifacts/file-upload";
+import { inferMimeFromFilename, isTextMimeType } from "@atlas/core/artifacts/file-upload";
 import { createLogger } from "@atlas/logger";
 import { stringifyError } from "@atlas/utils";
 import { encodeBase64 } from "@std/encoding/base64";
@@ -157,7 +157,7 @@ export function createArtifactsCreateTool({
           content: base64,
           contentEncoding: "base64" as const,
           originalName: filename,
-          ...(inferredMime ? { mimeType: inferredMime } : {}),
+          ...(inferredMime && isTextMimeType(inferredMime) ? { mimeType: inferredMime } : {}),
         };
 
         logger.info("artifacts_create called", { sessionId, path, workspaceId });

--- a/packages/system/agents/workspace-chat/tools/artifact-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/artifact-tools.ts
@@ -13,7 +13,7 @@ import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
 import type { AtlasTools } from "@atlas/agent-sdk";
 import { client, parseResult } from "@atlas/client/v2";
-import { getValidatedMimeType } from "@atlas/core/artifacts/file-upload";
+import { inferMimeFromFilename } from "@atlas/core/artifacts/file-upload";
 import { createLogger } from "@atlas/logger";
 import { stringifyError } from "@atlas/utils";
 import { encodeBase64 } from "@std/encoding/base64";
@@ -151,7 +151,7 @@ export function createArtifactsCreateTool({
         const base64 = encodeBase64(bytes);
 
         const filename = basename(path);
-        const inferredMime = getValidatedMimeType(filename);
+        const inferredMime = inferMimeFromFilename(filename);
         const data = {
           type: "file" as const,
           content: base64,

--- a/packages/system/agents/workspace-chat/tools/artifact-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/artifact-tools.ts
@@ -13,6 +13,7 @@ import { readFile } from "node:fs/promises";
 import { basename } from "node:path";
 import type { AtlasTools } from "@atlas/agent-sdk";
 import { client, parseResult } from "@atlas/client/v2";
+import { getValidatedMimeType } from "@atlas/core/artifacts/file-upload";
 import { createLogger } from "@atlas/logger";
 import { stringifyError } from "@atlas/utils";
 import { encodeBase64 } from "@std/encoding/base64";
@@ -149,11 +150,14 @@ export function createArtifactsCreateTool({
         // FileDataInput parser decodes when contentEncoding === "base64".
         const base64 = encodeBase64(bytes);
 
+        const filename = basename(path);
+        const inferredMime = getValidatedMimeType(filename);
         const data = {
           type: "file" as const,
           content: base64,
           contentEncoding: "base64" as const,
-          originalName: basename(path),
+          originalName: filename,
+          ...(inferredMime ? { mimeType: inferredMime } : {}),
         };
 
         logger.info("artifacts_create called", { sessionId, path, workspaceId });

--- a/tools/agent-playground/src/lib/components/chat/artifact-card.svelte
+++ b/tools/agent-playground/src/lib/components/chat/artifact-card.svelte
@@ -212,10 +212,18 @@
     <img src={imageUrl} alt={resolvedTitle} class="artifact-image" />
   {:else if htmlUrl}
     <div class="iframe-scaler" bind:this={scalerEl}>
+      <!--
+        `sandbox="allow-scripts"` (no `allow-same-origin`) drops the
+        iframe into an opaque origin so embedded JS can't reach the
+        chat UI's cookies, storage, or DOM via SOP — but `allow-scripts`
+        lets agent-rendered HTML actually run (Leaflet maps, charts,
+        etc). Pair with the daemon's `Content-Security-Policy: sandbox
+        allow-scripts; …` header on the /content route.
+      -->
       <iframe
         title={resolvedTitle}
         src={htmlUrl}
-        sandbox=""
+        sandbox="allow-scripts"
         class="artifact-iframe"
         style="--scale: {iframeScale}"
       ></iframe>

--- a/tools/agent-playground/src/lib/components/chat/artifact-card.svelte
+++ b/tools/agent-playground/src/lib/components/chat/artifact-card.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { browser } from "$app/environment";
+  import { stripMimeParams } from "@atlas/core/artifacts/file-upload";
   import { z } from "zod";
 
   interface Props {
@@ -98,12 +99,18 @@
     artifactId ? `/api/daemon/api/artifacts/${encodeURIComponent(artifactId)}/content` : null,
   );
 
+  // Storage adapters can round-trip text mimes with a charset parameter
+  // (`text/html; charset=utf-8`); equality checks against literal mimes
+  // would silently miss the parameterised form, falling through to the
+  // download tile instead of the inline iframe.
+  const baseMime = $derived(mimeType ? stripMimeParams(mimeType) : undefined);
+
   const imageUrl = $derived(
-    serveUrl && mimeType?.startsWith("image/") ? serveUrl : null,
+    serveUrl && baseMime?.startsWith("image/") ? serveUrl : null,
   );
 
   const htmlUrl = $derived(
-    serveUrl && mimeType === "text/html" ? serveUrl : null,
+    serveUrl && baseMime === "text/html" ? serveUrl : null,
   );
 
   // PDFs render natively in an iframe via the browser's built-in PDF
@@ -111,7 +118,7 @@
   // button for full-screen. No extra deps; this works in Chrome/Edge/
   // Safari/Firefox out of the box.
   const pdfUrl = $derived(
-    serveUrl && mimeType === "application/pdf" ? serveUrl : null,
+    serveUrl && baseMime === "application/pdf" ? serveUrl : null,
   );
 
   function mimeLabel(mt: string | undefined): string {
@@ -175,7 +182,7 @@
     <div class="artifact-title-wrap">
       <span class="artifact-title">{resolvedTitle}</span>
       {#if mimeType}
-        <span class="mime-badge">{mimeLabel(mimeType)}</span>
+        <span class="mime-badge">{mimeLabel(baseMime)}</span>
       {/if}
     </div>
 
@@ -240,8 +247,8 @@
       class="artifact-pdf"
       loading="lazy"
     ></iframe>
-  {:else if contents && isTextPreviewable(mimeType)}
-    <pre class="artifact-preview">{previewContents(contents, mimeType)}</pre>
+  {:else if contents && isTextPreviewable(baseMime)}
+    <pre class="artifact-preview">{previewContents(contents, baseMime)}</pre>
   {/if}
 
   {#if !loading && !fetchError && (originalName || sizeLabel || mimeType)}

--- a/tools/agent-playground/src/lib/components/chat/artifact-card.svelte
+++ b/tools/agent-playground/src/lib/components/chat/artifact-card.svelte
@@ -215,6 +215,7 @@
       <iframe
         title={resolvedTitle}
         src={htmlUrl}
+        sandbox=""
         class="artifact-iframe"
         style="--scale: {iframeScale}"
       ></iframe>

--- a/tools/agent-playground/src/lib/upload.ts
+++ b/tools/agent-playground/src/lib/upload.ts
@@ -47,7 +47,7 @@ export function validateFile(file: File): { valid: true } | { valid: false; erro
     return { valid: false, error: `${ext.slice(1).toUpperCase()} files must be under ${maxMB}MB.` };
   }
 
-  const mimeForExt = EXTENSION_TO_MIME.get(ext);
+  const mimeForExt = EXTENSION_TO_MIME.get(ext)?.mime;
   if (mimeForExt && isImageMimeType(mimeForExt) && file.size > MAX_IMAGE_SIZE) {
     return { valid: false, error: "Image files must be under 5MB." };
   }


### PR DESCRIPTION
Closes #173.

## Summary

Agent-side `artifacts_create` was registering scratch files with no `mimeType` hint. The storage layer's magic-byte sniff (`fileTypeFromBuffer`) is binary-only — text formats (md/json/csv/yaml/html/source code/...) have no magic bytes, so records persisted as `application/octet-stream`. The download route then rewrote `originalName`'s extension to `.bin`, so a `SKILL.md` artifact downloaded as `SKILL.bin`.

## Root cause

The original bug was a wrong default in `deriveDownloadFilename`: it computed the extension from the stored `mimeType` and overwrote `originalName`'s extension to match. That made every stored mime an implicit contract — it had to round-trip cleanly through `extFromMime` or the user got a renamed file. The `extFromMime` fallback uses a `[a-z0-9]+` regex on the mime's tail, which silently maps any hyphenated mime tail to `bin`. So even after layer-1 mime inference, ~12 of 22 inferred mimes would still rewrite incorrectly: `text/x-typescript` → `script.bin`, `text/javascript` → `app.javascript`, `text/x-python` → `main.bin`, etc.

Two-layer band-aids (caller-side inference + an octet-stream guard) didn't fix the contract — they just narrowed the failure window.

## Fix

**Flip the trust hierarchy in `deriveDownloadFilename`.** `originalName` is the source of truth when its extension agrees with the stored `mimeType` (or when the mime is `application/octet-stream`, meaning we have no better signal). The only unconditional override is the scrubber path: when the scrubber stamps `<tool>-<ts>.bin` before sniffing the mime, we swap `.bin` for the real extension once known. If the stored MIME proves the extension is wrong (e.g. PNG bytes uploaded as `misnamed.txt`), we rewrite to match the MIME.

Result: filename round-trip is automatic for every correctly-named text artifact, including ones that don't round-trip through `extFromMime`. Mismatched binary uploads still get corrected.

**Collapse the two extension→mime maps into one with a flag.** `EXTENSION_TO_MIME` is now `Map<string, { mime, uploadable }>`. `uploadable: true` entries gate `getValidatedMimeType` and `ALLOWED_EXTENSIONS`; `uploadable: false` entries are agent-side inferences only — markup/source/config text formats. Adding such an extension does NOT widen the UI upload allowlist. One source of truth, one flag, no duplicate map to keep in sync.

**Only infer text-ish MIME at `artifacts_create` time.** The caller-side helper now stamps `mimeType` only when `isTextMimeType(inferredMime)` is true. Binary/image/audio files are left for the storage layer's magic-byte sniff so filename alone can't mislabel them.

**Sandbox HTML artifact previews.** Because `.html` is now inferred as `text/html` and rendered inline, both the playground iframe (`sandbox=""`) and the daemon content route (`Content-Security-Policy: sandbox; default-src 'none'; img-src data: blob:; style-src 'unsafe-inline'`) are locked down so agent-written HTML can't execute as same-origin active content.

## Manual testing

To reproduce on your machine:

1. Run the playground against this branch: `deno task dev:playground`.
2. Open a chat, send: *"Write me a brief short story in a markdown file and call artifacts_create on it."*
3. The agent will run `write_file` → `artifacts_create` → `display_artifact`. Observe the artifact card in the chat:
   - **Badge** should say `markdown`, not `octet-stream`.
   - **Click Download** — file lands as `<title>.md`, not `<title>.bin`.
   - **Click Open** — opens with the correct viewer for markdown rather than triggering a binary download.
4. Repeat with other formats:
   - `.html` (e.g. *"write a one-page HTML status report and create an artifact"*) — badge says `html`, downloads as `.html`, previews inline in a sandboxed iframe.
   - `.ts` / `.py` / `.toml` etc. — badges show generic labels (`x-typescript`, `x-python`, `x-toml`) but downloads land with the right extension. *(This is the case Ken's review caught — `.ts` previously downloaded as `.bin` despite the layer-1 inference.)*
   - An extension outside the map (e.g. `.foo`) — badge says `octet-stream` (storage layer fell through), and the **download still preserves `.foo`** because the new logic trusts `originalName` when there is no better MIME signal.
5. Sanity-check the stored mime via the daemon API:
   ```sh
   curl -s http://localhost:8080/api/artifacts/<artifactId> | jq '.artifact.data | {mimeType, originalName}'
   ```
   Expected for a markdown file: `{ "mimeType": "text/markdown", "originalName": "story.md" }`.

## Test Plan

- [x] Unit test: `artifacts_create` infers `text/markdown` for `.md` filename
- [x] Unit test: `artifacts_create` infers `text/html` for `.html` filename (extension outside upload allowlist)
- [x] Unit test: `artifacts_create` omits `mimeType` for unknown extension (storage falls back to magic-byte sniff)
- [x] Unit test: `artifacts_create` omits `mimeType` for binary extensions (storage sniffs bytes instead of trusting filename)
- [x] Parametrized round-trip test: `deriveDownloadFilename` preserves `originalName` for every entry in the inferred map (25 cases — `.ts`, `.py`, `.go`, `.rs`, `.sh`, `.bash`, `.sql`, `.toml`, `.tsv`, `.js`, `.jsx`, `.mjs`, `.cjs`, `.tsx`, `.html`, `.htm`, `.xml`, `.svg`, `.css`, `.ini`, `.conf`, `.log`, `.md`, `.csv`, `.json`)
- [x] Unit test: `deriveDownloadFilename` rewrites `.bin` originalName when real mime known (no scrubber-path regression)
- [x] Unit test: `deriveDownloadFilename` rewrites proven-mismatched extension (e.g. PNG stored with `.txt` originalName → `.png`)
- [x] Unit test: `deriveDownloadFilename` appends extension when `originalName` has none
- [x] Unit test: `deriveDownloadFilename` falls back to `<title>.<ext>` when no `originalName`
- [x] Unit test: `inferMimeFromFilename` returns mime for both uploadable and agent-only extensions; `undefined` for unknown
- [x] Unit test: `getValidatedMimeType` returns `undefined` for non-uploadable extensions (gates UI uploads)
- [x] Unit test: `ALLOWED_EXTENSIONS` excludes agent-only inferred extensions
- [x] Route test: `text/html` artifact content response carries `Content-Security-Policy: sandbox` header
- [x] All 958 tests in related packages continue to pass
- [x] `deno check` clean across modified files + downstream callers (`tools/agent-playground/src/lib/upload.ts` adjusted for new map shape)
- [x] `svelte-check` clean (0 errors) in playground after adding `sandbox=""` to HTML iframe