### PR TITLE
fix(mcp-registry): tolerate unknown registryType + drop bad entries instead of 502

### DIFF
--- a/packages/core/src/mcp-registry/upstream-client.test.ts
+++ b/packages/core/src/mcp-registry/upstream-client.test.ts
@@ -196,6 +196,48 @@ describe("MCPUpstreamClient", () => {
 
       expect(result.servers).toHaveLength(1);
       expect(result.servers[0]?.server.name).toEqual("io.github.test/good-server");
+      expect(result.dropped).toEqual(2);
+    });
+
+    it("reports zero dropped when all entries are valid", async () => {
+      const mockResponse = {
+        servers: [
+          {
+            server: {
+              $schema: "https://schema.modelcontextprotocol.io/server/2025-04-18.json",
+              name: "io.github.test/server",
+              description: "Valid",
+              version: "1.0.0",
+            },
+            _meta: {
+              "io.modelcontextprotocol.registry/official": {
+                status: "active",
+                statusChangedAt: "2025-01-01T00:00:00Z",
+                publishedAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+                isLatest: true,
+              },
+            },
+          },
+        ],
+      };
+
+      const mockFetch: typeof fetch = (
+        _input: URL | RequestInfo,
+        _init?: RequestInit,
+      ): Promise<Response> =>
+        Promise.resolve(
+          new Response(JSON.stringify(mockResponse), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+
+      const client = new MCPUpstreamClient({ fetchFn: mockFetch });
+      const result = await client.search("test", 10);
+
+      expect(result.servers).toHaveLength(1);
+      expect(result.dropped).toEqual(0);
     });
   });
 

