### PR TITLE
fix(chat): sanitize chatId in JetStream KV key

### DIFF
--- a/packages/core/src/chat/jetstream-backend.ts
+++ b/packages/core/src/chat/jetstream-backend.ts
@@ -70,12 +70,22 @@ export interface ChatStreamLimits {
 
 const SAFE_NAME_RE = /[^A-Za-z0-9_-]/g;
 
-function sanitizeForStreamName(s: string): string {
+/**
+ * Sanitize a chat-id / workspace-id component for use in NATS-derived keys.
+ *
+ * Same rules used for both stream names and KV keys: nats.js's KV `validateKey`
+ * accepts `/^[-/=.\w]+$/` (no `:`), and stream names allow only word chars,
+ * `-`, `_`. The component IDs that flow through here can contain colons (e.g.
+ * Telegram chatIds shaped `telegram:6139663655`) and other punctuation, so we
+ * normalize to a single restricted alphabet for both targets. The original
+ * chatId is preserved in metadata (`Chat.id`) — only the lookup key is lossy.
+ */
+function sanitizeKeyComponent(s: string): string {
   return s.replace(SAFE_NAME_RE, "_");
 }
 
 function streamName(workspaceId: string, chatId: string): string {
-  return `CHAT_${sanitizeForStreamName(workspaceId)}_${sanitizeForStreamName(chatId)}`;
+  return `CHAT_${sanitizeKeyComponent(workspaceId)}_${sanitizeKeyComponent(chatId)}`;
 }
 
 /**
@@ -107,7 +117,11 @@ function messagesWildcardSubject(workspaceId: string, chatId: string): string {
 }
 
 function kvKey(workspaceId: string, chatId: string): string {
-  return `${workspaceId}/${chatId}`;
+  return `${sanitizeKeyComponent(workspaceId)}/${sanitizeKeyComponent(chatId)}`;
+}
+
+function kvPrefix(workspaceId: string): string {
+  return `${sanitizeKeyComponent(workspaceId)}/`;
 }
 
 function isStreamNotFound(err: unknown): boolean {
@@ -490,7 +504,7 @@ export function createJetStreamChatBackend(
 
   async function listAllMetadata(workspaceId?: string): Promise<ChatMetadata[]> {
     const k = await kv();
-    const prefix = workspaceId ? `${workspaceId}/` : null;
+    const prefix = workspaceId ? kvPrefix(workspaceId) : null;
     const it = await k.keys();
     const allKeys: string[] = [];
     for await (const key of it) {

--- a/packages/core/src/chat/storage.test.ts
+++ b/packages/core/src/chat/storage.test.ts
@@ -206,6 +206,36 @@ describe("ChatStorage (JetStream-backed)", () => {
     }
   });
 
+  it("supports chatIds with colons (telegram-shaped)", async () => {
+    // NATS KV keys reject `:` (`/^[-/=.\w]+$/`). Telegram chatIds carry the
+    // shape `telegram:<id>` — the storage must sanitize the lookup key while
+    // keeping the original id in metadata. Regression test for the broken
+    // path where appendMessage / getChat threw "invalid key:" on telegram
+    // chats and the agent ran with empty history.
+    const chatId = `telegram:${crypto.randomUUID()}`;
+    const wsId = `ws-colon-${crypto.randomUUID()}`;
+    const create = await ChatStorage.createChat({
+      chatId,
+      userId: "tg-user",
+      workspaceId: wsId,
+      source: "telegram",
+    });
+    expect(create.ok).toBe(true);
+
+    const append = await ChatStorage.appendMessage(chatId, createMessage("hi"), wsId);
+    expect(append.ok).toBe(true);
+
+    const get = await ChatStorage.getChat(chatId, wsId);
+    expect(get.ok && get.data).toBeTruthy();
+    if (get.ok && get.data) {
+      expect(get.data.id).toBe(chatId);
+      expect(get.data.messages.length).toBe(1);
+    }
+
+    const list = await ChatStorage.listChatsByWorkspace(wsId);
+    expect(list.ok && list.data.chats.length).toBe(1);
+  });
+
   it("sorts messages by metadata.startTimestamp / .timestamp on read", async () => {
     const chatId = crypto.randomUUID();
     await createTestChat(chatId);


### PR DESCRIPTION
## Summary

- Telegram (and any `<provider>:<id>`-shaped) chats blew up on first message: NATS KV's `validateKey` regex `/^[-/=.\w]+$/` rejects `:`, so writing metadata threw `Error: invalid key: …`. The agent then loaded empty history and crashed in `stream-text` with `AI_InvalidPromptError: messages must not be empty`, and the assistant reply also failed to persist.
- Stream names already routed through `sanitizeForStreamName` — the KV key path was the asymmetric gap. Both now flow through one `sanitizeKeyComponent` helper, and the workspace prefix used by `listChatsByWorkspace` gets the same treatment so listings still resolve.
- The original chatId stays in `Chat.id` (only the lookup key is lossy), so reads return the same id the caller passed in. NATS subjects tolerate `:`, so the message stream subject is unchanged — only the KV path needed the fix.

## Test Plan

- [x] `deno task test packages/core/src/chat/storage.test.ts` — added a regression test creating a `telegram:<uuid>` chat and exercising `appendMessage` / `getChat` / `listChatsByWorkspace`.
- [x] `deno task test packages/core` — 636 tests pass.
- [x] `deno task test apps/atlasd/src/chat-sdk/` — 124 tests pass.
- [x] `deno check` on the modified files — clean.
- [x] Manual: send a Telegram message into a workspace and confirm the agent reply persists (no `chat_sdk_append_message_failed` / `Invalid prompt: messages must not be empty` in the daemon log).