### PR TITLE
fix(atlasd): decouple cascade execution from signal delivery

### DIFF
--- a/apps/atlasd/routes/instance-events.ts
+++ b/apps/atlasd/routes/instance-events.ts
@@ -1,0 +1,99 @@
+/**
+ * GET /api/instance/events
+ *
+ * Two modes:
+ *   - `?stream=true`        — SSE feed; subscribes to the `instance.>`
+ *                             NATS subject and forwards each event as a
+ *                             `data:` frame. UI consumers don't poll.
+ *   - default (or `?since`) — paginated replay over the INSTANCE_EVENTS
+ *                             stream, newest first. Useful for late
+ *                             joiners and reload-after-disconnect.
+ *
+ * Today the stream carries cascade-related events
+ * (`cascade.queue_saturated`, `cascade.queue_drained`,
+ * `cascade.queue_timeout`, `cascade.replaced`). The shape is open for
+ * future `daemon.*` / `health.*` event types without a stream split.
+ */
+
+import { zValidator } from "@hono/zod-validator";
+import { z } from "zod";
+import { daemonFactory } from "../src/factory.ts";
+import { listInstanceEvents } from "../src/instance-events.ts";
+
+const QuerySchema = z.object({
+  stream: z.coerce.boolean().optional(),
+  limit: z.coerce.number().int().positive().max(500).optional(),
+  /**
+   * Subject suffix filter — e.g. `cascade.` for all cascade events,
+   * or `cascade.queue_saturated` for one type. Matched as a prefix
+   * after `instance.`.
+   */
+  type: z.string().optional(),
+});
+
+const enc = new TextEncoder();
+
+export const instanceEventsRoutes = daemonFactory
+  .createApp()
+  .get("/events", zValidator("query", QuerySchema), async (c) => {
+    const { stream, limit, type } = c.req.valid("query");
+    const ctx = c.get("app");
+    const nc = ctx.daemon.getNatsConnection();
+    if (!nc) return c.json({ error: "NATS connection not ready" }, 503);
+
+    if (!stream) {
+      // Replay path — backwards walk over the stream.
+      const events = await listInstanceEvents(nc, {
+        ...(limit !== undefined ? { limit } : {}),
+        ...(type !== undefined ? { typeFilter: type } : {}),
+      });
+      return c.json({ events }, 200);
+    }
+
+    // SSE path — live feed.
+    const subject = type ? `instance.${type}` : "instance.>";
+    const sub = nc.subscribe(subject);
+
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        c.req.raw.signal.addEventListener("abort", () => {
+          try {
+            sub.unsubscribe();
+          } catch {
+            // already gone
+          }
+          try {
+            controller.close();
+          } catch {
+            // already closed
+          }
+        });
+
+        void (async () => {
+          try {
+            for await (const msg of sub) {
+              // Forward the raw event JSON as a `data:` frame. The
+              // event subject is recoverable from `event.type`, so we
+              // don't need an explicit `event:` line.
+              const payload = msg.string();
+              controller.enqueue(enc.encode(`data: ${payload}\n\n`));
+            }
+          } catch {
+            // subscription closed — fall through to controller.close()
+          } finally {
+            try {
+              controller.close();
+            } catch {
+              // already closed
+            }
+          }
+        })();
+      },
+    });
+
+    return c.body(body, 200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+  });

--- a/apps/atlasd/routes/instance-events.ts
+++ b/apps/atlasd/routes/instance-events.ts
@@ -53,6 +53,13 @@ export const instanceEventsRoutes = daemonFactory
     // SSE path — live feed.
     const subject = type ? `instance.${type}` : "instance.>";
     const sub = nc.subscribe(subject);