--- a/packages/core/src/mcp-registry/upstream-client.test.ts
+++ b/packages/core/src/mcp-registry/upstream-client.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  MCPUpstreamClient,
-  UpstreamSearchResponseSchema,
-  UpstreamServerEntrySchema,
-} from "./upstream-client.ts";
+import { MCPUpstreamClient, UpstreamServerEntrySchema } from "./upstream-client.ts";
 
 describe("MCPUpstreamClient", () => {
   describe("search", () => {
@@ -454,65 +450,6 @@ describe("MCPUpstreamClient", () => {
 
       const parsed = UpstreamServerEntrySchema.safeParse(entry);
       expect(parsed.success).toBe(true);
-    });
-  });
-
-  describe("search response schema", () => {
-    it("validates search response with multiple results", () => {
-      const searchResponse = {
-        servers: [
-          {
-            server: {
-              $schema: "https://schema.modelcontextprotocol.io/server/2025-04-18.json",
-              name: "io.github.test/server-a",
-              description: "Server A",
-              version: "1.0.0",
-            },
-            _meta: {
-              "io.modelcontextprotocol.registry/official": {
-                status: "active",
-                statusChangedAt: "2025-01-01T00:00:00Z",
-                publishedAt: "2025-01-01T00:00:00Z",
-                updatedAt: "2025-01-01T00:00:00Z",
-                isLatest: true,
-              },
-            },
-          },
-          {
-            server: {
-              $schema: "https://schema.modelcontextprotocol.io/server/2025-04-18.json",
-              name: "io.github.test/server-b",
-              description: "Server B",
-              version: "2.0.0",
-            },
-            _meta: {
-              "io.modelcontextprotocol.registry/official": {
-                status: "active",
-                statusChangedAt: "2025-01-01T00:00:00Z",
-                publishedAt: "2025-01-01T00:00:00Z",
-                updatedAt: "2025-01-01T00:00:00Z",
-                isLatest: true,
-              },
-            },
-          },
-        ],
-      };
-
-      const parsed = UpstreamSearchResponseSchema.safeParse(searchResponse);
-      expect(parsed.success).toBe(true);
-      if (parsed.success) {
-        expect(parsed.data.servers).toHaveLength(2);
-      }
-    });
-
-    it("validates empty search response", () => {
-      const emptyResponse = { servers: [] };
-
-      const parsed = UpstreamSearchResponseSchema.safeParse(emptyResponse);
-      expect(parsed.success).toBe(true);
-      if (parsed.success) {
-        expect(parsed.data.servers).toHaveLength(0);
-      }
     });
   });
 

--- a/packages/core/src/mcp-registry/upstream-client.test.ts
+++ b/packages/core/src/mcp-registry/upstream-client.test.ts
@@ -132,6 +132,75 @@ describe("MCPUpstreamClient", () => {
 
       expect(capturedUrl).toContain("search=hello%20world%20%26%20more");
     });
+
+    it("drops malformed entries but keeps valid ones", async () => {
+      // Defense against upstream schema drift: one bad entry must not poison
+      // the whole response. Regression test for the 502 caused when a new
+      // upstream registryType appeared and the strict outer parse rejected
+      // every reddit search result.
+      const mockResponse = {
+        servers: [
+          {
+            server: {
+              $schema: "https://schema.modelcontextprotocol.io/server/2025-04-18.json",
+              name: "io.github.test/good-server",
+              description: "Valid",
+              version: "1.0.0",
+            },
+            _meta: {
+              "io.modelcontextprotocol.registry/official": {
+                status: "active",
+                statusChangedAt: "2025-01-01T00:00:00Z",
+                publishedAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+                isLatest: true,
+              },
+            },
+          },
+          {
+            // Broken: missing required `_meta` block.
+            server: {
+              $schema: "https://schema.modelcontextprotocol.io/server/2025-04-18.json",
+              name: "io.github.test/broken-server",
+              version: "1.0.0",
+            },
+          },
+          {
+            // Broken: server.version missing entirely.
+            server: {
+              $schema: "https://schema.modelcontextprotocol.io/server/2025-04-18.json",
+              name: "io.github.test/no-version",
+            },
+            _meta: {
+              "io.modelcontextprotocol.registry/official": {
+                status: "active",
+                statusChangedAt: "2025-01-01T00:00:00Z",
+                publishedAt: "2025-01-01T00:00:00Z",
+                updatedAt: "2025-01-01T00:00:00Z",
+                isLatest: true,
+              },
+            },
+          },
+        ],
+      };
+
+      const mockFetch: typeof fetch = (
+        _input: URL | RequestInfo,
+        _init?: RequestInit,
+      ): Promise<Response> =>
+        Promise.resolve(
+          new Response(JSON.stringify(mockResponse), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        );
+
+      const client = new MCPUpstreamClient({ fetchFn: mockFetch });
+      const result = await client.search("test", 10);
+
+      expect(result.servers).toHaveLength(1);
+      expect(result.servers[0]?.server.name).toEqual("io.github.test/good-server");
+    });
   });
 
   describe("fetchLatest", () => {
@@ -354,16 +423,19 @@ describe("MCPUpstreamClient", () => {
       expect(parsed.success).toBe(true);
     });
 
-    it("rejects invalid registry type", () => {
-      const invalidEntry = {
+    it("accepts arbitrary registry type strings", () => {
+      // Upstream spec defines registryType as an open-ended string with
+      // npm/pypi/oci/nuget/mcpb as examples; we must accept new values
+      // (e.g., "nuget", "cargo", "gem") rather than rejecting the whole entry.
+      const entry = {
         server: {
           $schema: "https://schema.modelcontextprotocol.io/server/2025-04-18.json",
-          name: "io.github.test/invalid",
+          name: "io.github.test/nuget-server",
           version: "1.0.0",
           packages: [
             {
-              registryType: "invalid-type", // Not in enum
-              identifier: "test",
+              registryType: "nuget",
+              identifier: "TestPackage",
               version: "1.0.0",
               transport: { type: "stdio" },
             },
@@ -380,8 +452,8 @@ describe("MCPUpstreamClient", () => {
         },
       };
 
-      const parsed = UpstreamServerEntrySchema.safeParse(invalidEntry);
-      expect(parsed.success).toBe(false);
+      const parsed = UpstreamServerEntrySchema.safeParse(entry);
+      expect(parsed.success).toBe(true);
     });
   });
 

--- a/packages/core/src/mcp-registry/upstream-client.ts
+++ b/packages/core/src/mcp-registry/upstream-client.ts
@@ -159,9 +159,14 @@ const NameProbeSchema = z.object({ server: z.object({ name: z.string() }).partia
 /**
  * Return shape of `search()`. Not a Zod schema — the wire response is parsed
  * via `UpstreamSearchEnvelopeSchema` + per-entry `UpstreamServerEntrySchema`.
+ *
+ * `dropped` counts entries that failed strict parsing and were skipped, so
+ * callers can surface drift signals (metrics, headers, etc.) without parsing
+ * logs.
  */
 export interface UpstreamSearchResponse {
   servers: UpstreamServerEntry[];
+  dropped: number;
 }
 
 // ─── Client ──────────────────────────────────────────────────────────────────
@@ -247,7 +252,7 @@ export class MCPUpstreamClient {
       logger.info("upstream search dropped malformed entries", { dropped, kept: servers.length });
     }
 
-    return { servers };
+    return { servers, dropped };
   }
 
   /**

--- a/packages/core/src/mcp-registry/upstream-client.ts
+++ b/packages/core/src/mcp-registry/upstream-client.ts
@@ -31,9 +31,15 @@ export type UpstreamEnvironmentVariable = z.infer<typeof UpstreamEnvironmentVari
 
 /**
  * Package entry from upstream registry.
+ *
+ * `registryType` is `z.string()` (not an enum) to match the upstream spec at
+ * `https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json`,
+ * which documents it as an open-ended string with `npm`/`pypi`/`oci`/`nuget`/`mcpb`
+ * as examples. Closed enums here have caused production 502s when the registry
+ * adds a new type — the translator already filters by known values.
  */
 export const UpstreamPackageSchema = z.object({
-  registryType: z.enum(["npm", "pypi", "oci", "mcpb"]),
+  registryType: z.string(),
   identifier: z.string(),
   version: z.string().optional(),
   transport: z.object({ type: z.string() }),
@@ -133,6 +139,18 @@ export const UpstreamServerEntrySchema = z.object({
 export type UpstreamServerEntry = z.infer<typeof UpstreamServerEntrySchema>;
 
 /**
+ * Outer envelope for the upstream /v0.1/servers search response.
+ *
+ * Entries are intentionally typed as `unknown` here: `search()` parses each
+ * one with `UpstreamServerEntrySchema` individually, so a single malformed
+ * entry can't sink the whole response.
+ */
+const UpstreamSearchEnvelopeSchema = z.object({
+  servers: z.array(z.unknown()),
+  metadata: z.object({ count: z.number() }).optional(),
+});
+
+/**
  * Full search response from upstream registry /v0.1/servers endpoint.
  * Each entry is a complete UpstreamServerEntry (server + _meta wrapper).
  */
@@ -195,15 +213,40 @@ export class MCPUpstreamClient {
     }
 
     const json: unknown = await response.json();
-    const parsed = UpstreamSearchResponseSchema.safeParse(json);
-    if (!parsed.success) {
-      logger.warn("upstream registry returned malformed search result", {
-        error: parsed.error.message,
+    const envelope = UpstreamSearchEnvelopeSchema.safeParse(json);
+    if (!envelope.success) {
+      logger.warn("upstream registry returned malformed search envelope", {
+        error: envelope.error.message,
       });
-      throw new Error(`upstream registry returned invalid response: ${parsed.error.message}`);
+      throw new Error(`upstream registry returned invalid response: ${envelope.error.message}`);
     }
 
-    return { servers: parsed.data.servers };
+    // Parse each entry independently so one malformed entry can't poison the
+    // whole response. This is the structural defense against upstream schema
+    // drift — when a new field/value appears, we lose only the affected entries
+    // instead of returning 502 for the whole search.
+    const servers: UpstreamServerEntry[] = [];
+    let dropped = 0;
+    // Loose schema used only for log context when an entry fails strict parse.
+    const NameProbeSchema = z.object({ server: z.object({ name: z.string() }).partial() });
+    for (const raw of envelope.data.servers) {
+      const parsed = UpstreamServerEntrySchema.safeParse(raw);
+      if (parsed.success) {
+        servers.push(parsed.data);
+      } else {
+        dropped++;
+        const probe = NameProbeSchema.safeParse(raw);
+        logger.warn("dropping malformed upstream registry entry", {
+          error: parsed.error.message,
+          name: probe.success ? (probe.data.server.name ?? "<unknown>") : "<unknown>",
+        });
+      }
+    }
+    if (dropped > 0) {
+      logger.info("upstream search dropped malformed entries", { dropped, kept: servers.length });
+    }
+
+    return { servers };
   }
 
   /**

--- a/packages/core/src/mcp-registry/upstream-client.ts
+++ b/packages/core/src/mcp-registry/upstream-client.ts
@@ -151,15 +151,18 @@ const UpstreamSearchEnvelopeSchema = z.object({
 });
 
 /**
- * Full search response from upstream registry /v0.1/servers endpoint.
- * Each entry is a complete UpstreamServerEntry (server + _meta wrapper).
+ * Loose probe used only to extract `server.name` for log context when an
+ * entry fails strict parsing.
  */
-export const UpstreamSearchResponseSchema = z.object({
-  servers: z.array(UpstreamServerEntrySchema),
-  metadata: z.object({ count: z.number() }).optional(),
-});
+const NameProbeSchema = z.object({ server: z.object({ name: z.string() }).partial() });
 
-export type UpstreamSearchResponse = z.infer<typeof UpstreamSearchResponseSchema>;
+/**
+ * Return shape of `search()`. Not a Zod schema — the wire response is parsed
+ * via `UpstreamSearchEnvelopeSchema` + per-entry `UpstreamServerEntrySchema`.
+ */
+export interface UpstreamSearchResponse {
+  servers: UpstreamServerEntry[];
+}
 
 // ─── Client ──────────────────────────────────────────────────────────────────
 
@@ -227,8 +230,6 @@ export class MCPUpstreamClient {
     // instead of returning 502 for the whole search.
     const servers: UpstreamServerEntry[] = [];
     let dropped = 0;
-    // Loose schema used only for log context when an entry fails strict parse.
-    const NameProbeSchema = z.object({ server: z.object({ name: z.string() }).partial() });
     for (const raw of envelope.data.servers) {
       const parsed = UpstreamServerEntrySchema.safeParse(raw);
       if (parsed.success) {


### PR DESCRIPTION
## Summary
- `/api/mcp-registry/search` was returning **502 `{\"error\":\"Search failed\"}`** for queries that matched a server with a package using a `registryType` outside our closed Zod enum (e.g. `nuget`). The upstream spec defines `registryType` as an open string, so a single unrecognized value tanked the entire response. Reproduced live with `?q=reddit` — 16 valid servers were being hidden behind one `nuget` entry (`io.github.mkerchenski/reddit-ads-mcp`).
- Loosened `registryType` to `z.string()` to match the upstream spec.
- Made `search()` parse each entry independently — malformed entries are dropped and logged with their server name, instead of failing the whole call. Structural defense against future upstream schema drift.

## Test plan
- [x] `vitest run packages/core/src/mcp-registry/` — 251/251 pass
- [x] `deno check` clean, biome clean
- [x] Live smoke test against `registry.modelcontextprotocol.io`: `?search=reddit` now returns all 16 servers including the `nuget` one
- [ ] Manual: hit `/api/daemon/api/mcp-registry/search?q=reddit&limit=20` in the running daemon and confirm 200 with full result set