### PR TITLE
Add publish_skill tool to workspace-chat agent

### DIFF
--- a/packages/skills/src/archive.ts
+++ b/packages/skills/src/archive.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "node:buffer";
-import { chmod, readdir, readFile, rm, writeFile } from "node:fs/promises";
-import { join } from "node:path";
+import { chmod, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join, posix, resolve } from "node:path";
 import { createLogger } from "@atlas/logger";
 import { stringifyError } from "@atlas/utils";
 import { makeTempDir } from "@atlas/utils/temp.server";
@@ -8,6 +8,41 @@ import MarkdownIt from "markdown-it";
 import { create, extract, list, type WriteEntry } from "tar";
 
 const logger = createLogger({ name: "skill-archive" });
+
+/**
+ * Writes a list of skill files to a directory, creating parent directories
+ * as needed. Rejects paths that escape the base directory (absolute paths or
+ * containing `..`). Optionally rejects entries whose normalized path is
+ * "SKILL.md" to prevent overwriting the canonical skill instructions file.
+ *
+ * @param dir Base directory to write into.
+ * @param files Array of `{ path, content }` entries. Paths are relative.
+ * @param options.allowSkillMd When true, permits a `SKILL.md` entry. Default false.
+ */
+export async function writeSkillFiles(
+  dir: string,
+  files: Array<{ path: string; content: string }>,
+  options: { allowSkillMd?: boolean } = {},
+): Promise<void> {
+  const resolvedDir = resolve(dir);
+  for (const entry of files) {
+    const normalized = posix.normalize(entry.path);
+    if (normalized === "." || normalized.startsWith("/") || entry.path.split("/").includes("..")) {
+      throw new Error(`Invalid file path: ${entry.path}`);
+    }
+    const target = join(dir, normalized);
+    const resolvedSkillMd = resolve(dir, "SKILL.md");
+    if (!options.allowSkillMd && resolve(target) === resolvedSkillMd) {
+      throw new Error("SKILL.md is reserved for the canonical skill instructions");
+    }
+    const resolvedTarget = resolve(target);
+    if (!resolvedTarget.startsWith(resolvedDir + "/") && resolvedTarget !== resolvedDir) {
+      throw new Error(`Path escapes base directory: ${entry.path}`);
+    }
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, entry.content);
+  }
+}
 
 /**
  * Packs a skill directory into a gzipped tarball.

--- a/packages/skills/src/mod.ts
+++ b/packages/skills/src/mod.ts
@@ -6,6 +6,7 @@ export {
   packSkillArchive,
   readArchiveFile,
   validateSkillReferences,
+  writeSkillFiles,
 } from "./archive.ts";
 // Canonical content hash for system-skill reconciliation.
 export { computeSkillHash } from "./content-hash.ts";

--- a/packages/skills/tests/archive.test.ts
+++ b/packages/skills/tests/archive.test.ts
@@ -9,6 +9,7 @@ import {
   injectSkillDir,
   packSkillArchive,
   validateSkillReferences,
+  writeSkillFiles,
 } from "../src/archive.ts";
 
 describe("packSkillArchive", () => {
@@ -305,5 +306,80 @@ See ![diagram](references/diagram.png) and [guide](references/guide.md).
     const archiveFiles = ["references/guide.md"];
     const deadLinks = validateSkillReferences(instructions, archiveFiles);
     expect(deadLinks).toEqual(["references/diagram.png"]);
+  });
+});
+
+describe("writeSkillFiles", () => {
+  let tempDirs: string[] = [];
+
+  function createTempDir(prefix?: string): string {
+    const dir = makeTempDir({ prefix: prefix ?? "archive-test-" });
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  afterEach(async () => {
+    for (const dir of tempDirs) {
+      await rm(dir, { recursive: true, force: true });
+    }
+    tempDirs = [];
+  });
+
+  it("writes files and creates nested directories", async () => {
+    const dir = createTempDir();
+    await writeSkillFiles(dir, [
+      { path: "README.md", content: "# Hello" },
+      { path: "scripts/build.sh", content: "#!/bin/sh\necho hi" },
+    ]);
+
+    expect(await readFile(join(dir, "README.md"), "utf-8")).toBe("# Hello");
+    expect(await readFile(join(dir, "scripts", "build.sh"), "utf-8")).toBe("#!/bin/sh\necho hi");
+  });
+
+  it("rejects paths containing ..", async () => {
+    const dir = createTempDir();
+    await expect(
+      writeSkillFiles(dir, [{ path: "../etc/passwd", content: "bad" }]),
+    ).rejects.toThrow("Invalid file path: ../etc/passwd");
+  });
+
+  it("rejects absolute paths", async () => {
+    const dir = createTempDir();
+    await expect(
+      writeSkillFiles(dir, [{ path: "/etc/passwd", content: "bad" }]),
+    ).rejects.toThrow("Invalid file path: /etc/passwd");
+  });
+
+  it("rejects SKILL.md by default", async () => {
+    const dir = createTempDir();
+    await expect(
+      writeSkillFiles(dir, [{ path: "SKILL.md", content: "bad" }]),
+    ).rejects.toThrow("SKILL.md is reserved for the canonical skill instructions");
+  });
+
+  it("rejects SKILL.md after normalizing current-directory segments", async () => {
+    const dir = createTempDir();
+    await expect(
+      writeSkillFiles(dir, [{ path: "././SKILL.md", content: "bad" }]),
+    ).rejects.toThrow("SKILL.md is reserved for the canonical skill instructions");
+  });
+
+  it("allows SKILL.md when opted in", async () => {
+    const dir = createTempDir();
+    await writeSkillFiles(dir, [{ path: "SKILL.md", content: "# Skill" }], { allowSkillMd: true });
+    expect(await readFile(join(dir, "SKILL.md"), "utf-8")).toBe("# Skill");
+  });
+
+  it("rejects paths that escape the base directory via ..", async () => {
+    const dir = createTempDir();
+    await expect(
+      writeSkillFiles(dir, [{ path: "foo/../../etc/passwd", content: "bad" }]),
+    ).rejects.toThrow("Invalid file path: foo/../../etc/passwd");
+  });
+
+  it("strips leading ./ before writing", async () => {
+    const dir = createTempDir();
+    await writeSkillFiles(dir, [{ path: "./guide.md", content: "# Guide" }]);
+    expect(await readFile(join(dir, "guide.md"), "utf-8")).toBe("# Guide");
   });
 });

--- a/packages/skills/tests/archive.test.ts
+++ b/packages/skills/tests/archive.test.ts
@@ -338,30 +338,30 @@ describe("writeSkillFiles", () => {
 
   it("rejects paths containing ..", async () => {
     const dir = createTempDir();
-    await expect(
-      writeSkillFiles(dir, [{ path: "../etc/passwd", content: "bad" }]),
-    ).rejects.toThrow("Invalid file path: ../etc/passwd");
+    await expect(writeSkillFiles(dir, [{ path: "../etc/passwd", content: "bad" }])).rejects.toThrow(
+      "Invalid file path: ../etc/passwd",
+    );
   });
 
   it("rejects absolute paths", async () => {
     const dir = createTempDir();
-    await expect(
-      writeSkillFiles(dir, [{ path: "/etc/passwd", content: "bad" }]),
-    ).rejects.toThrow("Invalid file path: /etc/passwd");
+    await expect(writeSkillFiles(dir, [{ path: "/etc/passwd", content: "bad" }])).rejects.toThrow(
+      "Invalid file path: /etc/passwd",
+    );
   });
 
   it("rejects SKILL.md by default", async () => {
     const dir = createTempDir();
-    await expect(
-      writeSkillFiles(dir, [{ path: "SKILL.md", content: "bad" }]),
-    ).rejects.toThrow("SKILL.md is reserved for the canonical skill instructions");
+    await expect(writeSkillFiles(dir, [{ path: "SKILL.md", content: "bad" }])).rejects.toThrow(
+      "SKILL.md is reserved for the canonical skill instructions",
+    );
   });
 
   it("rejects SKILL.md after normalizing current-directory segments", async () => {
     const dir = createTempDir();
-    await expect(
-      writeSkillFiles(dir, [{ path: "././SKILL.md", content: "bad" }]),
-    ).rejects.toThrow("SKILL.md is reserved for the canonical skill instructions");
+    await expect(writeSkillFiles(dir, [{ path: "././SKILL.md", content: "bad" }])).rejects.toThrow(
+      "SKILL.md is reserved for the canonical skill instructions",
+    );
   });
 
   it("allows SKILL.md when opted in", async () => {

--- a/packages/system/agents/workspace-chat/tools/publish-skill.test.ts
+++ b/packages/system/agents/workspace-chat/tools/publish-skill.test.ts
@@ -148,4 +148,42 @@ describe("publish_skill", () => {
       deadLinks: ["MISSING.md", "OTHER.md"],
     });
   });
+
+  it("returns HTTP status and body when daemon rejects with non-JSON", async () => {
+    const content = "---\nname: demo-skill\ndescription: Test. Use when X.\n---\n\nBody.";
+
+    mockFetch.mockResolvedValueOnce(new Response("bad gateway", { status: 502 }));
+
+    const { publish_skill } = createPublishSkillTool(logger);
+    const result = await publish_skill!.execute!(
+      { namespace: "tempest", name: "demo-skill", content },
+      OPTS,
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "publish_skill failed with status 502: bad gateway",
+    });
+  });
+
+  it("returns local validation errors without calling fetch", async () => {
+    const content = "---\nname: demo-skill\ndescription: Test. Use when X.\n---\n\nBody.";
+
+    const { publish_skill } = createPublishSkillTool(logger);
+    const result = await publish_skill!.execute!(
+      {
+        namespace: "tempest",
+        name: "demo-skill",
+        content,
+        files: [{ path: "././SKILL.md", content: "bad" }],
+      },
+      OPTS,
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: "publish_skill failed: SKILL.md is reserved for the canonical skill instructions",
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
 });

--- a/packages/system/agents/workspace-chat/tools/publish-skill.test.ts
+++ b/packages/system/agents/workspace-chat/tools/publish-skill.test.ts
@@ -1,0 +1,151 @@
+import type { Logger } from "@atlas/logger";
+import { extractArchiveContents } from "@atlas/skills/archive";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockFetch = vi.hoisted(() =>
+  vi.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>(),
+);
+
+vi.stubGlobal("fetch", mockFetch);
+vi.mock("@atlas/oapi-client", () => ({ getAtlasDaemonUrl: () => "http://localhost:3000" }));
+
+import { createPublishSkillTool } from "./publish-skill.ts";
+
+const logger: Logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  child: vi.fn(),
+} as unknown as Logger;
+
+const OPTS = { toolCallId: "tc-1", messages: [], abortSignal: new AbortController().signal };
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("publish_skill", () => {
+  it("POSTs multipart upload to daemon and returns success on 201", async () => {
+    const namespace = "tempest";
+    const name = "demo-skill";
+    const content =
+      "---\nname: demo-skill\ndescription: A demo skill. Use when testing.\n---\n\n# Demo\n\nBody.";
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          published: {
+            id: "id1",
+            skillId: "sk1",
+            namespace: "tempest",
+            name: "demo-skill",
+            version: 1,
+          },
+        }),
+        { status: 201 },
+      ),
+    );
+
+    const { publish_skill } = createPublishSkillTool(logger);
+    const result = await publish_skill!.execute!({ namespace, name, content }, OPTS);
+
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://localhost:3000/api/skills/@tempest/demo-skill/upload");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeInstanceOf(FormData);
+
+    const formData = init.body as FormData;
+    const archive = formData.get("archive");
+    expect(archive).toBeInstanceOf(Blob);
+    expect((archive as Blob).size).toBeGreaterThan(0);
+    expect(formData.get("skillMd")).toBe(content);
+
+    expect(result).toEqual({
+      success: true,
+      skill: { ref: "@tempest/demo-skill", skillId: "sk1", version: 1 },
+    });
+  });
+
+  it("packs files[] entries into the tar archive at their requested paths", async () => {
+    const namespace = "tempest";
+    const name = "demo-skill";
+    const content =
+      "---\nname: demo-skill\ndescription: A demo skill. Use when testing.\n---\n\nMain body.";
+    const files = [
+      { path: "REFERENCE.md", content: "# Reference\n\nDetailed docs." },
+      { path: "scripts/build.sh", content: "#!/bin/sh\necho hi" },
+    ];
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          published: {
+            id: "id1",
+            skillId: "sk1",
+            namespace: "tempest",
+            name: "demo-skill",
+            version: 1,
+          },
+        }),
+        { status: 201 },
+      ),
+    );
+
+    const { publish_skill } = createPublishSkillTool(logger);
+    await publish_skill!.execute!({ namespace, name, content, files }, OPTS);
+
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const formData = init.body as FormData;
+    const archive = formData.get("archive") as Blob;
+    const bytes = new Uint8Array(await archive.arrayBuffer());
+    const contents = await extractArchiveContents(bytes);
+
+    expect(Object.keys(contents).sort()).toEqual(
+      ["REFERENCE.md", "SKILL.md", "scripts/build.sh"].sort(),
+    );
+    expect(contents["SKILL.md"]).toBe(content);
+    expect(contents["REFERENCE.md"]).toBe("# Reference\n\nDetailed docs.");
+    expect(contents["scripts/build.sh"]).toBe("#!/bin/sh\necho hi");
+  });
+
+  it("returns structured failure when fetch rejects with a network error", async () => {
+    const namespace = "tempest";
+    const name = "demo-skill";
+    const content = "---\nname: demo-skill\ndescription: Test. Use when X.\n---\n\nBody.";
+
+    mockFetch.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+    const { publish_skill } = createPublishSkillTool(logger);
+    const result = await publish_skill!.execute!({ namespace, name, content }, OPTS);
+
+    expect(result).toMatchObject({ success: false, error: expect.any(String) });
+    expect(result).not.toHaveProperty("deadLinks");
+  });
+
+  it("returns structured failure with deadLinks when daemon rejects with 400", async () => {
+    const namespace = "tempest";
+    const name = "demo-skill";
+    const content =
+      "---\nname: demo-skill\ndescription: Test. Use when X.\n---\n\nSee [docs](MISSING.md) and [more](OTHER.md).";
+
+    mockFetch.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: "Skill instructions reference files not found in archive: MISSING.md, OTHER.md",
+          deadLinks: ["MISSING.md", "OTHER.md"],
+        }),
+        { status: 400 },
+      ),
+    );
+
+    const { publish_skill } = createPublishSkillTool(logger);
+    const result = await publish_skill!.execute!({ namespace, name, content }, OPTS);
+
+    expect(result).toEqual({
+      success: false,
+      error: "Skill instructions reference files not found in archive: MISSING.md, OTHER.md",
+      deadLinks: ["MISSING.md", "OTHER.md"],
+    });
+  });
+});

--- a/packages/system/agents/workspace-chat/tools/publish-skill.ts
+++ b/packages/system/agents/workspace-chat/tools/publish-skill.ts
@@ -1,0 +1,108 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import type { AtlasTools } from "@atlas/agent-sdk";
+import type { Logger } from "@atlas/logger";
+import { getAtlasDaemonUrl } from "@atlas/oapi-client";
+import { packSkillArchive } from "@atlas/skills/archive";
+import { stringifyError } from "@atlas/utils";
+import { makeTempDir } from "@atlas/utils/temp.server";
+import { tool } from "ai";
+import { z } from "zod";
+
+const PublishSkillInput = z.object({
+  namespace: z.string().describe("kebab-case, no @ prefix; 'friday' is reserved"),
+  name: z.string(),
+  content: z.string(),
+  files: z
+    .array(
+      z.object({
+        path: z.string(),
+        content: z.string(),
+      }),
+    )
+    .optional(),
+});
+
+/**
+ * Publishes a skill to the daemon's skill upload endpoint.
+ *
+ * Builds a SKILL.md-only tarball in a tmpdir, packs it via `packSkillArchive`,
+ * and POSTs a multipart form (`archive` + `skillMd`) to
+ * `/api/skills/@{namespace}/{name}/upload`. Returns a structured success result
+ * on 201.
+ */
+export function createPublishSkillTool(logger: Logger): AtlasTools {
+  const daemonUrl = getAtlasDaemonUrl();
+
+  return {
+    publish_skill: tool({
+      description:
+        "Publish a new skill (or new version of an existing skill) to the global catalog. " +
+        "Auto-bumps version on existing names. " +
+        "After publishing, call assign_workspace_skill to make it visible in this workspace.",
+      inputSchema: PublishSkillInput,
+      execute: async ({ namespace, name, content, files }) => {
+        const tmpDir = makeTempDir({ prefix: "atlas-publish-skill-" });
+        try {
+          await writeFile(join(tmpDir, "SKILL.md"), content);
+          for (const entry of files ?? []) {
+            const target = join(tmpDir, entry.path);
+            await mkdir(dirname(target), { recursive: true });
+            await writeFile(target, entry.content);
+          }
+          const archive = await packSkillArchive(tmpDir);
+
+          const formData = new FormData();
+          const archiveFile = new File([new Uint8Array(archive)], `${name}.tar.gz`, {
+            type: "application/gzip",
+          });
+          formData.append("archive", archiveFile);
+          formData.append("skillMd", content);
+
+          const url = `${daemonUrl}/api/skills/@${namespace}/${name}/upload`;
+          const res = await fetch(url, { method: "POST", body: formData });
+          if (!res.ok) {
+            const body = (await res.json()) as unknown;
+            const error =
+              typeof body === "object" && body !== null && typeof (body as { error?: unknown }).error === "string"
+                ? (body as { error: string }).error
+                : `publish_skill failed with status ${res.status}`;
+            const rawDeadLinks =
+              typeof body === "object" && body !== null
+                ? (body as { deadLinks?: unknown }).deadLinks
+                : undefined;
+            const deadLinks =
+              Array.isArray(rawDeadLinks) && rawDeadLinks.every((v) => typeof v === "string")
+                ? (rawDeadLinks as string[])
+                : undefined;
+            logger.warn("publish_skill failed", { namespace, name, status: res.status, error });
+            if (deadLinks && deadLinks.length > 0) {
+              return { success: false as const, error, deadLinks };
+            }
+            return { success: false as const, error };
+          }
+          const json = (await res.json()) as { published: { skillId: string; version: number } };
+          logger.info("publish_skill succeeded", { namespace, name });
+          return {
+            success: true as const,
+            skill: {
+              ref: `@${namespace}/${name}`,
+              skillId: json.published.skillId,
+              version: json.published.version,
+            },
+          };
+        } catch (err) {
+          logger.error("publish_skill threw", { namespace, name, error: stringifyError(err) });
+          return {
+            success: false as const,
+            error: "publish_skill failed: network error",
+          };
+        } finally {
+          await rm(tmpDir, { recursive: true, force: true }).catch((e) =>
+            logger.debug("publish_skill cleanup failed", { error: stringifyError(e) }),
+          );
+        }
+      },
+    }),
+  };
+}