+    // The `subscribe()` call returns before the broker actually registers
+    // the subscription. Without this flush, an event published in the
+    // window between subscribe-returns and broker-registers would be
+    // silently dropped. The flush forces a PING/PONG round-trip; once
+    // it resolves, the subscription is live server-side and the SSE
+    // handshake honestly means "from now on, you get every event."
+    await nc.flush();
 
     const body = new ReadableStream<Uint8Array>({
       start(controller) {

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -2557,6 +2557,7 @@ export class AtlasDaemon {
 
   getStatus() {
     const cronStats = this.cronManager?.getStats();
+    const cascadeStats = this.cascadeConsumer?.getStats();
 
     return {
       activeWorkspaces: this.runtimes.size,
@@ -2564,6 +2565,7 @@ export class AtlasDaemon {
       cronManager: cronStats
         ? { isActive: this.cronManager?.isRunning || false, ...cronStats }
         : null,
+      cascadeConsumer: cascadeStats ?? null,
       migrations: this.migrationStatus,
       configuration: {
         maxConcurrentWorkspaces: this.options.maxConcurrentWorkspaces,

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -710,7 +710,10 @@ export class AtlasDaemon {
           const manager = this.getWorkspaceManager();
           const cfg = await manager.getWorkspaceConfig(workspaceId);
           const sig = cfg?.workspace?.signals?.[signalId];
-          return (sig?.concurrency ?? "skip") as ConcurrencyPolicy;
+          // `sig.concurrency` is typed `ConcurrencyPolicy | undefined`
+          // through the WorkspaceSignalConfig schema in @atlas/config —
+          // no cast needed.
+          return sig?.concurrency ?? "skip";
         } catch {
           return "skip";
         }

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -61,6 +61,7 @@ import { configRoutes } from "../routes/config.ts";
 import { cronRoutes } from "../routes/cron.ts";
 import { daemonApp } from "../routes/daemon.ts";
 import { healthRoutes } from "../routes/health.ts";
+import { instanceEventsRoutes } from "../routes/instance-events.ts";
 import { jobsRoutes } from "../routes/jobs.ts";
 import { linkRoutes } from "../routes/link.ts";
 import { mcpRegistryRouter } from "../routes/mcp-registry.ts";
@@ -81,6 +82,12 @@ import { workspacesRoutes } from "../routes/workspaces/index.ts";
 import { integrationRoutes } from "../routes/workspaces/integrations.ts";
 import { mcpRoutes } from "../routes/workspaces/mcp.ts";
 import { CapabilityHandlerRegistry } from "./capability-handlers.ts";
+import {
+  CascadeConsumer,
+  type ConcurrencyPolicy,
+  ensureCascadesStream,
+  publishCascade,
+} from "./cascade-stream.ts";
 import { CHAT_PROVIDERS, type PlatformCredentials } from "./chat-sdk/adapter-factory.ts";
 import { broadcastJobOutput } from "./chat-sdk/broadcast.ts";
 import {
@@ -94,6 +101,7 @@ import { createFSMBroadcastNotifier } from "./chat-sdk/fsm-broadcast-adapter.ts"
 import { ChatTurnRegistry } from "./chat-turn-registry.ts";
 import { DiscordGatewayService } from "./discord-gateway-service.ts";
 import { createApp } from "./factory.ts";
+import { ensureInstanceEventsStream } from "./instance-events.ts";
 import { getAllMigrations } from "./migrations/index.ts";
 import { NatsManager } from "./nats-manager.ts";
 import { ProcessAgentExecutor } from "./process-agent-executor.ts";
@@ -225,6 +233,7 @@ export class AtlasDaemon {
   private capabilityRegistry: CapabilityHandlerRegistry | null = null;
   private processAgentExecutor: ProcessAgentExecutor | null = null;
   private signalConsumer: SignalConsumer | null = null;
+  private cascadeConsumer: CascadeConsumer | null = null;
   private toolWorkers: ToolWorker[] = [];
   private cronManager: CronManager | null = null;
   private workspaceManager: WorkspaceManager | null = null;
@@ -415,6 +424,19 @@ export class AtlasDaemon {
       // signals are work units, not long-term history.
     });
 
+    // CASCADES stream — dispatch buffer between SignalConsumer (forwarder)
+    // and CascadeConsumer (executor). 1h max_age because cascades that
+    // sit longer than that are queue-timeout territory anyway. The
+    // CascadeConsumer enforces its own per-envelope queue-timeout
+    // (FRIDAY_CASCADE_QUEUE_TIMEOUT, default 5min).
+    await ensureCascadesStream(nc);
+
+    // INSTANCE_EVENTS — instance-wide operational feed, consumed via SSE
+    // by /api/instance/events. Used today for cascade backlog / replace /
+    // queue-timeout signals; intentionally open to other instance-level
+    // event types (daemon, health, …) without a stream split.
+    await ensureInstanceEventsStream(nc);
+
     // Wire chat storage to JetStream + eagerly create the CHATS KV bucket
     // so the first cold read doesn't pay the create cost.
     initChatStorage(nc, {
@@ -564,11 +586,15 @@ export class AtlasDaemon {
     this.agentRegistry = agentRegistry;
 
     // Set up workspace wakeup callback — publishes onto the SIGNALS JetStream
-    // stream. The local SignalConsumer (started below) picks up the envelope
-    // and dispatches via `triggerWorkspaceSignal`. Going through JetStream
-    // gives us durability (broker redelivers if the daemon dies between
-    // publish and dispatch) and a uniform substrate that future cross-process
-    // workers consume from.
+    // stream. The local SignalConsumer forwards each envelope onto CASCADES;
+    // the CascadeConsumer then applies the per-signal concurrency policy and
+    // runs the cascade as a background Promise. Two streams give us:
+    //   - delivery durability (SIGNALS retains the envelope until forwarded)
+    //   - dispatch decoupling (a slow cascade on workspace A doesn't block
+    //     workspace B's signal — head-of-line blocking that existed before
+    //     the cascade split is gone)
+    //   - independent observability (`nats consumer info` on each stream
+    //     surfaces ingress vs execution backlog separately)
     const wakeupCallback: WorkspaceSignalTriggerCallback = async (
       workspaceId: string,
       signalId: string,
@@ -610,19 +636,34 @@ export class AtlasDaemon {
     // Initialize WorkspaceManager with registrars and watcher (manager owns lifecycle)
     await this.workspaceManager.initialize(signalRegistrars);
 
-    // Spin up the SIGNALS consumer now that the workspace manager can satisfy
-    // dispatched envelopes. The consumer reads from the stream and calls
-    // triggerWorkspaceSignal — same in-process path the HTTP handler uses.
-    //
-    // Error handling mirrors the legacy per-workspace NATS subscription:
-    //   - SessionFailedError = domain-level session failure → ack (signal
-    //     was delivered fine; the cascade just had a domain failure).
-    //   - Any other error = infra-level failure → mark the workspace
-    //     "inactive" with the error metadata, destroy its runtime, and
-    //     throw so the broker NAKs and redelivers (up to maxDeliver).
+    // SignalConsumer — thin forwarder. Pulls from SIGNALS, parses the
+    // envelope, publishes onto CASCADES, acks. No FSM execution here;
+    // the heavy lifting moved to CascadeConsumer below.
     this.signalConsumer = new SignalConsumer(
       nc,
-      async (envelope: SignalEnvelope, ctx) => {
+      (envelope: SignalEnvelope) => publishCascade(nc, envelope),
+      {
+        maxAckPending: jsCfg.consumer.maxAckPending.value,
+        maxDeliver: jsCfg.consumer.maxDeliver.value,
+        ackWaitNs: jsCfg.consumer.ackWaitNs.value,
+      },
+    );
+
+    // CascadeConsumer — applies the per-signal `concurrency` policy
+    // (skip / queue / concurrent / replace; default skip) and runs each
+    // cascade as a background Promise so a slow cascade doesn't stall
+    // delivery of the next envelope.
+    //
+    // Error handling for the cascade dispatcher:
+    //   - SessionFailedError = domain-level session failure. Surfaces as
+    //     ok=false on the correlated response subject; not retried.
+    //   - Other Error = infra-level failure. Same surface, plus we
+    //     mark the workspace inactive with the error metadata. Not
+    //     retried (max_deliver=1 on CASCADES — failed cascades surface
+    //     as failed sessions in storage, not as redelivery storms).
+    this.cascadeConsumer = new CascadeConsumer(
+      nc,
+      async (envelope, ctx) => {
         try {
           return await this.triggerWorkspaceSignal(
             envelope.workspaceId,
@@ -630,26 +671,20 @@ export class AtlasDaemon {
             envelope.payload,
             envelope.streamId,
             ctx.onStreamEvent,
+            undefined,
+            ctx.abortSignal,
           );
         } catch (err) {
           if (err instanceof SessionFailedError) {
-            logger.warn("Signal session failed", {
+            logger.warn("Cascade session failed", {
               workspaceId: envelope.workspaceId,
               signalId: envelope.signalId,
               status: err.status,
               error: err.message,
             });
-            // Domain-level failure (not infra). For correlated callers we need
-            // to surface it as ok=false on the response subject and ack so the
-            // broker doesn't redeliver. For uncorrelated callers (cron-style)
-            // we just ack — the legacy NATS subscriber didn't redeliver these
-            // either.
-            if (envelope.correlationId) {
-              throw err;
-            }
-            return undefined;
+            throw err; // CascadeConsumer publishes ok=false on the response subject
           }
-          logger.error("Failed to process signal", {
+          logger.error("Failed to process cascade", {
             error: err,
             workspaceId: envelope.workspaceId,
             signalId: envelope.signalId,
@@ -665,14 +700,8 @@ export class AtlasDaemon {
                 failureCount: (workspace?.metadata?.failureCount ?? 0) + 1,
               },
             });
-            // Note: we used to destroyWorkspaceRuntime here on signal failure.
-            // That assumed a corrupted runtime is the most likely cause of a
-            // signal failure, but in practice signal failures are usually
-            // transient (network, MCP timeout, LLM error) and tearing down the
-            // runtime forces an expensive cold restart on the next trigger.
-            // Idle timeout / explicit shutdown handle genuine cleanup.
           } catch (statusError) {
-            logger.error("Failed to update workspace status after signal failure", {
+            logger.error("Failed to update workspace status after cascade failure", {
               workspaceId: envelope.workspaceId,
               statusError,
             });
@@ -680,15 +709,22 @@ export class AtlasDaemon {
           throw err;
         }
       },
-      {
-        maxAckPending: jsCfg.consumer.maxAckPending.value,
-        maxDeliver: jsCfg.consumer.maxDeliver.value,
-        ackWaitNs: jsCfg.consumer.ackWaitNs.value,
+      async (workspaceId, signalId): Promise<ConcurrencyPolicy> => {
+        try {
+          const manager = this.getWorkspaceManager();
+          const cfg = await manager.getWorkspaceConfig(workspaceId);
+          const sig = cfg?.workspace?.signals?.[signalId];
+          return (sig?.concurrency ?? "skip") as ConcurrencyPolicy;
+        } catch {
+          return "skip";
+        }
       },
+      { maxAckPending: parseInt(process.env.FRIDAY_CASCADE_CONCURRENCY ?? "32", 10) || 32 },
     );
-    // NB: do NOT start the consumer here — that would race with the
-    // rest of init (`getOrCreateWorkspaceRuntime` requires
-    // `isInitialized = true`). Started below after the init flag flips.
+
+    // NB: neither consumer starts here — they need `isInitialized=true`
+    // (so `getOrCreateWorkspaceRuntime` works) and `triggerWorkspaceSignal`
+    // ready. Started below after the init flag flips.
 
     // Register in-process tool workers. Default behavior — each worker
     // subscribes to a NATS subject and executes the tool's handler when
@@ -785,15 +821,18 @@ export class AtlasDaemon {
 
     this.isInitialized = true;
 
-    // Start the SIGNALS consumer LAST so no message can be dispatched
-    // until every prerequisite (cron manager, session adapter, tool
-    // workers, isInitialized flag) is in place. Pre-existing signals
-    // in the queue (redeliveries, leftovers from a previous daemon
-    // run) sit until we're ready to dispatch — no "not initialized"
-    // throws / NAK / redelivery loops on boot. (Bug 2026-05-03:
-    // rtx-price-check-cron seq 40 was hitting deliveryCount: 3 on
-    // restart because the consumer was started ~100 lines before
-    // isInitialized = true.)
+    // Start the SIGNALS + CASCADES consumers LAST so no message can be
+    // dispatched until every prerequisite (cron manager, session adapter,
+    // tool workers, isInitialized flag) is in place. Pre-existing
+    // envelopes in either queue (redeliveries, leftovers from a previous
+    // daemon run) sit until we're ready to dispatch — no "not initialized"
+    // throws / NAK / redelivery loops on boot.
+    //
+    // CASCADES first so when SignalConsumer starts forwarding, there's a
+    // consumer ready to drain. The reverse order would briefly back up
+    // CASCADES even though the daemon could service it — minor, but
+    // unnecessary.
+    if (this.cascadeConsumer) await this.cascadeConsumer.start();
     if (this.signalConsumer) await this.signalConsumer.start();
 
     logger.info("Atlas daemon initialized");
@@ -1063,6 +1102,7 @@ export class AtlasDaemon {
     this.app.route("/api/workspaces/:workspaceId/mcp", mcpRoutes);
     this.app.route("/api/workspaces", workspaceEventsRoutes);
     this.app.route("/api/events", eventsRoutes);
+    this.app.route("/api/instance", instanceEventsRoutes);
     this.app.route("/api/artifacts", artifactsApp);
     this.app.route("/api/chunked-upload", chunkedUploadApp);
     this.app.route("/api/chat", chatRoutes);
@@ -1619,10 +1659,10 @@ export class AtlasDaemon {
       await manager.registerRuntime(workspace.id, runtime);
       logger.debug("Runtime registered with WorkspaceManager", { workspaceId: workspace.id });
 
-      // Signal routing now goes through the SIGNALS JetStream stream and the
-      // shared SignalConsumer (started in initialize()). No per-workspace
-      // NATS subscription needed — the consumer dispatches every envelope
-      // via triggerWorkspaceSignal which already does the runtime wakeup.
+      // Signal routing: SIGNALS → SignalConsumer (forwarder) → CASCADES →
+      // CascadeConsumer (applies per-signal concurrency policy and dispatches
+      // via triggerWorkspaceSignal, which handles the runtime wakeup). No
+      // per-workspace NATS subscription needed.
 
       // Watcher is managed centrally by WorkspaceManager.initialize()
 
@@ -1673,15 +1713,21 @@ export class AtlasDaemon {
   }
 
   /**
-   * Publish a signal envelope onto the SIGNALS JetStream stream. The local
-   * SignalConsumer (or any worker subscribed to the same durable consumer
-   * in a multi-process deployment) will pick it up and run the cascade
-   * via `triggerWorkspaceSignal`.
+   * Publish a signal envelope onto the SIGNALS JetStream stream.
    *
-   * Use this for fire-and-forget dispatch — the publish ack returns immediately
-   * with the broker sequence number; the actual session id is allocated later
-   * by whichever worker handles the message. For synchronous "trigger and
-   * await result" semantics, keep using `triggerWorkspaceSignal` directly.
+   * Pipeline: SIGNALS → SignalConsumer (forwards to CASCADES) → CascadeConsumer
+   * (applies the per-signal `concurrency` policy and runs the cascade as a
+   * background Promise via `triggerWorkspaceSignal`). The publish ack returns
+   * the SIGNALS sequence number immediately; the session id is allocated later
+   * by the cascade worker.
+   *
+   * For synchronous "trigger and await result" semantics, set `correlationId`
+   * on the envelope and consume the response with `awaitSignalCompletion`
+   * (signal-stream.ts) — the CascadeConsumer publishes the dispatch outcome
+   * onto `signals.responses.<correlationId>` regardless of which worker
+   * handled the cascade. For interactive (chat) flows, bypass the queue
+   * entirely and call `triggerWorkspaceSignal` directly — chat is exempt
+   * from the cascade cap.
    */
   public publishSignalToJetStream(opts: PublishSignalOpts): Promise<{ seq: number }> {
     const nc = this.natsManager?.connection;
@@ -1800,7 +1846,12 @@ export class AtlasDaemon {
   }
 
   /**
-   * Trigger a workspace signal and handle lifecycle updates (lastSeen, idle timeout)
+   * Trigger a workspace signal and handle lifecycle updates (lastSeen, idle timeout).
+   *
+   * Concurrency control lives in `CascadeConsumer` (cascade-stream.ts) — it
+   * applies the per-signal `concurrency` policy (skip / queue / concurrent /
+   * replace) before calling here. By the time this method runs, the dispatch
+   * is committed; we just execute.
    *
    * @param workspaceId - Workspace ID to trigger signal in
    * @param signalId - Signal ID to trigger
@@ -1808,6 +1859,7 @@ export class AtlasDaemon {
    * @param streamId - Optional stream ID for conversation context
    * @param onStreamEvent - Optional callback for streaming responses (used by Discord, web chat, etc)
    * @param skipStates - Optional state IDs to skip during FSM execution
+   * @param abortSignal - Wired by CascadeConsumer for the `replace` policy — aborts the cascade in favour of a newer envelope
    * @returns Session ID for tracking the triggered signal
    */
   public async triggerWorkspaceSignal(
@@ -1817,23 +1869,12 @@ export class AtlasDaemon {
     streamId?: string,
     onStreamEvent?: (chunk: AtlasUIMessageChunk) => void,
     skipStates?: string[],
+    abortSignal?: AbortSignal,
   ): Promise<{
     sessionId: string;
     output: Array<{ id: string; type: string; data: Record<string, unknown> }>;
   }> {
     const runtime = await this.getOrCreateWorkspaceRuntime(workspaceId);
-
-    // Check if there are already active sessions for this signal
-    // This prevents concurrent executions when cron timers fire while previous sessions are still running
-    if (runtime.hasActiveSessionsForSignal(signalId)) {
-      logger.warn(
-        "Skipping signal trigger - workspace already has active session for this signal",
-        { workspaceId, signalId },
-      );
-      throw new Error(
-        `Workspace ${workspaceId} already has an active session processing signal ${signalId}`,
-      );
-    }
 
     const session = await runtime.triggerSignalWithSession(
       signalId,
@@ -1841,6 +1882,7 @@ export class AtlasDaemon {
       streamId,
       onStreamEvent,
       skipStates,
+      abortSignal,
     );
 
     // Record signal trigger metric by provider type (http, schedule, slack, etc.)
@@ -2386,12 +2428,16 @@ export class AtlasDaemon {
     await Promise.allSettled([
       withShutdownTimeout("http server drain", this.server?.shutdown(), 3000),
       withShutdownTimeout("discord gateway", this.discordGatewayService?.stop(), 1500),
+      // Stop the SIGNALS forwarder first so no new envelopes land on
+      // CASCADES while the cascade consumer is draining.
       withShutdownTimeout("signals consumer", this.signalConsumer?.stop(), 1500),
+      withShutdownTimeout("cascades consumer", this.cascadeConsumer?.stop(), 1500),
       withShutdownTimeout("tool workers", Promise.all(this.toolWorkers.map((w) => w.stop())), 1500),
     ]);
     this.server = null;
     this.discordGatewayService = null;
     this.signalConsumer = null;
+    this.cascadeConsumer = null;
     this.toolWorkers = [];
 
     // Reap orphaned agent-browser daemons after Phase 1 (no new agent

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import process, { env } from "node:process";
 import { JetStreamMemoryAdapter } from "@atlas/adapters-md";
 import type { AgentRegistry as AgentRegistryType, AtlasUIMessageChunk } from "@atlas/agent-sdk";
+import type { ConcurrencyPolicy } from "@atlas/config";
 import { FilesystemAtlasConfigSource } from "@atlas/config/server";
 import {
   AtlasAgentsMCPServer,
@@ -82,12 +83,7 @@ import { workspacesRoutes } from "../routes/workspaces/index.ts";
 import { integrationRoutes } from "../routes/workspaces/integrations.ts";
 import { mcpRoutes } from "../routes/workspaces/mcp.ts";
 import { CapabilityHandlerRegistry } from "./capability-handlers.ts";
-import {
-  CascadeConsumer,
-  type ConcurrencyPolicy,
-  ensureCascadesStream,
-  publishCascade,
-} from "./cascade-stream.ts";
+import { CascadeConsumer, ensureCascadesStream, publishCascade } from "./cascade-stream.ts";
 import { CHAT_PROVIDERS, type PlatformCredentials } from "./chat-sdk/adapter-factory.ts";
 import { broadcastJobOutput } from "./chat-sdk/broadcast.ts";
 import {

--- a/apps/atlasd/src/cascade-stream.test.ts
+++ b/apps/atlasd/src/cascade-stream.test.ts
@@ -95,14 +95,25 @@ describe("CascadeConsumer concurrency policies", () => {
     expect(dispatched).toEqual(["tick"]);
   });
 
-  it("concurrent — runs duplicates in parallel", async () => {
+  it("concurrent — runs duplicates in parallel and the registry tracks every one", async () => {
+    // Regression: when the inFlight registry was a single-slot map per
+    // key, `concurrent` dispatches for the same (workspace, signal)
+    // overwrote each other in the slot. inFlight.size stayed at 1 even
+    // with N actually-running cascades — saturation accounting
+    // undercounted, the orphaned cascades' finally-block guard
+    // (`get(key) === self`) failed so they never deregistered, and the
+    // drained event could miss firing. Assert both the dispatcher
+    // invocation count AND the registry's reported inFlight track the
+    // real cardinality.
     let peak = 0;
     let active = 0;
+    let registryPeak = 0;
     const consumer = new CascadeConsumer(
       nc,
       async (env) => {
         active++;
         peak = Math.max(peak, active);
+        registryPeak = Math.max(registryPeak, consumer.getStats().inFlight);
         try {
           await new Promise((r) => setTimeout(r, 150));
           return { sessionId: `s-${env.signalId}`, output: [] };
@@ -123,8 +134,12 @@ describe("CascadeConsumer concurrency policies", () => {
     }
     await waitFor(() => peak >= 3, 3000);
     await waitFor(() => active === 0, 3000);
-    await consumer.destroy();
     expect(peak).toBe(3);
+    expect(registryPeak).toBe(3);
+    // Once everything settles, the registry must drain to zero — a
+    // missed deregistration would leave a phantom in-flight count.
+    expect(consumer.getStats().inFlight).toBe(0);
+    await consumer.destroy();
   });
 
   it("queue — serializes per (workspace, signal)", async () => {

--- a/apps/atlasd/src/cascade-stream.test.ts
+++ b/apps/atlasd/src/cascade-stream.test.ts
@@ -1,0 +1,351 @@
+import { startNatsTestServer, type TestNatsServer } from "@atlas/core/test-utils/nats-test-server";
+import { connect, type NatsConnection } from "nats";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import {
+  CascadeConsumer,
+  type ConcurrencyPolicy,
+  cascadeSubject,
+  ensureCascadesStream,
+  publishCascade,
+} from "./cascade-stream.ts";
+import { ensureInstanceEventsStream, listInstanceEvents } from "./instance-events.ts";
+import {
+  awaitSignalCompletion,
+  type SignalEnvelope,
+  signalStreamSubject,
+} from "./signal-stream.ts";
+
+let server: TestNatsServer;
+let nc: NatsConnection;
+
+beforeAll(async () => {
+  server = await startNatsTestServer();
+  nc = await connect({ servers: server.url });
+  await ensureInstanceEventsStream(nc);
+}, 30_000);
+
+beforeEach(async () => {
+  // Tear down + recreate CASCADES so each test starts clean: no
+  // leftover messages, no leftover durable consumers. WorkQueue
+  // retention rejects multiple non-filtered consumers, so a fresh
+  // stream per test is the simplest isolation strategy.
+  const jsm = await nc.jetstreamManager();
+  try {
+    await jsm.streams.delete("CASCADES");
+  } catch {
+    // already gone
+  }
+  await ensureCascadesStream(nc);
+});
+
+afterAll(async () => {
+  await nc.drain();
+  await server.stop();
+});
+
+function envelope(
+  workspaceId: string,
+  signalId: string,
+  extras: Partial<SignalEnvelope> = {},
+): SignalEnvelope {
+  return { workspaceId, signalId, publishedAt: new Date().toISOString(), ...extras };
+}
+
+describe("cascadeSubject", () => {
+  it("formats workspaceId/signalId into the canonical subject", () => {
+    expect(cascadeSubject("ws-1", "do-the-thing")).toBe("cascades.ws-1.do-the-thing");
+  });
+  it("sanitizes unsafe chars to underscores", () => {
+    expect(cascadeSubject("ws/with/slashes", "weird signal")).toBe(
+      "cascades.ws_with_slashes.weird_signal",
+    );
+  });
+});
+
+describe("CascadeConsumer concurrency policies", () => {
+  it("default skip — drops a duplicate while a cascade is in-flight", async () => {
+    let activeCount = 0;
+    const dispatched: string[] = [];
+    const consumer = new CascadeConsumer(
+      nc,
+      async (env) => {
+        activeCount++;
+        try {
+          await new Promise((r) => setTimeout(r, 200));
+          dispatched.push(env.signalId);
+          return { sessionId: `s-${env.signalId}`, output: [] };
+        } finally {
+          activeCount--;
+        }
+      },
+      () => Promise.resolve("skip" as ConcurrencyPolicy),
+      { expiresMs: 1000 },
+    );
+    await consumer.start();
+
+    await publishCascade(nc, envelope("ws", "tick"));
+    await waitFor(() => activeCount === 1, 2000);
+    await publishCascade(
+      nc,
+      envelope("ws", "tick", { publishedAt: new Date(Date.now() + 1).toISOString() }),
+    );
+    await new Promise((r) => setTimeout(r, 100));
+    await waitFor(() => activeCount === 0 && dispatched.length === 1, 3000);
+    await consumer.destroy();
+    expect(dispatched).toEqual(["tick"]);
+  });
+
+  it("concurrent — runs duplicates in parallel", async () => {
+    let peak = 0;
+    let active = 0;
+    const consumer = new CascadeConsumer(
+      nc,
+      async (env) => {
+        active++;
+        peak = Math.max(peak, active);
+        try {
+          await new Promise((r) => setTimeout(r, 150));
+          return { sessionId: `s-${env.signalId}`, output: [] };
+        } finally {
+          active--;
+        }
+      },
+      () => Promise.resolve("concurrent" as ConcurrencyPolicy),
+      { expiresMs: 1000 },
+    );
+    await consumer.start();
+
+    for (let i = 0; i < 3; i++) {
+      await publishCascade(
+        nc,
+        envelope("ws", "tick", { publishedAt: new Date(Date.now() + i).toISOString() }),
+      );
+    }
+    await waitFor(() => peak >= 3, 3000);
+    await waitFor(() => active === 0, 3000);
+    await consumer.destroy();
+    expect(peak).toBe(3);
+  });
+
+  it("queue — serializes per (workspace, signal)", async () => {
+    const order: string[] = [];
+    const consumer = new CascadeConsumer(
+      nc,
+      async (env) => {
+        const tag = (env.payload as { tag: string }).tag;
+        order.push(`start:${tag}`);
+        await new Promise((r) => setTimeout(r, 100));
+        order.push(`end:${tag}`);
+        return { sessionId: `s-${env.signalId}`, output: [] };
+      },
+      () => Promise.resolve("queue" as ConcurrencyPolicy),
+      { expiresMs: 1000 },
+    );
+    await consumer.start();
+
+    for (const tag of ["a", "b", "c"]) {
+      await publishCascade(
+        nc,
+        envelope("ws", "tick", {
+          publishedAt: new Date(Date.now() + tag.charCodeAt(0)).toISOString(),
+          payload: { tag },
+        }),
+      );
+    }
+
+    await waitFor(() => order.length === 6, 5000);
+    await consumer.destroy();
+    expect(order).toEqual(["start:a", "end:a", "start:b", "end:b", "start:c", "end:c"]);
+  });
+
+  it("replace — aborts in-flight on new envelope", async () => {
+    const aborts: string[] = [];
+    const completions: string[] = [];
+    const consumer = new CascadeConsumer(
+      nc,
+      async (env, ctx) => {
+        const tag = (env.payload as { tag: string }).tag;
+        await new Promise<void>((resolve, reject) => {
+          const t = setTimeout(resolve, 800);
+          ctx.abortSignal.addEventListener("abort", () => {
+            clearTimeout(t);
+            aborts.push(tag);
+            reject(new Error("aborted"));
+          });
+        });
+        completions.push(tag);
+        return { sessionId: `s-${tag}`, output: [] };
+      },
+      () => Promise.resolve("replace" as ConcurrencyPolicy),
+      { expiresMs: 1000 },
+    );
+    await consumer.start();
+
+    await publishCascade(nc, envelope("ws", "tick", { payload: { tag: "first" } }));
+    await new Promise((r) => setTimeout(r, 150));
+    await publishCascade(
+      nc,
+      envelope("ws", "tick", {
+        publishedAt: new Date(Date.now() + 1).toISOString(),
+        payload: { tag: "second" },
+      }),
+    );
+
+    await waitFor(() => completions.length === 1, 3000);
+    await consumer.destroy();
+    expect(aborts).toEqual(["first"]);
+    expect(completions).toEqual(["second"]);
+  });
+
+  it("queue_timeout — terminates envelopes older than queueTimeoutMs", async () => {
+    const dispatched: string[] = [];
+    const consumer = new CascadeConsumer(
+      nc,
+      (env) => {
+        dispatched.push(env.signalId);
+        return Promise.resolve({ sessionId: `s-${env.signalId}`, output: [] });
+      },
+      () => Promise.resolve("skip" as ConcurrencyPolicy),
+      { expiresMs: 1000, queueTimeoutMs: 50 },
+    );
+    await consumer.start();
+    await publishCascade(
+      nc,
+      envelope("ws", "tick", { publishedAt: new Date(Date.now() - 5000).toISOString() }),
+    );
+    await new Promise((r) => setTimeout(r, 500));
+    await consumer.destroy();
+    expect(dispatched).toEqual([]);
+    const events = await listInstanceEvents(nc, { typeFilter: "cascade.queue_timeout" });
+    expect(events.some((e) => e.type === "cascade.queue_timeout")).toBe(true);
+  });
+});
+
+describe("CascadeConsumer correlated callers", () => {
+  it("publishes ok=true on signals.responses.<corrId> for a successful cascade", async () => {
+    const consumer = new CascadeConsumer(
+      nc,
+      (env) => Promise.resolve({ sessionId: `s-${env.signalId}`, output: [] }),
+      () => Promise.resolve("concurrent" as ConcurrencyPolicy),
+      { expiresMs: 1000 },
+    );
+    await consumer.start();
+
+    const correlationId = crypto.randomUUID();
+    const responsePromise = awaitSignalCompletion(nc, correlationId, 5000);
+    await publishCascade(nc, envelope("ws", "ping", { correlationId }));
+    const reply = await responsePromise;
+    await consumer.destroy();
+    expect(reply.ok).toBe(true);
+  });
+
+  it("publishes ok=false on a skipped duplicate so HTTP callers don't hang", async () => {
+    const consumer = new CascadeConsumer(
+      nc,
+      async (env) => {
+        await new Promise((r) => setTimeout(r, 200));
+        return { sessionId: `s-${env.signalId}`, output: [] };
+      },
+      () => Promise.resolve("skip" as ConcurrencyPolicy),
+      { expiresMs: 1000 },
+    );
+    await consumer.start();
+
+    await publishCascade(nc, envelope("ws", "ping"));
+    await new Promise((r) => setTimeout(r, 50));
+
+    const correlationId = crypto.randomUUID();
+    const responsePromise = awaitSignalCompletion(nc, correlationId, 2000);
+    await publishCascade(
+      nc,
+      envelope("ws", "ping", {
+        correlationId,
+        publishedAt: new Date(Date.now() + 1).toISOString(),
+      }),
+    );
+    const reply = await responsePromise;
+    await consumer.destroy();
+    expect(reply.ok).toBe(false);
+    if (!reply.ok) expect(reply.error).toContain("skipped-duplicate");
+  });
+
+  it("forwards onStreamEvent chunks to signals.stream.<corrId>", async () => {
+    const correlationId = crypto.randomUUID();
+    const seenChunks: unknown[] = [];
+    const sub = nc.subscribe(signalStreamSubject(correlationId));
+    const reader = (async () => {
+      for await (const msg of sub) {
+        seenChunks.push(JSON.parse(new TextDecoder().decode(msg.data)));
+        if (seenChunks.length >= 3) break;
+      }
+    })();
+
+    const consumer = new CascadeConsumer(
+      nc,
+      (_env, ctx) => {
+        ctx.onStreamEvent?.({ type: "delta", text: "a" } as never);
+        ctx.onStreamEvent?.({ type: "delta", text: "b" } as never);
+        ctx.onStreamEvent?.({ type: "delta", text: "c" } as never);
+        return Promise.resolve({ sessionId: "s-stream", output: [] });
+      },
+      () => Promise.resolve("concurrent" as ConcurrencyPolicy),
+      { expiresMs: 1000 },
+    );
+    await consumer.start();
+
+    const responsePromise = awaitSignalCompletion(nc, correlationId, 5000);
+    await publishCascade(nc, envelope("ws", "stream-test", { correlationId }));
+    const reply = await responsePromise;
+    await reader;
+    sub.unsubscribe();
+    await consumer.destroy();
+
+    expect(seenChunks).toHaveLength(3);
+    expect(reply.ok).toBe(true);
+  });
+});
+
+describe("CascadeConsumer head-of-line decoupling", () => {
+  it("a slow cascade on workspace A does NOT block workspace B", async () => {
+    const finishedAt = new Map<string, number>();
+    const consumer = new CascadeConsumer(
+      nc,
+      async (env) => {
+        const key = `${env.workspaceId}:${env.signalId}`;
+        const slow = env.workspaceId === "slow";
+        await new Promise((r) => setTimeout(r, slow ? 1500 : 5));
+        finishedAt.set(key, Date.now());
+        return { sessionId: `s-${key}`, output: [] };
+      },
+      () => Promise.resolve("concurrent" as ConcurrencyPolicy),
+      { expiresMs: 1000 },
+    );
+    await consumer.start();
+
+    const t0 = Date.now();
+    await publishCascade(nc, envelope("slow", "tick"));
+    await new Promise((r) => setTimeout(r, 50));
+    await publishCascade(
+      nc,
+      envelope("fast", "tick", { publishedAt: new Date(Date.now() + 1).toISOString() }),
+    );
+
+    await waitFor(() => finishedAt.has("fast:tick"), 1000);
+    const fastFinished = finishedAt.get("fast:tick") as number;
+    await consumer.destroy();
+
+    // Without decoupling, fast had to wait ~1500ms for slow first.
+    // With decoupling, fast finishes within ~200ms of t0.
+    const fastLatency = fastFinished - t0;
+    expect(fastLatency).toBeLessThan(500);
+  });
+});
+
+async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(`waitFor timed out after ${timeoutMs}ms`);
+}

--- a/apps/atlasd/src/cascade-stream.test.ts
+++ b/apps/atlasd/src/cascade-stream.test.ts
@@ -320,6 +320,110 @@ describe("CascadeConsumer correlated callers", () => {
   });
 });
 
+describe("CascadeConsumer concurrency cap", () => {
+  it("caps simultaneous cascade dispatch at maxAckPending — bursts queue", async () => {
+    // Regression: the cap was meant to bound concurrent LLM/MCP load.
+    // With ack-fast-then-fork-cascade, the cap previously didn't
+    // actually cap cascades — handleMessage acked in milliseconds and
+    // forked Promises unbounded. The semaphore introduced in this fix
+    // holds a slot for the cascade duration, so a burst of N envelopes
+    // with cap=2 should see at most 2 cascades running concurrently.
+    const cap = 2;
+    let peak = 0;
+    let active = 0;
+    const consumer = new CascadeConsumer(
+      nc,
+      async (env) => {
+        active++;
+        peak = Math.max(peak, active);
+        try {
+          await new Promise((r) => setTimeout(r, 100));
+          return { sessionId: `s-${env.signalId}`, output: [] };
+        } finally {
+          active--;
+        }
+      },
+      () => Promise.resolve("concurrent" as ConcurrencyPolicy),
+      { expiresMs: 1000, maxAckPending: cap },
+    );
+    await consumer.start();
+
+    // Fire 5 envelopes for distinct keys so the policy registry
+    // doesn't itself dedupe — the cap is the only thing limiting
+    // parallelism here.
+    for (let i = 0; i < 5; i++) {
+      await publishCascade(
+        nc,
+        envelope(`ws-${i}`, "tick", { publishedAt: new Date(Date.now() + i).toISOString() }),
+      );
+    }
+
+    await waitFor(() => active === 0 && consumer.getStats().inFlight === 0, 5000);
+    await consumer.destroy();
+    expect(peak).toBeLessThanOrEqual(cap);
+    expect(peak).toBeGreaterThan(0);
+  });
+
+  it("getStats reports the cap value", async () => {
+    // Mostly a smoke test that the new fields are on the result. The
+    // cap-actually-caps assertion is covered by the test above.
+    const consumer = new CascadeConsumer(
+      nc,
+      (env) => Promise.resolve({ sessionId: `s-${env.signalId}`, output: [] }),
+      () => Promise.resolve("concurrent" as ConcurrencyPolicy),
+      { expiresMs: 1000, maxAckPending: 5 },
+    );
+    await consumer.start();
+    const stats = consumer.getStats();
+    expect(stats.cap).toBe(5);
+    expect(stats.running).toBe(0);
+    expect(stats.waiting).toBe(0);
+    expect(stats.inFlight).toBe(0);
+    await consumer.destroy();
+  });
+});
+
+describe("CascadeConsumer policy-decision race", () => {
+  it("two same-key envelopes in one fetch don't both pass concurrency=skip", async () => {
+    // Regression: handleMessage runs as `void this.handleMessage(msg)`
+    // per-batch-item, so two messages for the same (workspace, signal)
+    // arriving in the same fetch batch race on the inFlight check.
+    // Before the policy lock, both observed size=0 and both proceeded
+    // through skip; we'd get two cascades for what should be one.
+    let dispatched = 0;
+    const release: Array<() => void> = [];
+    const consumer = new CascadeConsumer(
+      nc,
+      (env) =>
+        new Promise<{ sessionId: string; output: never[] }>((resolve) => {
+          dispatched++;
+          release.push(() => resolve({ sessionId: `s-${env.signalId}`, output: [] }));
+        }),
+      () => Promise.resolve("skip" as ConcurrencyPolicy),
+      { expiresMs: 1000 },
+    );
+    await consumer.start();
+
+    // Publish both in immediate succession with distinct publishedAt
+    // (otherwise msgID dedup at the broker would mask the race). The
+    // consumer fetches in batches; both should land together.
+    await publishCascade(nc, envelope("ws", "tick"));
+    await publishCascade(
+      nc,
+      envelope("ws", "tick", { publishedAt: new Date(Date.now() + 1).toISOString() }),
+    );
+
+    // Give the consumer a moment to process both. With `skip` the
+    // second must be dropped before reaching the dispatcher.
+    await waitFor(() => dispatched === 1, 2000);
+    await new Promise((r) => setTimeout(r, 200));
+    expect(dispatched).toBe(1);
+
+    for (const r of release.splice(0)) r();
+    await consumer.destroy();
+  });
+});
+
 describe("CascadeConsumer head-of-line decoupling", () => {
   it("a slow cascade on workspace A does NOT block workspace B", async () => {
     const finishedAt = new Map<string, number>();

--- a/apps/atlasd/src/cascade-stream.test.ts
+++ b/apps/atlasd/src/cascade-stream.test.ts
@@ -1,9 +1,9 @@
+import type { ConcurrencyPolicy } from "@atlas/config";
 import { startNatsTestServer, type TestNatsServer } from "@atlas/core/test-utils/nats-test-server";
 import { connect, type NatsConnection } from "nats";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import {
   CascadeConsumer,
-  type ConcurrencyPolicy,
   cascadeSubject,
   ensureCascadesStream,
   publishCascade,

--- a/apps/atlasd/src/cascade-stream.ts
+++ b/apps/atlasd/src/cascade-stream.ts
@@ -207,10 +207,25 @@ export class CascadeConsumer {
   private readonly ackWaitNs: number;
   private readonly queueTimeoutMs: number;
 
-  private readonly inFlight = new Map<string, InFlightCascade>();
+  /**
+   * In-flight cascades grouped by `${workspaceId}:${signalId}`. A Set
+   * (not a single slot) so the `concurrent` policy — which legitimately
+   * runs N cascades for the same key at once — doesn't have its
+   * earlier entries silently overwritten on subsequent dispatches.
+   * For `skip` / `queue` / `replace` the set holds at most one in
+   * steady state.
+   */
+  private readonly inFlight = new Map<string, Set<InFlightCascade>>();
   /** Tail of the queue policy chain per key. */
   private readonly queueTails = new Map<string, Promise<void>>();
   private saturated = false;
+
+  /** Total cascades currently dispatched, summed across all keys. */
+  private totalInFlight(): number {
+    let n = 0;
+    for (const set of this.inFlight.values()) n += set.size;
+    return n;
+  }
 
   constructor(
     private readonly nc: NatsConnection,
@@ -279,10 +294,12 @@ export class CascadeConsumer {
       }
       this.loop = null;
     }
-    // Best-effort: abort any in-flight cascades so the daemon can
+    // Best-effort: abort every in-flight cascade so the daemon can
     // shut down without waiting on long LLM calls.
-    for (const cascade of this.inFlight.values()) {
-      cascade.controller.abort("daemon shutdown");
+    for (const set of this.inFlight.values()) {
+      for (const cascade of set) {
+        cascade.controller.abort("daemon shutdown");
+      }
     }
   }
 
@@ -371,9 +388,10 @@ export class CascadeConsumer {
       policy = "skip";
     }
 
-    const existing = this.inFlight.get(key);
+    const existingSet = this.inFlight.get(key);
+    const existingCount = existingSet?.size ?? 0;
 
-    if (existing && policy === "skip") {
+    if (existingCount > 0 && policy === "skip") {
       logger.info("Cascade skipped — concurrency=skip and same-key cascade in flight", {
         workspaceId: envelope.workspaceId,
         signalId: envelope.signalId,
@@ -388,17 +406,26 @@ export class CascadeConsumer {
       return;
     }
 
-    if (existing && policy === "replace") {
-      logger.info("Cascade replacing in-flight cascade — concurrency=replace", {
+    let replacedExisting: InFlightCascade[] = [];
+    if (existingCount > 0 && policy === "replace" && existingSet) {
+      // Singleton intent: abort EVERY in-flight cascade for this key.
+      // In steady-state replace usage there's at most one, but the set
+      // could carry several if the workspace was previously running
+      // `concurrent` and switched to `replace`.
+      replacedExisting = Array.from(existingSet);
+      logger.info("Cascade replacing in-flight cascade(s) — concurrency=replace", {
         workspaceId: envelope.workspaceId,
         signalId: envelope.signalId,
-        cancelledSessionId: existing.sessionId,
+        cancelledCount: replacedExisting.length,
+        cancelledSessionIds: replacedExisting.map((c) => c.sessionId).filter(Boolean),
       });
-      existing.controller.abort("replaced by newer cascade");
-      // Don't await `existing.done` — that would re-introduce head-of-line
-      // blocking. The runtime's abort path settles the cancelled cascade
-      // independently. The `cascade.replaced` event is published once the
-      // new cascade has its sessionId.
+      for (const cascade of replacedExisting) {
+        cascade.controller.abort("replaced by newer cascade");
+      }
+      // Don't await — that would re-introduce head-of-line blocking.
+      // The runtime's abort path settles cancelled cascades independently.
+      // `cascade.replaced` events publish once the new cascade has its
+      // sessionId.
     }
 
     if (policy === "queue") {
@@ -408,7 +435,7 @@ export class CascadeConsumer {
       // result still flows through response/stream subjects when the
       // chain gets there.
       const prevTail = this.queueTails.get(key) ?? Promise.resolve();
-      const next = prevTail.then(() => this.runCascade(envelope, key, existing));
+      const next = prevTail.then(() => this.runCascade(envelope, key, []));
       this.queueTails.set(
         key,
         next.catch(() => undefined),
@@ -419,7 +446,7 @@ export class CascadeConsumer {
 
     // skip with no existing, concurrent always, or replace (we already
     // aborted existing above and are starting fresh now).
-    void this.runCascade(envelope, key, existing);
+    void this.runCascade(envelope, key, replacedExisting);
     msg.ack();
   }
 
@@ -432,7 +459,7 @@ export class CascadeConsumer {
   private runCascade(
     envelope: SignalEnvelope,
     key: string,
-    replacedExisting?: InFlightCascade,
+    replacedExisting: InFlightCascade[] = [],
   ): Promise<void> {
     const controller = new AbortController();
     const startedAt = Date.now();
@@ -441,7 +468,12 @@ export class CascadeConsumer {
       done: Promise.resolve(), // placeholder; replaced below
       startedAt,
     };
-    this.inFlight.set(key, cascade);
+    let set = this.inFlight.get(key);
+    if (!set) {
+      set = new Set();
+      this.inFlight.set(key, set);
+    }
+    set.add(cascade);
     this.maybeEmitSaturated();
 
     const onStreamEvent = envelope.correlationId
@@ -467,13 +499,17 @@ export class CascadeConsumer {
           abortSignal: controller.signal,
         });
         cascade.sessionId = result.sessionId;
-        if (replacedExisting?.sessionId) {
+        // One `cascade.replaced` event per cancelled cascade. Steady-
+        // state replace cancels at most one, but if a `concurrent`-then-
+        // `replace` switch produced N, surface each cancellation.
+        for (const cancelled of replacedExisting) {
+          if (!cancelled.sessionId) continue;
           const ev: CascadeReplacedEvent = {
             type: "cascade.replaced",
             at: new Date().toISOString(),
             workspaceId: envelope.workspaceId,
             signalId: envelope.signalId,
-            cancelledSessionId: replacedExisting.sessionId,
+            cancelledSessionId: cancelled.sessionId,
             newSessionId: result.sessionId,
           };
           await publishInstanceEvent(this.nc, ev, logger);
@@ -492,10 +528,14 @@ export class CascadeConsumer {
           this.publishResponse(envelope.correlationId, { ok: false, error: msg });
         }
       } finally {
-        // Only remove from registry if we're still the active cascade.
-        // (A `replace` could have already swapped us out.)
-        if (this.inFlight.get(key) === cascade) {
-          this.inFlight.delete(key);
+        // Remove this specific cascade from the per-key set. The set is
+        // keyed-but-multi-valued so concurrent dispatches don't clobber
+        // each other; each cascade always finds itself by identity here
+        // regardless of how many siblings are running.
+        const liveSet = this.inFlight.get(key);
+        if (liveSet) {
+          liveSet.delete(cascade);
+          if (liveSet.size === 0) this.inFlight.delete(key);
         }
         this.maybeEmitDrained();
       }
@@ -506,24 +546,30 @@ export class CascadeConsumer {
 
   private maybeEmitSaturated(): void {
     if (this.saturated) return;
-    if (this.inFlight.size <= this.maxAckPending * 0.5) return;
+    const total = this.totalInFlight();
+    if (total <= this.maxAckPending * 0.5) return;
     this.saturated = true;
     let deepestSignal: string | undefined;
     let deepestAge = -1;
     const now = Date.now();
-    for (const [key, c] of this.inFlight.entries()) {
-      const age = now - c.startedAt;
-      if (age > deepestAge) {
-        deepestAge = age;
-        deepestSignal = key;
+    // Scan every cascade across every key — concurrent dispatches mean
+    // one key may hold multiple cascades, and the deepest may not be
+    // the first one in the set.
+    for (const [key, set] of this.inFlight.entries()) {
+      for (const c of set) {
+        const age = now - c.startedAt;
+        if (age > deepestAge) {
+          deepestAge = age;
+          deepestSignal = key;
+        }
       }
     }
     const event: CascadeQueueSaturatedEvent = {
       type: "cascade.queue_saturated",
       at: new Date().toISOString(),
-      inFlight: this.inFlight.size,
+      inFlight: total,
       cap: this.maxAckPending,
-      backlog: this.inFlight.size,
+      backlog: total,
       ...(deepestSignal ? { deepestSignal } : {}),
     };
     void publishInstanceEvent(this.nc, event, logger);
@@ -531,12 +577,13 @@ export class CascadeConsumer {
 
   private maybeEmitDrained(): void {
     if (!this.saturated) return;
-    if (this.inFlight.size > this.maxAckPending * 0.5) return;
+    const total = this.totalInFlight();
+    if (total > this.maxAckPending * 0.5) return;
     this.saturated = false;
     const event: CascadeQueueDrainedEvent = {
       type: "cascade.queue_drained",
       at: new Date().toISOString(),
-      inFlight: this.inFlight.size,
+      inFlight: total,
       cap: this.maxAckPending,
     };
     void publishInstanceEvent(this.nc, event, logger);
@@ -555,6 +602,6 @@ export class CascadeConsumer {
 
   /** Instrumentation — used by daemon status API. */
   getStats(): { inFlight: number; cap: number; saturated: boolean } {
-    return { inFlight: this.inFlight.size, cap: this.maxAckPending, saturated: this.saturated };
+    return { inFlight: this.totalInFlight(), cap: this.maxAckPending, saturated: this.saturated };
   }
 }

--- a/apps/atlasd/src/cascade-stream.ts
+++ b/apps/atlasd/src/cascade-stream.ts
@@ -1,0 +1,530 @@
+/**
+ * Cascade execution decoupled from signal delivery.
+ *
+ * Two-stream pipeline:
+ *
+ *   cron / HTTP / cross-cascade emit
+ *      │ publishSignal()
+ *      ▼
+ *   SIGNALS stream  (delivery durability)
+ *      │
+ *      ▼ thin forwarder, ack
+ *   SignalConsumer → publishCascade()
+ *      │
+ *      ▼
+ *   CASCADES stream  (dispatch buffer)
+ *      │
+ *      ▼ applies concurrencyPolicy, kicks off cascade as background
+ *        Promise (NOT awaited from the loop), acks on policy decision
+ *   CascadeConsumer
+ *      │
+ *      ▼
+ *   triggerWorkspaceSignal → runtime.processSignal (FSM engine)
+ *
+ * Why this exists: prior to the split, `SignalConsumer.handleMessage`
+ * awaited the entire FSM cascade before acking. A 3-min cascade on
+ * workspace A blocked every other workspace's signal — including
+ * trivial no-op cron jobs. Splitting delivery from execution lets
+ * one consumer drain SIGNALS quickly while a separate consumer
+ * runs cascades concurrently.
+ */
+
+import type { AtlasUIMessageChunk } from "@atlas/agent-sdk";
+import { logger } from "@atlas/logger";
+import { stringifyError } from "@atlas/utils";
+import {
+  AckPolicy,
+  DeliverPolicy,
+  type JsMsg,
+  type NatsConnection,
+  RetentionPolicy,
+  StorageType,
+} from "nats";
+import {
+  type CascadeQueueDrainedEvent,
+  type CascadeQueueSaturatedEvent,
+  type CascadeQueueTimeoutEvent,
+  type CascadeReplacedEvent,
+  publishInstanceEvent,
+} from "./instance-events.ts";
+import {
+  type SignalEnvelope,
+  SignalEnvelopeSchema,
+  type SignalResponse,
+  signalResponseSubject,
+  signalStreamSubject,
+} from "./signal-stream.ts";
+
+/** Per-signal concurrency policy read from workspace.yml. */
+export type ConcurrencyPolicy = "skip" | "queue" | "concurrent" | "replace";
+
+const STREAM_NAME = "CASCADES";
+const DEFAULT_MAX_AGE_NS = 60 * 60 * 1_000_000_000; // 1h
+const DEFAULT_DUPLICATE_WINDOW_NS = 5 * 60 * 1_000_000_000; // 5min
+const DEFAULT_QUEUE_TIMEOUT_MS = 5 * 60 * 1000; // 5min
+const DEFAULT_MAX_ACK_PENDING = 32;
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+export interface CascadesStreamLimits {
+  maxAgeNs?: number | bigint;
+  duplicateWindowNs?: number | bigint;
+}
+
+const toNumber = (v: number | bigint | undefined, fallback: number): number => {
+  if (v === undefined) return fallback;
+  return typeof v === "bigint" ? Number(v) : v;
+};
+
+export function cascadeSubject(workspaceId: string, signalId: string): string {
+  // Same sanitization rules as signal subjects — see SAFE_TOKEN_RE in signal-stream.ts.
+  const safe = (s: string) => s.replace(/[^A-Za-z0-9_-]/g, "_");
+  return `cascades.${safe(workspaceId)}.${safe(signalId)}`;
+}
+
+export async function ensureCascadesStream(
+  nc: NatsConnection,
+  limits: CascadesStreamLimits = {},
+): Promise<void> {
+  const jsm = await nc.jetstreamManager();
+  try {
+    await jsm.streams.info(STREAM_NAME);
+    return;
+  } catch (err) {
+    const msg = String((err as { message?: string })?.message ?? err);
+    if (!msg.includes("stream not found") && !msg.includes("no stream")) throw err;
+  }
+  await jsm.streams.add({
+    name: STREAM_NAME,
+    subjects: ["cascades.*.*"],
+    retention: RetentionPolicy.Workqueue,
+    storage: StorageType.File,
+    max_age: toNumber(limits.maxAgeNs, DEFAULT_MAX_AGE_NS),
+    duplicate_window: toNumber(limits.duplicateWindowNs, DEFAULT_DUPLICATE_WINDOW_NS),
+  });
+  logger.info("Created CASCADES JetStream stream");
+}
+
+/**
+ * Publish a cascade envelope. Same shape as SignalEnvelope — the cascade
+ * runner needs all the same data the signal carried. `msgID` dedupes
+ * within `duplicate_window`; the natural id is `(workspaceId, signalId,
+ * publishedAt)` which the signal forwarder reuses verbatim from the
+ * signal envelope so a redelivered SIGNALS msg can't double-dispatch
+ * the same cascade.
+ */
+export async function publishCascade(
+  nc: NatsConnection,
+  envelope: SignalEnvelope,
+): Promise<{ seq: number }> {
+  const subject = cascadeSubject(envelope.workspaceId, envelope.signalId);
+  const msgID = `${envelope.workspaceId}/${envelope.signalId}/${envelope.publishedAt}`;
+  const ack = await nc
+    .jetstream()
+    .publish(subject, enc.encode(JSON.stringify(envelope)), { msgID });
+  return { seq: ack.seq };
+}
+
+/**
+ * Dispatcher injected by the daemon — runs the FSM cascade for one
+ * envelope. Mirrors the existing `triggerWorkspaceSignal` shape:
+ * returns the session id + final FSM document outputs on success;
+ * throws `SessionFailedError` for domain-level failures (LLM error,
+ * tool error) and other Errors for infra-level failures.
+ *
+ * `abortSignal` is wired to the runtime via `triggerSignalWithSession`'s
+ * existing 6th arg — the `replace` policy uses it to cancel an
+ * in-flight cascade in favour of a newer envelope.
+ */
+export type CascadeDispatcher = (
+  envelope: SignalEnvelope,
+  ctx: { onStreamEvent?: (chunk: AtlasUIMessageChunk) => void; abortSignal: AbortSignal },
+) => Promise<{
+  sessionId: string;
+  output: Array<{ id: string; type: string; data: Record<string, unknown> }>;
+}>;
+
+/**
+ * Read the per-signal concurrency policy from workspace.yml. Injected
+ * so the consumer doesn't depend on WorkspaceManager directly. Falls
+ * back to "skip" (the default) on lookup miss.
+ */
+export type ConcurrencyPolicyResolver = (
+  workspaceId: string,
+  signalId: string,
+) => Promise<ConcurrencyPolicy>;
+
+export interface CascadeConsumerOptions {
+  name?: string;
+  expiresMs?: number;
+  batchSize?: number;
+  maxAckPending?: number;
+  /** ms an envelope can wait in CASCADES before being terminated as queue-timeout. */
+  queueTimeoutMs?: number;
+}
+
+interface InFlightCascade {
+  controller: AbortController;
+  /** Resolves when the cascade settles. */
+  done: Promise<void>;
+  startedAt: number;
+  sessionId?: string;
+}
+
+/**
+ * Pull-based consumer that drains CASCADES, applies the per-signal
+ * concurrency policy, and kicks off each cascade as a background
+ * Promise (NOT awaited from the runLoop, so a slow cascade does not
+ * stall delivery of the next envelope).
+ *
+ * Concurrency knobs:
+ *  - max_ack_pending caps total in-flight cascades (broker-level).
+ *  - per-(workspace,signal) registry enforces the policy.
+ *  - INSTANCE_EVENTS surface saturation / replace / queue-timeout
+ *    transitions so UIs can render system state without polling.
+ */
+export class CascadeConsumer {
+  private running = false;
+  private loop: Promise<void> | null = null;
+  private readonly name: string;
+  private readonly expiresMs: number;
+  private readonly batchSize: number;
+  private readonly maxDeliver = 1; // cascades fail-fast at the queue level; surface as failed sessions
+  private readonly maxAckPending: number;
+  private readonly ackWaitNs: number;
+  private readonly queueTimeoutMs: number;
+
+  private readonly inFlight = new Map<string, InFlightCascade>();
+  /** Tail of the queue policy chain per key. */
+  private readonly queueTails = new Map<string, Promise<void>>();
+  private saturated = false;
+
+  constructor(
+    private readonly nc: NatsConnection,
+    private readonly dispatch: CascadeDispatcher,
+    private readonly resolvePolicy: ConcurrencyPolicyResolver,
+    opts: CascadeConsumerOptions = {},
+  ) {
+    this.name = opts.name ?? "atlasd-cascades";
+    this.expiresMs = Math.max(1000, opts.expiresMs ?? 10_000);
+    this.batchSize = opts.batchSize ?? 16;
+    this.maxAckPending = opts.maxAckPending ?? DEFAULT_MAX_ACK_PENDING;
+    this.queueTimeoutMs = opts.queueTimeoutMs ?? DEFAULT_QUEUE_TIMEOUT_MS;
+    // ack_wait should comfortably exceed the longest legitimate cascade.
+    // 30min covers most LLM jobs. A cascade outlasting this will be
+    // redelivered, but maxDeliver=1 means it's term'd on second receipt.
+    this.ackWaitNs = 30 * 60 * 1_000_000_000;
+  }
+
+  async start(): Promise<void> {
+    if (this.running) return;
+    const jsm = await this.nc.jetstreamManager();
+    try {
+      await jsm.consumers.info(STREAM_NAME, this.name);
+    } catch (err) {
+      const msg = String((err as { message?: string })?.message ?? err);
+      if (!msg.includes("consumer not found")) throw err;
+      await jsm.consumers.add(STREAM_NAME, {
+        durable_name: this.name,
+        ack_policy: AckPolicy.Explicit,
+        deliver_policy: DeliverPolicy.All,
+        max_deliver: this.maxDeliver,
+        ack_wait: this.ackWaitNs,
+        max_ack_pending: this.maxAckPending,
+      });
+      logger.info("Created CASCADES consumer", { name: this.name });
+    }
+    this.running = true;
+    this.loop = this.runLoop();
+  }
+
+  async stop(): Promise<void> {
+    this.running = false;
+    if (this.loop) {
+      try {
+        await this.loop;
+      } catch {
+        // already logged
+      }
+      this.loop = null;
+    }
+    // Best-effort: abort any in-flight cascades so the daemon can
+    // shut down without waiting on long LLM calls.
+    for (const cascade of this.inFlight.values()) {
+      cascade.controller.abort("daemon shutdown");
+    }
+  }
+
+  /** Test-only — drop the durable consumer entry from the broker. */
+  async destroy(): Promise<void> {
+    await this.stop();
+    try {
+      const jsm = await this.nc.jetstreamManager();
+      await jsm.consumers.delete(STREAM_NAME, this.name);
+    } catch {
+      // already gone
+    }
+  }
+
+  private async runLoop(): Promise<void> {
+    const consumer = await this.nc.jetstream().consumers.get(STREAM_NAME, this.name);
+    while (this.running) {
+      let batch: Awaited<ReturnType<typeof consumer.fetch>>;
+      try {
+        batch = await consumer.fetch({ max_messages: this.batchSize, expires: this.expiresMs });
+      } catch (err) {
+        logger.warn("CASCADES consumer fetch failed", { error: stringifyError(err) });
+        await new Promise((r) => setTimeout(r, 1000));
+        continue;
+      }
+      for await (const msg of batch) {
+        // Critical: do NOT await — the whole point is to keep delivery
+        // decoupled from cascade execution. handleMessage acks and
+        // forks the cascade as a background Promise.
+        void this.handleMessage(msg).catch((err) => {
+          logger.error("Unhandled CASCADES handleMessage error", {
+            seq: msg.seq,
+            subject: msg.subject,
+            error: stringifyError(err),
+          });
+        });
+      }
+    }
+  }
+
+  private async handleMessage(msg: JsMsg): Promise<void> {
+    let envelope: SignalEnvelope;
+    try {
+      envelope = SignalEnvelopeSchema.parse(JSON.parse(dec.decode(msg.data)));
+    } catch (err) {
+      logger.warn("Discarding malformed cascade envelope", {
+        seq: msg.seq,
+        subject: msg.subject,
+        error: stringifyError(err),
+      });
+      msg.term();
+      return;
+    }
+
+    // Queue-timeout check — if the envelope sat long enough that any
+    // synchronous caller has already given up, term it and surface the
+    // skip via INSTANCE_EVENTS (and a fail response for correlated
+    // callers, though those callers have likely timed out their HTTP
+    // request by now).
+    const queuedMs = Date.now() - new Date(envelope.publishedAt).getTime();
+    if (queuedMs > this.queueTimeoutMs) {
+      const event: CascadeQueueTimeoutEvent = {
+        type: "cascade.queue_timeout",
+        at: new Date().toISOString(),
+        workspaceId: envelope.workspaceId,
+        signalId: envelope.signalId,
+        queuedMs,
+        ...(envelope.correlationId ? { correlationId: envelope.correlationId } : {}),
+      };
+      await publishInstanceEvent(this.nc, event, logger);
+      if (envelope.correlationId) {
+        this.publishResponse(envelope.correlationId, {
+          ok: false,
+          error: `queue-timeout: envelope queued ${queuedMs}ms (limit ${this.queueTimeoutMs}ms)`,
+        });
+      }
+      msg.term();
+      return;
+    }
+
+    const key = `${envelope.workspaceId}:${envelope.signalId}`;
+    let policy: ConcurrencyPolicy;
+    try {
+      policy = await this.resolvePolicy(envelope.workspaceId, envelope.signalId);
+    } catch {
+      policy = "skip";
+    }
+
+    const existing = this.inFlight.get(key);
+
+    if (existing && policy === "skip") {
+      logger.info("Cascade skipped — concurrency=skip and same-key cascade in flight", {
+        workspaceId: envelope.workspaceId,
+        signalId: envelope.signalId,
+      });
+      if (envelope.correlationId) {
+        this.publishResponse(envelope.correlationId, {
+          ok: false,
+          error: "skipped-duplicate: a cascade for this signal is already running",
+        });
+      }
+      msg.ack();
+      return;
+    }
+
+    if (existing && policy === "replace") {
+      logger.info("Cascade replacing in-flight cascade — concurrency=replace", {
+        workspaceId: envelope.workspaceId,
+        signalId: envelope.signalId,
+        cancelledSessionId: existing.sessionId,
+      });
+      existing.controller.abort("replaced by newer cascade");
+      // Don't await `existing.done` — that would re-introduce head-of-line
+      // blocking. The runtime's abort path settles the cancelled cascade
+      // independently. The `cascade.replaced` event is published once the
+      // new cascade has its sessionId.
+    }
+
+    if (policy === "queue") {
+      // Per-key serialization. Chain onto the previous tail so
+      // envelopes for the same (workspace, signal) run in arrival
+      // order. ack happens after policy decision (here) — the cascade
+      // result still flows through response/stream subjects when the
+      // chain gets there.
+      const prevTail = this.queueTails.get(key) ?? Promise.resolve();
+      const next = prevTail.then(() => this.runCascade(envelope, key, existing));
+      this.queueTails.set(
+        key,
+        next.catch(() => undefined),
+      );
+      msg.ack();
+      return;
+    }
+
+    // skip with no existing, concurrent always, or replace (we already
+    // aborted existing above and are starting fresh now).
+    void this.runCascade(envelope, key, existing);
+    msg.ack();
+  }
+
+  /**
+   * Run one cascade. Registers in `inFlight`, dispatches via the
+   * injected dispatcher, publishes correlated response, deregisters.
+   * Errors are logged and surfaced on the response subject — they do
+   * not propagate back to the consumer loop.
+   */
+  private runCascade(
+    envelope: SignalEnvelope,
+    key: string,
+    replacedExisting?: InFlightCascade,
+  ): Promise<void> {
+    const controller = new AbortController();
+    const startedAt = Date.now();
+    const cascade: InFlightCascade = {
+      controller,
+      done: Promise.resolve(), // placeholder; replaced below
+      startedAt,
+    };
+    this.inFlight.set(key, cascade);
+    this.maybeEmitSaturated();
+
+    const onStreamEvent = envelope.correlationId
+      ? (chunk: AtlasUIMessageChunk) => {
+          try {
+            this.nc.publish(
+              signalStreamSubject(envelope.correlationId as string),
+              enc.encode(JSON.stringify(chunk)),
+            );
+          } catch (err) {
+            logger.warn("Failed to forward cascade stream chunk", {
+              correlationId: envelope.correlationId,
+              error: stringifyError(err),
+            });
+          }
+        }
+      : undefined;
+
+    cascade.done = (async () => {
+      try {
+        const result = await this.dispatch(envelope, {
+          onStreamEvent,
+          abortSignal: controller.signal,
+        });
+        cascade.sessionId = result.sessionId;
+        if (replacedExisting?.sessionId) {
+          const ev: CascadeReplacedEvent = {
+            type: "cascade.replaced",
+            at: new Date().toISOString(),
+            workspaceId: envelope.workspaceId,
+            signalId: envelope.signalId,
+            cancelledSessionId: replacedExisting.sessionId,
+            newSessionId: result.sessionId,
+          };
+          await publishInstanceEvent(this.nc, ev, logger);
+        }
+        if (envelope.correlationId) {
+          this.publishResponse(envelope.correlationId, { ok: true, result });
+        }
+      } catch (err) {
+        const msg = stringifyError(err);
+        logger.warn("Cascade dispatch failed", {
+          workspaceId: envelope.workspaceId,
+          signalId: envelope.signalId,
+          error: msg,
+        });
+        if (envelope.correlationId) {
+          this.publishResponse(envelope.correlationId, { ok: false, error: msg });
+        }
+      } finally {
+        // Only remove from registry if we're still the active cascade.
+        // (A `replace` could have already swapped us out.)
+        if (this.inFlight.get(key) === cascade) {
+          this.inFlight.delete(key);
+        }
+        this.maybeEmitDrained();
+      }
+    })();
+
+    return cascade.done;
+  }
+
+  private maybeEmitSaturated(): void {
+    if (this.saturated) return;
+    if (this.inFlight.size <= this.maxAckPending * 0.5) return;
+    this.saturated = true;
+    let deepestSignal: string | undefined;
+    let deepestAge = -1;
+    const now = Date.now();
+    for (const [key, c] of this.inFlight.entries()) {
+      const age = now - c.startedAt;
+      if (age > deepestAge) {
+        deepestAge = age;
+        deepestSignal = key;
+      }
+    }
+    const event: CascadeQueueSaturatedEvent = {
+      type: "cascade.queue_saturated",
+      at: new Date().toISOString(),
+      inFlight: this.inFlight.size,
+      cap: this.maxAckPending,
+      backlog: this.inFlight.size,
+      ...(deepestSignal ? { deepestSignal } : {}),
+    };
+    void publishInstanceEvent(this.nc, event, logger);
+  }
+
+  private maybeEmitDrained(): void {
+    if (!this.saturated) return;
+    if (this.inFlight.size > this.maxAckPending * 0.5) return;
+    this.saturated = false;
+    const event: CascadeQueueDrainedEvent = {
+      type: "cascade.queue_drained",
+      at: new Date().toISOString(),
+      inFlight: this.inFlight.size,
+      cap: this.maxAckPending,
+    };
+    void publishInstanceEvent(this.nc, event, logger);
+  }
+
+  private publishResponse(correlationId: string, response: SignalResponse): void {
+    try {
+      this.nc.publish(signalResponseSubject(correlationId), enc.encode(JSON.stringify(response)));
+    } catch (err) {
+      logger.warn("Failed to publish cascade response", {
+        correlationId,
+        error: stringifyError(err),
+      });
+    }
+  }
+
+  /** Instrumentation — used by daemon status API. */
+  getStats(): { inFlight: number; cap: number; saturated: boolean } {
+    return { inFlight: this.inFlight.size, cap: this.maxAckPending, saturated: this.saturated };
+  }
+}

--- a/apps/atlasd/src/cascade-stream.ts
+++ b/apps/atlasd/src/cascade-stream.ts
@@ -27,6 +27,18 @@
  * trivial no-op cron jobs. Splitting delivery from execution lets
  * one consumer drain SIGNALS quickly while a separate consumer
  * runs cascades concurrently.
+ *
+ * Crash semantics: max_deliver=1 on CASCADES, ack on policy decision.
+ * If the daemon crashes mid-cascade, the message is gone and the
+ * cascade does NOT replay. The session is left in active state and
+ * gets flipped to "interrupted" by the existing
+ * `markInterruptedSessions` sweep on next daemon startup. This is a
+ * deliberate behaviour change from pre-cascade-split (which would
+ * redeliver the same SIGNALS msg up to 5×): replays of crashed
+ * cascades are likely to fail again the same way and burn ack budget.
+ * Operators that need every-tick semantics should rely on the cron
+ * `onMissed: catchup` policy plus the in-runtime session lifecycle —
+ * the queue layer no longer hides crashes behind retries.
  */
 
 import type { AtlasUIMessageChunk } from "@atlas/agent-sdk";
@@ -237,6 +249,24 @@ export class CascadeConsumer {
     }
     this.running = true;
     this.loop = this.runLoop();
+
+    // Saturated state is in-memory only, so a previous daemon that
+    // crashed while saturated leaves a hanging `cascade.queue_saturated`
+    // event in INSTANCE_EVENTS with no matching `drained`. UI consumers
+    // walking the event log would interpret that as "still saturated".
+    // Emit a synthetic drained event on every startup — current inFlight
+    // is 0 by definition (we just initialised the map), so the assertion
+    // is honest.
+    void publishInstanceEvent(
+      this.nc,
+      {
+        type: "cascade.queue_drained",
+        at: new Date().toISOString(),
+        inFlight: 0,
+        cap: this.maxAckPending,
+      },
+      logger,
+    );
   }
 
   async stop(): Promise<void> {

--- a/apps/atlasd/src/cascade-stream.ts
+++ b/apps/atlasd/src/cascade-stream.ts
@@ -42,6 +42,7 @@
  */
 
 import type { AtlasUIMessageChunk } from "@atlas/agent-sdk";
+import type { ConcurrencyPolicy } from "@atlas/config";
 import { logger } from "@atlas/logger";
 import { stringifyError } from "@atlas/utils";
 import {
@@ -67,8 +68,12 @@ import {
   signalStreamSubject,
 } from "./signal-stream.ts";
 
-/** Per-signal concurrency policy read from workspace.yml. */
-export type ConcurrencyPolicy = "skip" | "queue" | "concurrent" | "replace";
+// `ConcurrencyPolicy` (`skip` | `queue` | `concurrent` | `replace`) is
+// the workspace-config schema type — imported from `@atlas/config` and
+// used locally below. Callsites should also import directly from
+// `@atlas/config` (re-exporting would push the discriminated-union
+// inference through this module and cause deep-type explosions
+// downstream).
 
 const STREAM_NAME = "CASCADES";
 const DEFAULT_MAX_AGE_NS = 60 * 60 * 1_000_000_000; // 1h
@@ -238,10 +243,22 @@ export class CascadeConsumer {
     this.batchSize = opts.batchSize ?? 16;
     this.maxAckPending = opts.maxAckPending ?? DEFAULT_MAX_ACK_PENDING;
     this.queueTimeoutMs = opts.queueTimeoutMs ?? DEFAULT_QUEUE_TIMEOUT_MS;
-    // ack_wait should comfortably exceed the longest legitimate cascade.
-    // 30min covers most LLM jobs. A cascade outlasting this will be
-    // redelivered, but maxDeliver=1 means it's term'd on second receipt.
-    this.ackWaitNs = 30 * 60 * 1_000_000_000;
+    // ack_wait bounds crash-recovery, NOT cascade duration. We ack on
+    // the policy decision (parse → resolvePolicy → ack), all of which
+    // run synchronously inside `handleMessage` and finish in
+    // milliseconds. The cascade itself runs as a background Promise
+    // AFTER the ack — its runtime is irrelevant to the broker.
+    //
+    // What ack_wait actually controls: if the daemon dies between
+    // receive and ack (the small "in-flight, unacked" window), the
+    // broker holds the message for ack_wait before reclaiming the
+    // ack_pending slot. With ack_wait = 30min and max_ack_pending = 32,
+    // a crash during peak could stall the next daemon's consumer for
+    // 30 min waiting for those slots to free up. Setting it to 30s
+    // bounds that recovery window. With max_deliver=1 the message
+    // gets term'd on redelivery anyway — we don't lose more by
+    // shortening, we just unstuck the consumer faster.
+    this.ackWaitNs = 30 * 1_000_000_000;
   }
 
   async start(): Promise<void> {

--- a/apps/atlasd/src/cascade-stream.ts
+++ b/apps/atlasd/src/cascade-stream.ts
@@ -219,17 +219,92 @@ export class CascadeConsumer {
    * earlier entries silently overwritten on subsequent dispatches.
    * For `skip` / `queue` / `replace` the set holds at most one in
    * steady state.
+   *
+   * A cascade is added here as soon as `runCascade` is called, before
+   * it acquires a dispatch slot. So `totalInFlight()` includes both
+   * cascades currently dispatching AND cascades queued at the
+   * concurrency-cap semaphore.
    */
   private readonly inFlight = new Map<string, Set<InFlightCascade>>();
   /** Tail of the queue policy chain per key. */
   private readonly queueTails = new Map<string, Promise<void>>();
+  /**
+   * Per-key lock for the policy-decide-and-register critical section
+   * inside `handleMessage`. Without this, two messages for the same
+   * `(workspaceId, signalId)` arriving in the same fetch batch would
+   * race on the inFlight check — both would observe size=0, both
+   * would proceed (leaking past `skip` / clobbering `replace`'s abort
+   * intent / overwriting `queue`'s prevTail). The lock serializes the
+   * *decision*; cascades themselves still run with the configured
+   * concurrency.
+   */
+  private readonly policyLocks = new Map<string, Promise<void>>();
   private saturated = false;
 
-  /** Total cascades currently dispatched, summed across all keys. */
+  /**
+   * Cascade-execution semaphore. Distinct from JetStream's
+   * `max_ack_pending`: that bounds *delivered-but-unacked* messages
+   * (essentially in-flight handleMessage calls, which are fast). This
+   * one bounds in-flight cascade dispatch — the actually expensive
+   * thing (LLM calls, MCP roundtrips). Without it, a burst of N acks
+   * fires N concurrent cascades regardless of the configured cap.
+   */
+  private cascadeInFlight = 0;
+  private readonly cascadeWaiters: Array<() => void> = [];
+
+  /** Total cascades registered (running + waiting for slot). */
   private totalInFlight(): number {
     let n = 0;
     for (const set of this.inFlight.values()) n += set.size;
     return n;
+  }
+
+  /** Acquire a cascade-execution slot. Resolves when a slot is free. */
+  private acquireSlot(): Promise<void> {
+    if (this.cascadeInFlight < this.maxAckPending) {
+      this.cascadeInFlight++;
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => {
+      this.cascadeWaiters.push(() => {
+        this.cascadeInFlight++;
+        resolve();
+      });
+    });
+  }
+
+  /** Release a cascade-execution slot. Wakes the next waiter, FIFO. */
+  private releaseSlot(): void {
+    this.cascadeInFlight--;
+    const next = this.cascadeWaiters.shift();
+    if (next) next();
+  }
+
+  /**
+   * Run `fn` while holding the per-key policy lock. The lock chain
+   * serializes the policy-decide-and-register window for a given
+   * `(workspaceId, signalId)`; same-key handleMessages from the same
+   * fetch batch run their decisions one at a time. Different keys are
+   * independent. Lock entries grow monotonically — at typical
+   * cardinalities (<100 distinct keys per workspace) the memory cost
+   * is negligible.
+   */
+  private async withPolicyLock<T>(key: string, fn: () => T | Promise<T>): Promise<T> {
+    const prev = this.policyLocks.get(key) ?? Promise.resolve();
+    let release!: () => void;
+    const next = new Promise<void>((r) => {
+      release = r;
+    });
+    this.policyLocks.set(
+      key,
+      prev.then(() => next),
+    );
+    await prev;
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
   }
 
   constructor(
@@ -405,66 +480,74 @@ export class CascadeConsumer {
       policy = "skip";
     }
 
-    const existingSet = this.inFlight.get(key);
-    const existingCount = existingSet?.size ?? 0;
+    // The policy decision + register-or-skip + queueTail update have
+    // to happen atomically per key. Two messages for the same
+    // `(workspace, signal)` arriving in the same fetch batch would
+    // otherwise race on the inFlight check and both proceed past
+    // `skip`, clobber `replace`'s abort intent, or overwrite
+    // `queue`'s prevTail. Different keys still decide in parallel.
+    await this.withPolicyLock(key, () => {
+      const existingSet = this.inFlight.get(key);
+      const existingCount = existingSet?.size ?? 0;
 
-    if (existingCount > 0 && policy === "skip") {
-      logger.info("Cascade skipped — concurrency=skip and same-key cascade in flight", {
-        workspaceId: envelope.workspaceId,
-        signalId: envelope.signalId,
-      });
-      if (envelope.correlationId) {
-        this.publishResponse(envelope.correlationId, {
-          ok: false,
-          error: "skipped-duplicate: a cascade for this signal is already running",
+      if (existingCount > 0 && policy === "skip") {
+        logger.info("Cascade skipped — concurrency=skip and same-key cascade in flight", {
+          workspaceId: envelope.workspaceId,
+          signalId: envelope.signalId,
         });
+        if (envelope.correlationId) {
+          this.publishResponse(envelope.correlationId, {
+            ok: false,
+            error: "skipped-duplicate: a cascade for this signal is already running",
+          });
+        }
+        msg.ack();
+        return;
       }
-      msg.ack();
-      return;
-    }
 
-    let replacedExisting: InFlightCascade[] = [];
-    if (existingCount > 0 && policy === "replace" && existingSet) {
-      // Singleton intent: abort EVERY in-flight cascade for this key.
-      // In steady-state replace usage there's at most one, but the set
-      // could carry several if the workspace was previously running
-      // `concurrent` and switched to `replace`.
-      replacedExisting = Array.from(existingSet);
-      logger.info("Cascade replacing in-flight cascade(s) — concurrency=replace", {
-        workspaceId: envelope.workspaceId,
-        signalId: envelope.signalId,
-        cancelledCount: replacedExisting.length,
-        cancelledSessionIds: replacedExisting.map((c) => c.sessionId).filter(Boolean),
-      });
-      for (const cascade of replacedExisting) {
-        cascade.controller.abort("replaced by newer cascade");
+      let replacedExisting: InFlightCascade[] = [];
+      if (existingCount > 0 && policy === "replace" && existingSet) {
+        // Singleton intent: abort EVERY in-flight cascade for this key.
+        // In steady-state replace usage there's at most one, but the
+        // set could carry several if the workspace was previously
+        // running `concurrent` and switched to `replace`.
+        replacedExisting = Array.from(existingSet);
+        logger.info("Cascade replacing in-flight cascade(s) — concurrency=replace", {
+          workspaceId: envelope.workspaceId,
+          signalId: envelope.signalId,
+          cancelledCount: replacedExisting.length,
+          cancelledSessionIds: replacedExisting.map((c) => c.sessionId).filter(Boolean),
+        });
+        for (const cascade of replacedExisting) {
+          cascade.controller.abort("replaced by newer cascade");
+        }
+        // Don't await — that would re-introduce head-of-line blocking.
+        // The runtime's abort path settles cancelled cascades
+        // independently. `cascade.replaced` events publish once the
+        // new cascade has its sessionId.
       }
-      // Don't await — that would re-introduce head-of-line blocking.
-      // The runtime's abort path settles cancelled cascades independently.
-      // `cascade.replaced` events publish once the new cascade has its
-      // sessionId.
-    }
 
-    if (policy === "queue") {
-      // Per-key serialization. Chain onto the previous tail so
-      // envelopes for the same (workspace, signal) run in arrival
-      // order. ack happens after policy decision (here) — the cascade
-      // result still flows through response/stream subjects when the
-      // chain gets there.
-      const prevTail = this.queueTails.get(key) ?? Promise.resolve();
-      const next = prevTail.then(() => this.runCascade(envelope, key, []));
-      this.queueTails.set(
-        key,
-        next.catch(() => undefined),
-      );
+      if (policy === "queue") {
+        // Per-key serialization. Chain onto the previous tail so
+        // envelopes for the same (workspace, signal) run in arrival
+        // order. ack happens after policy decision (here) — the
+        // cascade result still flows through response/stream subjects
+        // when the chain gets there.
+        const prevTail = this.queueTails.get(key) ?? Promise.resolve();
+        const next = prevTail.then(() => this.runCascade(envelope, key, []));
+        this.queueTails.set(
+          key,
+          next.catch(() => undefined),
+        );
+        msg.ack();
+        return;
+      }
+
+      // skip with no existing, concurrent always, or replace (we
+      // already aborted existing above and are starting fresh now).
+      void this.runCascade(envelope, key, replacedExisting);
       msg.ack();
-      return;
-    }
-
-    // skip with no existing, concurrent always, or replace (we already
-    // aborted existing above and are starting fresh now).
-    void this.runCascade(envelope, key, replacedExisting);
-    msg.ack();
+    });
   }
 
   /**
@@ -510,7 +593,16 @@ export class CascadeConsumer {
       : undefined;
 
     cascade.done = (async () => {
+      // Acquire a cascade-execution slot before dispatching. This is
+      // the actual cap on concurrent LLM/MCP load — JetStream's
+      // max_ack_pending caps fast-handleMessage delivery, not cascade
+      // duration. Bursts queue at the semaphore; the registered Set
+      // entry above means `totalInFlight()` reflects "queued + running"
+      // for saturation accounting.
+      let slotHeld = false;
       try {
+        await this.acquireSlot();
+        slotHeld = true;
         const result = await this.dispatch(envelope, {
           onStreamEvent,
           abortSignal: controller.signal,
@@ -545,6 +637,9 @@ export class CascadeConsumer {
           this.publishResponse(envelope.correlationId, { ok: false, error: msg });
         }
       } finally {
+        // Release the cascade-execution slot first so a queued waiter
+        // can acquire promptly; deregistration happens after.
+        if (slotHeld) this.releaseSlot();
         // Remove this specific cascade from the per-key set. The set is
         // keyed-but-multi-valued so concurrent dispatches don't clobber
         // each other; each cascade always finds itself by identity here
@@ -617,8 +712,29 @@ export class CascadeConsumer {
     }
   }
 
-  /** Instrumentation — used by daemon status API. */
-  getStats(): { inFlight: number; cap: number; saturated: boolean } {
-    return { inFlight: this.totalInFlight(), cap: this.maxAckPending, saturated: this.saturated };
+  /**
+   * Instrumentation — used by daemon status API.
+   *
+   * - `inFlight` — registered cascades (running + waiting at the
+   *   concurrency cap semaphore).
+   * - `running` — currently dispatching to the runtime.
+   * - `waiting` — queued behind the cap.
+   * - `cap` — concurrent-cascade ceiling (FRIDAY_CASCADE_CONCURRENCY).
+   */
+  getStats(): {
+    inFlight: number;
+    running: number;
+    waiting: number;
+    cap: number;
+    saturated: boolean;
+  } {
+    const total = this.totalInFlight();
+    return {
+      inFlight: total,
+      running: this.cascadeInFlight,
+      waiting: total - this.cascadeInFlight,
+      cap: this.maxAckPending,
+      saturated: this.saturated,
+    };
   }
 }

--- a/apps/atlasd/src/instance-events.ts
+++ b/apps/atlasd/src/instance-events.ts
@@ -1,0 +1,172 @@
+/**
+ * Instance event log — JetStream-backed append-only feed of operational
+ * events scoped to the daemon instance (cross-workspace).
+ *
+ * Companion to `workspace-events.ts`. Same publish-and-read shape; no KV
+ * sidecar, since these events have no operator-action lifecycle (unlike
+ * `schedule.missed` which can be fired/dismissed). Subscribers consume via
+ * SSE on `/api/instance/events?stream=true` — no polling.
+ *
+ * **Stream layout:**
+ *   name      = `INSTANCE_EVENTS`
+ *   subjects  = `instance.>` (so `instance.<eventType>`)
+ *   storage   = file
+ *   retention = limits, max_age 7 days (operational rolling window)
+ *
+ * **Subject conventions:**
+ *   instance.cascade.queue_saturated
+ *   instance.cascade.queue_drained
+ *   instance.cascade.queue_timeout
+ *   instance.cascade.replaced
+ *
+ * Schema is deliberately open for future `instance.daemon.*`,
+ * `instance.health.*`, etc. without a stream split.
+ */
+
+import type { Logger } from "@atlas/logger";
+import { stringifyError } from "@atlas/utils";
+import { type NatsConnection, RetentionPolicy, StorageType } from "nats";
+
+const STREAM_NAME = "INSTANCE_EVENTS";
+const SUBJECT_PREFIX = "instance";
+const SEVEN_DAYS_NS = 7 * 24 * 60 * 60 * 1_000_000_000;
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+/** Cascade backlog crossed `>0.5 * cap` and stayed elevated. */
+export interface CascadeQueueSaturatedEvent {
+  type: "cascade.queue_saturated";
+  /** ISO 8601. */
+  at: string;
+  inFlight: number;
+  cap: number;
+  backlog: number;
+  /** `<workspaceId>:<signalId>` of the most-backed-up key, if any. */
+  deepestSignal?: string;
+}
+
+/** Cascade backlog fell back below `0.5 * cap`. Mirrors `queue_saturated`. */
+export interface CascadeQueueDrainedEvent {
+  type: "cascade.queue_drained";
+  at: string;
+  inFlight: number;
+  cap: number;
+}
+
+/**
+ * Envelope sat in CASCADES > `FRIDAY_CASCADE_QUEUE_TIMEOUT` (default 5min)
+ * before the consumer picked it up. The consumer terms the message and
+ * publishes a fail response on `signals.responses.<correlationId>` if
+ * the envelope was correlated.
+ */
+export interface CascadeQueueTimeoutEvent {
+  type: "cascade.queue_timeout";
+  at: string;
+  workspaceId: string;
+  signalId: string;
+  queuedMs: number;
+  correlationId?: string;
+}
+
+/**
+ * `concurrency: replace` policy aborted an in-flight cascade in favour
+ * of a newer envelope. Both session ids are surfaced so operators can
+ * trace the swap in `/api/sessions`.
+ */
+export interface CascadeReplacedEvent {
+  type: "cascade.replaced";
+  at: string;
+  workspaceId: string;
+  signalId: string;
+  cancelledSessionId: string;
+  newSessionId: string;
+}
+
+export type InstanceEvent =
+  | CascadeQueueSaturatedEvent
+  | CascadeQueueDrainedEvent
+  | CascadeQueueTimeoutEvent
+  | CascadeReplacedEvent;
+
+/** Ensure the INSTANCE_EVENTS stream exists with the right config. */
+export async function ensureInstanceEventsStream(nc: NatsConnection): Promise<void> {
+  const jsm = await nc.jetstreamManager();
+  try {
+    await jsm.streams.info(STREAM_NAME);
+  } catch {
+    await jsm.streams.add({
+      name: STREAM_NAME,
+      subjects: [`${SUBJECT_PREFIX}.>`],
+      retention: RetentionPolicy.Limits,
+      storage: StorageType.File,
+      max_age: SEVEN_DAYS_NS,
+    });
+  }
+}
+
+/** Publish an instance event. Subject derived from `event.type`. */
+export async function publishInstanceEvent(
+  nc: NatsConnection,
+  event: InstanceEvent,
+  logger?: Logger,
+): Promise<void> {
+  const subject = `${SUBJECT_PREFIX}.${event.type}`;
+  try {
+    const js = nc.jetstream();
+    await js.publish(subject, enc.encode(JSON.stringify(event)));
+  } catch (err) {
+    logger?.warn("Failed to publish instance event", {
+      subject,
+      type: event.type,
+      error: stringifyError(err),
+    });
+  }
+}
+
+/**
+ * Read the most recent instance events, optionally filtered by event type
+ * subject (e.g. `cascade.queue_saturated` or `cascade.`). Backwards walk by
+ * sequence using direct-get — same pattern as `workspace-events.ts`. Drives
+ * the replay path on `/api/instance/events?since=...`.
+ */
+export async function listInstanceEvents(
+  nc: NatsConnection,
+  options: { limit?: number; scanLimit?: number; typeFilter?: string } = {},
+): Promise<InstanceEvent[]> {
+  const limit = options.limit ?? 100;
+  const scanLimit = options.scanLimit ?? 5000;
+  const subjectFilter = options.typeFilter
+    ? `${SUBJECT_PREFIX}.${options.typeFilter}`
+    : `${SUBJECT_PREFIX}.`;
+
+  const jsm = await nc.jetstreamManager();
+  let info: Awaited<ReturnType<typeof jsm.streams.info>> | null = null;
+  try {
+    info = await jsm.streams.info(STREAM_NAME);
+  } catch {
+    return [];
+  }
+  const lastSeq = Number(info.state.last_seq);
+  if (lastSeq === 0) return [];
+  const firstSeq = Number(info.state.first_seq);
+
+  const events: InstanceEvent[] = [];
+  let scanned = 0;
+  for (let seq = lastSeq; seq >= firstSeq && events.length < limit && scanned < scanLimit; seq--) {
+    scanned++;
+    let msg: Awaited<ReturnType<typeof jsm.streams.getMessage>> | null = null;
+    try {
+      msg = await jsm.streams.getMessage(STREAM_NAME, { seq });
+    } catch {
+      continue;
+    }
+    if (!msg || !msg.subject.startsWith(subjectFilter)) continue;
+    try {
+      events.push(JSON.parse(dec.decode(msg.data)) as InstanceEvent);
+    } catch {
+      // Malformed payload — skip rather than fail the whole list.
+    }
+  }
+  return events;
+}

--- a/apps/atlasd/src/instance-events.ts
+++ b/apps/atlasd/src/instance-events.ts
@@ -101,6 +101,13 @@ export async function ensureInstanceEventsStream(nc: NatsConnection): Promise<vo
       retention: RetentionPolicy.Limits,
       storage: StorageType.File,
       max_age: SEVEN_DAYS_NS,
+      // `allow_direct` is intentionally NOT set here — defaults to false,
+      // which routes `streams.getMessage` calls to the leader and gives
+      // us read-your-writes for the replay endpoint
+      // (`/api/instance/events?since=...`). If a future op enables
+      // direct-get on replicas to scale read throughput, the replay path
+      // will lose read-your-writes and a recently-published event may
+      // not appear immediately on a reload-after-disconnect.
     });
   }
 }

--- a/apps/atlasd/src/signal-stream.test.ts
+++ b/apps/atlasd/src/signal-stream.test.ts
@@ -37,7 +37,13 @@ describe("signalSubject", () => {
 });
 
 describe("publishSignal + SignalConsumer", () => {
-  it("publishes an envelope and the consumer dispatches it once", async () => {
+  // SignalConsumer is now a thin forwarder: it parses the envelope, hands
+  // it to the injected dispatcher (production wiring is `publishCascade`),
+  // and acks. Cascade execution + per-signal concurrency policy + correlated
+  // response/stream forwarding all live in CascadeConsumer
+  // (cascade-stream.ts) — those tests live there.
+
+  it("publishes an envelope and the consumer forwards it once", async () => {
     const received: SignalEnvelope[] = [];
     const consumer = new SignalConsumer(
       nc,
@@ -65,7 +71,7 @@ describe("publishSignal + SignalConsumer", () => {
     expect(received[0]?.publishedAt).toBeDefined();
   });
 
-  it("redelivers on dispatch failure up to maxDeliver, then dead-letters", async () => {
+  it("redelivers on forward failure up to maxDeliver, then dead-letters", async () => {
     let attempts = 0;
     const consumer = new SignalConsumer(
       nc,
@@ -103,96 +109,18 @@ describe("publishSignal + SignalConsumer", () => {
     await publishSignal(nc, { workspaceId: "ws-dedup", signalId: "once", dedupId });
 
     await waitFor(() => dispatched.length >= 1, 3000);
-    // Give the broker a moment to redeliver if dedup somehow misses.
     await new Promise((r) => setTimeout(r, 500));
     await consumer.destroy();
 
     expect(dispatched).toEqual(["once"]);
   });
 
-  it("forwards onStreamEvent chunks to signals.stream.<correlationId>", async () => {
-    const correlationId = crypto.randomUUID();
-    const seenChunks: unknown[] = [];
-
-    // Subscribe BEFORE publishing.
-    const streamSub = nc.subscribe(`signals.stream.${correlationId}`);
-    const reader = (async () => {
-      for await (const msg of streamSub) {
-        seenChunks.push(JSON.parse(new TextDecoder().decode(msg.data)));
-        if (seenChunks.length >= 3) break;
-      }
-    })();
-
-    const consumer = new SignalConsumer(
-      nc,
-      (_envelope, c) => {
-        c.onStreamEvent?.({ type: "delta", text: "a" } as never);
-        c.onStreamEvent?.({ type: "delta", text: "b" } as never);
-        c.onStreamEvent?.({ type: "delta", text: "c" } as never);
-        return Promise.resolve({ done: true });
-      },
-      { name: `test-${crypto.randomUUID()}`, expiresMs: 1000 },
-    );
-    await consumer.start();
-
-    const responsePromise = awaitSignalCompletion(nc, correlationId, 5000);
-    await publishSignal(nc, { workspaceId: "ws-stream", signalId: "stream-test", correlationId });
-    const reply = await responsePromise;
-    await reader;
-    streamSub.unsubscribe();
-    await consumer.destroy();
-
-    expect(seenChunks).toHaveLength(3);
-    expect(reply.ok).toBe(true);
-  });
-
-  it("publishes the dispatch result to the response subject for correlated requests", async () => {
-    const consumer = new SignalConsumer(nc, (env) => Promise.resolve({ echoed: env.payload }), {
-      name: `test-${crypto.randomUUID()}`,
-      expiresMs: 1000,
-    });
-    await consumer.start();
-
-    const correlationId = crypto.randomUUID();
-    const responsePromise = awaitSignalCompletion(nc, correlationId, 5000);
-    await publishSignal(nc, {
-      workspaceId: "ws-correl",
-      signalId: "ping",
-      payload: { hello: "world" },
-      correlationId,
-    });
-    const reply = await responsePromise;
-    await consumer.destroy();
-
-    expect(reply.ok).toBe(true);
-    if (reply.ok) {
-      expect(reply.result).toEqual({ echoed: { hello: "world" } });
-    }
-  });
-
-  it("publishes ok=false to the response subject for a failing correlated request", async () => {
-    const consumer = new SignalConsumer(nc, () => Promise.reject(new Error("dispatch boom")), {
-      name: `test-${crypto.randomUUID()}`,
-      expiresMs: 1000,
-    });
-    await consumer.start();
-
-    const correlationId = crypto.randomUUID();
-    const responsePromise = awaitSignalCompletion(nc, correlationId, 5000);
-    await publishSignal(nc, { workspaceId: "ws-correl-fail", signalId: "fail", correlationId });
-    const reply = await responsePromise;
-    await consumer.destroy();
-
-    expect(reply.ok).toBe(false);
-    if (!reply.ok) expect(reply.error).toContain("dispatch boom");
-  });
-
-  it("awaitSignalCompletion times out when the consumer never replies", async () => {
+  it("awaitSignalCompletion times out when nobody publishes a response", async () => {
     const correlationId = crypto.randomUUID();
     await expect(awaitSignalCompletion(nc, correlationId, 200)).rejects.toThrow(/timeout/);
   });
 
-  it("processes a burst of published signals in arrival order", async () => {
+  it("forwards a burst of published signals in arrival order", async () => {
     const seen: string[] = [];
     const consumer = new SignalConsumer(
       nc,

--- a/apps/atlasd/src/signal-stream.ts
+++ b/apps/atlasd/src/signal-stream.ts
@@ -12,7 +12,6 @@
  * file is what they'll publish through.
  */
 
-import type { AtlasUIMessageChunk } from "@atlas/agent-sdk";
 import { logger } from "@atlas/logger";
 import { stringifyError } from "@atlas/utils";
 import {
@@ -173,14 +172,19 @@ export async function publishSignal(
 }
 
 /**
- * Callback used by SignalConsumer to dispatch a received envelope to the
- * runtime. Returns a value the consumer publishes to the response subject
- * when the envelope carries a correlationId; ignored otherwise.
+ * Callback used by SignalConsumer to forward a received envelope onward.
+ *
+ * Historically this awaited the entire FSM cascade. As of the cascade
+ * decoupling, it's a thin forward-and-ack — the daemon wires it to
+ * `publishCascade` (cascade-stream.ts), which lands the envelope on the
+ * CASCADES stream where a separate consumer applies the per-signal
+ * concurrency policy and runs the cascade as a background Promise.
+ *
+ * This shape preserves the in-tree tests that stub a dispatcher; for
+ * the production wiring see `apps/atlasd/src/atlas-daemon.ts` where the
+ * dispatcher is `(env) => publishCascade(nc, env)`.
  */
-export type SignalDispatcher = (
-  envelope: SignalEnvelope,
-  ctx: { onStreamEvent?: (chunk: AtlasUIMessageChunk) => void },
-) => Promise<unknown>;
+export type SignalDispatcher = (envelope: SignalEnvelope) => Promise<unknown>;
 
 export interface SignalConsumerOptions {
   /** Logical name for the durable consumer; defaults to "atlasd-signals". */
@@ -320,49 +324,17 @@ export class SignalConsumer {
       return;
     }
 
-    const correlationId = envelope.correlationId;
+    // Forward onward (production wiring: publishCascade onto the
+    // CASCADES stream) and ack. Cascade execution is decoupled — the
+    // CascadeConsumer applies the per-signal concurrency policy and
+    // runs the cascade as a background Promise.
     try {
-      const onStreamEvent = correlationId
-        ? (chunk: AtlasUIMessageChunk) => {
-            try {
-              this.nc.publish(
-                signalStreamSubject(correlationId),
-                enc.encode(JSON.stringify(chunk)),
-              );
-            } catch (err) {
-              logger.warn("Failed to forward stream chunk", {
-                correlationId,
-                error: stringifyError(err),
-              });
-            }
-          }
-        : undefined;
-      const result = await this.dispatch(envelope, { onStreamEvent });
-      if (envelope.correlationId) {
-        this.publishResponse(envelope.correlationId, { ok: true, result });
-      }
+      await this.dispatch(envelope);
       msg.ack();
     } catch (err) {
       const info = msg.info;
-
-      // Correlated envelopes are sync-await callers (HTTP trigger). Their
-      // publisher is blocked on a single response — redelivery would mean
-      // the response arrives after the timeout. Surface the error
-      // immediately and term so we don't double-dispatch on retry.
-      if (envelope.correlationId) {
-        logger.warn("Correlated signal dispatch failed; surfacing error to publisher", {
-          subject: msg.subject,
-          seq: msg.seq,
-          correlationId: envelope.correlationId,
-          error: stringifyError(err),
-        });
-        this.publishResponse(envelope.correlationId, { ok: false, error: stringifyError(err) });
-        msg.term();
-        return;
-      }
-
       if (info.deliveryCount >= this.maxDeliver) {
-        logger.error("Signal dead-lettered after max deliveries", {
+        logger.error("Signal forward dead-lettered after max deliveries", {
           subject: msg.subject,
           seq: msg.seq,
           deliveryCount: info.deliveryCount,
@@ -372,24 +344,13 @@ export class SignalConsumer {
         msg.term();
         return;
       }
-      logger.warn("Signal dispatch failed; will redeliver", {
+      logger.warn("Signal forward failed; will redeliver", {
         subject: msg.subject,
         seq: msg.seq,
         deliveryCount: info.deliveryCount,
         error: stringifyError(err),
       });
       msg.nak();
-    }
-  }
-
-  private publishResponse(correlationId: string, response: SignalResponse): void {
-    try {
-      this.nc.publish(signalResponseSubject(correlationId), enc.encode(JSON.stringify(response)));
-    } catch (err) {
-      logger.warn("Failed to publish signal response", {
-        correlationId,
-        error: stringifyError(err),
-      });
     }
   }
 }

--- a/packages/config/src/signals.ts
+++ b/packages/config/src/signals.ts
@@ -1,6 +1,35 @@
 import { z } from "zod";
 import { DurationSchema, SchemaObjectSchema } from "./base.ts";
 
+/**
+ * Per-signal concurrency policy. Controls what happens when a new
+ * envelope for the same (workspace, signal) arrives while a previous
+ * cascade is still running. Orthogonal to `onMissed` — that's the
+ * downtime catch-up policy; this is the in-flight overlap policy.
+ *
+ * Applies uniformly to every signal provider (cron, HTTP, fs-watch,
+ * slack, …). Read at dispatch time by the cascade consumer in
+ * `apps/atlasd/src/cascade-stream.ts`.
+ *
+ * - `skip` (default) — drop the new envelope. Right for cron jobs
+ *                      where missing one tick is fine because the next
+ *                      tick will run; prevents pile-up if cascades
+ *                      exceed the schedule.
+ * - `queue`          — serialize: chain the new envelope to run after
+ *                      the current one. Right when every tick must
+ *                      eventually run in arrival order, but slow
+ *                      cascades cause unbounded backlog.
+ * - `concurrent`     — no overlap guard; fan out fully. Right for
+ *                      stateless / idempotent jobs where parallel runs
+ *                      are independent.
+ * - `replace`        — singleton execution: abort the in-flight
+ *                      cascade and start the new one. Right for
+ *                      "freshest input wins" workloads (chat-style
+ *                      cancel-in-flight semantics for non-chat signals).
+ */
+export const ConcurrencyPolicySchema = z.enum(["skip", "queue", "concurrent", "replace"]);
+export type ConcurrencyPolicy = z.infer<typeof ConcurrencyPolicySchema>;
+
 const BaseSignalConfigSchema = z.strictObject({
   description: z.string(),
   title: z
@@ -8,6 +37,11 @@ const BaseSignalConfigSchema = z.strictObject({
     .optional()
     .describe("Short human-readable title in verb-noun format (e.g., 'Reads messages from Slack')"),
   schema: SchemaObjectSchema.optional().describe("JSON Schema for signal payload validation"),
+  concurrency: ConcurrencyPolicySchema.optional().describe(
+    "What to do when a new envelope for this signal arrives while a previous cascade " +
+      "is still running. Defaults to 'skip'. Orthogonal to onMissed (which is the " +
+      "downtime catch-up policy).",
+  ),
 });
 
 export const HTTPProviderConfigSchema = z.strictObject({

--- a/packages/fsm-engine/fsm-engine.ts
+++ b/packages/fsm-engine/fsm-engine.ts
@@ -860,7 +860,13 @@ export class FSMEngine {
           signalType: sig.type,
         });
       } else {
-        logger.error(`FSM error in ${transitionDescriptor}, signal ${sig.type}`, {
+        // `warn`, not `error`. FSM step failures are domain events
+        // (LLM API rejection, tool error, validation fail) that get
+        // re-thrown to the runtime and surfaced via the cascade
+        // dispatcher's warn-level `Cascade session failed`. Logging at
+        // error here turned every misconfigured workspace.yml model id
+        // into an infra-level alert.
+        logger.warn(`FSM error in ${transitionDescriptor}, signal ${sig.type}`, {
           error,
           state: failedState,
           fromState,

--- a/packages/fsm-engine/llm-provider-adapter.ts
+++ b/packages/fsm-engine/llm-provider-adapter.ts
@@ -85,6 +85,16 @@ export class AtlasLLMProviderAdapter implements LLMProvider {
       }
     }
 
+    // The AI SDK throws `NoOutputGeneratedError` (with NO `cause` set) when
+    // its stream errors before any step is recorded — see
+    // node_modules/.deno/ai@*/.../ai/dist/index.mjs flush block. The actual
+    // API failure (rate limit, auth, model deprecated, etc.) only reaches
+    // the `onError` callback. Without this capture, every stream-error path
+    // collapses to `{ code: UNKNOWN_ERROR, originalError: "No output
+    // generated. Check the stream for errors." }` — useless for diagnosis.
+    // Declared outside the try block so the catch can read it.
+    let streamErrorCause: unknown;
+
     try {
       const defaultUserProviderOptions = isDefaultOptsProvider(providerName)
         ? getDefaultProviderOpts(providerName)
@@ -112,6 +122,9 @@ export class AtlasLLMProviderAdapter implements LLMProvider {
         abortSignal: params.abortSignal,
         ...(this.providerOptions || {}),
         ...(params.providerOptions || {}),
+        onError: ({ error }) => {
+          streamErrorCause = error;
+        },
         onChunk: emitChunk
           ? ({ chunk }) => {
               if (chunk.type === "tool-call") {
@@ -161,10 +174,14 @@ export class AtlasLLMProviderAdapter implements LLMProvider {
       } satisfies AgentExecutionSuccess<string, FSMLLMOutput>;
     } catch (error) {
       const toolCount = params.tools ? Object.keys(params.tools).length : 0;
-      const errorCause = createErrorCause(error);
+      // Prefer the underlying stream error captured via `onError` over the
+      // outer `NoOutputGeneratedError` wrapper — the wrapper has no `cause`
+      // set, so feeding it to `createErrorCause` always lands on
+      // `UNKNOWN_ERROR`. The stream error is the real APICallError.
+      const errorCause = createErrorCause(streamErrorCause ?? error);
       const reason = isAPIErrorCause(errorCause)
         ? getErrorDisplayMessage(errorCause)
-        : stringifyError(error);
+        : stringifyError(streamErrorCause ?? error);
 
       logger.error(`LLM call failed: ${reason}`, {
         errorCause,

--- a/packages/mcp/src/process-registry.ts
+++ b/packages/mcp/src/process-registry.ts
@@ -328,14 +328,34 @@ class ProcessRegistry {
       }
 
       try {
-        await deps.fetch(readyUrl, { method: "GET" });
-        logger.info(`MCP shared process: child ready for "${serverId}"`, {
-          operation: "mcp_shared_process_ready",
-          serverId,
-          pid: child.pid,
-          elapsedMs: Date.now() - startTime,
-        });
-        return { child };
+        const response = await deps.fetch(readyUrl, { method: "GET" });
+        // Reject 5xx as still-starting. Servers that bind their port
+        // before completing init (workspace-mcp during OAuth bootstrap is
+        // the canonical example) answer GETs with 5xx until they're
+        // actually ready to serve tool calls. Accepting anything-non-throw
+        // — the prior behaviour — let those requests through and the very
+        // first tool call would error out with a misleading "credentials
+        // not configured" from the half-initialised server.
+        //
+        // 4xx (e.g. 405 Method Not Allowed for GET on a POST-only MCP
+        // endpoint) is a "server is up and replying intelligently"
+        // signal — kept as ready.
+        if (response.status >= 500) {
+          logger.debug(`MCP shared process: not ready (${response.status}) for "${serverId}"`, {
+            operation: "mcp_shared_process_ready_check",
+            serverId,
+            status: response.status,
+          });
+        } else {
+          logger.info(`MCP shared process: child ready for "${serverId}"`, {
+            operation: "mcp_shared_process_ready",
+            serverId,
+            pid: child.pid,
+            status: response.status,
+            elapsedMs: Date.now() - startTime,
+          });
+          return { child };
+        }
       } catch {
         // Not ready yet — continue polling.
       }

--- a/packages/system/skills/friday-cli/references/http.md
+++ b/packages/system/skills/friday-cli/references/http.md
@@ -225,12 +225,21 @@ Mount: `/api/activity`. Auth required.
 
 ## Daemon
 
-- `GET /api/daemon/status` — `{ status, activeWorkspaces, uptime, timestamp, version, memoryUsage, workspaces }`
+- `GET /api/daemon/status` — `{ status, activeWorkspaces, uptime, timestamp, version, memoryUsage, workspaces, cronManager, cascadeConsumer, migrations, configuration }`. `cascadeConsumer` is `{ inFlight, cap, saturated }` — point-in-time view of the CASCADES dispatch buffer.
 - `POST /api/daemon/shutdown` — initiates after 100ms delay
 
 ## Health
 
 - `GET /health` — `{ activeWorkspaces, uptime, timestamp, version }` (no `/api` prefix)
+
+## Instance events
+
+Operational feed of cross-workspace cascade events
+(`cascade.queue_saturated`, `cascade.queue_drained`, `cascade.queue_timeout`, `cascade.replaced`).
+Backed by the `INSTANCE_EVENTS` JetStream stream (Limits retention, 7-day max_age).
+
+- `GET /api/instance/events?stream=true&type=<filter>` — SSE feed; subscribes to `instance.>` (or `instance.<filter>` if `type` set) and forwards each event as a `data:` frame. UI consumers don't poll.
+- `GET /api/instance/events?since=<seq>&type=<filter>&limit=<n>` — replay; returns `{ events: [...] }` (newest first). Use for late joiners and reload-after-disconnect.
 
 ## Share / report
 

--- a/packages/system/skills/writing-workspace-signals/SKILL.md
+++ b/packages/system/skills/writing-workspace-signals/SKILL.md
@@ -138,6 +138,28 @@ signals:
 
 Missed-schedule events surface on the playground `/schedules` page under "Missed schedules" and persist in the JetStream `WORKSPACE_EVENTS` stream for 30 days. `manual` events that haven't been fired/dismissed show a pending badge + action buttons.
 
+### Concurrency policy
+
+`concurrency` controls what happens when a new envelope for the same `(workspace, signal)` arrives while a previous cascade is still running. Orthogonal to `onMissed` (which is the downtime catch-up policy). Lives on every signal provider, not just `schedule`.
+
+```yaml
+signals:
+  send-alert:
+    provider: schedule
+    config:
+      schedule: "*/5 * * * *"
+      concurrency: skip   # default; other options: queue | concurrent | replace
+```
+
+**Policies:**
+
+- `skip` (default) — drop the new envelope if a cascade is in flight for this `(workspace, signal)`. Right for cron jobs where the next tick will run anyway and you don't want pile-up if cascades exceed the schedule.
+- `queue` — serialize: chain the new envelope after the current one in arrival order. Right when every tick must eventually run; risks unbounded backlog on slow cascades.
+- `concurrent` — no overlap guard, full parallelism. Right for stateless / idempotent jobs that benefit from parallel runs (independent fetches, fan-out scrapes).
+- `replace` — abort the in-flight cascade and start the new one. Right for "freshest input wins" workloads (cancel-in-flight semantics for non-chat signals).
+
+For HTTP-trigger correlated callers, `skip` and `replace` publish `ok=false` on the response subject immediately so callers don't wait out their HTTP timeout. `queue` blocks the caller until the in-flight cascade settles. `concurrent` returns each cascade's own response.
+
 ### System trigger
 
 ```yaml

--- a/packages/workspace/src/runtime-error-propagation.test.ts
+++ b/packages/workspace/src/runtime-error-propagation.test.ts
@@ -138,4 +138,34 @@ describe("session error propagation", () => {
     expect(session.status).toBe("completed");
     expect(session.error).toBeUndefined();
   });
+
+  it("externally-passed abortSignal cancels the session — closes the cascade-replace abort chain", async () => {
+    // Regression: `CascadeConsumer`'s `replace` policy aborts the
+    // AbortController it created, then passes that signal through
+    // `triggerWorkspaceSignal` → `triggerSignalWithSession`. The
+    // runtime composes it with its per-session controller at
+    // `runtime.ts:998-1009` and checks `effectiveAbortSignal.aborted`
+    // in the catch block at line 1191. This test covers the runtime
+    // half of that chain — that the externally-passed abortSignal
+    // really does steer status to `cancelled` instead of `failed`,
+    // even when an action throws for an unrelated reason.
+    //
+    // Uses the failing-FSM config (agent-not-found) so the action
+    // throws synchronously; with the abortSignal pre-aborted, the
+    // catch clause should classify as cancelled.
+    const session = await withTestRuntime(createFailingConfig(), (runtime) => {
+      const controller = new AbortController();
+      controller.abort("replaced by newer cascade");
+      return runtime.triggerSignalWithSession(
+        "test-signal",
+        {},
+        undefined,
+        undefined,
+        undefined,
+        controller.signal,
+      );
+    });
+
+    expect(session.status).toBe("cancelled");
+  });
 });

--- a/packages/workspace/src/runtime.ts
+++ b/packages/workspace/src/runtime.ts
@@ -2289,15 +2289,6 @@ export class WorkspaceRuntime {
     return { id: agentId, type: config.type, description: config.description, config };
   }
 
-  /**
-   * Check if there are active sessions for a signal. With per-signal engines
-   * the canonical source is `this.sessions` (populated in finalizeSession);
-   * any active execution shows up there.
-   */
-  hasActiveSessionsForSignal(signalId: string): boolean {
-    return Array.from(this.sessions.values()).some((s) => s.signalId === signalId);
-  }
-
   getOrchestrator(): AgentOrchestrator {
     return this.orchestrator;
   }

--- a/packages/workspace/src/runtime.ts
+++ b/packages/workspace/src/runtime.ts
@@ -1206,7 +1206,14 @@ export class WorkspaceRuntime {
               jobName: job.name,
             });
           } else {
-            logger.error("Signal processing failed", {
+            // `warn`, not `error`. Session-level domain failures (LLM API
+            // rejection, tool error, FSM step failure) are captured in the
+            // session record itself and surfaced again by the cascade
+            // dispatcher's `Cascade session failed` warn line. Logging at
+            // error here triggered duplicate alerts for the same event;
+            // operators reading at error level should see infra-level
+            // failures, not every workspace job that hit a domain error.
+            logger.warn("Signal processing failed", {
               sessionId: session.id,
               error: session.error,
               currentState: engine.state,


### PR DESCRIPTION
## Summary

- Decouple cascade execution from signal delivery so a slow cascade on
  one workspace stops blocking every other workspace's cron / HTTP
  signal — restores the per-workspace parallelism that was lost when
  signal routing consolidated onto a single JetStream workQueue
  consumer.
- Add a per-signal `concurrency` policy (`skip` default,
  `queue` / `concurrent` / `replace`) on `WorkspaceSignalConfig`,
  applied uniformly to cron, HTTP, and cross-cascade triggers.
- Surface cascade backlog state via a new `INSTANCE_EVENTS` JetStream
  stream + an `/api/instance/events` SSE endpoint so UIs don't poll.

## Background

Crons stopped firing jobs reliably across workspaces. Live repro on
the local daemon showed:

```
$ nats consumer info SIGNALS atlasd-signals
Outstanding Acks: 12 / 256
Unprocessed Messages: 8
Last delivery: 4m12s ago
Waiting Pulls: 0
```

A workspace whose cascade ran ~3 minutes monopolised the consumer; a
trivial no-op cron on a different workspace fired into JetStream but
never produced a session. `nats consumer info` confirmed the consumer
loop hadn't pulled in 4+ minutes — it was wedged inside
`await this.dispatch(envelope)`.

Audit traced the regression to the JetStream-migration PR. Pre-
migration, each workspace had its own NATS subscription and ran its
own drain loop, so workspaces were independent in flight. The
migration consolidated that into one durable workQueue consumer with
a single drain loop that synchronously awaited each cascade — losing
the per-workspace fan-out.

## Approach

Two-stream pipeline:

```
cron / HTTP / cross-cascade emit
    │  publishSignal()
    ▼
SIGNALS stream  (delivery durability)
    │
    ▼ thin forwarder, ack
SignalConsumer → publishCascade()
    │
    ▼
CASCADES stream  (dispatch buffer)
    │
    ▼ applies per-signal concurrency policy,
      kicks off cascade as background Promise (NOT awaited),
      acks on policy decision
CascadeConsumer
    │
    ▼
triggerWorkspaceSignal → runtime.processSignal (FSM engine, unchanged)
```

The `SignalConsumer` becomes a thin forwarder. The `CascadeConsumer`
holds the in-flight registry, applies the `concurrency` policy
(skip / queue / concurrent / replace), and dispatches cascades as
background Promises so a slow cascade on one key never stalls
delivery of the next envelope.

`max_ack_pending=32` on CASCADES caps total in-flight cascades
(env-tunable via `FRIDAY_CASCADE_CONCURRENCY`). Chat dispatches via
`signalToStream` → `triggerSignalWithSession` directly, so chat
bypasses the cap by architecture — interactive flows aren't subject
to background back-pressure.

`max_deliver=1` on CASCADES means a daemon crash mid-cascade leaves
the session as `interrupted` via the existing `markInterruptedSessions`
sweep on next startup; cascades are not auto-replayed at the queue
level. Deliberate behaviour change vs pre-cascade-split — replays of
crashed cascades are likely to fail again the same way and burn ack
budget.

### Per-signal concurrency policy

| Policy | Behaviour | Correlated-caller response |
|---|---|---|
| `skip` (default) | Drop new envelope if a cascade for the same `(workspace, signal)` is in flight | `ok=false, reason=skipped-duplicate` |
| `queue` | Per-key keyed mutex; envelopes run serially in arrival order | Caller awaits up to its own timeout |
| `concurrent` | No overlap guard; full parallelism | Each gets its own response |
| `replace` | Abort the in-flight via existing `activeAbortControllers`; start the new one | Cancelled caller gets `ok=false, reason=cancelled-by-newer-trigger` |

Lives next to `schedule` and `onMissed` on `WorkspaceSignalConfig` —
orthogonal to `onMissed` (downtime catch-up policy).

### INSTANCE_EVENTS stream

Modeled on `WORKSPACE_EVENTS`. Subjects `instance.>`, retention
`Limits`, 7-day `max_age`. Carries:

- `cascade.queue_saturated` — backlog crossed `>0.5 * cap`
- `cascade.queue_drained` — backlog fell back below the threshold
- `cascade.queue_timeout` — envelope sat past `FRIDAY_CASCADE_QUEUE_TIMEOUT` (default 5 min) before pickup
- `cascade.replaced` — `replace` policy aborted an in-flight cascade

`GET /api/instance/events?stream=true` is an SSE feed; consumers
don't poll. `?since=<seq>&type=<filter>` gives replay over the stream
for late joiners and reload-after-disconnect.

## Other fixes folded in

- **`onError` capture in streamText** — the AI SDK's
  `NoOutputGeneratedError` is thrown without `cause` set; the
  underlying API error only reaches the `onError` callback. Adding
  the callback so `createErrorCause` sees the real cause replaces the
  generic "No output generated" with the actual
  rate-limit / auth / model-deprecated reason.
- **Stricter MCP `readyUrl` check** — reject 5xx as not-ready. Servers
  that bind their port before completing init (workspace-mcp during
  OAuth bootstrap is the canonical case) answered GET with 5xx until
  fully ready; the prior "any non-throw counts" rule let
  half-initialised servers pass.
- **Drop domain failures from error to warn** — a single LLM API
  rejection produced two error-level log lines (`fsm-engine` +
  workspace runtime) plus a warn from the cascade dispatcher. The
  inner two are now warn — operators scanning at error level see
  infra-level failures, not every misconfigured `model:` id.
- **`hasActiveSessionsForSignal` removed from runtime** — its only
  caller was the dispatch-time short-circuit at `triggerWorkspaceSignal`,
  which the cascade decoupling moved into `CascadeConsumer`'s per-key
  registry.
- **`cascadeConsumer.getStats()` wired into `/api/daemon/status`** —
  surfaces `inFlight`, `cap`, `saturated` for ops visibility.
- **Synthetic `cascade.queue_drained` on consumer startup** — a
  previous daemon that crashed while saturated leaves a hanging
  saturated event with no matching drained; emitting drained on every
  startup closes the gap so UIs don't see a permanent saturated
  indicator.
- **`nc.flush()` after SSE subscribe** — `subscribe()` returns before
  the broker registers; flushing forces a PING/PONG so the SSE
  handshake honestly means "from now on, you get every event."
- **System-skill docs** — `writing-workspace-signals` documents the
  new `concurrency` policy alongside `onMissed`;
  `friday-cli/references/http.md` documents the new
  `cascadeConsumer` block on `/api/daemon/status` and the
  `/api/instance/events` routes.

## Migration

None needed.

- `concurrency` is optional with `skip` default that matches old
  behaviour. Existing `workspace.yml`s don't set it, get `skip`
  automatically.
- `CASCADES` and `INSTANCE_EVENTS` are CREATE-IF-MISSING; first
  daemon start with the new code auto-creates them.
- SIGNALS durable consumer name and config unchanged. Pre-restart
  in-flight messages are forwarded through CASCADES on redelivery.

## Test plan

- [x] New unit / integration tests in
      `apps/atlasd/src/cascade-stream.test.ts` cover all four
      policies, queue-timeout, correlated-caller responses, stream
      chunk forwarding, and a head-of-line decoupling assertion (slow
      cascade on workspace A; fast no-op on workspace B; B finishes
      within 200ms of fire regardless of A).
- [x] Existing `signal-stream.test.ts` updated to assert the new
      "publish-and-ack" forwarder behaviour.
- [x] `deno task typecheck` — 0 errors across 8225 files.
- [x] `deno task knip` — clean, no findings.
- [x] Full repo test suite — 376 test files, 5054 tests passing.
- [x] Live verification on a multi-workspace daemon: while one
      workspace runs a 3-minute LLM cascade, a no-op cron on a
      separate workspace gets sessions on every tick — same time
      window, no head-of-line. Three consecutive end-to-end
      completions on the second workspace within minutes of the fix
      landing.