### PR TITLE
fix(atlasd): prevent cross-turn event leak in chat stream registry

### DIFF
--- a/apps/atlasd/src/chat-sdk/chat-sdk-instance.test.ts
+++ b/apps/atlasd/src/chat-sdk/chat-sdk-instance.test.ts
@@ -136,6 +136,74 @@ describe("createMessageHandler", () => {
     expect(buffer?.active).toBe(false);
   });
 
+  it("drops events from a stale turn that emits after a follow-up replaced its buffer", async () => {
+    // Cross-turn isolation: turn 1's late producer (e.g. a NATS chunk that
+    // arrived after `streamSub.unsubscribe()` had already drained one more
+    // message off the wire) must not bleed into turn 2's buffer. Without the
+    // identity check at appendEvent's expectedBuffer parameter, turn 1's
+    // text-delta would land in turn 2's buffer mid-stream — UI sees a
+    // text-delta with no matching text-start and the AI SDK throws.
+    const registry = new StreamRegistry();
+
+    let captureChunkCallback: ((chunk: unknown) => void) | undefined;
+    const triggerFn = vi.fn(
+      (
+        _signalName: string,
+        _payload: Record<string, unknown>,
+        _streamId: string,
+        onStreamEvent: (chunk: unknown) => void,
+      ) => {
+        captureChunkCallback = onStreamEvent;
+        return Promise.resolve({ sessionId: "sess-1" });
+      },
+    );
+
+    const handler = createMessageHandler("ws-test", triggerFn, registry);
+    const thread = makeThread("chat-cross");
+    const turn1Buffer = registry.createStream("chat-cross");
+
+    await handler(thread, makeMessage({ threadId: "chat-cross" }));
+
+    // Simulate a follow-up turn replacing the buffer mid-flight, then a
+    // late producer from turn 1 emits one more chunk.
+    const turn2Buffer = registry.createStream("chat-cross");
+    captureChunkCallback?.({ type: "text-delta", delta: "stale" });
+
+    expect(turn1Buffer.events).toEqual([]); // turn 1's buffer was closed by createStream replacement
+    expect(turn2Buffer.events).toEqual([]); // and turn 1's stale chunk did NOT leak into turn 2
+  });
+
+  it("does not finish a follow-up turn's buffer when the prior turn cleans up", async () => {
+    // Aborted-cleanup isolation: turn 1's `finally` must not flip turn 2's
+    // freshly-created buffer to inactive. Pre-fix this used finishStream
+    // (chatId-keyed only) and ripped subscribers off the new buffer; the
+    // identity-checked finishStreamIfCurrent makes it a no-op when the
+    // buffer has been replaced.
+    const registry = new StreamRegistry();
+
+    // Trigger fn replaces the buffer mid-flight (after the handler captured
+    // its ownBuffer at line 888 of chat-sdk-instance.ts), modeling a follow-up
+    // POST that lands while turn 1 is still streaming. Returns a promise that
+    // resolves immediately so the handler proceeds to its `finally`.
+    const triggerFn = vi.fn(
+      (_s: string, _p: Record<string, unknown>, _id: string, _cb: (c: unknown) => void) => {
+        registry.createStream("chat-no-rip"); // turn 2 replaces turn 1's buffer
+        return Promise.resolve({ sessionId: "sess-1" });
+      },
+    );
+
+    const handler = createMessageHandler("ws-test", triggerFn, registry);
+    const thread = makeThread("chat-no-rip");
+    registry.createStream("chat-no-rip"); // turn 1's buffer
+
+    await handler(thread, makeMessage({ threadId: "chat-no-rip" }));
+
+    // After turn 1's handler ran its finally, turn 2's buffer must still be
+    // active — the identity check made the finishStream call a no-op.
+    const current = registry.getStream("chat-no-rip");
+    expect(current?.active).toBe(true);
+  });
+
   it("filters internal FSM events from StreamRegistry but forwards them to thread.post", async () => {
     const registry = new StreamRegistry();
     const chunks = [

--- a/apps/atlasd/src/chat-sdk/chat-sdk-instance.ts
+++ b/apps/atlasd/src/chat-sdk/chat-sdk-instance.ts
@@ -877,6 +877,16 @@ export function createMessageHandler(
           .filter((id) => options?.exposeKernel || id !== KERNEL_WORKSPACE_ID)
       : undefined;
 
+    // Capture the buffer this turn owns so stale producers can't bleed into
+    // a follow-up turn's buffer. The web adapter creates the buffer in
+    // `handleWebhook` before dispatching here; non-web adapters (Slack etc.)
+    // never create one and `getStream` returns undefined — appendEvent then
+    // returns false silently for those, matching prior behavior. Without this
+    // capture, a late event from an aborted turn would land in the next
+    // turn's buffer (same chatId key) and arrive at the UI without a matching
+    // `text-start`, tripping the AI SDK validator with a "text delta error".
+    const ownBuffer = streamRegistry.getStream(chatId);
+
     // signalToStream fans events two ways: the tap pushes ALL client-safe
     // events to StreamRegistry for the full web SSE stream, while the async
     // iterable feeds thread.post() → fromFullStream for platform adapters
@@ -888,7 +898,7 @@ export function createMessageHandler(
       streamId,
       (chunk: unknown) => {
         if (isClientSafeEvent(chunk)) {
-          const appended = streamRegistry.appendEvent(chatId, chunk);
+          const appended = streamRegistry.appendEvent(chatId, chunk, ownBuffer);
           if (!appended) {
             logger.warn("stream_event_dropped", {
               chatId,
@@ -964,7 +974,13 @@ export function createMessageHandler(
       });
       throw error;
     } finally {
-      streamRegistry.finishStream(chatId);
+      // Identity-checked finish: if a follow-up turn has already replaced our
+      // buffer, that turn owns its own cleanup — don't rip its subscribers
+      // out from under it. When `ownBuffer` is undefined (non-web adapter
+      // with no buffer at all), this is a no-op, matching prior behavior.
+      if (ownBuffer) {
+        streamRegistry.finishStreamIfCurrent(chatId, ownBuffer);
+      }
     }
   };
 }

--- a/apps/atlasd/src/stream-registry.test.ts
+++ b/apps/atlasd/src/stream-registry.test.ts
@@ -129,6 +129,26 @@ describe("StreamRegistry", () => {
       const result = registry.appendEvent("chat-1", makeEvent(1));
       expect(result).toBe(false);
     });
+
+    // Identity check guards against cross-turn event leaks. The chatId-keyed
+    // lookup is shared across turns, so an aborted turn's late producer would
+    // otherwise write into the next turn's buffer — the UI then sees a
+    // text-delta with no preceding text-start and the AI SDK throws.
+    it("drops the event when expectedBuffer no longer matches the current buffer", () => {
+      const turn1 = registry.createStream("chat-1");
+      const turn2 = registry.createStream("chat-1"); // replaces turn1
+
+      const result = registry.appendEvent("chat-1", makeEvent(1), turn1);
+      expect(result).toBe(false);
+      expect(turn2.events).toHaveLength(0);
+    });
+
+    it("appends when expectedBuffer matches the current buffer", () => {
+      const turn = registry.createStream("chat-1");
+      const result = registry.appendEvent("chat-1", makeEvent(1), turn);
+      expect(result).toBe(true);
+      expect(turn.events).toHaveLength(1);
+    });
   });
 
   describe("buffer overflow", () => {

--- a/apps/atlasd/src/stream-registry.ts
+++ b/apps/atlasd/src/stream-registry.ts
@@ -195,6 +195,12 @@ export class StreamRegistry {
    * Append event to buffer. Broadcasts to subscribers.
    * Returns false if stream doesn't exist or is inactive.
    *
+   * Pass `expectedBuffer` to scope the write to a specific turn's buffer:
+   * if a follow-up turn has replaced the buffer for this chatId, the stale
+   * producer's late events are dropped instead of leaking into the new
+   * turn's stream (where they'd arrive without a matching `text-start` and
+   * trip the AI SDK's UI-message protocol validator).
+   *
    * Buffer overflow policy: we never evict recorded events. Dropping the
    * oldest chunk of a `text-start → text-delta* → text-end` triple breaks
    * the UI message protocol for any late subscriber that tries to replay.
@@ -202,9 +208,12 @@ export class StreamRegistry {
    * the buffer as non-replayable; live subscribers keep receiving events
    * via the broadcast below, but `subscribe()` refuses new joiners.
    */
-  appendEvent(chatId: string, event: AtlasUIMessageChunk): boolean {
+  appendEvent(chatId: string, event: AtlasUIMessageChunk, expectedBuffer?: StreamBuffer): boolean {
     const buffer = this.streams.get(chatId);
     if (!buffer?.active) {
+      return false;
+    }
+    if (expectedBuffer && buffer !== expectedBuffer) {
       return false;
     }
 


### PR DESCRIPTION
## Summary

Two cooperating bugs in the chat stream pipeline let a stopped turn's late events corrupt the next turn's stream, surfacing in the UI as a "text delta error":

1. **Cleanup killed the wrong buffer.** `chat-sdk-instance.ts` ran `streamRegistry.finishStream(chatId)` in its finally without an identity check. If a follow-up POST had already created a fresh buffer for the same chatId, the prior turn's cleanup flipped the new buffer to `active=false` — every subsequent text-delta from the new turn was then dropped at the registry and the UI went silent.

2. **`appendEvent` was chatId-keyed only.** Late events from an aborted turn (subprocess emit between abort and SIGTERM, NATS reconnect-buffer flush, `streamSub` drain) landed in whatever buffer was current — including the next turn's, where they arrived without a matching `text-start` and tripped the AI SDK's UI-message protocol validator.

The handler now captures `ownBuffer` once at turn start and threads it through both the write path (`appendEvent(chatId, chunk, ownBuffer)`) and the cleanup path (`finishStreamIfCurrent(chatId, ownBuffer)`). Putting the identity check at the registry write boundary means the guarantee holds even when an upstream layer fails to honor cancellation cleanly.

## Live-daemon QA

Repro: send a chat message, wait 0.8s, send a follow-up to abort it, subscribe to SSE for the chat.

| | events delivered | text content | violations |
|---|---|---|---|
| pre-fix | 6 | none | stream cut to `[DONE]` mid-flight |
| post-fix | 14 | full `text-start → text-delta → text-end` | 0 |

## Test plan

- [x] `apps/atlasd/src/stream-registry.test.ts` — 2 new cases covering identity drop + identity match
- [x] `apps/atlasd/src/chat-sdk/chat-sdk-instance.test.ts` — 2 new cases covering cross-turn isolation + cleanup non-interference
- [x] All 3 new tests fail against the pre-fix code; all pass with the fix
- [x] Full repo: typecheck (0 errors), knip (clean), tests (909 passed | 1 skipped)
- [x] Live daemon QA verified end-to-end via SSE subscriber comparison

## Known residual / followups

- **#192** — narrow ~10-50ms race between adapter `createStream` and handler `getStream` capture. Strict improvement, not introduced here. Closing it requires threading `turnBuffer` through `Message.raw`.
- **#193** — `stream_event_dropped` log spam from non-web adapters (Slack/Telegram). Pre-existing, surfaced more clearly now that real drops are quieter.