### PR TITLE
fix(workspace,mcp): apply registry platformEnv on FSM path; evict subprocess on spec drift

### DIFF
--- a/packages/mcp/src/process-registry.test.ts
+++ b/packages/mcp/src/process-registry.test.ts
@@ -258,6 +258,180 @@ describe("ProcessRegistry.acquire", () => {
   });
 });
 
+describe("ProcessRegistry.acquire spec eviction", () => {
+  it("env change for same serverId evicts the old child and respawns with new spec", async () => {
+    const oldChild = createMockChildProcess(1);
+    const newChild = createMockChildProcess(2);
+    const spawn = vi
+      .fn()
+      .mockImplementationOnce(() => oldChild)
+      .mockImplementationOnce(() => newChild);
+    const fetchImpl = vi.fn().mockResolvedValue({ status: 200, ok: true } as Response);
+    const deps: ProcessRegistryDeps = { spawn, fetch: fetchImpl, pidFile: noopPidFile() };
+
+    // First acquire — old spec missing the registry's platformEnv, e.g. spawned
+    // by the buggy raw-config FSM path before the fix.
+    const a = await sharedMCPProcesses.acquire("gmail", makeSpec(), deps, fakeLogger);
+    expect(a.child).toBe(oldChild);
+
+    // Second acquire — same serverId, env now includes platformEnv vars.
+    const newSpec = makeSpec({
+      env: {
+        WORKSPACE_MCP_PORT: "8001",
+        MCP_ENABLE_OAUTH21: "true",
+        EXTERNAL_OAUTH21_PROVIDER: "true",
+      },
+    });
+    const b = await sharedMCPProcesses.acquire("gmail", newSpec, deps, fakeLogger);
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(oldChild.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(b.child).toBe(newChild);
+  });
+
+  it("command change for same serverId evicts and respawns", async () => {
+    const oldChild = createMockChildProcess(1);
+    const newChild = createMockChildProcess(2);
+    const spawn = vi
+      .fn()
+      .mockImplementationOnce(() => oldChild)
+      .mockImplementationOnce(() => newChild);
+    const fetchImpl = vi.fn().mockResolvedValue({ status: 200, ok: true } as Response);
+    const deps: ProcessRegistryDeps = { spawn, fetch: fetchImpl, pidFile: noopPidFile() };
+
+    await sharedMCPProcesses.acquire("calendar", makeSpec({ command: "uvx" }), deps, fakeLogger);
+    const b = await sharedMCPProcesses.acquire(
+      "calendar",
+      makeSpec({ command: "/opt/homebrew/bin/uvx" }),
+      deps,
+      fakeLogger,
+    );
+
+    expect(spawn).toHaveBeenCalledTimes(2);
+    expect(oldChild.kill).toHaveBeenCalledWith("SIGTERM");
+    expect(b.child).toBe(newChild);
+  });
+
+  it("matching env+command+args reuses cached child even when poll timeouts differ", async () => {
+    // readyTimeoutMs / readyIntervalMs don't change subprocess behavior — only
+    // how long the registry waits for the child to come up. They must not
+    // count toward spec equality, otherwise every caller passing different
+    // timeout overrides would needlessly thrash the subprocess.
+    const child = createMockChildProcess();
+    const spawn = vi.fn().mockReturnValue(child);
+    const fetchImpl = vi.fn().mockResolvedValue({ status: 200, ok: true } as Response);
+    const deps: ProcessRegistryDeps = { spawn, fetch: fetchImpl, pidFile: noopPidFile() };
+
+    await sharedMCPProcesses.acquire(
+      "calendar",
+      makeSpec({ readyTimeoutMs: 500, readyIntervalMs: 25 }),
+      deps,
+      fakeLogger,
+    );
+    const b = await sharedMCPProcesses.acquire(
+      "calendar",
+      makeSpec({ readyTimeoutMs: 30000, readyIntervalMs: 500 }),
+      deps,
+      fakeLogger,
+    );
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(b.child).toBe(child);
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("env-key reordering does not cause a false eviction", async () => {
+    const child = createMockChildProcess();
+    const spawn = vi.fn().mockReturnValue(child);
+    const fetchImpl = vi.fn().mockResolvedValue({ status: 200, ok: true } as Response);
+    const deps: ProcessRegistryDeps = { spawn, fetch: fetchImpl, pidFile: noopPidFile() };
+
+    await sharedMCPProcesses.acquire(
+      "calendar",
+      makeSpec({ env: { A: "1", B: "2", C: "3" } }),
+      deps,
+      fakeLogger,
+    );
+    await sharedMCPProcesses.acquire(
+      "calendar",
+      makeSpec({ env: { C: "3", A: "1", B: "2" } }),
+      deps,
+      fakeLogger,
+    );
+
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("eviction SIGKILLs survivors that ignore SIGTERM, then respawns", async () => {
+    const stubbornChild = createMockChildProcess(1);
+    // Simulate a child that ignores SIGTERM but obeys SIGKILL.
+    (stubbornChild.kill as ReturnType<typeof vi.fn>).mockImplementation((sig: NodeJS.Signals) => {
+      if (sig === "SIGKILL") {
+        (stubbornChild as MockChildProcess)._emitExit(null, sig);
+      }
+      // SIGTERM ignored.
+      return true;
+    });
+    const newChild = createMockChildProcess(2);
+
+    const spawn = vi
+      .fn()
+      .mockImplementationOnce(() => stubbornChild)
+      .mockImplementationOnce(() => newChild);
+    const fetchImpl = vi.fn().mockResolvedValue({ status: 200, ok: true } as Response);
+    const deps: ProcessRegistryDeps = { spawn, fetch: fetchImpl, pidFile: noopPidFile() };
+
+    await sharedMCPProcesses.acquire("calendar", makeSpec(), deps, fakeLogger);
+
+    // Trigger eviction by changing env. Run under fake timers so the 2s
+    // SIGTERM grace window doesn't real-wait.
+    vi.useFakeTimers();
+    const acquirePromise = sharedMCPProcesses.acquire(
+      "calendar",
+      makeSpec({ env: { WORKSPACE_MCP_PORT: "8001", FOO: "bar" } }),
+      deps,
+      fakeLogger,
+    );
+    await vi.advanceTimersByTimeAsync(2100);
+    const b = await acquirePromise;
+    vi.useRealTimers();
+
+    const calls = (stubbornChild.kill as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]);
+    expect(calls).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(b.child).toBe(newChild);
+  });
+
+  it("eviction removes the old child's pid file before respawning", async () => {
+    const oldChild = createMockChildProcess(11);
+    const newChild = createMockChildProcess(22);
+    const spawn = vi
+      .fn()
+      .mockImplementationOnce(() => oldChild)
+      .mockImplementationOnce(() => newChild);
+    const fetchImpl = vi.fn().mockResolvedValue({ status: 200, ok: true } as Response);
+    const pidFile = noopPidFile();
+
+    await sharedMCPProcesses.acquire(
+      "calendar",
+      makeSpec(),
+      { spawn, fetch: fetchImpl, pidFile },
+      fakeLogger,
+    );
+    await sharedMCPProcesses.acquire(
+      "calendar",
+      makeSpec({ env: { WORKSPACE_MCP_PORT: "8001", FOO: "bar" } }),
+      { spawn, fetch: fetchImpl, pidFile },
+      fakeLogger,
+    );
+
+    expect(pidFile.remove).toHaveBeenCalledWith("calendar");
+    // Both pid writes happened — old child's then the new one's.
+    const writtenPids = (pidFile.write as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[1]);
+    expect(writtenPids).toEqual([11, 22]);
+  });
+});
+
 describe("ProcessRegistry.shutdown", () => {
   it("SIGTERMs all registered children", async () => {
     const calChild = createMockChildProcess(1);

--- a/packages/mcp/src/process-registry.ts
+++ b/packages/mcp/src/process-registry.ts
@@ -121,10 +121,32 @@ function defaultPidFileWriter(logger: Logger): PidFileWriter {
 
 interface InternalEntry {
   readonly promise: Promise<SharedProcessHandle>;
+  /** Stable hash of the spec that spawned this child. Used to detect when
+   * a subsequent `acquire` call passes a different env (e.g. registry
+   * `platformEnv` flipped on after a code path was fixed) so the old child
+   * can be evicted instead of silently serving a stale config. */
+  readonly specHash: string;
   /** Set once the spawn promise resolves. Used by `shutdown` to SIGTERM. */
   child?: ChildProcess;
   /** Set once the spawn promise resolves. Used by `shutdown` to clean up pid files. */
   pidFile?: PidFileWriter;
+}
+
+/** Stable JSON serialization for spec-hash equality. Sorts keys recursively. */
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>).sort(([a], [b]) =>
+    a < b ? -1 : a > b ? 1 : 0,
+  );
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`).join(",")}}`;
+}
+
+/** Hash the subset of spec that affects subprocess behavior. Ready-URL polling
+ * timeouts are excluded — they don't change what the child does, only how
+ * long we wait for it. */
+function hashSpec(spec: SharedProcessSpec): string {
+  return stableStringify({ command: spec.command, args: spec.args, env: spec.env });
 }
 
 /**
@@ -152,35 +174,51 @@ class ProcessRegistry {
    * On spawn failure or early exit, the cache entry is removed so a retry
    * can spawn fresh.
    */
-  acquire(
+  async acquire(
     serverId: string,
     spec: SharedProcessSpec,
     deps: ProcessRegistryDeps,
     logger: Logger,
   ): Promise<SharedProcessHandle> {
     if (this.disposed) {
-      return Promise.reject(
-        new MCPStartupError(
-          "spawn",
-          serverId,
-          spec.command,
-          new Error("process registry has been shut down"),
-        ),
+      throw new MCPStartupError(
+        "spawn",
+        serverId,
+        spec.command,
+        new Error("process registry has been shut down"),
       );
     }
 
+    const specHash = hashSpec(spec);
     const cached = this.entries.get(serverId);
     if (cached) {
-      logger.debug(`MCP shared process: reusing existing child for "${serverId}"`, {
-        operation: "mcp_shared_process_reuse",
+      if (cached.specHash === specHash) {
+        logger.debug(`MCP shared process: reusing existing child for "${serverId}"`, {
+          operation: "mcp_shared_process_reuse",
+          serverId,
+        });
+        return cached.promise;
+      }
+      // Spec drift — caller passed a different env/command than the cached
+      // child was spawned with. Common cause: a bug-fixed code path now
+      // applies registry `platformEnv` while the cached child was spawned
+      // before the fix. Tear down the stale child and respawn with the
+      // current spec. We MUST await full exit before falling through:
+      // workspace-mcp servers bind fixed ports (8001-8005), and a new
+      // spawn racing the old one through TIME_WAIT is the exact failure
+      // this registry was built to avoid (see file header).
+      logger.warn(`MCP shared process: spec mismatch, evicting child for "${serverId}"`, {
+        operation: "mcp_shared_process_evict",
         serverId,
+        reason: "spec_hash_changed",
       });
-      return cached.promise;
+      await this.evictEntry(serverId, cached, logger);
     }
 
     const pidFile = deps.pidFile ?? defaultPidFileWriter(logger);
 
     const entry: InternalEntry = {
+      specHash,
       promise: this.spawnAndWaitReady(serverId, spec, deps, logger).then(async (handle) => {
         entry.child = handle.child;
         entry.pidFile = pidFile;
@@ -211,6 +249,57 @@ class ProcessRegistry {
     });
 
     return entry.promise;
+  }
+
+  /**
+   * Stop a single entry's child and remove it from the cache. Awaits full
+   * exit so callers can spawn a replacement without racing TIME_WAIT on
+   * the child's bound port. Mirrors the SIGTERM-then-SIGKILL grace window
+   * used by `shutdown`.
+   */
+  private async evictEntry(serverId: string, entry: InternalEntry, logger: Logger): Promise<void> {
+    if (this.entries.get(serverId) === entry) {
+      this.entries.delete(serverId);
+    }
+
+    // The entry may still be spawning. Settle it first so we have a child
+    // handle (or a known failure) before we try to terminate it.
+    let child: ChildProcess | undefined;
+    try {
+      const handle = await entry.promise;
+      child = handle.child;
+    } catch {
+      child = entry.child;
+    }
+
+    if (child && child.exitCode === null && child.signalCode === null) {
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // Already dead — fall through.
+      }
+      await Promise.race([
+        waitForExit(child),
+        new Promise<void>((resolve) => setTimeout(resolve, 2000)),
+      ]);
+      if (child.exitCode === null && child.signalCode === null) {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // Already dead.
+        }
+        await waitForExit(child);
+      }
+    }
+
+    if (entry.pidFile) {
+      await entry.pidFile.remove(serverId).catch(() => {});
+    }
+
+    logger.info(`MCP shared process: evicted child for "${serverId}"`, {
+      operation: "mcp_shared_process_evicted",
+      serverId,
+    });
   }
 
   /**

--- a/packages/workspace/src/runtime.ts
+++ b/packages/workspace/src/runtime.ts
@@ -847,7 +847,20 @@ export class WorkspaceRuntime {
     const agentExecutor: AgentExecutor = (action, context, signal, options) =>
       this.executeAgent(action, context, job, signal, options);
 
-    const mcpServerConfigs = this.config.workspace.tools?.mcp?.servers || {};
+    // Apply registry-owned platformEnv (MCP_ENABLE_OAUTH21, dummy
+    // GOOGLE_OAUTH_CLIENT_ID/SECRET, stateless mode) before handing configs
+    // to the FSM engine. Without this, cron-triggered LLM actions spawn
+    // workspace-mcp in native-OAuth mode and reject every bearer-authed
+    // request — see registry-consolidated.ts:101-130 for the failure mode.
+    // Same idiom as line 1869-1872 in executeCodeAgent.
+    const rawMcpServers = this.config.workspace.tools?.mcp?.servers || {};
+    const mcpServerConfigs: Record<string, MCPServerConfig> = {};
+    for (const [id, config] of Object.entries(rawMcpServers)) {
+      const registryEntry = mcpServersRegistry.servers[id];
+      mcpServerConfigs[id] = registryEntry?.platformEnv
+        ? applyPlatformEnv(config, registryEntry.platformEnv)
+        : config;
+    }
 
     const scope = { workspaceId: this.workspace.id, workspaceName: this.workspace.name, sessionId };
     const platformModels = this.options.platformModels;


### PR DESCRIPTION
## Summary

- The FSM-engine path through `runtime.ts` handed raw workspace MCP server configs to the engine without applying registry-owned `platformEnv`. Cron-triggered LLM actions ended up spawning workspace-mcp without `MCP_ENABLE_OAUTH21=true` (and the dummy client_id/secret + stateless-mode vars), so workspace-mcp ran in native-OAuth mode and rejected every bearer-authed request. Chat (which goes through `discoverMCPServers` → `applyPlatformEnv`) was unaffected, hence the asymmetry. Fix mirrors the `applyPlatformEnv` idiom already in `executeCodeAgent`.
- `sharedMCPProcesses.acquire` was first-spawner-wins: whichever caller spawned a `serverId` first locked their `spec.env` for the daemon's lifetime. So even after fixing the runtime path, a previously cached subprocess from the buggy code path would keep serving stale config until daemon restart. Added a stable hash of `{command, args, env}` on the cached entry; on spec mismatch, gracefully evict (SIGTERM, 2s grace, SIGKILL fallback, await full exit) before respawning. The await is mandatory — workspace-mcp servers bind fixed ports and a racing respawn through TIME_WAIT is the failure this registry was built to avoid.

## Test plan

- [x] `deno task typecheck` — 0 errors
- [x] `npx knip` — 0 findings
- [x] `vitest run packages/mcp/src/process-registry.test.ts` — 24 passing (18 prior + 6 new)
- [x] `vitest run packages/mcp/src/create-mcp-tools-startup.test.ts` — 7 passing
- [x] Runtime QA: triggered cron-style signal end-to-end; verified spawned workspace-mcp subprocess has full `platformEnv`; second trigger reused cached subprocess (hash match path); both sessions completed cleanly.

New unit cases cover env change → eviction, command change → eviction, irrelevant `readyTimeoutMs`/`readyIntervalMs` differences → reuse, env-key reordering → reuse (stable JSON sort), SIGTERM-ignoring child → SIGKILL fallback within grace window, pid-file lifecycle across eviction.