### PR TITLE
Add skill export and support importing gzipped skills

### DIFF
--- a/apps/atlasd/routes/skills.test.ts
+++ b/apps/atlasd/routes/skills.test.ts
@@ -121,6 +121,29 @@ describe("Skills API Routes - Global Catalog", () => {
       expect(body.published).toMatchObject({ namespace: "atlas", name: "code-review", version: 1 });
     });
 
+    it("splits embedded frontmatter into the frontmatter column on JSON publish", async () => {
+      const fullSkillMd =
+        "---\nname: split-me\ndescription: This is a test skill description.\n---\n\n# Split Me\n\nBody content.\n";
+      const publishRes = await skillsRoutes.request("/@atlas/split-me", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ instructions: fullSkillMd }),
+      });
+      expect(publishRes.status).toBe(201);
+
+      const getRes = await skillsRoutes.request("/@atlas/split-me");
+      expect(getRes.status).toBe(200);
+      const body = (await getRes.json()) as {
+        skill: { instructions: string; frontmatter: Record<string, unknown>; description: string };
+      };
+      expect(body.skill.frontmatter).toMatchObject({
+        name: "split-me",
+        description: "This is a test skill description.",
+      });
+      expect(body.skill.instructions).not.toContain("---");
+      expect(body.skill.instructions).toContain("# Split Me");
+    });
+
     it("auto-increments version on subsequent publish", async () => {
       const response = await skillsRoutes.request("/@atlas/code-review", {
         method: "POST",

--- a/apps/atlasd/routes/skills.test.ts
+++ b/apps/atlasd/routes/skills.test.ts
@@ -381,6 +381,7 @@ describe("Skills API Routes - Global Catalog", () => {
       const bytes = new Uint8Array(await response.arrayBuffer());
       const contents = await extractArchiveContents(bytes);
       expect(contents["SKILL.md"]).toBeDefined();
+      expect(contents["SKILL.md"]).toContain("Review the code more carefully.");
     });
 
     it("returns 404 for non-existent skill", async () => {
@@ -485,6 +486,60 @@ describe("Skills API Routes - Global Catalog", () => {
 
       const getRes = await skillsRoutes.request("/@eric/just-a-name");
       expect(getRes.status).toBe(200);
+    });
+
+    it("returns 400 when SKILL.md has malformed frontmatter", async () => {
+      const { packSkillArchive } = await import("@atlas/skills/archive");
+      const tmpDir = join(testDir, `malformed-import-${Date.now()}`);
+      mkdirSync(tmpDir, { recursive: true });
+      try {
+        writeFileSync(join(tmpDir, "SKILL.md"), "---\nname: [unclosed\n---\n\nBody.\n");
+        const archiveBytes = await packSkillArchive(tmpDir);
+
+        const formData = new FormData();
+        formData.append(
+          "archive",
+          new File([new Uint8Array(archiveBytes)], "bad.tar.gz", { type: "application/gzip" }),
+        );
+
+        const response = await skillsRoutes.request("/import-archive", {
+          method: "POST",
+          body: formData,
+        });
+        expect(response.status).toBe(400);
+        const body = ErrorSchema.parse(await response.json());
+        expect(body.error).toContain("SKILL.md parse failed");
+      } finally {
+        rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it("returns 400 with deadLinks when instructions reference missing files", async () => {
+      const { packExportArchive } = await import("@atlas/skills/archive");
+      const archiveBytes = await packExportArchive({
+        instructions: "# Skill\n\nUses [missing](references/missing.md).\n",
+        frontmatter: {
+          name: "@atlas/dead-links",
+          description: "Skill with dead links. Use when testing dead link validation.",
+        },
+        archive: null,
+      });
+
+      const formData = new FormData();
+      formData.append(
+        "archive",
+        new File([new Uint8Array(archiveBytes)], "dead-links.tar.gz", { type: "application/gzip" }),
+      );
+
+      const response = await skillsRoutes.request("/import-archive", {
+        method: "POST",
+        body: formData,
+      });
+      expect(response.status).toBe(400);
+      const body = z
+        .object({ error: z.string(), deadLinks: z.array(z.string()) })
+        .parse(await response.json());
+      expect(body.deadLinks).toContain("references/missing.md");
     });
   });
 

--- a/apps/atlasd/routes/skills.test.ts
+++ b/apps/atlasd/routes/skills.test.ts
@@ -403,18 +403,12 @@ describe("Skills API Routes - Global Catalog", () => {
         description: "Imported skill for round-trip test. Use when testing import.",
       };
       const instructions = "# Imported\n\nDo the thing.";
-      const archiveBytes = await packExportArchive({
-        instructions,
-        frontmatter,
-        archive: null,
-      });
+      const archiveBytes = await packExportArchive({ instructions, frontmatter, archive: null });
 
       const formData = new FormData();
       formData.append(
         "archive",
-        new File([new Uint8Array(archiveBytes)], "imported.tar.gz", {
-          type: "application/gzip",
-        }),
+        new File([new Uint8Array(archiveBytes)], "imported.tar.gz", { type: "application/gzip" }),
       );
 
       const response = await skillsRoutes.request("/import-archive", {
@@ -448,9 +442,7 @@ describe("Skills API Routes - Global Catalog", () => {
       const formData = new FormData();
       formData.append(
         "archive",
-        new File([new Uint8Array(archiveBytes)], "imported.tar.gz", {
-          type: "application/gzip",
-        }),
+        new File([new Uint8Array(archiveBytes)], "imported.tar.gz", { type: "application/gzip" }),
       );
 
       const response = await skillsRoutes.request("/import-archive", {
@@ -479,9 +471,7 @@ describe("Skills API Routes - Global Catalog", () => {
       const formData = new FormData();
       formData.append(
         "archive",
-        new File([new Uint8Array(archiveBytes)], "imported.tar.gz", {
-          type: "application/gzip",
-        }),
+        new File([new Uint8Array(archiveBytes)], "imported.tar.gz", { type: "application/gzip" }),
       );
 
       const response = await skillsRoutes.request("/import-archive?namespace=eric", {

--- a/apps/atlasd/routes/skills.test.ts
+++ b/apps/atlasd/routes/skills.test.ts
@@ -144,6 +144,53 @@ describe("Skills API Routes - Global Catalog", () => {
       expect(body.skill.instructions).toContain("# Split Me");
     });
 
+    it("explicit frontmatter wins over embedded frontmatter on key conflict", async () => {
+      // Both sources provide `description`. The route comment in skills.ts
+      // promises "Explicit `input.frontmatter` wins on key conflicts" — lock
+      // that direction in so a future merge-order swap shows up as a failure.
+      const fullSkillMd =
+        "---\nname: merge-conflict\ndescription: embedded\n---\n\n# Merge Conflict\n\nBody.\n";
+      const publishRes = await skillsRoutes.request("/@atlas/merge-conflict", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          instructions: fullSkillMd,
+          frontmatter: { description: "explicit" },
+        }),
+      });
+      expect(publishRes.status).toBe(201);
+
+      const getRes = await skillsRoutes.request("/@atlas/merge-conflict");
+      expect(getRes.status).toBe(200);
+      const body = (await getRes.json()) as {
+        skill: { frontmatter: Record<string, unknown> };
+      };
+      expect(body.skill.frontmatter.description).toBe("explicit");
+    });
+
+    it("splits embedded frontmatter without a description into the frontmatter column (legacy row shape)", async () => {
+      // Legacy rows had embedded frontmatter without `description` in
+      // `instructions`. The strict parser rejected them, so the body was
+      // stored verbatim with the YAML preamble — exactly what this PR fixes.
+      const legacySkillMd =
+        "---\nname: legacy-skill\n---\n\n# Legacy Skill\n\nBody content.\n";
+      const publishRes = await skillsRoutes.request("/@atlas/legacy-skill", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ instructions: legacySkillMd }),
+      });
+      expect(publishRes.status).toBe(201);
+
+      const getRes = await skillsRoutes.request("/@atlas/legacy-skill");
+      expect(getRes.status).toBe(200);
+      const body = (await getRes.json()) as {
+        skill: { instructions: string; frontmatter: Record<string, unknown> };
+      };
+      expect(body.skill.frontmatter).toMatchObject({ name: "legacy-skill" });
+      expect(body.skill.instructions.trimStart().startsWith("---")).toBe(false);
+      expect(body.skill.instructions).toContain("# Legacy Skill");
+    });
+
     it("auto-increments version on subsequent publish", async () => {
       const response = await skillsRoutes.request("/@atlas/code-review", {
         method: "POST",
@@ -402,6 +449,7 @@ describe("Skills API Routes - Global Catalog", () => {
       const frontmatter = {
         name: "@atlas/imported-skill",
         description: "Imported skill for round-trip test. Use when testing import.",
+        metadata: { foo: "bar" },
       };
       const instructions = "# Imported\n\nDo the thing.";
       const archiveBytes = await packExportArchive({ instructions, frontmatter, archive: null });
@@ -427,6 +475,11 @@ describe("Skills API Routes - Global Catalog", () => {
       const skill = SkillResponseSchema.parse(await getRes.json());
       expect(skill.skill.description).toBe(frontmatter.description);
       expect(skill.skill.instructions).toBe(instructions);
+      expect(skill.skill.frontmatter).toMatchObject({
+        name: "@atlas/imported-skill",
+        description: frontmatter.description,
+        metadata: { foo: "bar" },
+      });
     });
 
     it("returns 400 with needsNamespace when frontmatter has no namespace", async () => {
@@ -486,6 +539,95 @@ describe("Skills API Routes - Global Catalog", () => {
 
       const getRes = await skillsRoutes.request("/@eric/just-a-name");
       expect(getRes.status).toBe(200);
+    });
+
+    it("uses ?namespace= and ?name= query params to override the frontmatter prefix", async () => {
+      const { packExportArchive } = await import("@atlas/skills/archive");
+      const archiveBytes = await packExportArchive({
+        instructions: "Body of skill.",
+        frontmatter: {
+          name: "@atlas/original-name",
+          description: "Skill that will be renamed via query params on import.",
+        },
+        archive: null,
+      });
+
+      const formData = new FormData();
+      formData.append(
+        "archive",
+        new File([new Uint8Array(archiveBytes)], "imported.tar.gz", { type: "application/gzip" }),
+      );
+
+      const response = await skillsRoutes.request(
+        "/import-archive?namespace=different-ns&name=overridden-name",
+        { method: "POST", body: formData },
+      );
+      expect(response.status).toBe(201);
+      const body = PublishedResponseSchema.parse(await response.json());
+      expect(body.published.namespace).toBe("different-ns");
+      expect(body.published.name).toBe("overridden-name");
+
+      const getRes = await skillsRoutes.request("/@different-ns/overridden-name");
+      expect(getRes.status).toBe(200);
+    });
+
+    it("end-to-end: export with refs then re-import preserves reference files", async () => {
+      // Publish the source skill with a reference file via the /upload endpoint.
+      const { packSkillArchive } = await import("@atlas/skills/archive");
+      const archiveDir = join(tmpdir(), `skills-roundtrip-src-${Date.now()}`);
+      mkdirSync(join(archiveDir, "references"), { recursive: true });
+      writeFileSync(join(archiveDir, "references", "foo.md"), "# Foo\nReference content.");
+
+      const sourceArchive = await packSkillArchive(archiveDir);
+      rmSync(archiveDir, { recursive: true, force: true });
+
+      const uploadForm = new FormData();
+      uploadForm.append(
+        "archive",
+        new File([new Uint8Array(sourceArchive)], "skill.tar.gz", { type: "application/gzip" }),
+      );
+      uploadForm.append("description", "Source skill for round-trip with references.");
+      uploadForm.append(
+        "instructions",
+        "# Source\n\nUses [foo](references/foo.md) as a reference.",
+      );
+
+      const uploadRes = await skillsRoutes.request("/@atlas/roundtrip-src/upload", {
+        method: "POST",
+        body: uploadForm,
+      });
+      expect(uploadRes.status).toBe(201);
+
+      // Export the published skill and re-import it under a different ns/name.
+      const exportRes = await skillsRoutes.request("/@atlas/roundtrip-src/export");
+      expect(exportRes.status).toBe(200);
+      const exportedBytes = new Uint8Array(await exportRes.arrayBuffer());
+
+      const importForm = new FormData();
+      importForm.append(
+        "archive",
+        new File([exportedBytes], "exported.tar.gz", { type: "application/gzip" }),
+      );
+
+      const importRes = await skillsRoutes.request(
+        "/import-archive?namespace=roundtrip-dst&name=roundtrip-dst-name",
+        { method: "POST", body: importForm },
+      );
+      expect(importRes.status).toBe(201);
+      const imported = PublishedResponseSchema.parse(await importRes.json());
+      expect(imported.published.namespace).toBe("roundtrip-dst");
+      expect(imported.published.name).toBe("roundtrip-dst-name");
+
+      // The reference file content should survive the export -> import round-trip.
+      const fileRes = await skillsRoutes.request(
+        "/@roundtrip-dst/roundtrip-dst-name/files/references/foo.md",
+      );
+      expect(fileRes.status).toBe(200);
+      const fileBody = z
+        .object({ path: z.string(), content: z.string() })
+        .parse(await fileRes.json());
+      expect(fileBody.content).toContain("# Foo");
+      expect(fileBody.content).toContain("Reference content.");
     });
 
     it("returns 400 when SKILL.md has malformed frontmatter", async () => {

--- a/apps/atlasd/routes/skills.test.ts
+++ b/apps/atlasd/routes/skills.test.ts
@@ -341,6 +341,141 @@ describe("Skills API Routes - Global Catalog", () => {
   });
 
   // ═══════════════════════════════════════════════════════════════════════════
+  // EXPORT (self-contained tar.gz with reconstructed SKILL.md)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe("GET /:namespace/:name/export", () => {
+    it("exports a published skill as a tar.gz containing SKILL.md", async () => {
+      const response = await skillsRoutes.request("/@atlas/code-review/export");
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/gzip");
+      const disposition = response.headers.get("content-disposition") ?? "";
+      expect(disposition).toContain("attachment");
+      expect(disposition).toContain('filename="@atlas-code-review-v');
+      expect(disposition).toContain('.tar.gz"');
+
+      const { extractArchiveContents } = await import("@atlas/skills/archive");
+      const bytes = new Uint8Array(await response.arrayBuffer());
+      const contents = await extractArchiveContents(bytes);
+      expect(contents["SKILL.md"]).toBeDefined();
+    });
+
+    it("returns 404 for non-existent skill", async () => {
+      const response = await skillsRoutes.request("/@atlas/nonexistent/export");
+      expect(response.status).toBe(404);
+      const body = ErrorSchema.parse(await response.json());
+      expect(body.error).toBe("Skill not found");
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
+  // IMPORT (round-trip from exported tar.gz)
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  describe("POST /import-archive", () => {
+    it("imports a previously-exported tar.gz and republishes the skill", async () => {
+      const { packExportArchive } = await import("@atlas/skills/archive");
+      const frontmatter = {
+        name: "@atlas/imported-skill",
+        description: "Imported skill for round-trip test. Use when testing import.",
+      };
+      const instructions = "# Imported\n\nDo the thing.";
+      const archiveBytes = await packExportArchive({
+        instructions,
+        frontmatter,
+        archive: null,
+      });
+
+      const formData = new FormData();
+      formData.append(
+        "archive",
+        new File([new Uint8Array(archiveBytes)], "imported.tar.gz", {
+          type: "application/gzip",
+        }),
+      );
+
+      const response = await skillsRoutes.request("/import-archive", {
+        method: "POST",
+        body: formData,
+      });
+      expect(response.status).toBe(201);
+      const body = PublishedResponseSchema.parse(await response.json());
+      expect(body.published.namespace).toBe("atlas");
+      expect(body.published.name).toBe("imported-skill");
+
+      // Verify the skill is fetchable + content survived the round trip
+      const getRes = await skillsRoutes.request("/@atlas/imported-skill");
+      expect(getRes.status).toBe(200);
+      const skill = SkillResponseSchema.parse(await getRes.json());
+      expect(skill.skill.description).toBe(frontmatter.description);
+      expect(skill.skill.instructions).toBe(instructions);
+    });
+
+    it("returns 400 with needsNamespace when frontmatter has no namespace", async () => {
+      const { packExportArchive } = await import("@atlas/skills/archive");
+      const archiveBytes = await packExportArchive({
+        instructions: "Body of skill.",
+        frontmatter: {
+          name: "just-a-name",
+          description: "Skill without namespace. Use when something happens.",
+        },
+        archive: null,
+      });
+
+      const formData = new FormData();
+      formData.append(
+        "archive",
+        new File([new Uint8Array(archiveBytes)], "imported.tar.gz", {
+          type: "application/gzip",
+        }),
+      );
+
+      const response = await skillsRoutes.request("/import-archive", {
+        method: "POST",
+        body: formData,
+      });
+      expect(response.status).toBe(400);
+      const body = z
+        .object({ error: z.string(), needsNamespace: z.literal(true), defaultName: z.string() })
+        .parse(await response.json());
+      expect(body.needsNamespace).toBe(true);
+      expect(body.defaultName).toBe("just-a-name");
+    });
+
+    it("uses ?namespace= query param to supply a missing namespace", async () => {
+      const { packExportArchive } = await import("@atlas/skills/archive");
+      const archiveBytes = await packExportArchive({
+        instructions: "Body of skill.",
+        frontmatter: {
+          name: "just-a-name",
+          description: "Skill without namespace. Use when something happens.",
+        },
+        archive: null,
+      });
+
+      const formData = new FormData();
+      formData.append(
+        "archive",
+        new File([new Uint8Array(archiveBytes)], "imported.tar.gz", {
+          type: "application/gzip",
+        }),
+      );
+
+      const response = await skillsRoutes.request("/import-archive?namespace=eric", {
+        method: "POST",
+        body: formData,
+      });
+      expect(response.status).toBe(201);
+      const body = PublishedResponseSchema.parse(await response.json());
+      expect(body.published.namespace).toBe("eric");
+      expect(body.published.name).toBe("just-a-name");
+
+      const getRes = await skillsRoutes.request("/@eric/just-a-name");
+      expect(getRes.status).toBe(200);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════════
   // CREATE BLANK SKILL
   // ═══════════════════════════════════════════════════════════════════════════
 

--- a/apps/atlasd/routes/skills.test.ts
+++ b/apps/atlasd/routes/skills.test.ts
@@ -162,9 +162,7 @@ describe("Skills API Routes - Global Catalog", () => {
 
       const getRes = await skillsRoutes.request("/@atlas/merge-conflict");
       expect(getRes.status).toBe(200);
-      const body = (await getRes.json()) as {
-        skill: { frontmatter: Record<string, unknown> };
-      };
+      const body = (await getRes.json()) as { skill: { frontmatter: Record<string, unknown> } };
       expect(body.skill.frontmatter.description).toBe("explicit");
     });
 
@@ -172,8 +170,7 @@ describe("Skills API Routes - Global Catalog", () => {
       // Legacy rows had embedded frontmatter without `description` in
       // `instructions`. The strict parser rejected them, so the body was
       // stored verbatim with the YAML preamble — exactly what this PR fixes.
-      const legacySkillMd =
-        "---\nname: legacy-skill\n---\n\n# Legacy Skill\n\nBody content.\n";
+      const legacySkillMd = "---\nname: legacy-skill\n---\n\n# Legacy Skill\n\nBody content.\n";
       const publishRes = await skillsRoutes.request("/@atlas/legacy-skill", {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/apps/atlasd/routes/skills.ts
+++ b/apps/atlasd/routes/skills.ts
@@ -10,6 +10,7 @@ import {
   lintSkill,
   listArchiveFiles,
   localAudit,
+  packExportArchive,
   packSkillArchive,
   parseSkillMd,
   readArchiveFile,
@@ -521,6 +522,135 @@ export const skillsRoutes = daemonFactory
       return c.body(null, 204);
     },
   )
+  // ─── IMPORT FROM EXPORTED TAR.GZ ────────────────────────────────────────────
+  // Inverse of GET /:namespace/:name/export. Accepts a self-contained tar.gz
+  // (SKILL.md at root + reference files) and publishes it. Namespace comes
+  // from `?namespace=` if provided, otherwise the `@<ns>/<name>` prefix in
+  // SKILL.md frontmatter. When neither yields a namespace, returns 400 with
+  // `needsNamespace: true` so the caller can prompt and re-POST.
+  // Must be registered before /:namespace/... so Hono doesn't match
+  // "import-archive" as a namespace param.
+  .post("/import-archive", async (c) => {
+    const auth = await requireUser();
+    if (!auth.ok) return c.json({ error: auth.error }, 401);
+
+    const formData = await c.req.formData();
+    const file = formData.get("archive");
+    if (!(file instanceof File)) {
+      return c.json({ error: "archive field is required and must be a File" }, 400);
+    }
+
+    const archiveBytes = new Uint8Array(await file.arrayBuffer());
+    const extracted = await extractArchiveContents(archiveBytes);
+    const skillMdContent = extracted["SKILL.md"];
+    if (!skillMdContent) {
+      return c.json({ error: "Archive must contain SKILL.md at root" }, 400);
+    }
+
+    const parsed = parseSkillMd(skillMdContent);
+    if (!parsed.ok) return c.json({ error: `SKILL.md parse failed: ${parsed.error}` }, 400);
+    const { frontmatter, instructions } = parsed.data;
+
+    // Derive (namespace, name). Query param wins; otherwise split `@ns/name`
+    // from frontmatter. The bare name (after the slash, or whole string when
+    // no slash) is always taken from frontmatter.
+    const fmName = typeof frontmatter.name === "string" ? frontmatter.name : "";
+    const queryNs = c.req.query("namespace");
+    let namespace: string | undefined;
+    let name: string;
+    if (fmName.startsWith("@") && fmName.includes("/")) {
+      const slash = fmName.indexOf("/");
+      namespace = fmName.slice(1, slash);
+      name = fmName.slice(slash + 1);
+    } else {
+      name = fmName;
+    }
+    if (queryNs) namespace = queryNs;
+
+    if (!name) {
+      return c.json({ error: "SKILL.md frontmatter must include a `name` field" }, 400);
+    }
+    if (!namespace) {
+      return c.json(
+        {
+          error:
+            "SKILL.md frontmatter has no namespace. Re-upload with ?namespace=<ns> to choose one.",
+          needsNamespace: true,
+          defaultName: name,
+        },
+        400,
+      );
+    }
+
+    const nsCheck = NamespaceSchema.safeParse(namespace);
+    if (!nsCheck.success) {
+      return c.json({ error: `Invalid namespace: ${nsCheck.error.message}` }, 400);
+    }
+    const nameCheck = SkillNameSchema.safeParse(name);
+    if (!nameCheck.success) {
+      return c.json({ error: `Invalid skill name: ${nameCheck.error.message}` }, 400);
+    }
+
+    if (isFridayNamespaceBlockedForUser(namespace, auth.userId)) {
+      return c.json({ error: "The @friday namespace is reserved for bundled system skills" }, 403);
+    }
+
+    // Storage-format archive excludes SKILL.md. Repack the rest into a fresh
+    // tar.gz, or skip the archive entirely if SKILL.md was the only entry.
+    const otherFiles = Object.entries(extracted).filter(([p]) => p !== "SKILL.md");
+    let storageArchive: Uint8Array | undefined;
+    if (otherFiles.length > 0) {
+      const tmpDir = makeTempDir({ prefix: "atlas-import-" });
+      try {
+        for (const [path, content] of otherFiles) {
+          const fullPath = join(tmpDir, path);
+          await mkdir(dirname(fullPath), { recursive: true });
+          await writeFile(fullPath, content, "utf-8");
+        }
+        storageArchive = new Uint8Array(await packSkillArchive(tmpDir));
+      } finally {
+        await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+      }
+    }
+
+    const archiveFiles = otherFiles.map(([p]) => p);
+    const deadLinks = validateSkillReferences(instructions, archiveFiles);
+    if (deadLinks.length > 0) {
+      return c.json(
+        {
+          error: `Skill instructions reference files not found in archive: ${deadLinks.join(", ")}`,
+          deadLinks,
+        },
+        400,
+      );
+    }
+
+    const description =
+      typeof frontmatter.description === "string" ? frontmatter.description : "";
+
+    const input = PublishSkillInputSchema.safeParse({
+      description,
+      instructions,
+      frontmatter,
+      archive: storageArchive,
+    });
+    if (!input.success) return c.json({ error: input.error.message }, 400);
+
+    const result = await SkillStorage.publish(namespace, name, auth.userId, input.data);
+    if (!result.ok) return c.json({ error: result.error }, 500);
+    return c.json(
+      {
+        published: {
+          id: result.data.id,
+          skillId: result.data.skillId,
+          namespace,
+          name: result.data.name,
+          version: result.data.version,
+        },
+      },
+      201,
+    );
+  })
   // ─── GET LATEST ─────────────────────────────────────────────────────────────
   .get(
     "/:namespace/:name",
@@ -547,6 +677,32 @@ export const skillsRoutes = daemonFactory
     const result = await SkillStorage.listVersions(namespace, name);
     if (!result.ok) return c.json({ error: result.error }, 500);
     return c.json({ versions: result.data });
+  })
+  // ─── EXPORT AS SELF-CONTAINED TAR.GZ ───────────────────────────────────────
+  // Reconstructs SKILL.md from frontmatter + instructions and packs it
+  // alongside any reference files from the stored archive. The result is a
+  // single tar.gz the user can download, share, or re-import.
+  // Must be registered before /:version to avoid Hono matching "export" as a version.
+  .get("/:namespace/:name/export", zValidator("param", NamespacedParams), async (c) => {
+    const { namespace, name } = c.req.valid("param");
+    const result = await SkillStorage.get(namespace, name);
+    if (!result.ok) return c.json({ error: result.error }, 500);
+    if (!result.data) return c.json({ error: "Skill not found" }, 404);
+
+    const bytes = await packExportArchive({
+      instructions: result.data.instructions,
+      frontmatter: result.data.frontmatter,
+      archive: result.data.archive,
+    });
+    const body = new Uint8Array(bytes);
+    return new Response(body, {
+      status: 200,
+      headers: {
+        "Content-Type": "application/gzip",
+        "Content-Disposition": `attachment; filename="@${namespace}-${name}-v${String(result.data.version)}.tar.gz"`,
+        "Content-Length": String(body.byteLength),
+      },
+    });
   })
   // ─── AUTO-FIX A LINT FINDING ───────────────────────────────────────────────
   // Applies a one-shot fix for a single lint rule. Deterministic rules

--- a/apps/atlasd/routes/skills.ts
+++ b/apps/atlasd/routes/skills.ts
@@ -17,6 +17,7 @@ import {
   readArchiveFile,
   SkillStorage,
   SkillsShClient,
+  splitSkillMd,
   validateSkillReferences,
 } from "@atlas/skills";
 import { PublishSkillInputSchema, SkillSortSchema } from "@atlas/skills/schemas";
@@ -723,7 +724,7 @@ export const skillsRoutes = daemonFactory
       status: 200,
       headers: {
         "Content-Type": "application/gzip",
-        "Content-Disposition": `attachment; filename="@${namespace.replace(/["\r\n\0]/g, "")}-${name.replace(/["\r\n\0]/g, "")}-v${String(result.data.version)}.tar.gz"`,
+        "Content-Disposition": `attachment; filename="@${namespace}-${name}-v${String(result.data.version)}.tar.gz"`,
         "Content-Length": String(body.byteLength),
       },
     });
@@ -1112,14 +1113,12 @@ export const skillsRoutes = daemonFactory
       // frontmatter block — split it here so the column gets populated and
       // the body stored without the YAML preamble. Explicit `input.frontmatter`
       // wins on key conflicts (it's the caller's deliberate signal).
-      const parsedSkillMd = parseSkillMd(rawInput.instructions);
-      const input = parsedSkillMd.ok
-        ? {
-            ...rawInput,
-            instructions: parsedSkillMd.data.instructions,
-            frontmatter: { ...parsedSkillMd.data.frontmatter, ...(rawInput.frontmatter ?? {}) },
-          }
-        : rawInput;
+      const { frontmatter: embedded, instructions: body } = splitSkillMd(rawInput.instructions);
+      const input = {
+        ...rawInput,
+        instructions: body,
+        frontmatter: { ...embedded, ...(rawInput.frontmatter ?? {}) },
+      };
 
       // Validate references against the text files that will actually be
       // extracted to the sandbox — not the full archive (which includes binaries

--- a/apps/atlasd/routes/skills.ts
+++ b/apps/atlasd/routes/skills.ts
@@ -622,7 +622,10 @@ export const skillsRoutes = daemonFactory
       }
 
       if (isFridayNamespaceBlockedForUser(namespace, auth.userId)) {
-        return c.json({ error: "The @friday namespace is reserved for bundled system skills" }, 403);
+        return c.json(
+          { error: "The @friday namespace is reserved for bundled system skills" },
+          403,
+        );
       }
 
       // Collect file paths (excluding SKILL.md) for dead-link validation.
@@ -648,7 +651,8 @@ export const skillsRoutes = daemonFactory
         storageArchive = new Uint8Array(await packSkillArchive(extractedDir));
       }
 
-      const description = typeof frontmatter.description === "string" ? frontmatter.description : "";
+      const description =
+        typeof frontmatter.description === "string" ? frontmatter.description : "";
 
       const input = PublishSkillInputSchema.safeParse({
         description,

--- a/apps/atlasd/routes/skills.ts
+++ b/apps/atlasd/routes/skills.ts
@@ -1080,7 +1080,22 @@ export const skillsRoutes = daemonFactory
           403,
         );
       }
-      const input = c.req.valid("json");
+      const rawInput = c.req.valid("json");
+
+      // Storage invariant: `instructions` is body-only, `frontmatter` is the
+      // parsed YAML. Callers (the editor's Save button, the SKILL.md drop in
+      // SkillLoader) often POST `instructions` containing an embedded
+      // frontmatter block — split it here so the column gets populated and
+      // the body stored without the YAML preamble. Explicit `input.frontmatter`
+      // wins on key conflicts (it's the caller's deliberate signal).
+      const parsedSkillMd = parseSkillMd(rawInput.instructions);
+      const input = parsedSkillMd.ok
+        ? {
+            ...rawInput,
+            instructions: parsedSkillMd.data.instructions,
+            frontmatter: { ...parsedSkillMd.data.frontmatter, ...(rawInput.frontmatter ?? {}) },
+          }
+        : rawInput;
 
       // Validate references against the text files that will actually be
       // extracted to the sandbox — not the full archive (which includes binaries

--- a/apps/atlasd/routes/skills.ts
+++ b/apps/atlasd/routes/skills.ts
@@ -625,8 +625,7 @@ export const skillsRoutes = daemonFactory
       );
     }
 
-    const description =
-      typeof frontmatter.description === "string" ? frontmatter.description : "";
+    const description = typeof frontmatter.description === "string" ? frontmatter.description : "";
 
     const input = PublishSkillInputSchema.safeParse({
       description,

--- a/apps/atlasd/routes/skills.ts
+++ b/apps/atlasd/routes/skills.ts
@@ -1,4 +1,5 @@
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { Buffer } from "node:buffer";
+import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import process from "node:process";
 import { NamespaceSchema, RESERVED_WORDS, SkillNameSchema } from "@atlas/config";
@@ -89,6 +90,21 @@ async function requireUser(): Promise<{ ok: true; userId: string } | { ok: false
  * matching the bootstrap loader's sentinel user id — which interactive
  * callers never hold. Returns true when the caller should be rejected.
  */
+async function listFilesRecursively(dir: string, base = ""): Promise<string[]> {
+  const currentDir = base ? join(dir, base) : dir;
+  const entries = await readdir(currentDir, { withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const relPath = base ? `${base}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      files.push(...(await listFilesRecursively(dir, relPath)));
+    } else if (entry.isFile()) {
+      files.push(relPath);
+    }
+  }
+  return files;
+}
+
 function isFridayNamespaceBlockedForUser(namespace: string, userId: string): boolean {
   return namespace === "friday" && userId !== "system";
 }
@@ -540,115 +556,124 @@ export const skillsRoutes = daemonFactory
       return c.json({ error: "archive field is required and must be a File" }, 400);
     }
 
+    const MAX_IMPORT_SIZE = 50 * 1024 * 1024; // 50 MB
+    if (file.size > MAX_IMPORT_SIZE) {
+      return c.json({ error: "Archive exceeds 50 MB limit" }, 413);
+    }
+
     const archiveBytes = new Uint8Array(await file.arrayBuffer());
-    const extracted = await extractArchiveContents(archiveBytes);
-    const skillMdContent = extracted["SKILL.md"];
-    if (!skillMdContent) {
-      return c.json({ error: "Archive must contain SKILL.md at root" }, 400);
-    }
 
-    const parsed = parseSkillMd(skillMdContent);
-    if (!parsed.ok) return c.json({ error: `SKILL.md parse failed: ${parsed.error}` }, 400);
-    const { frontmatter, instructions } = parsed.data;
-
-    // Derive (namespace, name). Query param wins; otherwise split `@ns/name`
-    // from frontmatter. The bare name (after the slash, or whole string when
-    // no slash) is always taken from frontmatter.
-    const fmName = typeof frontmatter.name === "string" ? frontmatter.name : "";
-    const queryNs = c.req.query("namespace");
-    let namespace: string | undefined;
-    let name: string;
-    if (fmName.startsWith("@") && fmName.includes("/")) {
-      const slash = fmName.indexOf("/");
-      namespace = fmName.slice(1, slash);
-      name = fmName.slice(slash + 1);
-    } else {
-      name = fmName;
-    }
-    if (queryNs) namespace = queryNs;
-
-    if (!name) {
-      return c.json({ error: "SKILL.md frontmatter must include a `name` field" }, 400);
-    }
-    if (!namespace) {
-      return c.json(
-        {
-          error:
-            "SKILL.md frontmatter has no namespace. Re-upload with ?namespace=<ns> to choose one.",
-          needsNamespace: true,
-          defaultName: name,
-        },
-        400,
-      );
-    }
-
-    const nsCheck = NamespaceSchema.safeParse(namespace);
-    if (!nsCheck.success) {
-      return c.json({ error: `Invalid namespace: ${nsCheck.error.message}` }, 400);
-    }
-    const nameCheck = SkillNameSchema.safeParse(name);
-    if (!nameCheck.success) {
-      return c.json({ error: `Invalid skill name: ${nameCheck.error.message}` }, 400);
-    }
-
-    if (isFridayNamespaceBlockedForUser(namespace, auth.userId)) {
-      return c.json({ error: "The @friday namespace is reserved for bundled system skills" }, 403);
-    }
-
-    // Storage-format archive excludes SKILL.md. Repack the rest into a fresh
-    // tar.gz, or skip the archive entirely if SKILL.md was the only entry.
-    const otherFiles = Object.entries(extracted).filter(([p]) => p !== "SKILL.md");
-    let storageArchive: Uint8Array | undefined;
-    if (otherFiles.length > 0) {
-      const tmpDir = makeTempDir({ prefix: "atlas-import-" });
+    // Extract to temp dir — preserves binary fidelity and filters unsafe paths.
+    const extractedDir = await extractSkillArchive(Buffer.from(archiveBytes), "atlas-import-");
+    try {
+      const skillMdPath = join(extractedDir, "SKILL.md");
+      let skillMdContent: string;
       try {
-        for (const [path, content] of otherFiles) {
-          const fullPath = join(tmpDir, path);
-          await mkdir(dirname(fullPath), { recursive: true });
-          await writeFile(fullPath, content, "utf-8");
-        }
-        storageArchive = new Uint8Array(await packSkillArchive(tmpDir));
-      } finally {
-        await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+        skillMdContent = await readFile(skillMdPath, "utf-8");
+      } catch {
+        return c.json({ error: "Archive must contain SKILL.md at root" }, 400);
       }
-    }
 
-    const archiveFiles = otherFiles.map(([p]) => p);
-    const deadLinks = validateSkillReferences(instructions, archiveFiles);
-    if (deadLinks.length > 0) {
+      const parsed = parseSkillMd(skillMdContent);
+      if (!parsed.ok) return c.json({ error: `SKILL.md parse failed: ${parsed.error}` }, 400);
+      const { frontmatter, instructions } = parsed.data;
+
+      // Derive (namespace, name). Query params win; otherwise split `@ns/name`
+      // from frontmatter. The bare name (after the slash, or whole string when
+      // no slash) is always taken from frontmatter.
+      const fmName = typeof frontmatter.name === "string" ? frontmatter.name : "";
+      const queryNs = c.req.query("namespace");
+      const queryName = c.req.query("name");
+      let namespace: string | undefined;
+      let name: string;
+      if (fmName.startsWith("@") && fmName.includes("/")) {
+        const slash = fmName.indexOf("/");
+        namespace = fmName.slice(1, slash);
+        name = fmName.slice(slash + 1);
+      } else {
+        name = fmName;
+      }
+      if (queryNs) namespace = queryNs;
+      if (queryName) name = queryName;
+
+      if (!name) {
+        return c.json({ error: "SKILL.md frontmatter must include a `name` field" }, 400);
+      }
+      if (!namespace) {
+        return c.json(
+          {
+            error:
+              "SKILL.md frontmatter has no namespace. Re-upload with ?namespace=<ns> to choose one.",
+            needsNamespace: true,
+            defaultName: name,
+          },
+          400,
+        );
+      }
+
+      const nsCheck = NamespaceSchema.safeParse(namespace);
+      if (!nsCheck.success) {
+        return c.json({ error: `Invalid namespace: ${nsCheck.error.message}` }, 400);
+      }
+      const nameCheck = SkillNameSchema.safeParse(name);
+      if (!nameCheck.success) {
+        return c.json({ error: `Invalid skill name: ${nameCheck.error.message}` }, 400);
+      }
+
+      if (isFridayNamespaceBlockedForUser(namespace, auth.userId)) {
+        return c.json({ error: "The @friday namespace is reserved for bundled system skills" }, 403);
+      }
+
+      // Collect file paths (excluding SKILL.md) for dead-link validation.
+      const archiveFiles = (await listFilesRecursively(extractedDir)).filter(
+        (p) => p !== "SKILL.md",
+      );
+      const deadLinks = validateSkillReferences(instructions, archiveFiles);
+      if (deadLinks.length > 0) {
+        return c.json(
+          {
+            error: `Skill instructions reference files not found in archive: ${deadLinks.join(", ")}`,
+            deadLinks,
+          },
+          400,
+        );
+      }
+
+      // Remove SKILL.md before packing the rest into a storage-format archive.
+      await rm(skillMdPath, { force: true });
+
+      let storageArchive: Uint8Array | undefined;
+      if (archiveFiles.length > 0) {
+        storageArchive = new Uint8Array(await packSkillArchive(extractedDir));
+      }
+
+      const description = typeof frontmatter.description === "string" ? frontmatter.description : "";
+
+      const input = PublishSkillInputSchema.safeParse({
+        description,
+        instructions,
+        frontmatter,
+        archive: storageArchive,
+      });
+      if (!input.success) return c.json({ error: input.error.message }, 400);
+
+      const result = await SkillStorage.publish(namespace, name, auth.userId, input.data);
+      if (!result.ok) return c.json({ error: result.error }, 500);
       return c.json(
         {
-          error: `Skill instructions reference files not found in archive: ${deadLinks.join(", ")}`,
-          deadLinks,
+          published: {
+            id: result.data.id,
+            skillId: result.data.skillId,
+            namespace,
+            name: result.data.name,
+            version: result.data.version,
+          },
         },
-        400,
+        201,
       );
+    } finally {
+      await rm(extractedDir, { recursive: true, force: true }).catch(() => {});
     }
-
-    const description = typeof frontmatter.description === "string" ? frontmatter.description : "";
-
-    const input = PublishSkillInputSchema.safeParse({
-      description,
-      instructions,
-      frontmatter,
-      archive: storageArchive,
-    });
-    if (!input.success) return c.json({ error: input.error.message }, 400);
-
-    const result = await SkillStorage.publish(namespace, name, auth.userId, input.data);
-    if (!result.ok) return c.json({ error: result.error }, 500);
-    return c.json(
-      {
-        published: {
-          id: result.data.id,
-          skillId: result.data.skillId,
-          namespace,
-          name: result.data.name,
-          version: result.data.version,
-        },
-      },
-      201,
-    );
   })
   // ─── GET LATEST ─────────────────────────────────────────────────────────────
   .get(
@@ -698,7 +723,7 @@ export const skillsRoutes = daemonFactory
       status: 200,
       headers: {
         "Content-Type": "application/gzip",
-        "Content-Disposition": `attachment; filename="@${namespace}-${name}-v${String(result.data.version)}.tar.gz"`,
+        "Content-Disposition": `attachment; filename="@${namespace.replace(/["\r\n\0]/g, "")}-${name.replace(/["\r\n\0]/g, "")}-v${String(result.data.version)}.tar.gz"`,
         "Content-Length": String(body.byteLength),
       },
     });

--- a/packages/skills/src/archive.test.ts
+++ b/packages/skills/src/archive.test.ts
@@ -52,6 +52,33 @@ describe("packExportArchive", () => {
     expect(parsed.data.frontmatter.description).toContain("sparring partner");
   });
 
+  it("splits embedded frontmatter even when it lacks a description (legacy row shape)", async () => {
+    // Legacy rows from before the JSON-publish split fix have an embedded
+    // `---...---` block in `instructions` and an empty `frontmatter` column.
+    // The strict parser rejects these (no `description` key), so the export
+    // path used to fall back to raw input and emit two frontmatter blocks.
+    const instructionsWithLegacyFm =
+      "---\nname: legacy-skill\n---\n\n# Legacy Skill\n\nBody here.\n";
+
+    const result = await packExportArchive({
+      instructions: instructionsWithLegacyFm,
+      frontmatter: {},
+      archive: null,
+    });
+
+    const contents = await extractArchiveContents(result);
+    const skillMd = contents["SKILL.md"] as string;
+
+    // Exactly one frontmatter block: 2 `---` delimiters, not 4.
+    const frontmatterDelimiters = skillMd.match(/^---$/gm);
+    expect(frontmatterDelimiters?.length ?? 0).toBe(2);
+
+    // Body must not start with a frontmatter delimiter.
+    const body = skillMd.split(/^---$/gm).slice(2).join("---").trimStart();
+    expect(body.startsWith("---")).toBe(false);
+    expect(body).toContain("# Legacy Skill");
+  });
+
   it("preserves bundled reference files alongside SKILL.md", async () => {
     const refDir = makeTempDir({ prefix: "atlas-export-test-refs-" });
     const refContent = "# Foo reference\n\nDetails here.\n";

--- a/packages/skills/src/archive.test.ts
+++ b/packages/skills/src/archive.test.ts
@@ -1,0 +1,53 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { makeTempDir } from "@atlas/utils/temp.server";
+import { describe, expect, it } from "vitest";
+import { extractArchiveContents, packExportArchive, packSkillArchive } from "./archive.ts";
+import { parseSkillMd } from "./skill-md-parser.ts";
+
+describe("packExportArchive", () => {
+  it("packs a SKILL.md from frontmatter + body when no archive is provided", async () => {
+    const frontmatter = {
+      name: "processing-pdfs",
+      description: "Extracts text from PDFs. Use when working with PDFs.",
+    };
+    const instructions = "# Processing PDFs\n\nUse pdfplumber.\n";
+
+    const result = await packExportArchive({ instructions, frontmatter, archive: null });
+
+    const contents = await extractArchiveContents(result);
+    const skillMd = contents["SKILL.md"];
+    expect(skillMd).toBeDefined();
+
+    const parsed = parseSkillMd(skillMd as string);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.data.frontmatter).toMatchObject(frontmatter);
+    expect(parsed.data.instructions).toBe(instructions.trim());
+  });
+
+  it("preserves bundled reference files alongside SKILL.md", async () => {
+    const refDir = makeTempDir({ prefix: "atlas-export-test-refs-" });
+    const refContent = "# Foo reference\n\nDetails here.\n";
+    try {
+      await mkdir(join(refDir, "references"), { recursive: true });
+      await writeFile(join(refDir, "references", "foo.md"), refContent);
+      const inputArchive = await packSkillArchive(refDir);
+
+      const result = await packExportArchive({
+        instructions: "# Skill\n\nUses [foo](references/foo.md).\n",
+        frontmatter: {
+          name: "with-refs",
+          description: "A skill with references. Use when you need foo.",
+        },
+        archive: inputArchive,
+      });
+
+      const contents = await extractArchiveContents(result);
+      expect(contents["SKILL.md"]).toContain("with-refs");
+      expect(contents["references/foo.md"]).toBe(refContent);
+    } finally {
+      await rm(refDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/skills/src/archive.test.ts
+++ b/packages/skills/src/archive.test.ts
@@ -26,6 +26,32 @@ describe("packExportArchive", () => {
     expect(parsed.data.instructions).toBe(instructions.trim());
   });
 
+  it("does not double-write frontmatter when instructions already contain a frontmatter block", async () => {
+    // Reproduces the JSON-publish path where the body was stored verbatim
+    // with frontmatter still embedded; the `frontmatter` column is empty.
+    const instructionsWithEmbeddedFm =
+      "---\nname: workspace-sparring\ndescription: Acts as a sparring partner. Use when designing workspaces.\n---\n\n# Workspace Sparring\n\nBody here.\n";
+
+    const result = await packExportArchive({
+      instructions: instructionsWithEmbeddedFm,
+      frontmatter: {},
+      archive: null,
+    });
+
+    const contents = await extractArchiveContents(result);
+    const skillMd = contents["SKILL.md"] as string;
+
+    // The output must have exactly one frontmatter block, not two.
+    const frontmatterDelimiters = skillMd.match(/^---$/gm);
+    expect(frontmatterDelimiters?.length ?? 0).toBe(2);
+
+    const parsed = parseSkillMd(skillMd);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.data.frontmatter.name).toBe("workspace-sparring");
+    expect(parsed.data.frontmatter.description).toContain("sparring partner");
+  });
+
   it("preserves bundled reference files alongside SKILL.md", async () => {
     const refDir = makeTempDir({ prefix: "atlas-export-test-refs-" });
     const refContent = "# Foo reference\n\nDetails here.\n";

--- a/packages/skills/src/archive.ts
+++ b/packages/skills/src/archive.ts
@@ -7,7 +7,7 @@ import { makeTempDir } from "@atlas/utils/temp.server";
 import { stringify as stringifyYaml } from "@std/yaml";
 import MarkdownIt from "markdown-it";
 import { create, extract, list, type WriteEntry } from "tar";
-import { parseSkillMd } from "./skill-md-parser.ts";
+import { splitSkillMd } from "./skill-md-parser.ts";
 
 const logger = createLogger({ name: "skill-archive" });
 
@@ -64,9 +64,7 @@ export async function packExportArchive(input: {
   frontmatter: Record<string, unknown>;
   archive: Uint8Array | null;
 }): Promise<Buffer> {
-  const parsed = parseSkillMd(input.instructions);
-  const embeddedFm = parsed.ok ? parsed.data.frontmatter : {};
-  const body = parsed.ok ? parsed.data.instructions : input.instructions;
+  const { frontmatter: embeddedFm, instructions: body } = splitSkillMd(input.instructions);
   const mergedFm = { ...embeddedFm, ...input.frontmatter };
   const fmYaml = Object.keys(mergedFm).length > 0 ? `---\n${stringifyYaml(mergedFm)}---\n\n` : "";
   const skillMd = `${fmYaml}${body}`;

--- a/packages/skills/src/archive.ts
+++ b/packages/skills/src/archive.ts
@@ -7,6 +7,7 @@ import { makeTempDir } from "@atlas/utils/temp.server";
 import { stringify as stringifyYaml } from "@std/yaml";
 import MarkdownIt from "markdown-it";
 import { create, extract, list, type WriteEntry } from "tar";
+import { parseSkillMd } from "./skill-md-parser.ts";
 
 const logger = createLogger({ name: "skill-archive" });
 
@@ -51,13 +52,23 @@ export async function packSkillArchive(dirPath: string): Promise<Buffer> {
  * alongside any reference files from `archive` (a tar.gz that excludes
  * SKILL.md, matching how skills are stored). Returns a self-contained
  * tar.gz suitable for sharing or re-importing.
+ *
+ * Skills published via the JSON path (`POST /:namespace/:name`) are stored
+ * with the `instructions` body verbatim — including any leading frontmatter
+ * block — and an empty `frontmatter` column. To avoid emitting a double
+ * frontmatter, we always re-parse `instructions` first; embedded fields are
+ * the base, and the column-extracted `frontmatter` overlays them.
  */
 export async function packExportArchive(input: {
   instructions: string;
   frontmatter: Record<string, unknown>;
   archive: Uint8Array | null;
 }): Promise<Buffer> {
-  const skillMd = `---\n${stringifyYaml(input.frontmatter)}---\n\n${input.instructions}`;
+  const parsed = parseSkillMd(input.instructions);
+  const embeddedFm = parsed.ok ? parsed.data.frontmatter : {};
+  const body = parsed.ok ? parsed.data.instructions : input.instructions;
+  const mergedFm = { ...embeddedFm, ...input.frontmatter };
+  const skillMd = `---\n${stringifyYaml(mergedFm)}---\n\n${body}`;
   const dir = input.archive
     ? await extractSkillArchive(Buffer.from(input.archive), "atlas-export-")
     : makeTempDir({ prefix: "atlas-export-" });

--- a/packages/skills/src/archive.ts
+++ b/packages/skills/src/archive.ts
@@ -68,7 +68,8 @@ export async function packExportArchive(input: {
   const embeddedFm = parsed.ok ? parsed.data.frontmatter : {};
   const body = parsed.ok ? parsed.data.instructions : input.instructions;
   const mergedFm = { ...embeddedFm, ...input.frontmatter };
-  const skillMd = `---\n${stringifyYaml(mergedFm)}---\n\n${body}`;
+  const fmYaml = Object.keys(mergedFm).length > 0 ? `---\n${stringifyYaml(mergedFm)}---\n\n` : "";
+  const skillMd = `${fmYaml}${body}`;
   const dir = input.archive
     ? await extractSkillArchive(Buffer.from(input.archive), "atlas-export-")
     : makeTempDir({ prefix: "atlas-export-" });

--- a/packages/skills/src/archive.ts
+++ b/packages/skills/src/archive.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { createLogger } from "@atlas/logger";
 import { stringifyError } from "@atlas/utils";
 import { makeTempDir } from "@atlas/utils/temp.server";
+import { stringify as stringifyYaml } from "@std/yaml";
 import MarkdownIt from "markdown-it";
 import { create, extract, list, type WriteEntry } from "tar";
 
@@ -43,6 +44,31 @@ export async function packSkillArchive(dirPath: string): Promise<Buffer> {
     logger.debug("cleanup failed", { error: stringifyError(e) }),
   );
   return Buffer.from(buf);
+}
+
+/**
+ * Reconstructs SKILL.md from `frontmatter` + `instructions` and packs it
+ * alongside any reference files from `archive` (a tar.gz that excludes
+ * SKILL.md, matching how skills are stored). Returns a self-contained
+ * tar.gz suitable for sharing or re-importing.
+ */
+export async function packExportArchive(input: {
+  instructions: string;
+  frontmatter: Record<string, unknown>;
+  archive: Uint8Array | null;
+}): Promise<Buffer> {
+  const skillMd = `---\n${stringifyYaml(input.frontmatter)}---\n\n${input.instructions}`;
+  const dir = input.archive
+    ? await extractSkillArchive(Buffer.from(input.archive), "atlas-export-")
+    : makeTempDir({ prefix: "atlas-export-" });
+  try {
+    await writeFile(join(dir, "SKILL.md"), skillMd);
+    return await packSkillArchive(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true }).catch((e) =>
+      logger.debug("export cleanup failed", { error: stringifyError(e) }),
+    );
+  }
 }
 
 /**

--- a/packages/skills/src/mod.ts
+++ b/packages/skills/src/mod.ts
@@ -3,6 +3,7 @@ export {
   extractArchiveContents,
   extractSkillArchive,
   listArchiveFiles,
+  packExportArchive,
   packSkillArchive,
   readArchiveFile,
   validateSkillReferences,

--- a/packages/skills/src/mod.ts
+++ b/packages/skills/src/mod.ts
@@ -39,7 +39,7 @@ export {
 export type { LintFinding, LintInput, LintMode, LintResult, LintSeverity } from "./skill-linter.ts";
 export { invalidateLintCache, lintCache, lintSkill } from "./skill-linter.ts";
 export type { SkillFrontmatter } from "./skill-md-parser.ts";
-export { parseSkillMd, SkillFrontmatterSchema } from "./skill-md-parser.ts";
+export { parseSkillMd, SkillFrontmatterSchema, splitSkillMd } from "./skill-md-parser.ts";
 // skills.sh client
 export type {
   SkillsShDownloadResult,

--- a/packages/skills/src/skill-md-parser.ts
+++ b/packages/skills/src/skill-md-parser.ts
@@ -45,6 +45,40 @@ function splitFrontmatter(content: string): { raw: string; body: string } | null
   return { raw, body };
 }
 
+/**
+ * Relaxed splitter for the storage-layer use case: separates an embedded
+ * `---...---` YAML preamble from the body without validating against
+ * `KnownFrontmatterSchema`. Use this when you just need to move YAML out of
+ * `instructions` into the `frontmatter` column on legacy rows that may be
+ * missing required keys (e.g. `description`) or otherwise fail strict
+ * validation. For caller-facing parsing where field types matter, use
+ * `parseSkillMd`.
+ *
+ * Returns empty frontmatter when the YAML can't be parsed as a mapping, but
+ * still strips the body so we don't double-emit the preamble downstream.
+ */
+export function splitSkillMd(
+  content: string,
+): { frontmatter: Record<string, unknown>; instructions: string } {
+  const normalized = content.replace(/\r\n/g, "\n");
+  const split = splitFrontmatter(normalized);
+  if (!split) return { frontmatter: {}, instructions: content.trim() };
+
+  const { raw, body } = split;
+  if (!raw.trim()) return { frontmatter: {}, instructions: body.trim() };
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(raw);
+  } catch {
+    return { frontmatter: {}, instructions: body.trim() };
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return { frontmatter: {}, instructions: body.trim() };
+  }
+  return { frontmatter: parsed as Record<string, unknown>, instructions: body.trim() };
+}
+
 /** Returns full content as instructions when no frontmatter block is present. */
 export function parseSkillMd(
   content: string,

--- a/packages/skills/src/skill-md-parser.ts
+++ b/packages/skills/src/skill-md-parser.ts
@@ -57,9 +57,10 @@ function splitFrontmatter(content: string): { raw: string; body: string } | null
  * Returns empty frontmatter when the YAML can't be parsed as a mapping, but
  * still strips the body so we don't double-emit the preamble downstream.
  */
-export function splitSkillMd(
-  content: string,
-): { frontmatter: Record<string, unknown>; instructions: string } {
+export function splitSkillMd(content: string): {
+  frontmatter: Record<string, unknown>;
+  instructions: string;
+} {
   const normalized = content.replace(/\r\n/g, "\n");
   const split = splitFrontmatter(normalized);
   if (!split) return { frontmatter: {}, instructions: content.trim() };

--- a/tools/agent-playground/src/lib/components/skills/skill-loader.svelte
+++ b/tools/agent-playground/src/lib/components/skills/skill-loader.svelte
@@ -1,9 +1,11 @@
 <!--
-  Skill upload drop zone — accepts SKILL.md files or skill directories.
+  Skill upload drop zone — accepts SKILL.md files, skill folders, or .tar.gz archives.
 
-  Single SKILL.md: publishes instructions via JSON endpoint (no archive).
-  Directory with references: packs a tar.gz in the browser and uploads
-  via the multipart endpoint so reference files are included.
+  Every drop becomes a tar.gz POSTed to /import-archive. The server owns SKILL.md
+  parsing, namespace derivation, and the prompt-when-missing protocol. When the
+  archive's frontmatter has no `@<ns>/<name>` prefix, the server returns 400 with
+  `{ needsNamespace, defaultName }` and we re-POST with `?namespace=<ns>` after
+  prompting the user.
 
   @component
 -->
@@ -11,14 +13,13 @@
   import { useQueryClient } from "@tanstack/svelte-query";
   import { goto } from "$app/navigation";
   import { skillQueries } from "$lib/queries";
-  import { parse as parseYaml } from "yaml";
 
   interface Props {
     inline?: boolean;
     onclose?: () => void;
-    /** When set, uploads publish as a new version of this skill (skips namespace/name extraction). */
+    /** When set, uploads publish as a new version of this skill (server uses ?namespace= override). */
     forceNamespace?: string;
-    /** When set, uploads publish as a new version of this skill (skips namespace/name extraction). */
+    /** When set, uploads publish as a new version of this skill (used for filename hint only). */
     forceName?: string;
   }
 
@@ -26,23 +27,14 @@
 
   const queryClient = useQueryClient();
 
-  interface PendingSkill {
-    name: string;
-    description: string;
-    skillMdContent: string;
-    files: File[] | null; // null = single SKILL.md (JSON publish), File[] = directory (multipart upload)
-  }
-
   let dragOver = $state(false);
   let error = $state<string | null>(null);
   let loading = $state(false);
   let needsNamespace = $state(false);
   let namespaceInput = $state("tempest");
-  let pendingSkill = $state<PendingSkill | null>(null);
-  /** Tarball waiting on a namespace prompt. Separate from `pendingSkill`
-   *  because the server (not the client) is parsing SKILL.md, so we don't
-   *  have parsed fields yet — only the raw archive and the suggested name. */
-  let pendingTarball = $state<{ file: File; defaultName: string } | null>(null);
+  /** Archive waiting on a namespace prompt. The server parses SKILL.md, so we
+   *  only have the raw blob and the suggested name — re-POST with ?namespace=. */
+  let pendingArchive = $state<{ blob: Blob; filename: string; defaultName: string } | null>(null);
 
   function handleDragOver(e: DragEvent) {
     e.preventDefault();
@@ -65,7 +57,7 @@
       // webkitGetAsEntry is the standard way to detect directories
       const entry = firstItem.webkitGetAsEntry?.();
       if (entry?.isDirectory) {
-        await loadDirectory(entry as FileSystemDirectoryEntry);
+        await loadDirectoryEntry(entry as FileSystemDirectoryEntry);
         return;
       }
     }
@@ -75,25 +67,92 @@
     if (!file) return;
 
     if (file.name.endsWith(".tar.gz") || file.name.endsWith(".tgz")) {
-      await loadTarball(file);
+      await loadArchive(file, file.name);
     } else if (file.name === "SKILL.md" || file.name.endsWith(".md")) {
-      await loadSkillMd(file);
+      loading = true;
+      try {
+        const tarball = await createTarGz([new File([file], "SKILL.md", { type: file.type })]);
+        await loadArchive(tarball, file.name);
+      } catch (err) {
+        error = err instanceof Error ? err.message : "Failed to package SKILL.md";
+        loading = false;
+      }
     } else {
       error = "Drop a SKILL.md file, a folder containing one, or a .tar.gz archive";
     }
   }
 
-  /** Send an exported tar.gz to the import-archive endpoint. Server parses
-   *  SKILL.md inside and publishes. Falls back to the namespace prompt when
-   *  the tarball's frontmatter has no `@<ns>/<name>` prefix. */
-  async function loadTarball(file: File, namespaceOverride?: string) {
+  async function handleFolderInput(e: Event) {
+    const input = e.target as HTMLInputElement;
+    const fileList = input.files;
+    if (!fileList || fileList.length === 0) return;
+    error = null;
+    loading = true;
+
+    try {
+      // webkitdirectory gives us a flat FileList with webkitRelativePath set
+      const files: File[] = [];
+      let dirName = "skill";
+      let hasSkillMd = false;
+
+      for (let i = 0; i < fileList.length; i++) {
+        const f = fileList[i];
+        // webkitRelativePath is "dirname/path/to/file" — strip the root dir prefix
+        const relPath = f.webkitRelativePath;
+        const slashIdx = relPath.indexOf("/");
+        if (slashIdx >= 0 && i === 0) dirName = relPath.slice(0, slashIdx);
+        const innerPath = slashIdx >= 0 ? relPath.slice(slashIdx + 1) : f.name;
+
+        if (innerPath === "SKILL.md") hasSkillMd = true;
+
+        files.push(new File([f], innerPath, { type: f.type }));
+      }
+
+      if (!hasSkillMd) {
+        error = "Folder must contain a SKILL.md file";
+        return;
+      }
+
+      const tarball = await createTarGz(files);
+      await loadArchive(tarball, `${dirName}.tar.gz`);
+    } catch (err) {
+      error = err instanceof Error ? err.message : "Failed to read folder";
+    } finally {
+      loading = false;
+      input.value = "";
+    }
+  }
+
+  /** Walk a dropped directory, build a tar.gz, and ship to /import-archive. */
+  async function loadDirectoryEntry(dirEntry: FileSystemDirectoryEntry) {
+    loading = true;
+    try {
+      const files = await readDirectoryEntries(dirEntry);
+      if (!files.some((f) => f.name === "SKILL.md")) {
+        error = "Directory must contain a SKILL.md file";
+        return;
+      }
+      const tarball = await createTarGz(files);
+      await loadArchive(tarball, `${dirEntry.name}.tar.gz`);
+    } catch (err) {
+      error = err instanceof Error ? err.message : "Failed to read directory";
+    } finally {
+      loading = false;
+    }
+  }
+
+  /** POST a tar.gz to /import-archive. Server parses SKILL.md, derives namespace,
+   *  and either publishes or returns 400 with `{ needsNamespace, defaultName }`. */
+  async function loadArchive(blob: Blob, filename: string, namespaceOverride?: string) {
     loading = true;
     error = null;
     try {
+      // Force-namespace from Replace flow takes precedence over any caller-supplied override.
+      const ns = forceNamespace ?? namespaceOverride;
       const formData = new FormData();
-      formData.append("archive", file);
-      const url = namespaceOverride
-        ? `/api/daemon/api/skills/import-archive?namespace=${encodeURIComponent(namespaceOverride)}`
+      formData.append("archive", new File([blob], filename, { type: "application/gzip" }));
+      const url = ns
+        ? `/api/daemon/api/skills/import-archive?namespace=${encodeURIComponent(ns)}`
         : `/api/daemon/api/skills/import-archive`;
       const res = await fetch(url, { method: "POST", body: formData });
       const body = (await res.json().catch(() => ({}))) as {
@@ -104,7 +163,7 @@
       };
 
       if (res.status === 400 && body.needsNamespace && body.defaultName) {
-        pendingTarball = { file, defaultName: body.defaultName };
+        pendingArchive = { blob, filename, defaultName: body.defaultName };
         needsNamespace = true;
         return;
       }
@@ -122,269 +181,14 @@
     }
   }
 
-  async function handleFolderInput(e: Event) {
-    const input = e.target as HTMLInputElement;
-    const fileList = input.files;
-    if (!fileList || fileList.length === 0) return;
-    error = null;
-    loading = true;
-
-    try {
-      // webkitdirectory gives us a flat FileList with webkitRelativePath set
-      const files: File[] = [];
-      let skillMdFile: File | undefined;
-
-      for (let i = 0; i < fileList.length; i++) {
-        const f = fileList[i];
-        // webkitRelativePath is "dirname/path/to/file" — strip the root dir prefix
-        const relPath = f.webkitRelativePath;
-        const slashIdx = relPath.indexOf("/");
-        const innerPath = slashIdx >= 0 ? relPath.slice(slashIdx + 1) : f.name;
-
-        if (innerPath === "SKILL.md") {
-          skillMdFile = f;
-        }
-
-        files.push(new File([f], innerPath, { type: f.type }));
-      }
-
-      if (!skillMdFile) {
-        error = "Folder must contain a SKILL.md file";
-        return;
-      }
-
-      const skillMdText = await skillMdFile.text();
-      const parsed = parseFrontmatter(skillMdText);
-
-      // When forced namespace/name are set, skip frontmatter name validation
-      if (forceNamespace && forceName) {
-        await publishWithArchive(forceNamespace, forceName, skillMdText, files);
-        return;
-      }
-
-      if (!parsed.name) {
-        error = "SKILL.md frontmatter must include a 'name' field";
-        return;
-      }
-
-      const { namespace, skillName } = splitRef(parsed.name);
-
-      if (!namespace) {
-        pendingSkill = {
-          name: skillName,
-          description: parsed.description ?? "",
-          skillMdContent: skillMdText,
-          files,
-        };
-        needsNamespace = true;
-        return;
-      }
-
-      await publishWithArchive(namespace, skillName, skillMdText, files);
-    } catch (err) {
-      error = err instanceof Error ? err.message : "Failed to read folder";
-    } finally {
-      loading = false;
-      input.value = "";
-    }
-  }
-
-  /** Parse a single SKILL.md file and publish via JSON endpoint. */
-  async function loadSkillMd(file: File) {
-    loading = true;
-    try {
-      const text = await file.text();
-      const parsed = parseFrontmatter(text);
-
-      // When forced namespace/name are set, skip frontmatter name validation
-      if (forceNamespace && forceName) {
-        await publishJsonSkill(forceNamespace, forceName, parsed.description ?? "", text);
-        return;
-      }
-
-      if (!parsed.name) {
-        error = "SKILL.md frontmatter must include a 'name' field";
-        return;
-      }
-
-      const { namespace, skillName } = splitRef(parsed.name);
-
-      if (!namespace) {
-        pendingSkill = {
-          name: skillName,
-          description: parsed.description ?? "",
-          skillMdContent: text,
-          files: null,
-        };
-        needsNamespace = true;
-        return;
-      }
-
-      await publishJsonSkill(namespace, skillName, parsed.description ?? "", text);
-    } catch (err) {
-      error = err instanceof Error ? err.message : "Failed to parse SKILL.md";
-    } finally {
-      loading = false;
-    }
-  }
-
-  /** Load a dropped directory — find SKILL.md and upload with all files as archive. */
-  async function loadDirectory(dirEntry: FileSystemDirectoryEntry) {
-    loading = true;
-    try {
-      const files = await readDirectoryEntries(dirEntry);
-      const skillMdFile = files.find((f) => f.name === "SKILL.md");
-
-      if (!skillMdFile) {
-        error = "Directory must contain a SKILL.md file";
-        return;
-      }
-
-      const skillMdText = await skillMdFile.text();
-      const parsed = parseFrontmatter(skillMdText);
-
-      // When forced namespace/name are set, skip frontmatter name validation
-      if (forceNamespace && forceName) {
-        await publishWithArchive(forceNamespace, forceName, skillMdText, files);
-        return;
-      }
-
-      if (!parsed.name) {
-        error = "SKILL.md frontmatter must include a 'name' field";
-        return;
-      }
-
-      const { namespace, skillName } = splitRef(parsed.name);
-
-      if (!namespace) {
-        pendingSkill = {
-          name: skillName,
-          description: parsed.description ?? "",
-          skillMdContent: skillMdText,
-          files,
-        };
-        needsNamespace = true;
-        return;
-      }
-
-      await publishWithArchive(namespace, skillName, skillMdText, files);
-    } catch (err) {
-      error = err instanceof Error ? err.message : "Failed to read directory";
-    } finally {
-      loading = false;
-    }
-  }
-
-  /** Submit the namespace form and publish. */
+  /** Submit the namespace form — re-POST the stashed archive with ?namespace=. */
   async function submitNamespace() {
-    if (!namespaceInput.trim()) return;
+    if (!namespaceInput.trim() || !pendingArchive) return;
     const ns = namespaceInput.trim();
-
-    if (pendingTarball) {
-      const tarball = pendingTarball;
-      pendingTarball = null;
-      needsNamespace = false;
-      await loadTarball(tarball.file, ns);
-      return;
-    }
-
-    if (!pendingSkill) return;
-    loading = true;
-    error = null;
+    const archive = pendingArchive;
+    pendingArchive = null;
     needsNamespace = false;
-
-    try {
-      if (pendingSkill.files) {
-        await publishWithArchive(
-          ns,
-          pendingSkill.name,
-          pendingSkill.skillMdContent,
-          pendingSkill.files,
-        );
-      } else {
-        await publishJsonSkill(
-          ns,
-          pendingSkill.name,
-          pendingSkill.description,
-          pendingSkill.skillMdContent,
-        );
-      }
-    } catch (err) {
-      error = err instanceof Error ? err.message : "Failed to publish skill";
-    } finally {
-      loading = false;
-      pendingSkill = null;
-    }
-  }
-
-  // ── Publish methods ─────────────────────────────────────────────────────
-
-  /** Publish a single SKILL.md (no archive) via JSON endpoint. The server
-   *  splits embedded frontmatter into the `frontmatter` column, so we send
-   *  the full SKILL.md text rather than stripping it client-side. */
-  async function publishJsonSkill(
-    namespace: string,
-    name: string,
-    description: string,
-    skillMdContent: string,
-  ) {
-    // If description contains < or >, the server rejects it (XML injection guard).
-    // Omit it so the server auto-generates one from instructions via LLM.
-    const safeDescription =
-      description.includes("<") || description.includes(">") ? undefined : description || undefined;
-
-    const res = await fetch(
-      `/api/daemon/api/skills/@${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`,
-      {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ description: safeDescription, instructions: skillMdContent }),
-      },
-    );
-
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({ error: `Publish failed: ${res.status}` }));
-      throw new Error(
-        typeof body.error === "string" ? body.error : `Publish failed: ${res.status}`,
-      );
-    }
-
-    await onPublishSuccess(namespace, name);
-  }
-
-  /** Publish a skill directory with all reference files as a tar.gz archive. */
-  async function publishWithArchive(
-    namespace: string,
-    name: string,
-    skillMdContent: string,
-    files: File[],
-  ) {
-    // Exclude SKILL.md from the archive — its content is sent separately as skillMd
-    const archiveFiles = files.filter((f) => f.name !== "SKILL.md");
-    const archive = await createTarGz(archiveFiles);
-
-    const formData = new FormData();
-    formData.append("archive", new File([archive], "skill.tar.gz", { type: "application/gzip" }));
-    formData.append("skillMd", skillMdContent);
-
-    // Extract description from frontmatter and send separately if safe
-    const parsed = parseFrontmatter(skillMdContent);
-    const desc = parsed.description ?? "";
-    if (desc && !desc.includes("<") && !desc.includes(">")) {
-      formData.append("description", desc);
-    }
-
-    const res = await fetch(
-      `/api/daemon/api/skills/@${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/upload`,
-      { method: "POST", body: formData },
-    );
-
-    if (!res.ok) {
-      const body = await res.json().catch(() => ({ error: `Upload failed: ${res.status}` }));
-      throw new Error(typeof body.error === "string" ? body.error : `Upload failed: ${res.status}`);
-    }
-
-    await onPublishSuccess(namespace, name);
+    await loadArchive(archive.blob, archive.filename, ns);
   }
 
   async function onPublishSuccess(namespace: string, name: string) {
@@ -398,40 +202,6 @@
   }
 
   // ── Helpers ──────────────────────────────────────────────────────────────
-
-  function splitRef(ref: string): { namespace: string | null; skillName: string } {
-    const match = ref.match(/^@([a-z0-9-]+)\/([a-z0-9-]+)$/);
-    return match
-      ? { namespace: match[1], skillName: match[2] }
-      : { namespace: null, skillName: ref };
-  }
-
-  function parseFrontmatter(content: string): {
-    name: string | null;
-    description: string | null;
-    instructions: string;
-  } {
-    if (!content.startsWith("---")) {
-      return { name: null, description: null, instructions: content.trim() };
-    }
-
-    const closingIndex = content.indexOf("\n---", 3);
-    if (closingIndex === -1) {
-      return { name: null, description: null, instructions: content.trim() };
-    }
-
-    const yamlBlock = content.slice(4, closingIndex);
-    const body = content.slice(closingIndex + 4).trim();
-
-    const parsed = parseYaml(yamlBlock);
-    const fields = typeof parsed === "object" && parsed !== null ? parsed : {};
-
-    return {
-      name: typeof fields.name === "string" ? fields.name : null,
-      description: typeof fields.description === "string" ? fields.description : null,
-      instructions: body,
-    };
-  }
 
   /**
    * Creates a gzipped tarball from a list of files in the browser.
@@ -555,7 +325,7 @@
 </script>
 
 {#if needsNamespace}
-  {@const promptName = pendingTarball?.defaultName ?? pendingSkill?.name ?? ""}
+  {@const promptName = pendingArchive?.defaultName ?? ""}
   <div class="drop-zone" class:inline>
     <div class="drop-content">
       <p class="drop-label">Skill namespace</p>
@@ -589,8 +359,7 @@
         class="close-btn"
         onclick={() => {
           needsNamespace = false;
-          pendingSkill = null;
-          pendingTarball = null;
+          pendingArchive = null;
           onclose?.();
         }}
       >

--- a/tools/agent-playground/src/lib/components/skills/skill-loader.svelte
+++ b/tools/agent-playground/src/lib/components/skills/skill-loader.svelte
@@ -319,16 +319,15 @@
 
   // ── Publish methods ─────────────────────────────────────────────────────
 
-  /** Publish a single SKILL.md (no archive) via JSON endpoint. */
+  /** Publish a single SKILL.md (no archive) via JSON endpoint. The server
+   *  splits embedded frontmatter into the `frontmatter` column, so we send
+   *  the full SKILL.md text rather than stripping it client-side. */
   async function publishJsonSkill(
     namespace: string,
     name: string,
     description: string,
     skillMdContent: string,
   ) {
-    const parsed = parseFrontmatter(skillMdContent);
-    const instructions = parsed.instructions;
-
     // If description contains < or >, the server rejects it (XML injection guard).
     // Omit it so the server auto-generates one from instructions via LLM.
     const safeDescription =
@@ -339,7 +338,7 @@
       {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ description: safeDescription, instructions }),
+        body: JSON.stringify({ description: safeDescription, instructions: skillMdContent }),
       },
     );
 

--- a/tools/agent-playground/src/lib/components/skills/skill-loader.svelte
+++ b/tools/agent-playground/src/lib/components/skills/skill-loader.svelte
@@ -151,8 +151,12 @@
       const ns = forceNamespace ?? namespaceOverride;
       const formData = new FormData();
       formData.append("archive", new File([blob], filename, { type: "application/gzip" }));
-      const url = ns
-        ? `/api/daemon/api/skills/import-archive?namespace=${encodeURIComponent(ns)}`
+      const params = new URLSearchParams();
+      if (ns) params.set("namespace", ns);
+      if (forceName) params.set("name", forceName);
+      const query = params.toString();
+      const url = query
+        ? `/api/daemon/api/skills/import-archive?${query}`
         : `/api/daemon/api/skills/import-archive`;
       const res = await fetch(url, { method: "POST", body: formData });
       const body = (await res.json().catch(() => ({}))) as {

--- a/tools/agent-playground/src/lib/components/skills/skill-loader.svelte
+++ b/tools/agent-playground/src/lib/components/skills/skill-loader.svelte
@@ -39,6 +39,10 @@
   let needsNamespace = $state(false);
   let namespaceInput = $state("tempest");
   let pendingSkill = $state<PendingSkill | null>(null);
+  /** Tarball waiting on a namespace prompt. Separate from `pendingSkill`
+   *  because the server (not the client) is parsing SKILL.md, so we don't
+   *  have parsed fields yet — only the raw archive and the suggested name. */
+  let pendingTarball = $state<{ file: File; defaultName: string } | null>(null);
 
   function handleDragOver(e: DragEvent) {
     e.preventDefault();
@@ -70,10 +74,51 @@
     const file = e.dataTransfer?.files[0];
     if (!file) return;
 
-    if (file.name === "SKILL.md" || file.name.endsWith(".md")) {
+    if (file.name.endsWith(".tar.gz") || file.name.endsWith(".tgz")) {
+      await loadTarball(file);
+    } else if (file.name === "SKILL.md" || file.name.endsWith(".md")) {
       await loadSkillMd(file);
     } else {
-      error = "Drop a SKILL.md file or a folder containing one";
+      error = "Drop a SKILL.md file, a folder containing one, or a .tar.gz archive";
+    }
+  }
+
+  /** Send an exported tar.gz to the import-archive endpoint. Server parses
+   *  SKILL.md inside and publishes. Falls back to the namespace prompt when
+   *  the tarball's frontmatter has no `@<ns>/<name>` prefix. */
+  async function loadTarball(file: File, namespaceOverride?: string) {
+    loading = true;
+    error = null;
+    try {
+      const formData = new FormData();
+      formData.append("archive", file);
+      const url = namespaceOverride
+        ? `/api/daemon/api/skills/import-archive?namespace=${encodeURIComponent(namespaceOverride)}`
+        : `/api/daemon/api/skills/import-archive`;
+      const res = await fetch(url, { method: "POST", body: formData });
+      const body = (await res.json().catch(() => ({}))) as {
+        error?: string;
+        needsNamespace?: boolean;
+        defaultName?: string;
+        published?: { namespace: string; name: string };
+      };
+
+      if (res.status === 400 && body.needsNamespace && body.defaultName) {
+        pendingTarball = { file, defaultName: body.defaultName };
+        needsNamespace = true;
+        return;
+      }
+      if (!res.ok) {
+        throw new Error(body.error ?? `Import failed: ${res.status}`);
+      }
+      if (!body.published) {
+        throw new Error("Import succeeded but response was malformed");
+      }
+      await onPublishSuccess(body.published.namespace, body.published.name);
+    } catch (err) {
+      error = err instanceof Error ? err.message : "Failed to import archive";
+    } finally {
+      loading = false;
     }
   }
 
@@ -232,13 +277,23 @@
 
   /** Submit the namespace form and publish. */
   async function submitNamespace() {
-    if (!pendingSkill || !namespaceInput.trim()) return;
+    if (!namespaceInput.trim()) return;
+    const ns = namespaceInput.trim();
+
+    if (pendingTarball) {
+      const tarball = pendingTarball;
+      pendingTarball = null;
+      needsNamespace = false;
+      await loadTarball(tarball.file, ns);
+      return;
+    }
+
+    if (!pendingSkill) return;
     loading = true;
     error = null;
     needsNamespace = false;
 
     try {
-      const ns = namespaceInput.trim();
       if (pendingSkill.files) {
         await publishWithArchive(
           ns,
@@ -501,11 +556,12 @@
 </script>
 
 {#if needsNamespace}
+  {@const promptName = pendingTarball?.defaultName ?? pendingSkill?.name ?? ""}
   <div class="drop-zone" class:inline>
     <div class="drop-content">
       <p class="drop-label">Skill namespace</p>
       <p class="drop-hint">
-        Enter the namespace for <strong>{pendingSkill?.name}</strong>
+        Enter the namespace for <strong>{promptName}</strong>
       </p>
       <div class="namespace-form">
         <span class="namespace-prefix">@</span>
@@ -519,7 +575,7 @@
           }}
         />
         <span class="namespace-sep">/</span>
-        <span class="namespace-name">{pendingSkill?.name}</span>
+        <span class="namespace-name">{promptName}</span>
       </div>
       <button class="browse-btn" onclick={submitNamespace} disabled={!namespaceInput.trim()}>
         Publish
@@ -535,6 +591,7 @@
         onclick={() => {
           needsNamespace = false;
           pendingSkill = null;
+          pendingTarball = null;
           onclose?.();
         }}
       >
@@ -556,7 +613,7 @@
       {#if loading}
         <p class="drop-label">Publishing skill...</p>
       {:else}
-        <p class="drop-label">Drop a skill folder here, or click to browse</p>
+        <p class="drop-label">Drop a skill folder or .tar.gz here, or click to browse</p>
       {/if}
 
       {#if error}

--- a/tools/agent-playground/src/routes/skills/[namespace]/[name]/+page.svelte
+++ b/tools/agent-playground/src/routes/skills/[namespace]/[name]/+page.svelte
@@ -452,6 +452,13 @@
               <DropdownMenu.Item onclick={() => uploadDialogOpen.set(true)}>
                 Replace
               </DropdownMenu.Item>
+              <DropdownMenu.Item
+                onclick={() => {
+                  window.location.href = `/api/daemon/api/skills/@${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/export`;
+                }}
+              >
+                Export
+              </DropdownMenu.Item>
               <DropdownMenu.Separator />
               <DropdownMenu.Item class="delete-item" onclick={handleDeleteClick}>
                 {deleteChecking ? "Checking..." : "Remove skill"}


### PR DESCRIPTION
Closes #174.

## Summary

- Skills can now be downloaded as a self-contained tar.gz from the \"…\" menu and dropped back into another Friday instance via the existing skill loader.
- The server's `/skills/import-archive` endpoint owns parsing, namespace derivation, and the prompt-when-missing protocol. The playground client used to duplicate all three; now it doesn't.
- Two storage-invariant bugs surfaced and got fixed along the way: the JSON publish handler was leaving SKILL.md frontmatter embedded in the `instructions` body, which broke export round-trips. Both publish paths now split frontmatter at the boundary.

## What changed

**Server (`apps/atlasd/routes/skills.ts`)**

- New `GET /:namespace/:name/export` packs the stored skill into a fresh tar.gz (SKILL.md + reference files). Always succeeds for valid skills, including SKILL.md-only ones.
- New `POST /import-archive` accepts a tar.gz upload, extracts SKILL.md, parses frontmatter for `@<ns>/<name>`, repacks the rest into the storage-format archive, and publishes. Returns `400 { needsNamespace, defaultName }` when frontmatter has no namespace so the client can prompt and re-POST with `?namespace=`.
- The existing JSON publish handler (`POST /:namespace/:name`) now runs `parseSkillMd` on incoming `instructions` and splits any embedded frontmatter into the proper column. Stops the column from staying empty when the editor's Save button posts a full SKILL.md buffer.

**Helper (`packages/skills/src/archive.ts`)**

- `packExportArchive({ instructions, frontmatter, archive })` reconstructs SKILL.md from the storage shape and packs the result. Handles the empty-archive case (SKILL.md only) and the column-empty-but-instructions-has-embedded-frontmatter case (legacy rows from before the publish-path fix).

**Playground UI**

- New \"Export\" item in the skill detail page's \"…\" menu. Just sets `window.location.href` to the export endpoint; the browser handles the download.
- `SkillLoader` now funnels every drop type through `/import-archive`. Single .md files get wrapped in a one-entry tar.gz; folder drops use the existing `createTarGz`; tar.gz drops pass through. Deleted ~230 lines of client-side parsing, namespace splitting, and dual-state machines.

## Test Plan

Backend tests: 48 passing (including new round-trip tests, the namespace-prompt protocol, and the embedded-frontmatter regression).

Manual cases to verify before merge:

**Export**
1. Open any published skill in the playground (`/skills/@<ns>/<name>`).
2. Click the \"…\" menu → \"Export\".
3. Browser downloads `@<ns>-<name>-v<version>.tar.gz`.
4. Extract it. Confirm:
   - `SKILL.md` is present with valid frontmatter (single `---` block, not double).
   - `description` and `name` survive the round-trip.
   - Reference files preserve their original paths.

**Import a bare SKILL.md**
1. Drop a `.md` file onto the importer (or into the \"Add skill\" dialog from the sidebar).
2. If the SKILL.md frontmatter has `name: @<ns>/<n>`, it publishes immediately.
3. If frontmatter has just `name: foo` with no namespace, the namespace prompt should appear with `foo` pre-filled. Type a namespace, hit Publish.
4. Confirm the skill appears in the catalog and SKILL.md renders correctly in the detail view.

**Import a directory**
1. Drop a folder containing SKILL.md plus reference files (or use the picker via \"click to browse\").
2. Same prompt behavior as above when frontmatter lacks a namespace.
3. Verify the skill detail page shows reference files at their original paths under the file tree.

**Import a tar.gz**
1. Drop the file you exported in step 1 onto a separate Friday instance (or delete the original and re-import as a sanity check).
2. Should publish at v1 under the original namespace, with description and frontmatter intact.
3. Test the namespace-prompt path: hand-edit a SKILL.md to remove the `@<ns>/` prefix, repack as `tar -czf test.tar.gz SKILL.md`, drop it. Prompt should appear with the bare name pre-filled.

**Round-trip (the bug from #174's debug session)**
1. Export `workspace-sparring` (or any skill published before this branch landed).
2. Re-import the downloaded tar.gz.
3. Re-export. Confirm the second export's SKILL.md has the same frontmatter as the first (not `---\n{}\n---`).

## Notes

- The server still has `/upload` (multipart) and the JSON publish endpoint. The playground UI no longer hits the multipart one but `usePublishSkill` (the editor's Save button) still uses JSON publish, which is correct — that's a different use case.
- Frontmatter is exported as-stored. If a skill came from skills.sh, the recipient's UI will offer \"Check for updates\" pointing at the original. Documented as intentional in the issue; revisit if it bites.