### PR TITLE
fix(atlasd): cache + prewarm MCP tool probe to avoid cold-start timeout

### DIFF
--- a/apps/atlasd/routes/mcp-registry.test.ts
+++ b/apps/atlasd/routes/mcp-registry.test.ts
@@ -78,10 +78,12 @@ beforeEach(() => {
   mockSearch.mockReset();
   mockCreateMCPTools.mockReset();
   mockStreamText.mockReset();
+  _resetCacheForTest();
 });
 
 // Import AFTER mock setup (vi.mock is hoisted, but this makes intent clear)
 const { mcpRegistryRouter } = await import("./mcp-registry.ts");
+const { _resetCacheForTest, _flushPrewarmsForTest } = await import("./mcp-tool-cache.ts");
 
 /** Build a Hono app that wraps the MCP registry router with a partial mock app context. */
 function createWrappedRouter(context: Record<string, unknown>) {
@@ -2090,6 +2092,131 @@ describe("MCP Registry Routes", () => {
       const body = ToolProbeSuccessSchema.parse(await res.json());
       expect(body.tools).toHaveLength(1);
       expect(body.tools[0]).toEqual({ name: "bare-tool", description: undefined });
+    });
+
+    it("serves a cached tool list on the second probe without re-invoking createMCPTools", async () => {
+      const entry = createTestEntry("probe-cache-hit");
+      // Seed without prewarm side effects: prewarm uses createMCPTools too.
+      // Mock first to count both prewarm + probe calls.
+      mockCreateMCPTools.mockResolvedValue({
+        tools: { "cached-tool": { description: "cached" } },
+        dispose: vi.fn().mockResolvedValue(undefined),
+      });
+
+      await mcpRegistryRouter.request("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entry }),
+      });
+      await _flushPrewarmsForTest();
+      const callsAfterAdd = mockCreateMCPTools.mock.calls.length;
+
+      const first = await mcpRegistryRouter.request(`/${entry.id}/tools`);
+      expect(first.status).toBe(200);
+      const firstBody = ToolProbeSuccessSchema.parse(await first.json());
+      expect(firstBody.tools[0]?.name).toBe("cached-tool");
+
+      const callsAfterFirst = mockCreateMCPTools.mock.calls.length;
+      // Either prewarm filled the cache (first probe is a hit, no new call) or
+      // prewarm was racy and the foreground probe ran. Either way, a *second*
+      // /tools call must be a cache hit.
+      const second = await mcpRegistryRouter.request(`/${entry.id}/tools`);
+      expect(second.status).toBe(200);
+      const secondBody = ToolProbeSuccessSchema.parse(await second.json());
+      expect(secondBody.tools[0]?.name).toBe("cached-tool");
+
+      expect(mockCreateMCPTools.mock.calls.length).toBe(callsAfterFirst);
+      // Sanity: at least the prewarm fired on add.
+      expect(callsAfterAdd).toBeGreaterThanOrEqual(1);
+    });
+
+    it("does not cache failed probes — retry sees a fresh probe", async () => {
+      const entry = createTestEntry("probe-no-cache-on-fail");
+      // Prewarm fails (cold install timeout simulation).
+      mockCreateMCPTools.mockRejectedValueOnce(new Error("ECONNREFUSED 127.0.0.1:8080"));
+
+      await mcpRegistryRouter.request("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entry }),
+      });
+      await _flushPrewarmsForTest();
+
+      // First foreground probe fails too.
+      mockCreateMCPTools.mockRejectedValueOnce(new Error("ECONNREFUSED 127.0.0.1:8080"));
+      const failed = await mcpRegistryRouter.request(`/${entry.id}/tools`);
+      const failedBody = ToolProbeErrorSchema.parse(await failed.json());
+      expect(failedBody.ok).toBe(false);
+
+      // Now succeed — cache must not contain the prior failure.
+      mockCreateMCPTools.mockResolvedValueOnce({
+        tools: { "recovered-tool": { description: "ok" } },
+        dispose: vi.fn().mockResolvedValue(undefined),
+      });
+      const ok = await mcpRegistryRouter.request(`/${entry.id}/tools`);
+      const okBody = ToolProbeSuccessSchema.parse(await ok.json());
+      expect(okBody.tools[0]?.name).toBe("recovered-tool");
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // Prewarm — POST mutations populate the tool cache
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe("prewarm on add", () => {
+    it("invokes createMCPTools after POST /", async () => {
+      mockCreateMCPTools.mockResolvedValue({
+        tools: { "warmed-tool": { description: "warmed" } },
+        dispose: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const entry = createTestEntry("prewarm-create");
+      const res = await mcpRegistryRouter.request("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entry }),
+      });
+      expect(res.status).toBe(201);
+
+      await _flushPrewarmsForTest();
+      expect(mockCreateMCPTools).toHaveBeenCalled();
+    });
+
+    it("invalidates cache on DELETE /:id", async () => {
+      const entry = createTestEntry("prewarm-delete");
+      mockCreateMCPTools.mockResolvedValue({
+        tools: { "v1-tool": { description: "v1" } },
+        dispose: vi.fn().mockResolvedValue(undefined),
+      });
+      await mcpRegistryRouter.request("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entry }),
+      });
+      await _flushPrewarmsForTest();
+
+      const del = await mcpRegistryRouter.request(`/${entry.id}`, { method: "DELETE" });
+      expect(del.status).toBe(204);
+
+      // Re-add same id with a different config; must not serve stale cached tools.
+      const reAdded = {
+        ...entry,
+        configTemplate: { transport: { type: "stdio", command: "echo", args: ["different"] } },
+      };
+      mockCreateMCPTools.mockResolvedValue({
+        tools: { "v2-tool": { description: "v2" } },
+        dispose: vi.fn().mockResolvedValue(undefined),
+      });
+      await mcpRegistryRouter.request("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entry: reAdded }),
+      });
+      await _flushPrewarmsForTest();
+
+      const probe = await mcpRegistryRouter.request(`/${entry.id}/tools`);
+      const body = ToolProbeSuccessSchema.parse(await probe.json());
+      expect(body.tools[0]?.name).toBe("v2-tool");
     });
   });
 

--- a/apps/atlasd/routes/mcp-registry.test.ts
+++ b/apps/atlasd/routes/mcp-registry.test.ts
@@ -2094,10 +2094,8 @@ describe("MCP Registry Routes", () => {
       expect(body.tools[0]).toEqual({ name: "bare-tool", description: undefined });
     });
 
