### PR TITLE
fix(studio-release): brace $publish_wf so trailing ellipsis isn't absorbed

### DIFF
--- a/scripts/studio-release.sh
+++ b/scripts/studio-release.sh
@@ -229,7 +229,7 @@ cmd_publish() {
     *) echo "aborted."; exit 0 ;;
   esac
 
-  echo "→ Triggering $publish_wf…"
+  echo "→ Triggering ${publish_wf}…"
   local since
   since=$(buffered_since)
   gh workflow run "$publish_wf" \


### PR DESCRIPTION
## Summary
- `./scripts/studio-release.sh publish installer` failed with `publish_wf�: unbound variable` on line 232.
- Under some locales bash treats UTF-8 continuation bytes (the `…` U+2026 ellipsis right after `$publish_wf`) as identifier chars, so it looked up `publish_wf<bytes>` and tripped `set -u`.
- Brace the variable (`${publish_wf}`) so the parser stops at the `}`.

## Test plan
- [ ] Re-run `./scripts/studio-release.sh publish installer` and confirm it dispatches the workflow instead of erroring.