### PR TITLE
fix(google): make Sheets read-only end-to-end (OAuth scope + MCP tool catalog)

### DIFF
--- a/apps/link/src/providers/google-providers.ts
+++ b/apps/link/src/providers/google-providers.ts
@@ -75,7 +75,13 @@ const GOOGLE_SCOPES = {
   ],
   drive: ["https://www.googleapis.com/auth/drive"],
   gmail: ["https://www.googleapis.com/auth/gmail.modify"],
-  sheets: ["https://www.googleapis.com/auth/spreadsheets.readonly"],
+  sheets: [
+    "https://www.googleapis.com/auth/spreadsheets.readonly",
+    // Required by workspace-mcp's `list_spreadsheets` tool (it queries Drive
+    // for files of mimeType=spreadsheet). Without it, list-style tools 403
+    // even though raw sheet reads succeed.
+    "https://www.googleapis.com/auth/drive.readonly",
+  ],
 } as const;
 
 type GoogleService = keyof typeof GOOGLE_SCOPES;

--- a/apps/link/src/providers/google-providers.ts
+++ b/apps/link/src/providers/google-providers.ts
@@ -60,6 +60,12 @@ function encodeGeminiState({
  * GCP project verified. See `gemini-cli-extensions/workspace`'s
  * `feature-config.ts` — anything outside that set will re-introduce the
  * unverified-app warning, defeating the purpose of this swap.
+ *
+ * Notably absent: `spreadsheets` (sheets write), `presentations` (slides
+ * write), and `tasks*`. These are flagged `defaultEnabled: false` in
+ * upstream `feature-config.ts` with the comment "not in published GCP
+ * project" — requesting them triggers Google's "This app is blocked"
+ * page for any external user. Sheets is therefore read-only here.
  */
 const GOOGLE_SCOPES = {
   calendar: ["https://www.googleapis.com/auth/calendar"],
@@ -69,10 +75,7 @@ const GOOGLE_SCOPES = {
   ],
   drive: ["https://www.googleapis.com/auth/drive"],
   gmail: ["https://www.googleapis.com/auth/gmail.modify"],
-  sheets: [
-    "https://www.googleapis.com/auth/spreadsheets",
-    "https://www.googleapis.com/auth/drive.readonly",
-  ],
+  sheets: ["https://www.googleapis.com/auth/spreadsheets.readonly"],
 } as const;
 
 type GoogleService = keyof typeof GOOGLE_SCOPES;

--- a/packages/core/src/mcp-registry/registry-consolidated.ts
+++ b/packages/core/src/mcp-registry/registry-consolidated.ts
@@ -15,8 +15,15 @@ type GoogleWorkspaceServiceSpec = {
   toolFlag: string;
   description: string;
   constraints: string;
-  /** Per-service additions to the workspace-mcp subprocess env. */
-  extraStartupEnv?: Record<string, string>;
+  /**
+   * Optional per-service permission level. When set, workspace-mcp is
+   * launched with `--permissions <toolFlag>:<level>` instead of
+   * `--tools <toolFlag>`, which restricts the registered tool catalog
+   * to operations the level allows. Levels per service: `readonly`,
+   * `full` (gmail also: `organize`, `drafts`, `send`).
+   * `--permissions` is mutually exclusive with `--tools`.
+   */
+  permissionLevel?: string;
 };
 const GOOGLE_WORKSPACE_SERVICES: GoogleWorkspaceServiceSpec[] = [
   {
@@ -77,10 +84,11 @@ const GOOGLE_WORKSPACE_SERVICES: GoogleWorkspaceServiceSpec[] = [
     description:
       "Read-only Google Sheets access via workspace-mcp — list spreadsheets, read cell values and ranges, get spreadsheet metadata. Write operations (create sheets, update cells, format) are not currently supported because the `spreadsheets` (write) scope is not in the verified GCP project Friday delegates OAuth through.",
     constraints:
-      "Requires OAuth. Read-only — no cell writes, sheet creation, or formatting. Use when data lives in Google Sheets and you need to read it. For analyzing data already uploaded as CSV/database artifacts, use the data-analyst agent instead. Launch: MCP_ENABLE_OAUTH21=true EXTERNAL_OAUTH21_PROVIDER=true WORKSPACE_MCP_STATELESS_MODE=true GOOGLE_OAUTH_CLIENT_ID=external GOOGLE_OAUTH_CLIENT_SECRET=external WORKSPACE_MCP_PORT=8005 WORKSPACE_FEATURE_OVERRIDES=sheets.write:off uvx workspace-mcp --tools sheets --transport streamable-http",
-    // sheets.write tools would 403 at runtime without the spreadsheets scope —
-    // disable them at the MCP layer so they don't appear in the tool catalog.
-    extraStartupEnv: { WORKSPACE_FEATURE_OVERRIDES: "sheets.write:off" },
+      "Requires OAuth. Read-only — no cell writes, sheet creation, or formatting. Use when data lives in Google Sheets and you need to read it. For analyzing data already uploaded as CSV/database artifacts, use the data-analyst agent instead. Launch: MCP_ENABLE_OAUTH21=true EXTERNAL_OAUTH21_PROVIDER=true WORKSPACE_MCP_STATELESS_MODE=true GOOGLE_OAUTH_CLIENT_ID=external GOOGLE_OAUTH_CLIENT_SECRET=external WORKSPACE_MCP_PORT=8005 uvx workspace-mcp --permissions sheets:readonly --transport streamable-http",
+    // Use --permissions instead of --tools so workspace-mcp filters out the
+    // 8 sheets-write tools (modify_sheet_values, create_*, format_*, etc.)
+    // that would 403 at runtime without the spreadsheets scope.
+    permissionLevel: "readonly",
   },
 ];
 
@@ -106,8 +114,15 @@ function createGoogleWorkspaceEntry(spec: GoogleWorkspaceServiceSpec): MCPServer
       startup: {
         type: "command",
         command: "uvx",
-        args: ["workspace-mcp", "--tools", spec.toolFlag, "--transport", "streamable-http"],
-        env: { WORKSPACE_MCP_PORT: String(spec.defaultPort), ...spec.extraStartupEnv },
+        args: [
+          "workspace-mcp",
+          ...(spec.permissionLevel
+            ? ["--permissions", `${spec.toolFlag}:${spec.permissionLevel}`]
+            : ["--tools", spec.toolFlag]),
+          "--transport",
+          "streamable-http",
+        ],
+        env: { WORKSPACE_MCP_PORT: String(spec.defaultPort) },
         ready_url: defaultUrl,
       },
     },

--- a/packages/core/src/mcp-registry/registry-consolidated.ts
+++ b/packages/core/src/mcp-registry/registry-consolidated.ts
@@ -6,7 +6,19 @@ import type { MCPServerMetadata, MCPServersRegistry } from "./schemas.ts";
  * Each service runs its own workspace-mcp instance with `--tools` filtering
  * for tool isolation. Bearer tokens are pulled from per-service Link providers.
  */
-const GOOGLE_WORKSPACE_SERVICES = [
+type GoogleWorkspaceServiceSpec = {
+  id: string;
+  name: string;
+  urlDomains: string[];
+  urlEnvKey: string;
+  defaultPort: number;
+  toolFlag: string;
+  description: string;
+  constraints: string;
+  /** Per-service additions to the workspace-mcp subprocess env. */
+  extraStartupEnv?: Record<string, string>;
+};
+const GOOGLE_WORKSPACE_SERVICES: GoogleWorkspaceServiceSpec[] = [
   {
     id: "google-calendar",
     name: "Google Calendar",
@@ -63,15 +75,16 @@ const GOOGLE_WORKSPACE_SERVICES = [
     defaultPort: 8005,
     toolFlag: "sheets",
     description:
-      "Full Google Sheets management via workspace-mcp — list spreadsheets, read/write cell values, create sheets, format cells, conditional formatting.",
+      "Read-only Google Sheets access via workspace-mcp — list spreadsheets, read cell values and ranges, get spreadsheet metadata. Write operations (create sheets, update cells, format) are not currently supported because the `spreadsheets` (write) scope is not in the verified GCP project Friday delegates OAuth through.",
     constraints:
-      "Requires OAuth. Use when data lives in Google Sheets. For analyzing data already uploaded as CSV/database artifacts, use the data-analyst agent instead. Launch: MCP_ENABLE_OAUTH21=true EXTERNAL_OAUTH21_PROVIDER=true WORKSPACE_MCP_STATELESS_MODE=true GOOGLE_OAUTH_CLIENT_ID=external GOOGLE_OAUTH_CLIENT_SECRET=external WORKSPACE_MCP_PORT=8005 uvx workspace-mcp --tools sheets --transport streamable-http",
+      "Requires OAuth. Read-only — no cell writes, sheet creation, or formatting. Use when data lives in Google Sheets and you need to read it. For analyzing data already uploaded as CSV/database artifacts, use the data-analyst agent instead. Launch: MCP_ENABLE_OAUTH21=true EXTERNAL_OAUTH21_PROVIDER=true WORKSPACE_MCP_STATELESS_MODE=true GOOGLE_OAUTH_CLIENT_ID=external GOOGLE_OAUTH_CLIENT_SECRET=external WORKSPACE_MCP_PORT=8005 WORKSPACE_FEATURE_OVERRIDES=sheets.write:off uvx workspace-mcp --tools sheets --transport streamable-http",
+    // sheets.write tools would 403 at runtime without the spreadsheets scope —
+    // disable them at the MCP layer so they don't appear in the tool catalog.
+    extraStartupEnv: { WORKSPACE_FEATURE_OVERRIDES: "sheets.write:off" },
   },
 ];
 
-function createGoogleWorkspaceEntry(
-  spec: (typeof GOOGLE_WORKSPACE_SERVICES)[number],
-): MCPServerMetadata {
+function createGoogleWorkspaceEntry(spec: GoogleWorkspaceServiceSpec): MCPServerMetadata {
   // Token env var: google-calendar -> GOOGLE_CALENDAR_ACCESS_TOKEN
   const tokenEnvKey = `${spec.id.toUpperCase().replace(/-/g, "_")}_ACCESS_TOKEN`;
   const defaultUrl = `http://localhost:${spec.defaultPort}/mcp`;
@@ -94,7 +107,7 @@ function createGoogleWorkspaceEntry(
         type: "command",
         command: "uvx",
         args: ["workspace-mcp", "--tools", spec.toolFlag, "--transport", "streamable-http"],
-        env: { WORKSPACE_MCP_PORT: String(spec.defaultPort) },
+        env: { WORKSPACE_MCP_PORT: String(spec.defaultPort), ...spec.extraStartupEnv },
         ready_url: defaultUrl,
       },
     },

--- a/packages/core/src/mcp-registry/registry.test.ts
+++ b/packages/core/src/mcp-registry/registry.test.ts
@@ -139,8 +139,14 @@ describe("mcpServersRegistry", () => {
       expect(startup!.type).toBe("command");
       expect(startup!.command).toBe("uvx");
       expect(startup!.args).toEqual(
-        expect.arrayContaining(["workspace-mcp", "--tools", "--transport", "streamable-http"]),
+        expect.arrayContaining(["workspace-mcp", "--transport", "streamable-http"]),
       );
+      // Either tool-set filtering (--tools) or permission-level filtering
+      // (--permissions) — these flags are mutually exclusive in workspace-mcp.
+      const hasToolsFlag = startup!.args!.includes("--tools");
+      const hasPermissionsFlag = startup!.args!.includes("--permissions");
+      expect(hasToolsFlag || hasPermissionsFlag).toBe(true);
+      expect(hasToolsFlag && hasPermissionsFlag).toBe(false);
       expect(startup!.env).toBeDefined();
       // Per-server config only — OAuth vars live in platformEnv
       expect(startup!.env).toHaveProperty("WORKSPACE_MCP_PORT");


### PR DESCRIPTION
## Summary

Two coordinated changes that together fully fix Google's "This app is blocked" error and avoid follow-on runtime 403s on Sheets write tools:

1. **`apps/link/src/providers/google-providers.ts`** — sheets OAuth scope changed from `spreadsheets` (write, unverified in the upstream GCP project) to `spreadsheets.readonly`. Keeps `drive.readonly` because workspace-mcp's `list_spreadsheets` tool queries Drive.
2. **`packages/core/src/mcp-registry/registry-consolidated.ts`** — Sheets entry now describes itself as read-only, and a new per-service `permissionLevel` field on the spec switches the workspace-mcp launch from `--tools sheets` to `--permissions sheets:readonly`. This is what actually filters the tool catalog: 13 tools → 5 (read only). Without (2), write tools would still register and silently 403.

Calendar, Drive, Docs, Gmail are unaffected.

## Why

A Friday user (personal @gmail) hit Google's `accounts.google.com/signin/oauth/warning` block page when connecting Sheets. The cause: Friday delegates OAuth through the Gemini CLI Workspace Extension's verified GCP project (a tactical shim per `google-providers.ts:19-23`), and that project's verified scope set does **not** include `spreadsheets` (write). Upstream `feature-config.ts` flags it as `defaultEnabled: false` with the comment "not in published GCP project" — confirmed by their v0.0.8 cleanup: https://github.com/gemini-cli-extensions/workspace/pull/347.

Audited the other Friday scopes against the upstream verified list. `spreadsheets` was the only Friday-requested scope outside the verified set. (`presentations` write and `tasks*` are also unverified, but Friday doesn't request either.)

## Trade-off

Sheets goes from advertised "read/write" to actually read-only. Path back to write:
- Friday gets its own verified GCP project (called out as the long-term fix in `google-providers.ts:19-23`), or
- Gemini extension applies for `spreadsheets` verification upstream.

## QA — full per-provider verification

### Static checks
- [x] `deno task typecheck` — 0 errors
- [x] `deno task -f @atlas/link test src/providers/google-providers.test.ts` — 2/2 passed
- [x] `deno task -f @atlas/core test src/mcp-registry/` — 250/250 passed (registry test updated to accept either `--tools` or `--permissions`)
- Pre-existing 3 failures in `apps/atlasd/daemon-startup.test.ts` are unrelated (groq/litellm credential resolution) — not introduced by this branch

### Auth-URL audit (all 5 providers, scope query param on the redirect to Google)

| Provider | Scopes |
|---|---|
| google-calendar | `openid email calendar` |
| google-drive | `openid email drive` |
| google-docs | `openid email documents drive.readonly` |
| google-gmail | `openid email gmail.modify` |
| google-sheets | `openid email spreadsheets.readonly drive.readonly` ← fixed |

### MCP tool catalog (each provider's launch config, MCP `tools/list` response)

| Provider | Launch | Tools registered |
|---|---|---|
| calendar | `--tools calendar` | 7 (list_calendars, get_events, manage_event, create_calendar, query_freebusy, manage_focus_time, manage_out_of_office) |
| drive | `--tools drive` | 14 (list/search/create/copy/update/manage permissions, etc.) |
| docs | `--tools docs` | 20 (search/create/edit/format/comment/export, etc.) |
| gmail | `--tools gmail` | 14 (search/get/send/draft/labels/filters, etc.) |
| sheets | `--permissions sheets:readonly` | **5** (list_spreadsheets, get_spreadsheet_info, read_sheet_values, list_sheet_tables, list_spreadsheet_comments) ← was 13 with 8 write tools, now read-only only |

### Browser OAuth flow (every provider, end-to-end on personal @gmail)

Ran Link locally on this branch, used a personal `@gmail.com` account (matches the original report's account class), walked the full OAuth consent flow for each of the 5 providers. **All 5 reached `accounts.google.com/signin/oauth/v2/consentsummary` (legitimate consent), not `accounts.google.com/signin/oauth/warning` (the block page).**

| Provider | Consent screen wording |
|---|---|
| calendar | "See, edit, share, and permanently delete all the calendars you can access using Google Calendar" |
| drive | "See, edit, create, and delete all of your Google Drive files" |
| docs | "See and download all your Google Drive files" + "See, edit, create, and delete all your Google Docs documents" |
| gmail | "Read, compose, and send emails from your Gmail account" |
| sheets | "See and download all your Google Drive files" + **"See all your Google Sheets spreadsheets"** (read-only wording — fix verified) |

### End-to-end MCP execution against real Google APIs (sheets, the changed provider)

Granted the sheets OAuth flow on the personal @gmail account, captured the real bearer token, launched workspace-mcp with the **exact** launch config Friday's registry now produces (`--permissions sheets:readonly --transport streamable-http`), and called each of the 5 read tools via MCP `tools/call` JSON-RPC.

| MCP tool | Result |
|---|---|
| `list_spreadsheets` | ✓ "Successfully listed 3 spreadsheets for jagiello.lukasz@gmail.com" (Drive API call worked → confirms `drive.readonly` is sufficient) |
| `get_spreadsheet_info` | ✓ "Spreadsheet: 'Urodzenia i zgony GUS' (ID: …) | Locale: pl_PL" (Sheets API metadata) |
| `read_sheet_values` | ✓ Range read returned (empty range, no error) |
| `list_sheet_tables` | ✓ "No structured tables found" |
| `list_spreadsheet_comments` | ✓ "No comments found" |

**Negative test:** attempted `modify_sheet_values` (a write tool) — workspace-mcp returned `"Unknown tool: 'modify_sheet_values'"`. Write tools are correctly filtered out by `--permissions sheets:readonly`.

**Direct Google API checks** (sanity, before MCP run):
- `tokeninfo` confirms granted scopes: `email + drive.readonly + spreadsheets.readonly + userinfo.email + openid`
- Drive `files.list` (mimeType=spreadsheet) → 200 with real files
- Sheets `spreadsheets.get` + `values.get` → 200 with metadata + range
- Sheets `values.update` (write attempt) → **403 PERMISSION_DENIED, ACCESS_TOKEN_SCOPE_INSUFFICIENT** (expected — proves write scope is correctly absent)

Test token revoked after QA via `https://oauth2.googleapis.com/revoke`.

## Notes for reviewers

- The first revision of this PR set `WORKSPACE_FEATURE_OVERRIDES=sheets.write:off` on the workspace-mcp env. That env var doesn't exist in the Python `workspace-mcp` Friday actually launches via uvx — I'd confused it with the unrelated TypeScript `workspace-server` from gemini-cli-extensions. Caught by actually running the binary and listing tools. Replaced with `--permissions sheets:readonly`.
- The first revision also dropped `drive.readonly` from the sheets OAuth scope. That broke `list_spreadsheets` (which queries Drive). Restored — both `spreadsheets.readonly` and `drive.readonly` are in the verified GCP project, so this doesn't reintroduce the original block.