-    it("serves a cached tool list on the second probe without re-invoking createMCPTools", async () => {
+    it("serves cached tools — prewarm populates, GET is a hit, no second probe", async () => {
       const entry = createTestEntry("probe-cache-hit");
-      // Seed without prewarm side effects: prewarm uses createMCPTools too.
-      // Mock first to count both prewarm + probe calls.
       mockCreateMCPTools.mockResolvedValue({
         tools: { "cached-tool": { description: "cached" } },
         dispose: vi.fn().mockResolvedValue(undefined),
@@ -2109,25 +2107,22 @@ describe("MCP Registry Routes", () => {
         body: JSON.stringify({ entry }),
       });
       await _flushPrewarmsForTest();
-      const callsAfterAdd = mockCreateMCPTools.mock.calls.length;
+      // Prewarm probed exactly once.
+      expect(mockCreateMCPTools.mock.calls.length).toBe(1);
 
+      // First GET must be a cache hit — no new probe.
       const first = await mcpRegistryRouter.request(`/${entry.id}/tools`);
       expect(first.status).toBe(200);
       const firstBody = ToolProbeSuccessSchema.parse(await first.json());
       expect(firstBody.tools[0]?.name).toBe("cached-tool");
+      expect(mockCreateMCPTools.mock.calls.length).toBe(1);
 
-      const callsAfterFirst = mockCreateMCPTools.mock.calls.length;
-      // Either prewarm filled the cache (first probe is a hit, no new call) or
-      // prewarm was racy and the foreground probe ran. Either way, a *second*
-      // /tools call must be a cache hit.
+      // Second GET also a cache hit.
       const second = await mcpRegistryRouter.request(`/${entry.id}/tools`);
       expect(second.status).toBe(200);
       const secondBody = ToolProbeSuccessSchema.parse(await second.json());
       expect(secondBody.tools[0]?.name).toBe("cached-tool");
-
-      expect(mockCreateMCPTools.mock.calls.length).toBe(callsAfterFirst);
-      // Sanity: at least the prewarm fired on add.
-      expect(callsAfterAdd).toBeGreaterThanOrEqual(1);
+      expect(mockCreateMCPTools.mock.calls.length).toBe(1);
     });
 
     it("does not cache failed probes — retry sees a fresh probe", async () => {
@@ -2164,7 +2159,7 @@ describe("MCP Registry Routes", () => {
   // ═══════════════════════════════════════════════════════════════════════
 
   describe("prewarm on add", () => {
-    it("invokes createMCPTools after POST /", async () => {
+    it("populates the cache after POST / — follow-up GET is a hit", async () => {
       mockCreateMCPTools.mockResolvedValue({
         tools: { "warmed-tool": { description: "warmed" } },
         dispose: vi.fn().mockResolvedValue(undefined),
@@ -2177,12 +2172,18 @@ describe("MCP Registry Routes", () => {
         body: JSON.stringify({ entry }),
       });
       expect(res.status).toBe(201);
-
       await _flushPrewarmsForTest();
-      expect(mockCreateMCPTools).toHaveBeenCalled();
+      expect(mockCreateMCPTools.mock.calls.length).toBe(1);
+
+      // The follow-up GET must be a cache hit — call count stays at 1.
+      const probe = await mcpRegistryRouter.request(`/${entry.id}/tools`);
+      expect(probe.status).toBe(200);
+      const body = ToolProbeSuccessSchema.parse(await probe.json());
+      expect(body.tools[0]?.name).toBe("warmed-tool");
+      expect(mockCreateMCPTools.mock.calls.length).toBe(1);
     });
 
-    it("invalidates cache on DELETE /:id", async () => {
+    it("invalidates cache on DELETE /:id — same id+config re-add returns fresh tools", async () => {
       const entry = createTestEntry("prewarm-delete");
       mockCreateMCPTools.mockResolvedValue({
         tools: { "v1-tool": { description: "v1" } },
@@ -2198,11 +2199,10 @@ describe("MCP Registry Routes", () => {
       const del = await mcpRegistryRouter.request(`/${entry.id}`, { method: "DELETE" });
       expect(del.status).toBe(204);
 
-      // Re-add same id with a different config; must not serve stale cached tools.
-      const reAdded = {
-        ...entry,
-        configTemplate: { transport: { type: "stdio", command: "echo", args: ["different"] } },
-      };
+      // Re-add with the SAME configTemplate. configHash matches, so only
+      // invalidateCache(id) on DELETE can keep the cache from serving v1-tool
+      // (otherwise prewarmTools would short-circuit on the still-cached entry
+      // and skip probing — caller would see stale tools).
       mockCreateMCPTools.mockResolvedValue({
         tools: { "v2-tool": { description: "v2" } },
         dispose: vi.fn().mockResolvedValue(undefined),
@@ -2210,13 +2210,58 @@ describe("MCP Registry Routes", () => {
       await mcpRegistryRouter.request("/", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ entry: reAdded }),
+        body: JSON.stringify({ entry }),
       });
       await _flushPrewarmsForTest();
 
       const probe = await mcpRegistryRouter.request(`/${entry.id}/tools`);
       const body = ToolProbeSuccessSchema.parse(await probe.json());
       expect(body.tools[0]?.name).toBe("v2-tool");
+    });
+
+    it("invalidates and reprewarms on POST /:id/update — old tools gone, new tools cached", async () => {
+      const canonicalName = "io.github.test/update-prewarm";
+      const v1 = createNpmStdioUpstreamEntry(canonicalName, "1.0.0");
+      mockFetchLatest.mockResolvedValueOnce(v1);
+
+      mockCreateMCPTools.mockResolvedValueOnce({
+        tools: { "v1-tool": { description: "v1" } },
+        dispose: vi.fn().mockResolvedValue(undefined),
+      });
+      const installRes = await mcpRegistryRouter.request("/install", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ registryName: canonicalName }),
+      });
+      expect(installRes.status).toBe(201);
+      const storedId = InstallResponseSchema.parse(await installRes.json()).server.id;
+      await _flushPrewarmsForTest();
+      // Confirm v1 tools cached.
+      const beforeUpdate = await mcpRegistryRouter.request(`/${storedId}/tools`);
+      expect(ToolProbeSuccessSchema.parse(await beforeUpdate.json()).tools[0]?.name).toBe(
+        "v1-tool",
+      );
+      const callsAfterInstall = mockCreateMCPTools.mock.calls.length;
+
+      // Pull update to v2 — handler must invalidateCache + prewarm with new config.
+      const v2 = createNpmStdioUpstreamEntry(canonicalName, "2.0.0");
+      mockFetchLatest.mockResolvedValueOnce(v2);
+      mockCreateMCPTools.mockResolvedValueOnce({
+        tools: { "v2-tool": { description: "v2" } },
+        dispose: vi.fn().mockResolvedValue(undefined),
+      });
+      const updateRes = await mcpRegistryRouter.request(`/${storedId}/update`, { method: "POST" });
+      expect(updateRes.status).toBe(200);
+      await _flushPrewarmsForTest();
+
+      // Reprewarm probed exactly once after install.
+      expect(mockCreateMCPTools.mock.calls.length).toBe(callsAfterInstall + 1);
+
+      // GET /tools must serve the new v2 tools and stay a cache hit.
+      const probe = await mcpRegistryRouter.request(`/${storedId}/tools`);
+      const body = ToolProbeSuccessSchema.parse(await probe.json());
+      expect(body.tools[0]?.name).toBe("v2-tool");
+      expect(mockCreateMCPTools.mock.calls.length).toBe(callsAfterInstall + 1);
     });
   });
 

--- a/apps/atlasd/routes/mcp-registry.test.ts
+++ b/apps/atlasd/routes/mcp-registry.test.ts
@@ -88,7 +88,9 @@ beforeEach(() => {
 
 // Import AFTER mock setup (vi.mock is hoisted, but this makes intent clear)
 const { mcpRegistryRouter } = await import("./mcp-registry.ts");
-const { _resetCacheForTest, _flushPrewarmsForTest } = await import("./mcp-tool-cache.ts");
+const { _resetCacheForTest, _flushPrewarmsForTest, _setRaceCapForTest } = await import(
+  "./mcp-tool-cache.ts"
+);
 
 /** Build a Hono app that wraps the MCP registry router with a partial mock app context. */
 function createWrappedRouter(context: Record<string, unknown>) {
@@ -2330,7 +2332,11 @@ describe("MCP Registry Routes", () => {
         tools: {},
         dispose: vi.fn().mockResolvedValue(undefined),
         disconnected: [
-          { serverId: entry.id, kind: "credential_not_found", message: "no credential" },
+          {
+            serverId: entry.id,
+            kind: "credential_not_found",
+            message: "Credential 'github' was deleted. Reconnect to continue.",
+          },
         ],
       });
 
@@ -2347,6 +2353,82 @@ describe("MCP Registry Routes", () => {
       const body = ToolProbeErrorSchema.parse(await probe.json());
       expect(body.ok).toBe(false);
       expect(body.phase).toBe("auth");
+      // Error must be the entry.message verbatim — not the constructor's
+      // template wrapped around it (which would produce nested gibberish).
+      expect(body.error).toBe("Credential 'github' was deleted. Reconnect to continue.");
+    });
+
+    it("dedup branch surfaces classified prewarm failure when GET arrives mid-prewarm", async () => {
+      const entry = createTestEntry("dedup-prewarm-error");
+      // Defer the prewarm so the GET enters the dedup branch BEFORE the
+      // prewarm settles. Resolves to disconnected — probeAndExtract throws
+      // inside prewarmTools, which classifies to auth and resolves the
+      // PrewarmResult with { ok: false, phase: "auth" }.
+      let resolveDisconnected: (() => void) | undefined;
+      mockCreateMCPTools.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveDisconnected = () =>
+              resolve({
+                tools: {},
+                dispose: vi.fn().mockResolvedValue(undefined),
+                disconnected: [
+                  {
+                    serverId: entry.id,
+                    kind: "credential_not_found",
+                    message: "Credential missing — reconnect to continue.",
+                  },
+                ],
+              });
+          }),
+      );
+
+      await mcpRegistryRouter.request("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entry }),
+      });
+
+      // GET while prewarm is still pending — must enter the dedup branch.
+      const probePromise = mcpRegistryRouter.request(`/${entry.id}/tools`);
+      // Wait for the handler to advance past `await adapter.get` and into
+      // `await Promise.race(...)` before the prewarm settles — otherwise the
+      // IIFE's microtasks (dispose → throw → catch → classify → finally →
+      // delete) can finish first, evicting `inFlightPrewarm` before the
+      // handler ever consults it. 50ms is generous; KV lookup is fast.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      resolveDisconnected!();
+      const probe = await probePromise;
+
+      const body = ToolProbeErrorSchema.parse(await probe.json());
+      expect(body.ok).toBe(false);
+      expect(body.phase).toBe("auth");
+      expect(body.error).toBe("Credential missing — reconnect to continue.");
+      // The dedup branch consumed the prewarm's classified result — no
+      // duplicate foreground probe was spawned.
+      expect(mockCreateMCPTools.mock.calls.length).toBe(1);
+    });
+
+    it("returns retryable hint when in-flight prewarm exceeds the race cap", async () => {
+      _setRaceCapForTest(50);
+      const entry = createTestEntry("dedup-retryable");
+      // Prewarm hangs forever — race cap will fire first.
+      mockCreateMCPTools.mockImplementationOnce(() => new Promise(() => {}));
+
+      await mcpRegistryRouter.request("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entry }),
+      });
+
+      const probe = await mcpRegistryRouter.request(`/${entry.id}/tools`);
+      expect(probe.status).toBe(200);
+      const body = z
+        .object({ ok: z.literal(false), retryable: z.literal(true), error: z.string() })
+        .parse(await probe.json());
+      expect(body.retryable).toBe(true);
+      // The GET did not spawn its own probe — only the still-pending prewarm.
+      expect(mockCreateMCPTools.mock.calls.length).toBe(1);
     });
   });
 

--- a/apps/atlasd/routes/mcp-registry.test.ts
+++ b/apps/atlasd/routes/mcp-registry.test.ts
@@ -2358,6 +2358,33 @@ describe("MCP Registry Routes", () => {
       expect(body.error).toBe("Credential 'github' was deleted. Reconnect to continue.");
     });
 
+    it("silently-failed probe (empty tools, no disconnected) surfaces as connect, not cached []", async () => {
+      // Mirrors the QA finding: createMCPTools warn-logs and silently drops
+      // servers that fail to start (typo'd npm package, MCPStartupError,
+      // connect error). No `disconnected` entry, just `tools: {}`. Without
+      // the empty-tools guard in probeAndExtract, the probe would cache `[]`
+      // and the user would see "no tools" instead of a real error.
+      const entry = createTestEntry("connect-failed-probe");
+      mockCreateMCPTools.mockResolvedValue({
+        tools: {},
+        dispose: vi.fn().mockResolvedValue(undefined),
+        disconnected: [],
+      });
+
+      await mcpRegistryRouter.request("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entry }),
+      });
+      await _flushPrewarmsForTest();
+
+      const probe = await mcpRegistryRouter.request(`/${entry.id}/tools`);
+      const body = ToolProbeErrorSchema.parse(await probe.json());
+      expect(body.ok).toBe(false);
+      expect(body.phase).toBe("connect");
+      expect(body.error).toContain("failed to start");
+    });
+
     it("dedup branch surfaces classified prewarm failure when GET arrives mid-prewarm", async () => {
       const entry = createTestEntry("dedup-prewarm-error");
       // Defer the prewarm so the GET enters the dedup branch BEFORE the

--- a/apps/atlasd/routes/mcp-registry.test.ts
+++ b/apps/atlasd/routes/mcp-registry.test.ts
@@ -39,13 +39,18 @@ vi.mock("@atlas/core/mcp-registry/upstream-client", () => ({
 
 // Mock createMCPTools for tool probe tests
 type MockTool = { description?: string };
+type MockDisconnected = { serverId: string; kind: string; message: string };
 const mockCreateMCPTools =
   vi.fn<
     (
       configs: Record<string, unknown>,
       logger: unknown,
       options?: { signal?: AbortSignal; toolPrefix?: string },
-    ) => Promise<{ tools: Record<string, MockTool>; dispose: () => Promise<void> }>
+    ) => Promise<{
+      tools: Record<string, MockTool>;
+      dispose: () => Promise<void>;
+      disconnected: MockDisconnected[];
+    }>
   >();
 
 vi.mock("@atlas/mcp", () => ({
@@ -1935,6 +1940,7 @@ describe("MCP Registry Routes", () => {
           "send-data": { description: "Send data to the server" },
         },
         dispose: vi.fn().mockResolvedValue(undefined),
+        disconnected: [],
       });
 
       const res = await mcpRegistryRouter.request(`/${entry.id}/tools`);
@@ -2062,6 +2068,7 @@ describe("MCP Registry Routes", () => {
       mockCreateMCPTools.mockResolvedValue({
         tools: { "static-tool": { description: "A static tool" } },
         dispose: vi.fn().mockResolvedValue(undefined),
+        disconnected: [],
       });
 
       const res = await mcpRegistryRouter.request(`/${blessedId}/tools`);
@@ -2084,6 +2091,7 @@ describe("MCP Registry Routes", () => {
       mockCreateMCPTools.mockResolvedValue({
         tools: { "bare-tool": {} },
         dispose: vi.fn().mockResolvedValue(undefined),
+        disconnected: [],
       });
 
       const res = await mcpRegistryRouter.request(`/${entry.id}/tools`);
@@ -2099,6 +2107,7 @@ describe("MCP Registry Routes", () => {
       mockCreateMCPTools.mockResolvedValue({
         tools: { "cached-tool": { description: "cached" } },
         dispose: vi.fn().mockResolvedValue(undefined),
+        disconnected: [],
       });
 
       await mcpRegistryRouter.request("/", {
@@ -2147,6 +2156,7 @@ describe("MCP Registry Routes", () => {
       mockCreateMCPTools.mockResolvedValueOnce({
         tools: { "recovered-tool": { description: "ok" } },
         dispose: vi.fn().mockResolvedValue(undefined),
+        disconnected: [],
       });
       const ok = await mcpRegistryRouter.request(`/${entry.id}/tools`);
       const okBody = ToolProbeSuccessSchema.parse(await ok.json());
@@ -2163,6 +2173,7 @@ describe("MCP Registry Routes", () => {
       mockCreateMCPTools.mockResolvedValue({
         tools: { "warmed-tool": { description: "warmed" } },
         dispose: vi.fn().mockResolvedValue(undefined),
+        disconnected: [],
       });
 
       const entry = createTestEntry("prewarm-create");
@@ -2188,6 +2199,7 @@ describe("MCP Registry Routes", () => {
       mockCreateMCPTools.mockResolvedValue({
         tools: { "v1-tool": { description: "v1" } },
         dispose: vi.fn().mockResolvedValue(undefined),
+        disconnected: [],
       });
       await mcpRegistryRouter.request("/", {
         method: "POST",
@@ -2206,6 +2218,7 @@ describe("MCP Registry Routes", () => {
       mockCreateMCPTools.mockResolvedValue({
         tools: { "v2-tool": { description: "v2" } },
         dispose: vi.fn().mockResolvedValue(undefined),
+        disconnected: [],
       });
       await mcpRegistryRouter.request("/", {
         method: "POST",
@@ -2227,6 +2240,7 @@ describe("MCP Registry Routes", () => {
       mockCreateMCPTools.mockResolvedValueOnce({
         tools: { "v1-tool": { description: "v1" } },
         dispose: vi.fn().mockResolvedValue(undefined),
+        disconnected: [],
       });
       const installRes = await mcpRegistryRouter.request("/install", {
         method: "POST",
@@ -2249,6 +2263,7 @@ describe("MCP Registry Routes", () => {
       mockCreateMCPTools.mockResolvedValueOnce({
         tools: { "v2-tool": { description: "v2" } },
         dispose: vi.fn().mockResolvedValue(undefined),
+        disconnected: [],
       });
       const updateRes = await mcpRegistryRouter.request(`/${storedId}/update`, { method: "POST" });
       expect(updateRes.status).toBe(200);
@@ -2262,6 +2277,104 @@ describe("MCP Registry Routes", () => {
       const body = ToolProbeSuccessSchema.parse(await probe.json());
       expect(body.tools[0]?.name).toBe("v2-tool");
       expect(mockCreateMCPTools.mock.calls.length).toBe(callsAfterInstall + 1);
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // GET /:id/tools — in-flight prewarm dedup
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe("GET /:id/tools dedup", () => {
+    it("waits for in-flight prewarm instead of spawning a duplicate probe", async () => {
+      const entry = createTestEntry("dedup-wait");
+      // Defer the prewarm's createMCPTools so the GET races into the dedup branch.
+      let resolvePrewarm: (() => void) | undefined;
+      mockCreateMCPTools.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolvePrewarm = () =>
+              resolve({
+                tools: { "warmed-tool": { description: "warmed" } },
+                dispose: vi.fn().mockResolvedValue(undefined),
+                disconnected: [],
+              });
+          }),
+      );
+
+      // Add — prewarm starts but does not resolve yet.
+      await mcpRegistryRouter.request("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entry }),
+      });
+
+      // Click "list tools" while prewarm is still pending.
+      const probePromise = mcpRegistryRouter.request(`/${entry.id}/tools`);
+
+      // Now resolve the prewarm. The pending GET awaits the same in-flight
+      // promise — must not have spawned its own probe.
+      resolvePrewarm!();
+      const probe = await probePromise;
+      await _flushPrewarmsForTest();
+
+      expect(probe.status).toBe(200);
+      const body = ToolProbeSuccessSchema.parse(await probe.json());
+      expect(body.tools[0]?.name).toBe("warmed-tool");
+      // Exactly one probe — no duplicate spawned by the GET.
+      expect(mockCreateMCPTools.mock.calls.length).toBe(1);
+    });
+
+    it("disconnected probe surfaces as auth phase, not cached as []", async () => {
+      const entry = createTestEntry("disconnected-probe");
+      mockCreateMCPTools.mockResolvedValue({
+        tools: {},
+        dispose: vi.fn().mockResolvedValue(undefined),
+        disconnected: [
+          { serverId: entry.id, kind: "credential_not_found", message: "no credential" },
+        ],
+      });
+
+      await mcpRegistryRouter.request("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entry }),
+      });
+      await _flushPrewarmsForTest();
+
+      // Foreground GET — prewarm finished with auth error, surfaced via the dedup
+      // path or via foreground probe (both get classified as auth).
+      const probe = await mcpRegistryRouter.request(`/${entry.id}/tools`);
+      const body = ToolProbeErrorSchema.parse(await probe.json());
+      expect(body.ok).toBe(false);
+      expect(body.phase).toBe("auth");
+    });
+  });
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // mcp-tool-cache.ts — direct unit tests
+  // ═══════════════════════════════════════════════════════════════════════
+
+  describe("mcp-tool-cache direct", () => {
+    it("invalidateCache(id) clears the entry — getCachedTools returns null", async () => {
+      const { putCachedTools, getCachedTools, invalidateCache } = await import(
+        "./mcp-tool-cache.ts"
+      );
+      const config = { transport: { type: "stdio" as const, command: "echo", args: ["x"] } };
+      putCachedTools("direct-id", config, [
+        { name: "t1", description: "first", inputSchema: null },
+      ]);
+      expect(getCachedTools("direct-id", config)?.[0]?.name).toBe("t1");
+      invalidateCache("direct-id");
+      expect(getCachedTools("direct-id", config)).toBeNull();
+    });
+
+    it("getCachedTools returns null when configHash differs", async () => {
+      const { putCachedTools, getCachedTools } = await import("./mcp-tool-cache.ts");
+      const v1 = { transport: { type: "stdio" as const, command: "echo", args: ["1"] } };
+      const v2 = { transport: { type: "stdio" as const, command: "echo", args: ["2"] } };
+      putCachedTools("hash-id", v1, [{ name: "t-v1", inputSchema: null }]);
+      expect(getCachedTools("hash-id", v1)?.[0]?.name).toBe("t-v1");
+      expect(getCachedTools("hash-id", v2)).toBeNull();
     });
   });
 
@@ -2343,6 +2456,7 @@ describe("MCP Registry Routes", () => {
       mockCreateMCPTools.mockResolvedValue({
         tools: { "fetch-data": { description: "Fetch data" } },
         dispose: vi.fn().mockResolvedValue(undefined),
+        disconnected: [],
       });
 
       mockStreamText.mockReturnValue(
@@ -2439,6 +2553,7 @@ describe("MCP Registry Routes", () => {
       mockCreateMCPTools.mockResolvedValue({
         tools: { "fetch-data": { description: "Fetch data" } },
         dispose: vi.fn().mockResolvedValue(undefined),
+        disconnected: [],
       });
 
       mockStreamText.mockReturnValue(
@@ -2525,6 +2640,7 @@ describe("MCP Registry Routes", () => {
       mockCreateMCPTools.mockResolvedValue({
         tools: { "fetch-data": { description: "Fetch data" } },
         dispose: vi.fn().mockResolvedValue(undefined),
+        disconnected: [],
       });
 
       mockStreamText.mockReturnValue(

--- a/apps/atlasd/routes/mcp-registry.test.ts
+++ b/apps/atlasd/routes/mcp-registry.test.ts
@@ -2492,6 +2492,64 @@ describe("MCP Registry Routes", () => {
       expect(getCachedTools("hash-id", v1)?.[0]?.name).toBe("t-v1");
       expect(getCachedTools("hash-id", v2)).toBeNull();
     });
+
+    it("evicts the entry on TTL expiry — getCachedTools returns null and the map is clean", async () => {
+      vi.useFakeTimers();
+      try {
+        const { putCachedTools, getCachedTools } = await import("./mcp-tool-cache.ts");
+        const config = { transport: { type: "stdio" as const, command: "echo", args: ["x"] } };
+        putCachedTools("ttl-id", config, [{ name: "t1", inputSchema: null }]);
+        expect(getCachedTools("ttl-id", config)?.[0]?.name).toBe("t1");
+        // Advance past the 1h TTL.
+        vi.advanceTimersByTime(60 * 60 * 1000 + 1);
+        expect(getCachedTools("ttl-id", config)).toBeNull();
+        // The expired entry must actually be removed (not just returned-as-null).
+        // Re-put would prove the slot is reusable; checking again post-eviction
+        // confirms no stale entry lingers under the same id+hash.
+        expect(getCachedTools("ttl-id", config)).toBeNull();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("prewarmTools dedupes same-config callers but starts a fresh probe when config changes", async () => {
+      const { prewarmTools, getInFlightPrewarm, _resetCacheForTest } = await import(
+        "./mcp-tool-cache.ts"
+      );
+      _resetCacheForTest();
+
+      // Two never-resolving probes so we can inspect in-flight state without
+      // the IIFE settling between assertions.
+      mockCreateMCPTools.mockImplementation(() => new Promise(() => {}));
+
+      const fakeLogger = {
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      } as unknown as Parameters<typeof prewarmTools>[2];
+
+      const v1 = { transport: { type: "stdio" as const, command: "echo", args: ["v1"] } };
+      const v2 = { transport: { type: "stdio" as const, command: "echo", args: ["v2"] } };
+
+      const p1a = prewarmTools("race-id", v1, fakeLogger);
+      const p1b = prewarmTools("race-id", v1, fakeLogger);
+      // Same config → second caller dedupes onto the same in-flight promise.
+      expect(p1a).toBe(p1b);
+      expect(mockCreateMCPTools.mock.calls.length).toBe(1);
+
+      // Different config → must start a fresh probe, not return p1.
+      const p2 = prewarmTools("race-id", v2, fakeLogger);
+      expect(p2).not.toBe(p1a);
+      expect(mockCreateMCPTools.mock.calls.length).toBe(2);
+
+      // getInFlightPrewarm now returns the v2 promise for v2 callers, and
+      // undefined for v1 callers (the v1 prewarm is still running but its
+      // slot has been replaced — a v1-config GET would correctly fall
+      // through rather than wait on v2 tools).
+      expect(getInFlightPrewarm("race-id", v2)).toBe(p2);
+      expect(getInFlightPrewarm("race-id", v1)).toBeUndefined();
+    });
   });
 
   // ═══════════════════════════════════════════════════════════════════════

--- a/apps/atlasd/routes/mcp-registry.test.ts
+++ b/apps/atlasd/routes/mcp-registry.test.ts
@@ -2391,12 +2391,17 @@ describe("MCP Registry Routes", () => {
 
       // GET while prewarm is still pending — must enter the dedup branch.
       const probePromise = mcpRegistryRouter.request(`/${entry.id}/tools`);
-      // Wait for the handler to advance past `await adapter.get` and into
-      // `await Promise.race(...)` before the prewarm settles — otherwise the
+      // Wait for the handler to advance past `await getMCPRegistryAdapter()`
+      // and `await adapter.get(id)` (in-memory KV, normally <1ms) and reach
+      // `await Promise.race(...)` BEFORE the prewarm settles. Otherwise the
       // IIFE's microtasks (dispose → throw → catch → classify → finally →
-      // delete) can finish first, evicting `inFlightPrewarm` before the
-      // handler ever consults it. 50ms is generous; KV lookup is fast.
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      // delete) finish first, evicting `inFlightPrewarm` before the handler
+      // consults it; the GET then falls through to the foreground probe
+      // path, which still classifies disconnect to "auth" via mockResolved
+      // carry-over OR fails on the exhausted `mockImplementationOnce`. Use
+      // 250ms to stay well clear of GC pauses / loaded-CI jitter — failure
+      // mode (`expected "auth" got "connect"`) doesn't point at timing.
+      await new Promise((resolve) => setTimeout(resolve, 250));
       resolveDisconnected!();
       const probe = await probePromise;
 
@@ -2412,7 +2417,9 @@ describe("MCP Registry Routes", () => {
     it("returns retryable hint when in-flight prewarm exceeds the race cap", async () => {
       _setRaceCapForTest(50);
       const entry = createTestEntry("dedup-retryable");
-      // Prewarm hangs forever — race cap will fire first.
+      // Prewarm hangs forever — race cap will fire first. The pending IIFE
+      // is GC-eligible after `_resetCacheForTest` clears `inFlightPrewarm`
+      // in the next test's beforeEach (the map holds the only live ref).
       mockCreateMCPTools.mockImplementationOnce(() => new Promise(() => {}));
 
       await mcpRegistryRouter.request("/", {

--- a/apps/atlasd/routes/mcp-registry.ts
+++ b/apps/atlasd/routes/mcp-registry.ts
@@ -31,6 +31,7 @@ import { z } from "zod";
 import { daemonFactory } from "../src/factory.ts";
 import {
   getCachedTools,
+  getInFlightPrewarm,
   invalidateCache,
   prewarmTools,
   probeAndExtract,
@@ -735,6 +736,25 @@ export const mcpRegistryRouter = daemonFactory
       const cached = getCachedTools(id, server.configTemplate);
       if (cached) {
         return c.json({ ok: true as const, tools: cached });
+      }
+
+      // If a prewarm is already in flight (just-added server, cold install
+      // still downloading), wait for it instead of spawning a duplicate
+      // npx/uvx process. Race-cap the wait at 5s — if the cold install runs
+      // longer than that, tell the user to retry shortly rather than block
+      // for the prewarm's 60s budget.
+      const inFlight = getInFlightPrewarm(id);
+      if (inFlight) {
+        await Promise.race([inFlight, new Promise<void>((resolve) => setTimeout(resolve, 5000))]);
+        const afterWait = getCachedTools(id, server.configTemplate);
+        if (afterWait) {
+          return c.json({ ok: true as const, tools: afterWait });
+        }
+        return c.json({
+          ok: false as const,
+          error: "MCP server is still starting up. Retry in a few seconds.",
+          phase: "connect" as const,
+        });
       }
 
       try {

--- a/apps/atlasd/routes/mcp-registry.ts
+++ b/apps/atlasd/routes/mcp-registry.ts
@@ -29,6 +29,13 @@ import { RetryError } from "@std/async/retry";
 import { stepCountIs, streamText } from "ai";
 import { z } from "zod";
 import { daemonFactory } from "../src/factory.ts";
+import {
+  getCachedTools,
+  invalidateCache,
+  prewarmTools,
+  probeAndExtract,
+  putCachedTools,
+} from "./mcp-tool-cache.ts";
 
 const logger = createLogger({ name: "mcp-registry-routes" });
 
@@ -270,6 +277,7 @@ export const mcpRegistryRouter = daemonFactory
     // Atomic add - throws if entry already exists
     try {
       await adapter.add(entry);
+      prewarmTools(entry.id, entry.configTemplate, logger);
       return c.json({ server: entry }, 201);
     } catch {
       const suggested = `${entry.id}-${Date.now().toString(36).slice(-4)}`;
@@ -409,6 +417,7 @@ export const mcpRegistryRouter = daemonFactory
 
       // Persist the entry
       await adapter.add(entry);
+      prewarmTools(entry.id, entry.configTemplate, logger);
 
       let warning: string | undefined;
 
@@ -532,6 +541,7 @@ export const mcpRegistryRouter = daemonFactory
     };
 
     await adapter.add(entry);
+    prewarmTools(entry.id, entry.configTemplate, logger);
 
     let warning: string | undefined;
     if (linkProvider) {
@@ -658,6 +668,9 @@ export const mcpRegistryRouter = daemonFactory
           return c.json({ error: "Server was modified concurrently." }, 409);
         }
 
+        invalidateCache(updatedEntry.id);
+        prewarmTools(updatedEntry.id, updatedEntry.configTemplate, logger);
+
         return c.json({ server: updatedEntry });
       } catch (error) {
         logger.error("pull-update failed", { error, id });
@@ -691,6 +704,7 @@ export const mcpRegistryRouter = daemonFactory
       }
 
       await adapter.delete(id);
+      invalidateCache(id);
       return new Response(null, { status: 204 });
     },
   )
@@ -718,22 +732,14 @@ export const mcpRegistryRouter = daemonFactory
         return c.json({ error: "Server not found" }, 404);
       }
 
+      const cached = getCachedTools(id, server.configTemplate);
+      if (cached) {
+        return c.json({ ok: true as const, tools: cached });
+      }
+
       try {
-        const result = await createMCPTools({ [id]: server.configTemplate }, logger, {
-          signal: AbortSignal.timeout(5000),
-        });
-
-        const tools = Object.entries(result.tools).map(([name, tool]) => {
-          const t = tool as Record<string, unknown>;
-          const schema = t.inputSchema as Record<string, unknown> | undefined;
-          return {
-            name,
-            description: typeof t.description === "string" ? t.description : undefined,
-            inputSchema: (schema?.jsonSchema ?? null) as Record<string, unknown> | null,
-          };
-        });
-
-        await result.dispose();
+        const tools = await probeAndExtract(id, server.configTemplate, logger, 5000);
+        putCachedTools(id, server.configTemplate, tools);
         return c.json({ ok: true as const, tools });
       } catch (error) {
         const classified = classifyProbeError(error);

--- a/apps/atlasd/routes/mcp-registry.ts
+++ b/apps/atlasd/routes/mcp-registry.ts
@@ -624,6 +624,13 @@ export const mcpRegistryRouter = daemonFactory
       }
 
       await adapter.delete(id);
+      // Deliberate leak window: an in-flight prewarm started moments before
+      // this DELETE will eventually `putCachedTools` *after* this
+      // `invalidateCache(id)`, leaving a stale entry until TTL eviction or
+      // process restart. Re-add with the same config hits the stale entry
+      // (correct tools); re-add with different config sees configHash
+      // mismatch and re-probes. Not worth wiring an AbortController through
+      // prewarm.
       invalidateCache(id);
       return new Response(null, { status: 204 });
     },
@@ -662,7 +669,7 @@ export const mcpRegistryRouter = daemonFactory
       // npx/uvx process. Race-cap the wait at 5s — if the cold install runs
       // longer, return a retryable hint rather than block for the prewarm's
       // full 60s budget.
-      const inFlight = getInFlightPrewarm(id);
+      const inFlight = getInFlightPrewarm(id, server.configTemplate);
       if (inFlight) {
         const TIMED_OUT = Symbol("timeout");
         let timer: ReturnType<typeof setTimeout> | undefined;

--- a/apps/atlasd/routes/mcp-registry.ts
+++ b/apps/atlasd/routes/mcp-registry.ts
@@ -27,6 +27,7 @@ import {
   classifyProbeError,
   getCachedTools,
   getInFlightPrewarm,
+  getRaceCapMs,
   invalidateCache,
   prewarmTools,
   probeAndExtract,
@@ -666,7 +667,7 @@ export const mcpRegistryRouter = daemonFactory
         const TIMED_OUT = Symbol("timeout");
         let timer: ReturnType<typeof setTimeout> | undefined;
         const timed = new Promise<typeof TIMED_OUT>((resolve) => {
-          timer = setTimeout(() => resolve(TIMED_OUT), 5000);
+          timer = setTimeout(() => resolve(TIMED_OUT), getRaceCapMs());
         });
         const winner = await Promise.race([inFlight, timed]);
         if (timer) clearTimeout(timer);

--- a/apps/atlasd/routes/mcp-registry.ts
+++ b/apps/atlasd/routes/mcp-registry.ts
@@ -2,11 +2,6 @@ import process from "node:process";
 import type { LinkCredentialRef, MCPServerConfig } from "@atlas/agent-sdk";
 import { client, parseResult } from "@atlas/client/v2";
 import { buildBearerAuthConfig } from "@atlas/core/mcp-registry/auth-config";
-import {
-  LinkCredentialExpiredError,
-  LinkCredentialNotFoundError,
-  NoDefaultCredentialError,
-} from "@atlas/core/mcp-registry/credential-resolver";
 import { discoverMCPServers, type LinkSummary } from "@atlas/core/mcp-registry/discovery";
 import {
   getOfficialOverride,
@@ -25,11 +20,11 @@ import { MCPUpstreamClient } from "@atlas/core/mcp-registry/upstream-client";
 import { createLogger } from "@atlas/logger";
 import { createMCPTools } from "@atlas/mcp";
 import { zValidator } from "@hono/zod-validator";
-import { RetryError } from "@std/async/retry";
 import { stepCountIs, streamText } from "ai";
 import { z } from "zod";
 import { daemonFactory } from "../src/factory.ts";
 import {
+  classifyProbeError,
   getCachedTools,
   getInFlightPrewarm,
   invalidateCache,
@@ -49,83 +44,6 @@ function deriveId(name: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-|-$/g, "")
     .slice(0, 64);
-}
-
-/**
- * Classify an MCP tool probe error into a user-facing phase.
- */
-function classifyProbeError(error: unknown): {
-  error: string;
-  phase: "dns" | "connect" | "auth" | "tools";
-} {
-  // Unwrap RetryError so we classify the underlying failure, not the retry wrapper.
-  let inner = error;
-  if (error instanceof RetryError && error.cause) {
-    inner = error.cause;
-  }
-
-  if (
-    inner instanceof LinkCredentialNotFoundError ||
-    inner instanceof LinkCredentialExpiredError ||
-    inner instanceof NoDefaultCredentialError
-  ) {
-    return { error: error instanceof Error ? error.message : String(error), phase: "auth" };
-  }
-
-  if (
-    inner instanceof Error &&
-    inner.name === "MCPStartupError" &&
-    "kind" in inner &&
-    typeof inner.kind === "string"
-  ) {
-    const msg = inner.message + (inner.cause instanceof Error ? ` ${inner.cause.message}` : "");
-    if (isDnsPattern(msg)) {
-      return { error: inner.message, phase: "dns" };
-    }
-    return { error: inner.message, phase: "connect" };
-  }
-
-  if (inner instanceof Error) {
-    const msg = inner.message + (inner.cause instanceof Error ? ` ${inner.cause.message}` : "");
-    if (isDnsPattern(msg)) {
-      return { error: inner.message, phase: "dns" };
-    }
-    if (isConnectPattern(msg)) {
-      return { error: inner.message, phase: "connect" };
-    }
-    if (
-      msg.toLowerCase().includes("tool") &&
-      (msg.toLowerCase().includes("timeout") || msg.toLowerCase().includes("timed out"))
-    ) {
-      return { error: inner.message, phase: "tools" };
-    }
-    return { error: inner.message, phase: "connect" };
-  }
-
-  return { error: String(inner), phase: "connect" };
-}
-
-function isDnsPattern(msg: string): boolean {
-  const lower = msg.toLowerCase();
-  return (
-    lower.includes("enotfound") ||
-    lower.includes("getaddrinfo") ||
-    lower.includes("eai_again") ||
-    lower.includes("eai_nodata") ||
-    lower.includes("name or service not known")
-  );
-}
-
-function isConnectPattern(msg: string): boolean {
-  const lower = msg.toLowerCase();
-  return (
-    lower.includes("econnrefused") ||
-    lower.includes("econnreset") ||
-    lower.includes("etimedout") ||
-    lower.includes("connection refused") ||
-    lower.includes("connect etimedout") ||
-    lower.includes("network is unreachable")
-  );
 }
 
 /**
@@ -741,20 +659,37 @@ export const mcpRegistryRouter = daemonFactory
       // If a prewarm is already in flight (just-added server, cold install
       // still downloading), wait for it instead of spawning a duplicate
       // npx/uvx process. Race-cap the wait at 5s — if the cold install runs
-      // longer than that, tell the user to retry shortly rather than block
-      // for the prewarm's 60s budget.
+      // longer, return a retryable hint rather than block for the prewarm's
+      // full 60s budget.
       const inFlight = getInFlightPrewarm(id);
       if (inFlight) {
-        await Promise.race([inFlight, new Promise<void>((resolve) => setTimeout(resolve, 5000))]);
-        const afterWait = getCachedTools(id, server.configTemplate);
-        if (afterWait) {
-          return c.json({ ok: true as const, tools: afterWait });
-        }
-        return c.json({
-          ok: false as const,
-          error: "MCP server is still starting up. Retry in a few seconds.",
-          phase: "connect" as const,
+        const TIMED_OUT = Symbol("timeout");
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const timed = new Promise<typeof TIMED_OUT>((resolve) => {
+          timer = setTimeout(() => resolve(TIMED_OUT), 5000);
         });
+        const winner = await Promise.race([inFlight, timed]);
+        if (timer) clearTimeout(timer);
+
+        if (winner === TIMED_OUT) {
+          return c.json({
+            ok: false as const,
+            retryable: true as const,
+            error: "MCP server is still starting up. Retry in a few seconds.",
+          });
+        }
+        if (winner.ok) {
+          return c.json({ ok: true as const, tools: winner.tools });
+        }
+        // Prewarm finished with a classified error (DNS, auth, etc.) — surface
+        // it directly instead of forcing the user to retry into the foreground
+        // probe just to learn what went wrong.
+        logger.warn("MCP tool probe failed", {
+          serverId: id,
+          phase: winner.phase,
+          error: winner.error,
+        });
+        return c.json({ ok: false as const, error: winner.error, phase: winner.phase });
       }
 
       try {

--- a/apps/atlasd/routes/mcp-tool-cache.ts
+++ b/apps/atlasd/routes/mcp-tool-cache.ts
@@ -16,16 +16,20 @@ const PREWARM_TIMEOUT_MS = 60_000;
 const cache = new Map<string, Entry>();
 const inFlightPrewarm = new Map<string, Promise<void>>();
 
-function stableStringify(value: unknown): string {
-  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
-  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
-  const obj = value as Record<string, unknown>;
-  const keys = Object.keys(obj).sort();
-  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(",")}}`;
-}
-
 function hashConfig(config: MCPServerConfig): string {
-  return stableStringify(config);
+  // Native JSON.stringify drops `undefined` values inside objects, so two
+  // configs that differ only by an explicit-undefined vs missing key hash
+  // identically. The replacer makes object key ordering deterministic.
+  return JSON.stringify(config, (_key, val) => {
+    if (val && typeof val === "object" && !Array.isArray(val)) {
+      const sorted: Record<string, unknown> = {};
+      for (const k of Object.keys(val).sort()) {
+        sorted[k] = (val as Record<string, unknown>)[k];
+      }
+      return sorted;
+    }
+    return val;
+  });
 }
 
 export function getCachedTools(serverId: string, config: MCPServerConfig): CachedTool[] | null {
@@ -46,6 +50,10 @@ export function putCachedTools(
 
 export function invalidateCache(serverId: string): void {
   cache.delete(serverId);
+}
+
+export function getInFlightPrewarm(serverId: string): Promise<void> | undefined {
+  return inFlightPrewarm.get(serverId);
 }
 
 export function _resetCacheForTest(): void {

--- a/apps/atlasd/routes/mcp-tool-cache.ts
+++ b/apps/atlasd/routes/mcp-tool-cache.ts
@@ -1,0 +1,117 @@
+import type { MCPServerConfig } from "@atlas/agent-sdk";
+import type { Logger } from "@atlas/logger";
+import { createMCPTools } from "@atlas/mcp";
+
+export type CachedTool = {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown> | null;
+};
+
+type Entry = { configHash: string; tools: CachedTool[]; cachedAt: number };
+
+const CACHE_TTL_MS = 60 * 60 * 1000;
+const PREWARM_TIMEOUT_MS = 60_000;
+
+const cache = new Map<string, Entry>();
+const inFlightPrewarm = new Map<string, Promise<void>>();
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const obj = value as Record<string, unknown>;
+  const keys = Object.keys(obj).sort();
+  return `{${keys.map((k) => `${JSON.stringify(k)}:${stableStringify(obj[k])}`).join(",")}}`;
+}
+
+function hashConfig(config: MCPServerConfig): string {
+  return stableStringify(config);
+}
+
+export function getCachedTools(serverId: string, config: MCPServerConfig): CachedTool[] | null {
+  const entry = cache.get(serverId);
+  if (!entry) return null;
+  if (entry.configHash !== hashConfig(config)) return null;
+  if (Date.now() - entry.cachedAt > CACHE_TTL_MS) return null;
+  return entry.tools;
+}
+
+export function putCachedTools(
+  serverId: string,
+  config: MCPServerConfig,
+  tools: CachedTool[],
+): void {
+  cache.set(serverId, { configHash: hashConfig(config), tools, cachedAt: Date.now() });
+}
+
+export function invalidateCache(serverId: string): void {
+  cache.delete(serverId);
+}
+
+export function _resetCacheForTest(): void {
+  cache.clear();
+  inFlightPrewarm.clear();
+}
+
+export async function _flushPrewarmsForTest(): Promise<void> {
+  await Promise.allSettled(inFlightPrewarm.values());
+}
+
+export async function probeAndExtract(
+  serverId: string,
+  config: MCPServerConfig,
+  logger: Logger,
+  timeoutMs: number,
+): Promise<CachedTool[]> {
+  const result = await createMCPTools({ [serverId]: config }, logger, {
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  const tools: CachedTool[] = Object.entries(result.tools).map(([name, tool]) => {
+    const t = tool as Record<string, unknown>;
+    const schema = t.inputSchema as Record<string, unknown> | undefined;
+    return {
+      name,
+      description: typeof t.description === "string" ? t.description : undefined,
+      inputSchema: (schema?.jsonSchema ?? null) as Record<string, unknown> | null,
+    };
+  });
+  await result.dispose();
+  return tools;
+}
+
+/**
+ * Best-effort background probe. Caches the tool list on success so the next
+ * `GET /:id/tools` is instant. Failures are swallowed (logged at debug) — the
+ * foreground probe will surface a real error if the user clicks before the
+ * prewarm finishes. Generous timeout covers cold `npx`/`uvx` package downloads.
+ */
+export function prewarmTools(
+  serverId: string,
+  config: MCPServerConfig,
+  logger: Logger,
+): Promise<void> {
+  if (inFlightPrewarm.has(serverId)) {
+    return inFlightPrewarm.get(serverId)!;
+  }
+  if (getCachedTools(serverId, config)) {
+    return Promise.resolve();
+  }
+
+  const promise = (async () => {
+    try {
+      const tools = await probeAndExtract(serverId, config, logger, PREWARM_TIMEOUT_MS);
+      putCachedTools(serverId, config, tools);
+      logger.debug("MCP tools prewarmed", { serverId, toolCount: tools.length });
+    } catch (error) {
+      logger.debug("MCP tools prewarm failed", {
+        serverId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      inFlightPrewarm.delete(serverId);
+    }
+  })();
+
+  inFlightPrewarm.set(serverId, promise);
+  return promise;
+}

--- a/apps/atlasd/routes/mcp-tool-cache.ts
+++ b/apps/atlasd/routes/mcp-tool-cache.ts
@@ -14,6 +14,22 @@ export type CachedTool = {
   inputSchema: Record<string, unknown> | null;
 };
 
+/**
+ * Distinct from a generic connect failure: the server *appeared* to start
+ * (no thrown error, no `disconnected` entry) but exposed no tools. In
+ * practice this is `createMCPTools` silently dropping a server that hit a
+ * connect error / MCPStartupError / list-tools timeout — for the user the
+ * outcome is the same as a connect failure, but the dedicated type lets
+ * callers distinguish "we couldn't reach the server" from "the server is
+ * legitimately tool-less" if that ever matters.
+ */
+export class MCPProbeNoToolsError extends Error {
+  constructor(public readonly serverId: string) {
+    super(`MCP server "${serverId}" failed to start or expose tools`);
+    this.name = "MCPProbeNoToolsError";
+  }
+}
+
 export type ProbePhase = "dns" | "connect" | "auth" | "tools";
 
 export type PrewarmResult =
@@ -158,7 +174,7 @@ export async function probeAndExtract(
   // caching `[]` for an hour.
   if (Object.keys(result.tools).length === 0) {
     await result.dispose();
-    throw new Error(`MCP server "${serverId}" failed to start or expose tools`);
+    throw new MCPProbeNoToolsError(serverId);
   }
   const tools: CachedTool[] = Object.entries(result.tools).map(([name, tool]) => {
     const t = tool as Record<string, unknown>;
@@ -231,17 +247,11 @@ export function classifyProbeError(error: unknown): { error: string; phase: Prob
     inner = error.cause;
   }
 
-  // Match by `name` as well as `instanceof` — tests that drive the prewarm
-  // through a deferred mock can produce instances whose prototype chain
-  // disagrees with this module's class reference (vitest module-graph
-  // quirk). The constructors all set `name` to a stable string.
-  const credName =
-    inner instanceof Error &&
-    (inner.name === "LinkCredentialNotFoundError" ||
-      inner.name === "LinkCredentialExpiredError" ||
-      inner.name === "NoDefaultCredentialError");
+  if (inner instanceof MCPProbeNoToolsError) {
+    return { error: inner.message, phase: "connect" };
+  }
+
   if (
-    credName ||
     inner instanceof LinkCredentialNotFoundError ||
     inner instanceof LinkCredentialExpiredError ||
     inner instanceof NoDefaultCredentialError

--- a/apps/atlasd/routes/mcp-tool-cache.ts
+++ b/apps/atlasd/routes/mcp-tool-cache.ts
@@ -36,7 +36,14 @@ export function _setRaceCapForTest(ms: number): void {
 }
 
 const cache = new Map<string, Entry>();
-const inFlightPrewarm = new Map<string, Promise<PrewarmResult>>();
+
+// In-flight prewarms carry their configHash so that a mid-flight update
+// (which races a v1 prewarm against a fresh v2 prewarm) doesn't dedupe v2
+// onto the v1 promise — that would cache v1 tools under a v2 hash, leaving
+// a subsequent GET to fall through to the foreground 5s probe instead of
+// the prewarm fast-path.
+type InFlightPrewarm = { configHash: string; promise: Promise<PrewarmResult> };
+const inFlightPrewarm = new Map<string, InFlightPrewarm>();
 
 function hashConfig(config: MCPServerConfig): string {
   // We rely on JSON.stringify dropping `undefined` values inside objects so
@@ -59,7 +66,13 @@ export function getCachedTools(serverId: string, config: MCPServerConfig): Cache
   const entry = cache.get(serverId);
   if (!entry) return null;
   if (entry.configHash !== hashConfig(config)) return null;
-  if (Date.now() - entry.cachedAt > CACHE_TTL_MS) return null;
+  // Evict on read so expired entries don't accumulate over the daemon's
+  // lifetime. The map otherwise grows monotonically with stale entries
+  // (TTL is checked here but never followed by a delete).
+  if (Date.now() - entry.cachedAt > CACHE_TTL_MS) {
+    cache.delete(serverId);
+    return null;
+  }
   return entry.tools;
 }
 
@@ -75,8 +88,17 @@ export function invalidateCache(serverId: string): void {
   cache.delete(serverId);
 }
 
-export function getInFlightPrewarm(serverId: string): Promise<PrewarmResult> | undefined {
-  return inFlightPrewarm.get(serverId);
+export function getInFlightPrewarm(
+  serverId: string,
+  config: MCPServerConfig,
+): Promise<PrewarmResult> | undefined {
+  const inFlight = inFlightPrewarm.get(serverId);
+  // Only dedupe onto the in-flight prewarm if its configHash matches the
+  // requested config. A stale (e.g. v1) prewarm running while the caller
+  // wants v2 must not be returned — the caller would block on it and then
+  // see configHash mismatch on the cached result.
+  if (!inFlight || inFlight.configHash !== hashConfig(config)) return undefined;
+  return inFlight.promise;
 }
 
 // Callers must register prewarms synchronously after the preceding `await
@@ -89,7 +111,7 @@ export function _resetCacheForTest(): void {
 }
 
 export async function _flushPrewarmsForTest(): Promise<void> {
-  await Promise.allSettled(inFlightPrewarm.values());
+  await Promise.allSettled(Array.from(inFlightPrewarm.values()).map((v) => v.promise));
 }
 
 /**
@@ -154,13 +176,20 @@ export function prewarmTools(
   config: MCPServerConfig,
   logger: Logger,
 ): Promise<PrewarmResult> {
+  const newHash = hashConfig(config);
   const existing = inFlightPrewarm.get(serverId);
-  if (existing) return existing;
+  // Only dedupe onto an existing prewarm when configs match. If a v1 prewarm
+  // is still in flight when an update fires this with v2, start a fresh v2
+  // prewarm — the v1 promise keeps running and will write v1 tools to the
+  // cache (under v1 hash, harmless), but we need a v2 in-flight so a GET
+  // racing the update finds something to await on.
+  if (existing && existing.configHash === newHash) return existing.promise;
   const cached = getCachedTools(serverId, config);
   if (cached) {
     return Promise.resolve({ ok: true, tools: cached });
   }
 
+  let entry: InFlightPrewarm | undefined;
   const promise = (async (): Promise<PrewarmResult> => {
     try {
       const tools = await probeAndExtract(serverId, config, logger, PREWARM_TIMEOUT_MS);
@@ -172,11 +201,14 @@ export function prewarmTools(
       logger.debug("MCP tools prewarm failed", { serverId, ...classified });
       return { ok: false, error: classified.error, phase: classified.phase };
     } finally {
-      inFlightPrewarm.delete(serverId);
+      // Only clear our own slot — a racing v2 prewarm may have replaced us
+      // and we mustn't evict it.
+      if (inFlightPrewarm.get(serverId) === entry) inFlightPrewarm.delete(serverId);
     }
   })();
+  entry = { configHash: newHash, promise };
 
-  inFlightPrewarm.set(serverId, promise);
+  inFlightPrewarm.set(serverId, entry);
   return promise;
 }
 

--- a/apps/atlasd/routes/mcp-tool-cache.ts
+++ b/apps/atlasd/routes/mcp-tool-cache.ts
@@ -120,6 +120,16 @@ export async function probeAndExtract(
     err.message = entry.message;
     throw err;
   }
+  // createMCPTools also silently drops servers that fail to start (connect
+  // error, MCPStartupError, list-tools timeout) — they're warn-logged but
+  // don't appear in `disconnected`. For a single-server probe, an empty
+  // `tools` map with no `disconnected` entry means *this* probe failed
+  // silently. Throw so the classifier surfaces a real error rather than
+  // caching `[]` for an hour.
+  if (Object.keys(result.tools).length === 0) {
+    await result.dispose();
+    throw new Error(`MCP server "${serverId}" failed to start or expose tools`);
+  }
   const tools: CachedTool[] = Object.entries(result.tools).map(([name, tool]) => {
     const t = tool as Record<string, unknown>;
     const schema = t.inputSchema as Record<string, unknown> | undefined;

--- a/apps/atlasd/routes/mcp-tool-cache.ts
+++ b/apps/atlasd/routes/mcp-tool-cache.ts
@@ -42,7 +42,15 @@ const cache = new Map<string, Entry>();
 // onto the v1 promise — that would cache v1 tools under a v2 hash, leaving
 // a subsequent GET to fall through to the foreground 5s probe instead of
 // the prewarm fast-path.
-type InFlightPrewarm = { configHash: string; promise: Promise<PrewarmResult> };
+type InFlightPrewarm = {
+  configHash: string;
+  promise: Promise<PrewarmResult>;
+  // Unique marker the IIFE compares against in its `finally` so it only
+  // evicts the slot if it's still the registered entry. Avoids a forward
+  // reference to its own promise — TS doesn't track that the IIFE body is
+  // async-deferred and would flag `promise === promise` as use-before-assign.
+  marker: symbol;
+};
 const inFlightPrewarm = new Map<string, InFlightPrewarm>();
 
 function hashConfig(config: MCPServerConfig): string {
@@ -189,7 +197,7 @@ export function prewarmTools(
     return Promise.resolve({ ok: true, tools: cached });
   }
 
-  let entry: InFlightPrewarm | undefined;
+  const marker = Symbol();
   const promise = (async (): Promise<PrewarmResult> => {
     try {
       const tools = await probeAndExtract(serverId, config, logger, PREWARM_TIMEOUT_MS);
@@ -203,10 +211,10 @@ export function prewarmTools(
     } finally {
       // Only clear our own slot — a racing v2 prewarm may have replaced us
       // and we mustn't evict it.
-      if (inFlightPrewarm.get(serverId) === entry) inFlightPrewarm.delete(serverId);
+      if (inFlightPrewarm.get(serverId)?.marker === marker) inFlightPrewarm.delete(serverId);
     }
   })();
-  entry = { configHash: newHash, promise };
+  const entry: InFlightPrewarm = { configHash: newHash, promise, marker };
 
   inFlightPrewarm.set(serverId, entry);
   return promise;

--- a/apps/atlasd/routes/mcp-tool-cache.ts
+++ b/apps/atlasd/routes/mcp-tool-cache.ts
@@ -25,6 +25,16 @@ type Entry = { configHash: string; tools: CachedTool[]; cachedAt: number };
 const CACHE_TTL_MS = 60 * 60 * 1000;
 const PREWARM_TIMEOUT_MS = 60_000;
 
+// Time the GET handler waits on an in-flight prewarm before returning a
+// retryable hint. Module-level so tests can shorten it without faking timers.
+let raceCapMs = 5000;
+export function getRaceCapMs(): number {
+  return raceCapMs;
+}
+export function _setRaceCapForTest(ms: number): void {
+  raceCapMs = ms;
+}
+
 const cache = new Map<string, Entry>();
 const inFlightPrewarm = new Map<string, Promise<PrewarmResult>>();
 
@@ -75,6 +85,7 @@ export function getInFlightPrewarm(serverId: string): Promise<PrewarmResult> | u
 export function _resetCacheForTest(): void {
   cache.clear();
   inFlightPrewarm.clear();
+  raceCapMs = 5000;
 }
 
 export async function _flushPrewarmsForTest(): Promise<void> {
@@ -101,7 +112,13 @@ export async function probeAndExtract(
   if (result.disconnected.length > 0) {
     await result.dispose();
     const entry = result.disconnected[0]!;
-    throw new LinkCredentialNotFoundError(entry.serverId, entry.message);
+    // Throw a credential error so classifyProbeError routes this to phase:
+    // "auth". `entry.message` is already a complete user-facing sentence
+    // composed by buildDisconnectedEntry — preserve it verbatim instead of
+    // re-templating through the constructor.
+    const err = new LinkCredentialNotFoundError(entry.serverId);
+    err.message = entry.message;
+    throw err;
   }
   const tools: CachedTool[] = Object.entries(result.tools).map(([name, tool]) => {
     const t = tool as Record<string, unknown>;
@@ -164,7 +181,17 @@ export function classifyProbeError(error: unknown): { error: string; phase: Prob
     inner = error.cause;
   }
 
+  // Match by `name` as well as `instanceof` — tests that drive the prewarm
+  // through a deferred mock can produce instances whose prototype chain
+  // disagrees with this module's class reference (vitest module-graph
+  // quirk). The constructors all set `name` to a stable string.
+  const credName =
+    inner instanceof Error &&
+    (inner.name === "LinkCredentialNotFoundError" ||
+      inner.name === "LinkCredentialExpiredError" ||
+      inner.name === "NoDefaultCredentialError");
   if (
+    credName ||
     inner instanceof LinkCredentialNotFoundError ||
     inner instanceof LinkCredentialExpiredError ||
     inner instanceof NoDefaultCredentialError

--- a/apps/atlasd/routes/mcp-tool-cache.ts
+++ b/apps/atlasd/routes/mcp-tool-cache.ts
@@ -1,6 +1,12 @@
 import type { MCPServerConfig } from "@atlas/agent-sdk";
+import {
+  LinkCredentialExpiredError,
+  LinkCredentialNotFoundError,
+  NoDefaultCredentialError,
+} from "@atlas/core/mcp-registry/credential-resolver";
 import type { Logger } from "@atlas/logger";
 import { createMCPTools } from "@atlas/mcp";
+import { RetryError } from "@std/async/retry";
 
 export type CachedTool = {
   name: string;
@@ -8,18 +14,25 @@ export type CachedTool = {
   inputSchema: Record<string, unknown> | null;
 };
 
+export type ProbePhase = "dns" | "connect" | "auth" | "tools";
+
+export type PrewarmResult =
+  | { ok: true; tools: CachedTool[] }
+  | { ok: false; error: string; phase: ProbePhase };
+
 type Entry = { configHash: string; tools: CachedTool[]; cachedAt: number };
 
 const CACHE_TTL_MS = 60 * 60 * 1000;
 const PREWARM_TIMEOUT_MS = 60_000;
 
 const cache = new Map<string, Entry>();
-const inFlightPrewarm = new Map<string, Promise<void>>();
+const inFlightPrewarm = new Map<string, Promise<PrewarmResult>>();
 
 function hashConfig(config: MCPServerConfig): string {
-  // Native JSON.stringify drops `undefined` values inside objects, so two
-  // configs that differ only by an explicit-undefined vs missing key hash
-  // identically. The replacer makes object key ordering deterministic.
+  // We rely on JSON.stringify dropping `undefined` values inside objects so
+  // that `{env: undefined}` and `{}` hash identically — structurally
+  // equivalent configs from different code paths must produce the same hash.
+  // The replacer makes object key ordering deterministic.
   return JSON.stringify(config, (_key, val) => {
     if (val && typeof val === "object" && !Array.isArray(val)) {
       const sorted: Record<string, unknown> = {};
@@ -52,10 +65,13 @@ export function invalidateCache(serverId: string): void {
   cache.delete(serverId);
 }
 
-export function getInFlightPrewarm(serverId: string): Promise<void> | undefined {
+export function getInFlightPrewarm(serverId: string): Promise<PrewarmResult> | undefined {
   return inFlightPrewarm.get(serverId);
 }
 
+// Callers must register prewarms synchronously after the preceding `await
+// adapter.add` (or equivalent) — this helper does not poll for late
+// registrations.
 export function _resetCacheForTest(): void {
   cache.clear();
   inFlightPrewarm.clear();
@@ -65,6 +81,11 @@ export async function _flushPrewarmsForTest(): Promise<void> {
   await Promise.allSettled(inFlightPrewarm.values());
 }
 
+/**
+ * Probe an MCP server and extract its tool list. Throws on failure (including
+ * credential-disconnected servers — those get surfaced as auth errors via
+ * the classifier rather than caching an empty tool list).
+ */
 export async function probeAndExtract(
   serverId: string,
   config: MCPServerConfig,
@@ -74,6 +95,14 @@ export async function probeAndExtract(
   const result = await createMCPTools({ [serverId]: config }, logger, {
     signal: AbortSignal.timeout(timeoutMs),
   });
+  // createMCPTools does not throw on missing/expired credentials — it routes
+  // the server into `disconnected` with an empty tools map. For a single-
+  // server probe, any disconnected entry means *this* probe failed.
+  if (result.disconnected.length > 0) {
+    await result.dispose();
+    const entry = result.disconnected[0]!;
+    throw new LinkCredentialNotFoundError(entry.serverId, entry.message);
+  }
   const tools: CachedTool[] = Object.entries(result.tools).map(([name, tool]) => {
     const t = tool as Record<string, unknown>;
     const schema = t.inputSchema as Record<string, unknown> | undefined;
@@ -88,33 +117,33 @@ export async function probeAndExtract(
 }
 
 /**
- * Best-effort background probe. Caches the tool list on success so the next
- * `GET /:id/tools` is instant. Failures are swallowed (logged at debug) — the
- * foreground probe will surface a real error if the user clicks before the
- * prewarm finishes. Generous timeout covers cold `npx`/`uvx` package downloads.
+ * Background probe with a generous 60s timeout for cold `npx`/`uvx` installs.
+ * Returns a structured result so the GET handler can surface the real error
+ * (DNS, auth, MCPStartupError) when a user clicks before the prewarm
+ * finishes — instead of a misleading "still starting up" hint.
  */
 export function prewarmTools(
   serverId: string,
   config: MCPServerConfig,
   logger: Logger,
-): Promise<void> {
-  if (inFlightPrewarm.has(serverId)) {
-    return inFlightPrewarm.get(serverId)!;
-  }
-  if (getCachedTools(serverId, config)) {
-    return Promise.resolve();
+): Promise<PrewarmResult> {
+  const existing = inFlightPrewarm.get(serverId);
+  if (existing) return existing;
+  const cached = getCachedTools(serverId, config);
+  if (cached) {
+    return Promise.resolve({ ok: true, tools: cached });
   }
 
-  const promise = (async () => {
+  const promise = (async (): Promise<PrewarmResult> => {
     try {
       const tools = await probeAndExtract(serverId, config, logger, PREWARM_TIMEOUT_MS);
       putCachedTools(serverId, config, tools);
       logger.debug("MCP tools prewarmed", { serverId, toolCount: tools.length });
+      return { ok: true, tools };
     } catch (error) {
-      logger.debug("MCP tools prewarm failed", {
-        serverId,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      const classified = classifyProbeError(error);
+      logger.debug("MCP tools prewarm failed", { serverId, ...classified });
+      return { ok: false, error: classified.error, phase: classified.phase };
     } finally {
       inFlightPrewarm.delete(serverId);
     }
@@ -122,4 +151,79 @@ export function prewarmTools(
 
   inFlightPrewarm.set(serverId, promise);
   return promise;
+}
+
+/**
+ * Classify an MCP tool probe error into a user-facing phase. Shared with the
+ * foreground probe path in `mcp-registry.ts`.
+ */
+export function classifyProbeError(error: unknown): { error: string; phase: ProbePhase } {
+  // Unwrap RetryError so we classify the underlying failure, not the retry wrapper.
+  let inner = error;
+  if (error instanceof RetryError && error.cause) {
+    inner = error.cause;
+  }
+
+  if (
+    inner instanceof LinkCredentialNotFoundError ||
+    inner instanceof LinkCredentialExpiredError ||
+    inner instanceof NoDefaultCredentialError
+  ) {
+    return { error: error instanceof Error ? error.message : String(error), phase: "auth" };
+  }
+
+  if (
+    inner instanceof Error &&
+    inner.name === "MCPStartupError" &&
+    "kind" in inner &&
+    typeof inner.kind === "string"
+  ) {
+    const msg = inner.message + (inner.cause instanceof Error ? ` ${inner.cause.message}` : "");
+    if (isDnsPattern(msg)) {
+      return { error: inner.message, phase: "dns" };
+    }
+    return { error: inner.message, phase: "connect" };
+  }
+
+  if (inner instanceof Error) {
+    const msg = inner.message + (inner.cause instanceof Error ? ` ${inner.cause.message}` : "");
+    if (isDnsPattern(msg)) {
+      return { error: inner.message, phase: "dns" };
+    }
+    if (isConnectPattern(msg)) {
+      return { error: inner.message, phase: "connect" };
+    }
+    if (
+      msg.toLowerCase().includes("tool") &&
+      (msg.toLowerCase().includes("timeout") || msg.toLowerCase().includes("timed out"))
+    ) {
+      return { error: inner.message, phase: "tools" };
+    }
+    return { error: inner.message, phase: "connect" };
+  }
+
+  return { error: String(inner), phase: "connect" };
+}
+
+function isDnsPattern(msg: string): boolean {
+  const lower = msg.toLowerCase();
+  return (
+    lower.includes("enotfound") ||
+    lower.includes("getaddrinfo") ||
+    lower.includes("eai_again") ||
+    lower.includes("eai_nodata") ||
+    lower.includes("name or service not known")
+  );
+}
+
+function isConnectPattern(msg: string): boolean {
+  const lower = msg.toLowerCase();
+  return (
+    lower.includes("econnrefused") ||
+    lower.includes("econnreset") ||
+    lower.includes("etimedout") ||
+    lower.includes("connection refused") ||
+    lower.includes("connect etimedout") ||
+    lower.includes("network is unreachable")
+  );
 }

--- a/tools/agent-playground/src/lib/components/mcp/mcp-connection-test.svelte
+++ b/tools/agent-playground/src/lib/components/mcp/mcp-connection-test.svelte
@@ -23,7 +23,7 @@
     enabled: shouldTest,
   }));
 
-  function phaseLabel(phase: string): string {
+  function phaseLabel(phase: string | undefined): string {
     switch (phase) {
       case "dns":
         return "DNS resolution failed";
@@ -34,11 +34,11 @@
       case "tools":
         return "Tool discovery timed out";
       default:
-        return phase;
+        return "Still starting up";
     }
   }
 
-  function phaseColor(phase: string): string {
+  function phaseColor(phase: string | undefined): string {
     switch (phase) {
       case "dns":
         return "var(--color-warning)";
@@ -49,7 +49,7 @@
       case "tools":
         return "var(--color-info)";
       default:
-        return "var(--color-text)";
+        return "var(--color-info)";
     }
   }
 

--- a/tools/agent-playground/src/lib/queries/mcp-queries.ts
+++ b/tools/agent-playground/src/lib/queries/mcp-queries.ts
@@ -52,7 +52,12 @@ const ToolsProbeSuccessSchema = z.object({
 const ToolsProbeFailureSchema = z.object({
   ok: z.literal(false),
   error: z.string(),
-  phase: z.enum(["dns", "connect", "auth", "tools"]),
+  // `phase` is set on terminal probe failures (DNS, connect, auth, tools).
+  // `retryable: true` is set when the server is still warming up (cold
+  // npx/uvx install in progress) — the next click will most likely succeed.
+  // Exactly one of the two is set on a given failure response.
+  phase: z.enum(["dns", "connect", "auth", "tools"]).optional(),
+  retryable: z.boolean().optional(),
 });
 
 const ToolsProbeResponseSchema = z.union([ToolsProbeSuccessSchema, ToolsProbeFailureSchema]);


### PR DESCRIPTION
## Summary

When a user adds a custom MCP server backed by `npx`/`uvx` and clicks "list tools" right after, the first probe times out for ~5s before the next click succeeds. Logs show the cause:

```
07:27:39.559  MCP stdio connection attempt for "reddit-mcp"
07:27:45.446  MCP stdio connected (5887ms — npx had to download the package)
07:27:45.447  MCP tool probe failed — aborted due to timeout
07:27:58.295  retry → connected in 541ms (npm cache warm) → 16 tools
```

The probe has a hardcoded 5s `AbortSignal.timeout`, just below the cold-install duration. Bumping the timeout would "fix" it but trades a brief wrong error for a long wrong wait. Two better levers:

- **Cache** the tool list, keyed by `serverId` + stable hash of `configTemplate` (1h TTL, success-only). Most repeat clicks become instant cache hits. Invalidated on update / delete.
- **Prewarm** in the background after add / install / custom-add / update with a generous 60s timeout so the npm download finishes before the user clicks.

The PR went through four review rounds that addressed: foreground/prewarm dedup (no duplicate `npx` spawn), credential-disconnect handling (don't cache `[]`), classified prewarm failures (no misleading "still starting up"), retryable response shape, and a regression caught at QA where `createMCPTools` silently drops servers that fail to start (typo'd npm package, MCPStartupError) — those now surface as a real connect-phase error instead of an empty tool list.

## QA — end-to-end verification

Tested against a live dev daemon + playground in Chrome. All four cases verified via the UI's Connection Test panel.

| Scenario | Setup | Expected | Result |
|---|---|---|---|
| **Cache hit on second click** | Add `reddit-mcp` (npx package), wait for prewarm, click "Test Connection" twice | 2nd click instant from cache, no daemon log | ✅ 2nd GET **1ms** (HTTP 200, 16 tools) |
| **Dedup during cold install** | Add `@modelcontextprotocol/server-everything` (uncached), click "Test Connection" immediately while prewarm is still cold-installing | GET awaits in-flight prewarm, no duplicate `npx` spawned | ✅ Cold install 3812ms; GET completes at the same instant (3797ms), single subprocess; subsequent GET 1ms cache hit |
| **Credential disconnect (auth)** | Add MCP with `envVars: [{key: "REDDIT_CLIENT_ID"}]`, no credential connected, click "Test Connection" | UI shows "Authentication failed" with verbatim Link error | ✅ "Authentication failed: No default credential set for cred-test-mcp. Go to Settings > Connections to pick one." (no nested templating) |
| **Typo'd command (connect)** | Add MCP with `args: ["-y", "@nonexistent-org-12345/no-such-mcp-package"]`, click "Test Connection" | UI shows "Connection failed" with real error, not empty tool list | ✅ After fix in `88aca050` — "Connection failed: MCP server 'typo-mcp' failed to start or expose tools" |

### Bug QA caught (and fixed in this PR)

The unit tests mocked `createMCPTools` directly with `{tools: {x: ...}, disconnected: []}`. But the real failure mode for connection errors is `{tools: {}, disconnected: []}` — the server is silently *dropped*, not pushed to `disconnected`. `probeAndExtract` was caching that as `{ok: true, tools: []}` for an hour. The fix in `88aca050` adds an empty-tools guard after the disconnected check; classifier maps the generic Error to `phase: "connect"`. Regression test included.

## Test plan

- [x] `deno task test apps/atlasd/routes/mcp-registry.test.ts` — **80/80 pass** (10 new + 70 pre-existing)
- [x] `deno task typecheck` — 0 errors across 8228 files
- [x] E2E QA via Chrome browser automation against live dev stack (4 scenarios above)