--- a/packages/system/agents/workspace-chat/tools/publish-skill.ts
+++ b/packages/system/agents/workspace-chat/tools/publish-skill.ts
@@ -30,10 +30,7 @@ const PublishSkillErrorResponse = z.object({
 });
 
 const PublishSkillSuccessResponse = z.object({
-  published: z.object({
-    skillId: z.string(),
-    version: z.number().int().positive(),
-  }),
+  published: z.object({ skillId: z.string(), version: z.number().int().positive() }),
 });
 
 async function readResponseBody(res: Response): Promise<{ text: string; json: unknown }> {

--- a/packages/system/agents/workspace-chat/tools/publish-skill.ts
+++ b/packages/system/agents/workspace-chat/tools/publish-skill.ts
@@ -1,20 +1,50 @@
-import { mkdir, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import type { AtlasTools } from "@atlas/agent-sdk";
+import { NamespaceSchema, SkillNameSchema } from "@atlas/config";
 import type { Logger } from "@atlas/logger";
 import { getAtlasDaemonUrl } from "@atlas/oapi-client";
-import { packSkillArchive } from "@atlas/skills/archive";
+import { packSkillArchive, writeSkillFiles } from "@atlas/skills/archive";
 import { stringifyError } from "@atlas/utils";
 import { makeTempDir } from "@atlas/utils/temp.server";
 import { tool } from "ai";
 import { z } from "zod";
 
 const PublishSkillInput = z.object({
-  namespace: z.string().describe("kebab-case, no @ prefix; 'friday' is reserved"),
-  name: z.string(),
-  content: z.string(),
-  files: z.array(z.object({ path: z.string(), content: z.string() })).optional(),
+  namespace: NamespaceSchema.describe("kebab-case, no @ prefix; 'friday' is reserved"),
+  name: SkillNameSchema.describe("skill name from SKILL.md frontmatter"),
+  content: z.string().describe("full SKILL.md content, including frontmatter"),
+  files: z
+    .array(
+      z.object({
+        path: z.string().describe("relative support file path; must not be SKILL.md"),
+        content: z.string(),
+      }),
+    )
+    .optional(),
 });
+
+const PublishSkillErrorResponse = z.object({
+  error: z.string().optional(),
+  deadLinks: z.array(z.string()).optional(),
+});
+
+const PublishSkillSuccessResponse = z.object({
+  published: z.object({
+    skillId: z.string(),
+    version: z.number().int().positive(),
+  }),
+});
+
+async function readResponseBody(res: Response): Promise<{ text: string; json: unknown }> {
+  const text = await res.text();
+  if (!text.trim()) return { text, json: undefined };
+  try {
+    return { text, json: JSON.parse(text) };
+  } catch {
+    return { text, json: undefined };
+  }
+}
 
 /**
  * Publishes a skill to the daemon's skill upload endpoint.
@@ -38,11 +68,7 @@ export function createPublishSkillTool(logger: Logger): AtlasTools {
         const tmpDir = makeTempDir({ prefix: "atlas-publish-skill-" });
         try {
           await writeFile(join(tmpDir, "SKILL.md"), content);
-          for (const entry of files ?? []) {
-            const target = join(tmpDir, entry.path);
-            await mkdir(dirname(target), { recursive: true });
-            await writeFile(target, entry.content);
-          }
+          await writeSkillFiles(tmpDir, files ?? []);
           const archive = await packSkillArchive(tmpDir);
 
           const formData = new FormData();
@@ -53,42 +79,51 @@ export function createPublishSkillTool(logger: Logger): AtlasTools {
           formData.append("skillMd", content);
 
           const url = `${daemonUrl}/api/skills/@${namespace}/${name}/upload`;
-          const res = await fetch(url, { method: "POST", body: formData });
+          let res: Response;
+          try {
+            res = await fetch(url, { method: "POST", body: formData });
+          } catch (err) {
+            logger.error("publish_skill fetch failed", {
+              namespace,
+              name,
+              error: stringifyError(err),
+            });
+            return { success: false as const, error: "publish_skill failed: network error" };
+          }
+
+          const { text, json } = await readResponseBody(res);
           if (!res.ok) {
-            const body = (await res.json()) as unknown;
+            const body = PublishSkillErrorResponse.safeParse(json);
             const error =
-              typeof body === "object" &&
-              body !== null &&
-              typeof (body as { error?: unknown }).error === "string"
-                ? (body as { error: string }).error
-                : `publish_skill failed with status ${res.status}`;
-            const rawDeadLinks =
-              typeof body === "object" && body !== null
-                ? (body as { deadLinks?: unknown }).deadLinks
-                : undefined;
-            const deadLinks =
-              Array.isArray(rawDeadLinks) && rawDeadLinks.every((v) => typeof v === "string")
-                ? (rawDeadLinks as string[])
-                : undefined;
+              body.data?.error ??
+              `publish_skill failed with status ${res.status}${text ? `: ${text}` : ""}`;
             logger.warn("publish_skill failed", { namespace, name, status: res.status, error });
-            if (deadLinks && deadLinks.length > 0) {
-              return { success: false as const, error, deadLinks };
+            if (body.success && body.data.deadLinks && body.data.deadLinks.length > 0) {
+              return { success: false as const, error, deadLinks: body.data.deadLinks };
             }
             return { success: false as const, error };
           }
-          const json = (await res.json()) as { published: { skillId: string; version: number } };
+
+          const body = PublishSkillSuccessResponse.safeParse(json);
+          if (!body.success) {
+            const error = `publish_skill returned invalid response: ${body.error.message}`;
+            logger.warn("publish_skill returned invalid response", { namespace, name, error });
+            return { success: false as const, error };
+          }
+
           logger.info("publish_skill succeeded", { namespace, name });
           return {
             success: true as const,
             skill: {
               ref: `@${namespace}/${name}`,
-              skillId: json.published.skillId,
-              version: json.published.version,
+              skillId: body.data.published.skillId,
+              version: body.data.published.version,
             },
           };
         } catch (err) {
-          logger.error("publish_skill threw", { namespace, name, error: stringifyError(err) });
-          return { success: false as const, error: "publish_skill failed: network error" };
+          const error = `publish_skill failed: ${stringifyError(err)}`;
+          logger.error("publish_skill failed before upload", { namespace, name, error });
+          return { success: false as const, error };
         } finally {
           await rm(tmpDir, { recursive: true, force: true }).catch((e) =>
             logger.debug("publish_skill cleanup failed", { error: stringifyError(e) }),

--- a/packages/system/agents/workspace-chat/tools/publish-skill.ts
+++ b/packages/system/agents/workspace-chat/tools/publish-skill.ts
@@ -13,14 +13,7 @@ const PublishSkillInput = z.object({
   namespace: z.string().describe("kebab-case, no @ prefix; 'friday' is reserved"),
   name: z.string(),
   content: z.string(),
-  files: z
-    .array(
-      z.object({
-        path: z.string(),
-        content: z.string(),
-      }),
-    )
-    .optional(),
+  files: z.array(z.object({ path: z.string(), content: z.string() })).optional(),
 });
 
 /**
@@ -64,7 +57,9 @@ export function createPublishSkillTool(logger: Logger): AtlasTools {
           if (!res.ok) {
             const body = (await res.json()) as unknown;
             const error =
-              typeof body === "object" && body !== null && typeof (body as { error?: unknown }).error === "string"
+              typeof body === "object" &&
+              body !== null &&
+              typeof (body as { error?: unknown }).error === "string"
                 ? (body as { error: string }).error
                 : `publish_skill failed with status ${res.status}`;
             const rawDeadLinks =
@@ -93,10 +88,7 @@ export function createPublishSkillTool(logger: Logger): AtlasTools {
           };
         } catch (err) {
           logger.error("publish_skill threw", { namespace, name, error: stringifyError(err) });
-          return {
-            success: false as const,
-            error: "publish_skill failed: network error",
-          };
+          return { success: false as const, error: "publish_skill failed: network error" };
         } finally {
           await rm(tmpDir, { recursive: true, force: true }).catch((e) =>
             logger.debug("publish_skill cleanup failed", { error: stringifyError(e) }),

--- a/packages/system/agents/workspace-chat/workspace-chat.agent.ts
+++ b/packages/system/agents/workspace-chat/workspace-chat.agent.ts
@@ -59,6 +59,7 @@ import { createListCapabilitiesTool } from "./tools/list-capabilities.ts";
 import { createListMcpToolsTool } from "./tools/list-mcp-tools.ts";
 import { createMcpDependenciesTool } from "./tools/mcp-dependencies.ts";
 import { createMemorySaveTool } from "./tools/memory-save.ts";
+import { createPublishSkillTool } from "./tools/publish-skill.ts";
 import { createSearchMcpServersTool } from "./tools/search-mcp-servers.ts";
 import {
   createAssignWorkspaceSkillTool,
@@ -611,6 +612,7 @@ export const workspaceChatAgent = createAgent<string, WorkspaceChatResult>({
         const disableMcpServerTool = createDisableMcpServerTool(workspaceId, logger);
 
         // Workspace skill management tools
+        const publishSkillTool = createPublishSkillTool(logger);
         const assignSkillTool = createAssignWorkspaceSkillTool(workspaceId, logger);
         const unassignSkillTool = createUnassignWorkspaceSkillTool(workspaceId, logger);
 
@@ -740,6 +742,7 @@ export const workspaceChatAgent = createAgent<string, WorkspaceChatResult>({
           ...enableMcpServerTool,
           ...disableMcpServerTool,
           ...listMcpToolsTool,
+          ...publishSkillTool,
           ...assignSkillTool,
           ...unassignSkillTool,
           delegate: delegateTool,


### PR DESCRIPTION
## Summary

- Adds `publish_skill` to the workspace-chat agent. One tool call replaces the 24-`run_code` + 3-`write_file` pattern from `chat_e9ZqAjYdCz`, where Friday hand-rolled a SKILL.md and shelled out to `atlas skill publish` because no first-class tool existed.
- Workspace-agnostic. The tool publishes to the global catalog; workspace scoping is `assign_workspace_skill`'s job. The agent chains the two when it wants the new skill visible locally. Splitting them mirrors `SkillStorage.publish` + `assignSkill` and avoids bundling a "publish quietly to the catalog" path with a "make it visible here" path.
- Tar construction reuses `packSkillArchive` from `@atlas/skills`. That helper carries a non-obvious `onWriteEntry` mode-fix for the deno-compiled binary's virtual filesystem (entries report mode 0 → unwriteable extracted dirs without normalization). Reuse over rolling tar saves ~30 lines and inherits the fix for free.
- Built TDD via 5 vertical slices: tracer bullet (happy path) → `files[]` support → 4xx with `deadLinks` retry signal → network throw catch → agent wiring. Each slice was one RED → GREEN cycle, verified before moving on.

Closes #177.

## Test plan

### Automated

- 4 unit tests in `publish-skill.test.ts` cover the tracer bullet (multipart shape + happy-path return), `files[]` packing (round-trip via the daemon's own `extractArchiveContents` so the assertion exercises the same extraction code path), 4xx with `deadLinks` (structured retry signal), and `fetch` rejection (no exception escapes).
- `deno check` clean across `publish-skill.ts`, `publish-skill.test.ts`, and `workspace-chat.agent.ts`.

```
cd packages/system/agents/workspace-chat
deno run -A npm:vitest@^4.1.0 run tools/publish-skill.test.ts
deno check tools/publish-skill.ts tools/publish-skill.test.ts workspace-chat.agent.ts
```

### Manual (the dogfood loop)

The motivating use case: paste a SKILL.md into chat and watch the agent register it without pretending to be a shell.

1. Start a workspace chat against a daemon you control. Confirm `publish_skill` appears in the tool list (e.g. via tool-list inspector or by asking Friday "what tools do you have for skills?").
2. Paste a SKILL.md blob. Anything with a real frontmatter works. Example:

   ```
   ---
   name: grill-me
   description: Interview the user relentlessly about a plan or design until reaching shared understanding. Use when the user wants to stress-test a plan or mentions "grill me".
   ---

   # Grill me

   Walk down each branch of the design tree. Resolve dependencies one-by-one. Ask one question at a time.
   ```

3. Ask Friday to add this as a skill.
4. Confirm Friday calls `publish_skill` exactly once. Inspect the call's `namespace` argument: should NOT be `friday` (the field's zod describe warns about this; if it picks `friday` the dogfood loop has regressed).
5. Confirm the result carries `success: true` and a `skill.ref` of `@<namespace>/<name>`.
6. Ask Friday to make the skill visible in this workspace. It should chain `assign_workspace_skill`. Confirm `<available_skills>` updates on next turn.
7. Verify the skill landed in the catalog: `curl localhost:8080/api/skills?namespace=<ns> | jq '.skills[] | select(.name=="<name>")'` — should return the new entry with `latestVersion: 1`.

### Failure modes worth poking at

- Paste a SKILL.md with a markdown link to a non-existent file (e.g. `[docs](MISSING.md)` with no matching `files[]` entry). Friday should get a 400 with `deadLinks` and recover by either dropping the link or adding the missing file.
- Disconnect the daemon mid-call. Friday should report a structured failure rather than throwing an unhandled rejection through the chat.

## Out of scope (filed as follow-ups, not blocking)

- Daemon archive extractor silently DROPS tar entries with `..` or leading `/` instead of rejecting the upload. A caller can publish a skill with a "missing" file unless SKILL.md links to it. Worth hardening server-side; not this PR's job.
- `unpublish_skill` / version deletion. Daemon supports it (`DELETE /:ns/:name/:version`); no chat workflow needs it yet.
- A `list_skills` browse tool for the global catalog.