### PR TITLE
fix(fsm-engine): interpolate {{inputs.x}} in agent action prompts

### DIFF
--- a/packages/fsm-engine/fsm-engine.ts
+++ b/packages/fsm-engine/fsm-engine.ts
@@ -102,8 +102,12 @@ type PrepareResult = z.infer<typeof PrepareResultSchema>;
  *
  * A Liquid-style `| default: 'fallback'` filter is supported on the placeholder
  * itself (`{{inputs.style | default: 'classic'}}`); it kicks in when the path
- * resolves to undefined/null so optional fields don't have to be set on every
- * invocation. Both single- and double-quoted fallback literals are accepted.
+ * resolves to undefined, null, or empty string, matching Liquid's default
+ * semantics. UI forms commonly submit "" for unfilled optional fields, and
+ * substituting an empty string instead of the fallback would make the filter
+ * useless for its primary use case. Both single- and double-quoted fallback
+ * literals are accepted. Numbers/booleans (including 0/false) are not treated
+ * as missing — those are legitimate values, not absence.
  *
  * Uses only properties already exposed via `PrepareResult` (`task`, `config`,
  * `artifactRefs`); does not reach into ambient FSM state, so there's no way
@@ -136,7 +140,11 @@ export function interpolatePromptPlaceholders(
       cursor = (cursor as Record<string, unknown>)[segment];
     }
     if (cursor === undefined || cursor === null) return fallback ?? original;
-    if (typeof cursor === "string") return cursor;
+    // Empty strings are treated as missing for the `default:` filter (Liquid
+    // convention). Without this, an explicit `default: 'classic'` would do
+    // nothing for the very case authors reach for it — a form field that
+    // arrives as "" rather than absent.
+    if (typeof cursor === "string") return cursor === "" ? (fallback ?? cursor) : cursor;
     if (typeof cursor === "number" || typeof cursor === "boolean") return String(cursor);
     return JSON.stringify(cursor);
   });

--- a/packages/fsm-engine/fsm-engine.ts
+++ b/packages/fsm-engine/fsm-engine.ts
@@ -100,6 +100,11 @@ type PrepareResult = z.infer<typeof PrepareResultSchema>;
  * unresolved placeholders are kept verbatim so typos stay visible during
  * authoring rather than silently rendering as empty strings.
  *
+ * A Liquid-style `| default: 'fallback'` filter is supported on the placeholder
+ * itself (`{{inputs.style | default: 'classic'}}`); it kicks in when the path
+ * resolves to undefined/null so optional fields don't have to be set on every
+ * invocation. Both single- and double-quoted fallback literals are accepted.
+ *
  * Uses only properties already exposed via `PrepareResult` (`task`, `config`,
  * `artifactRefs`); does not reach into ambient FSM state, so there's no way
  * an agent's prompt can smuggle context from outside its invocation payload.
@@ -108,22 +113,29 @@ export function interpolatePromptPlaceholders(
   prompt: string,
   prepareResult: PrepareResult | undefined,
 ): string {
-  if (!prepareResult) return prompt;
-  const config = prepareResult.config ?? {};
+  const config = prepareResult?.config ?? {};
   // Expose the same bag under multiple well-known roots — different agent
   // frameworks use different names for this, and the cost of accepting all
   // three is one line per alias. `inputs.*` is the most common.
   const scopes: Record<string, unknown> = { inputs: config, config, signal: { payload: config } };
-  return prompt.replace(/\{\{\s*([a-zA-Z_][a-zA-Z0-9_.]*)\s*\}\}/g, (original, path) => {
+  // Pattern: `{{ path[ | default: 'literal' ] }}`
+  // - path: dotted identifier
+  // - optional `| default: '...'` (single or double quoted) supplies a fallback
+  //   when the path is missing — matches Liquid/Jinja convention used by most
+  //   prompt-templating frameworks.
+  const placeholderRe =
+    /\{\{\s*([a-zA-Z_][a-zA-Z0-9_.]*)\s*(?:\|\s*default\s*:\s*(?:'([^']*)'|"([^"]*)"))?\s*\}\}/g;
+  return prompt.replace(placeholderRe, (original, path, sq, dq) => {
+    const fallback: string | undefined = sq ?? dq;
     const segments = String(path).split(".");
     let cursor: unknown = scopes;
     for (const segment of segments) {
       if (cursor === null || cursor === undefined || typeof cursor !== "object") {
-        return original;
+        return fallback ?? original;
       }
       cursor = (cursor as Record<string, unknown>)[segment];
     }
-    if (cursor === undefined || cursor === null) return original;
+    if (cursor === undefined || cursor === null) return fallback ?? original;
     if (typeof cursor === "string") return cursor;
     if (typeof cursor === "number" || typeof cursor === "boolean") return String(cursor);
     return JSON.stringify(cursor);

--- a/packages/fsm-engine/mod.ts
+++ b/packages/fsm-engine/mod.ts
@@ -19,7 +19,7 @@ export type {
   AgentExecutor,
   FSMEngineOptions,
 } from "./fsm-engine.ts";
-export { FSMEngine } from "./fsm-engine.ts";
+export { FSMEngine, interpolatePromptPlaceholders } from "./fsm-engine.ts";
 // LLM integration
 export { AtlasLLMProviderAdapter } from "./llm-provider-adapter.ts";
 // FSM loader with validation

--- a/packages/fsm-engine/tests/prompt-interpolation.test.ts
+++ b/packages/fsm-engine/tests/prompt-interpolation.test.ts
@@ -89,4 +89,48 @@ describe("interpolatePromptPlaceholders", () => {
     });
     expect(out).toBe("Save x");
   });
+
+  it("falls back to the `| default: '...'` literal when the path is missing", () => {
+    // Liquid/Jinja convention used by every prompt-templating framework users
+    // bring in. Without this, an optional input forced authors to either set
+    // every field on every invocation or get a literal `{{...}}` rendered
+    // into the agent prompt.
+    const out = interpolatePromptPlaceholders(
+      "Style: {{inputs.style | default: 'classic SNES/GBA style'}}",
+      { config: {} },
+    );
+    expect(out).toBe("Style: classic SNES/GBA style");
+  });
+
+  it("uses the resolved value over the default when both are present", () => {
+    const out = interpolatePromptPlaceholders(
+      "Style: {{inputs.style | default: 'classic'}}",
+      { config: { style: "fantasy anime" } },
+    );
+    expect(out).toBe("Style: fantasy anime");
+  });
+
+  it("supports double-quoted default literals", () => {
+    const out = interpolatePromptPlaceholders(
+      'Style: {{inputs.style | default: "classic"}}',
+      { config: {} },
+    );
+    expect(out).toBe("Style: classic");
+  });
+
+  it("applies defaults even when no prepareResult is provided", () => {
+    // Authors writing standalone prompts shouldn't need a prepareResult at
+    // all to get fallback values rendered.
+    const out = interpolatePromptPlaceholders(
+      "Style: {{inputs.style | default: 'classic'}}",
+      undefined,
+    );
+    expect(out).toBe("Style: classic");
+  });
+
+  it("still leaves an unresolved placeholder intact when no default is given and prepareResult is undefined", () => {
+    expect(interpolatePromptPlaceholders("Save {{inputs.content}}", undefined)).toBe(
+      "Save {{inputs.content}}",
+    );
+  });
 });

--- a/packages/fsm-engine/tests/prompt-interpolation.test.ts
+++ b/packages/fsm-engine/tests/prompt-interpolation.test.ts
@@ -103,18 +103,16 @@ describe("interpolatePromptPlaceholders", () => {
   });
 
   it("uses the resolved value over the default when both are present", () => {
-    const out = interpolatePromptPlaceholders(
-      "Style: {{inputs.style | default: 'classic'}}",
-      { config: { style: "fantasy anime" } },
-    );
+    const out = interpolatePromptPlaceholders("Style: {{inputs.style | default: 'classic'}}", {
+      config: { style: "fantasy anime" },
+    });
     expect(out).toBe("Style: fantasy anime");
   });
 
   it("supports double-quoted default literals", () => {
-    const out = interpolatePromptPlaceholders(
-      'Style: {{inputs.style | default: "classic"}}',
-      { config: {} },
-    );
+    const out = interpolatePromptPlaceholders('Style: {{inputs.style | default: "classic"}}', {
+      config: {},
+    });
     expect(out).toBe("Style: classic");
   });
 

--- a/packages/fsm-engine/tests/prompt-interpolation.test.ts
+++ b/packages/fsm-engine/tests/prompt-interpolation.test.ts
@@ -126,9 +126,29 @@ describe("interpolatePromptPlaceholders", () => {
     expect(out).toBe("Style: classic");
   });
 
-  it("still leaves an unresolved placeholder intact when no default is given and prepareResult is undefined", () => {
-    expect(interpolatePromptPlaceholders("Save {{inputs.content}}", undefined)).toBe(
-      "Save {{inputs.content}}",
+  it("uses default when the path resolves to null", () => {
+    const out = interpolatePromptPlaceholders("Style: {{inputs.style | default: 'classic'}}", {
+      config: { style: null },
+    });
+    expect(out).toBe("Style: classic");
+  });
+
+  it("uses default when the path resolves to an empty string", () => {
+    // Liquid convention: forms that submit "" for unfilled fields still get
+    // the fallback. Without this, `default:` would be useless for its primary
+    // use case.
+    const out = interpolatePromptPlaceholders("Style: {{inputs.style | default: 'classic'}}", {
+      config: { style: "" },
+    });
+    expect(out).toBe("Style: classic");
+  });
+
+  it("does NOT treat 0 or false as missing for default", () => {
+    // 0/false are legitimate values; only nil/empty-string trigger fallback.
+    const out = interpolatePromptPlaceholders(
+      "i={{inputs.i | default: '99'}} ok={{inputs.ok | default: 'yes'}}",
+      { config: { i: 0, ok: false } },
     );
+    expect(out).toBe("i=0 ok=false");
   });
 });

--- a/packages/fsm-engine/tests/prompt-interpolation.test.ts
+++ b/packages/fsm-engine/tests/prompt-interpolation.test.ts
@@ -151,4 +151,23 @@ describe("interpolatePromptPlaceholders", () => {
     );
     expect(out).toBe("i=0 ok=false");
   });
+
+  it("supports apostrophes inside double-quoted default literals", () => {
+    // Authors reach for the double-quoted form precisely when the fallback
+    // contains an apostrophe ("don't", "it's"). Single-quoted literals don't
+    // support backslash escapes, so this is the documented way to embed `'`.
+    const out = interpolatePromptPlaceholders(`Reply: {{inputs.greeting | default: "it's me"}}`, {
+      config: {},
+    });
+    expect(out).toBe("Reply: it's me");
+  });
+
+  it("renders an empty string when default is `''` and the path is missing", () => {
+    // Edge of the falsy-handling rule: an explicit empty fallback should
+    // still apply, producing an empty substitution rather than leaving the
+    // placeholder verbatim. Pin it so the `?? cursor` fallthrough doesn't
+    // accidentally start treating `""` defaults as absent.
+    const out = interpolatePromptPlaceholders("[{{inputs.x | default: ''}}]", { config: {} });
+    expect(out).toBe("[]");
+  });
 });

--- a/packages/workspace/src/runtime.ts
+++ b/packages/workspace/src/runtime.ts
@@ -73,6 +73,7 @@ import {
   type FSMEngine,
   type FSMEvent,
   type FSMStateSkippedEvent,
+  interpolatePromptPlaceholders,
   type SignalWithContext,
   validateFSMStructure,
 } from "@atlas/fsm-engine";
@@ -1515,7 +1516,26 @@ export class WorkspaceRuntime {
       ArtifactStorage,
     );
 
-    const prompt = buildFinalAgentPrompt(action.prompt, agentConfigPrompt, context);
+    // Resolve `{{inputs.x}}` / `{{config.x}}` / `{{signal.payload.x}}` against
+    // the prepare-result payload before composing the final prompt. The LLM
+    // action path does this in `buildContextPrompt`; agent actions skipped it,
+    // so Friday workspaces (which exclusively use agent actions) saw literal
+    // `{{inputs.description}}` and the agent fell back to whatever it could
+    // glean from the appended `## Input` block instead. Interpolating here
+    // makes the convention work uniformly across both action types.
+    const prepareResult = fsmContext.input;
+    const interpolatedActionPrompt = action.prompt
+      ? interpolatePromptPlaceholders(action.prompt, prepareResult)
+      : action.prompt;
+    const interpolatedConfigPrompt = interpolatePromptPlaceholders(
+      agentConfigPrompt,
+      prepareResult,
+    );
+    const prompt = buildFinalAgentPrompt(
+      interpolatedActionPrompt,
+      interpolatedConfigPrompt,
+      context,
+    );
 
     let standingOrdersBlock = "";
     if (process.env.FRIDAY_STANDING_ORDERS_BOOTSTRAP === "1" && this.options.memoryAdapter) {

--- a/tools/evals/agents/prompt-interpolation/prompt-interpolation.eval.ts
+++ b/tools/evals/agents/prompt-interpolation/prompt-interpolation.eval.ts
@@ -1,0 +1,274 @@
+/**
+ * Prompt-interpolation end-to-end eval.
+ *
+ * Anchors the behavior PR #199 fixes: agent prompts that reference
+ * `{{inputs.x}}` (and the Liquid-style `| default: '...'` filter) are resolved
+ * by `interpolatePromptPlaceholders` BEFORE being sent to the LLM, so the
+ * model sees real data instead of literal mustache syntax.
+ *
+ * The unit tests in `packages/fsm-engine/tests/prompt-interpolation.test.ts`
+ * pin the substring-substitution contract. This eval pins the downstream
+ * effect: an interpolated prompt produces an LLM response that addresses the
+ * substituted values, contains no `{{...}}` leakage, and isn't a
+ * "missing input" refusal — which is exactly the failure shape the PR cites.
+ *
+ * Why a real-LLM eval on top of unit tests: a future refactor that kept the
+ * function correct but broke the call ordering (e.g. interpolating after the
+ * prompt was sent) would not fail the unit tests but WOULD fail this eval,
+ * because the LLM's output would suddenly start echoing `{{inputs.x}}` or
+ * refusing.
+ */
+
+import { interpolatePromptPlaceholders } from "@atlas/fsm-engine";
+import { registry, traceModel } from "@atlas/llm";
+import { generateText } from "ai";
+import { AgentContextAdapter } from "../../lib/context.ts";
+import { loadCredentials } from "../../lib/load-credentials.ts";
+import { type BaseEvalCase, defineEval, type EvalRegistration } from "../../lib/registration.ts";
+import { createScore, type Score } from "../../lib/scoring.ts";
+
+await loadCredentials();
+
+const adapter = new AgentContextAdapter();
+
+// Haiku: cheap, fast, and faithful enough to surface placeholder leakage.
+const MODEL_ID = "anthropic:claude-haiku-4-5";
+
+// ---------------------------------------------------------------------------
+// Scorers
+// ---------------------------------------------------------------------------
+
+/**
+ * Penalize raw mustache leak in the LLM output. The whole point of
+ * interpolation is that the model never sees `{{...}}`; if the response
+ * contains the syntax, either interpolation didn't run, or the model is
+ * echoing the prompt back at us — both regressions worth catching.
+ */
+function noPlaceholderLeakScore(text: string): Score {
+  const hasOpenBraces = text.includes("{{");
+  const hasCloseBraces = text.includes("}}");
+  if (hasOpenBraces || hasCloseBraces) {
+    return createScore("NoPlaceholderLeak", 0, "Output contains literal {{ or }}");
+  }
+  return createScore("NoPlaceholderLeak", 1, "No mustache syntax in output");
+}
+
+/**
+ * Penalize the specific refusal shape the PR description cites:
+ * "required input values are missing" / "no input was provided" / similar.
+ * These are the LLM behaviors that motivated the fix; a successful
+ * interpolation prevents them.
+ */
+function notARefusalScore(text: string): Score {
+  const lower = text.toLowerCase();
+  const refusalPatterns = [
+    /required input/,
+    /missing (required )?input/,
+    /no input (was )?(provided|given|supplied)/,
+    /placeholder/,
+    /template (variable|reference)/,
+    /unresolved (variable|reference)/,
+    /i (don't|do not|cannot|can't) (have|see) (the )?(input|value)/,
+  ];
+  for (const pattern of refusalPatterns) {
+    if (pattern.test(lower)) {
+      return createScore("NotARefusal", 0, `Matched refusal pattern: ${pattern}`);
+    }
+  }
+  return createScore("NotARefusal", 1, "No refusal markers");
+}
+
+/**
+ * Rule-based: did the response actually mention the data we substituted in?
+ * Lowercased substring match, all keywords required.
+ */
+function addressesDataScore(text: string, keywords: string[]): Score {
+  const lower = text.toLowerCase();
+  const matches = keywords.filter((k) => lower.includes(k.toLowerCase()));
+  const value = matches.length / keywords.length;
+  return createScore(
+    "AddressesData",
+    value,
+    `${matches.length}/${keywords.length} keywords matched: [${keywords.join(", ")}]`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+interface InterpolationCase extends BaseEvalCase {
+  /** Raw author-written agent prompt (with placeholders). */
+  template: string;
+  /** prepareResult.config — what the FSM would pass at runtime. */
+  config: Record<string, unknown>;
+  /** Expected substring(s) in the *interpolated* prompt — sanity check on the function. */
+  expectInPrompt: string[];
+  /** Substrings that must NOT appear in the interpolated prompt. */
+  expectNotInPrompt: string[];
+  /** Expected substring(s) in the LLM response (lowercased match). */
+  expectInResponse: string[];
+}
+
+const cases: InterpolationCase[] = [
+  {
+    id: "simple-substitution",
+    name: "single {{inputs.x}} resolved against config",
+    // Mirrors the workspace-chat save_entry shape from the PR description.
+    template: "Summarize the user's request in one short sentence. Request: {{inputs.description}}",
+    config: {
+      description:
+        "I want a workspace that watches my email inbox and forwards finance-related messages to a Slack channel.",
+    },
+    input: "save-entry: forward finance email",
+    expectInPrompt: ["watches my email inbox", "finance-related"],
+    expectNotInPrompt: ["{{", "}}"],
+    expectInResponse: ["finance"],
+  },
+  {
+    id: "dotted-path",
+    name: "nested object accessed via dotted path",
+    template:
+      "Write one sentence introducing {{inputs.author.name}}, who is a {{inputs.author.role}}.",
+    config: { author: { name: "Ada Lovelace", role: "mathematician" } },
+    input: "intro: Ada Lovelace",
+    expectInPrompt: ["Ada Lovelace", "mathematician"],
+    expectNotInPrompt: ["{{", "}}"],
+    expectInResponse: ["ada"],
+  },
+  {
+    id: "multi-placeholder",
+    name: "multiple placeholders all resolved",
+    template:
+      "Draft a {{inputs.tone}} one-sentence message to {{inputs.recipient}} about {{inputs.topic}}.",
+    config: { tone: "casual", recipient: "Sam", topic: "lunch on Friday" },
+    input: "draft: lunch message to Sam",
+    expectInPrompt: ["casual", "Sam", "lunch on Friday"],
+    expectNotInPrompt: ["{{", "}}"],
+    expectInResponse: ["sam", "lunch"],
+  },
+  {
+    id: "default-filter-fallback",
+    name: "default filter kicks in when input is missing",
+    // Pulled from the PR description's example: a workspace UI form that
+    // doesn't pass `style` should still produce a usable prompt.
+    template:
+      "List three concrete visual elements for {{inputs.style | default: 'classic SNES/GBA pixel art'}} of {{inputs.subject}}.",
+    config: { subject: "a brave knight" },
+    input: "art-prompt: brave knight (no style)",
+    expectInPrompt: ["classic SNES/GBA pixel art", "brave knight"],
+    // Critical assertion: the un-piped placeholder syntax must not leak.
+    expectNotInPrompt: ["{{", "}}", "default:"],
+    // Knight is the subject; we don't insist on "snes" because Haiku may
+    // paraphrase ("16-bit", "retro pixel"). Subject is the firmer anchor.
+    expectInResponse: ["knight"],
+  },
+  {
+    id: "default-filter-override",
+    name: "explicit value beats the default",
+    template:
+      "List two visual elements for {{inputs.style | default: 'classic SNES/GBA pixel art'}} of {{inputs.subject}}.",
+    config: { style: "neon cyberpunk", subject: "a brave knight" },
+    input: "art-prompt: cyberpunk knight",
+    // The default literal should NOT appear — value won.
+    expectInPrompt: ["neon cyberpunk", "brave knight"],
+    expectNotInPrompt: ["{{", "}}", "classic SNES/GBA"],
+    expectInResponse: ["knight"],
+  },
+  {
+    id: "empty-string-fallback",
+    name: "empty-string input still triggers the default (Liquid convention)",
+    // Forms commonly post "" for unfilled optional fields. Without the
+    // empty-string-as-missing rule, the default would never fire here.
+    template: "Greet the visitor in {{inputs.language | default: 'English'}}. Keep it to one line.",
+    config: { language: "" },
+    input: "greeting: empty language",
+    expectInPrompt: ["English"],
+    expectNotInPrompt: ["{{", "}}"],
+    // Hello / hi / welcome — any common English greeting token.
+    expectInResponse: [],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Run helper
+// ---------------------------------------------------------------------------
+
+interface RunOutcome {
+  /** The fully-interpolated prompt sent to the LLM. */
+  interpolatedPrompt: string;
+  /** The LLM's response text. */
+  responseText: string;
+  /** End-to-end latency in milliseconds. */
+  latencyMs: number;
+}
+
+async function runInterpolationCase(testCase: InterpolationCase): Promise<RunOutcome> {
+  const interpolatedPrompt = interpolatePromptPlaceholders(testCase.template, {
+    config: testCase.config,
+  });
+
+  const start = performance.now();
+  const result = await generateText({
+    model: traceModel(registry.languageModel(MODEL_ID)),
+    // Steer Haiku to short, on-task output so keyword scoring isn't noisy.
+    system:
+      "You follow the user's instruction precisely and respond in plain prose. Keep responses short.",
+    prompt: interpolatedPrompt,
+    maxOutputTokens: 200,
+  });
+  const latencyMs = performance.now() - start;
+
+  return { interpolatedPrompt, responseText: result.text, latencyMs };
+}
+
+// ---------------------------------------------------------------------------
+// Eval registrations
+// ---------------------------------------------------------------------------
+
+export const evals: EvalRegistration[] = cases.map((testCase) =>
+  defineEval<RunOutcome>({
+    name: `prompt-interpolation/${testCase.id}`,
+    adapter,
+    config: {
+      input: testCase.input,
+      run: () => runInterpolationCase(testCase),
+      // Assert the function-level contract first — if interpolation didn't
+      // do its job, scoring the LLM output is meaningless.
+      assert: ({ interpolatedPrompt }) => {
+        for (const needle of testCase.expectInPrompt) {
+          if (!interpolatedPrompt.includes(needle)) {
+            throw new Error(
+              `Interpolated prompt missing expected substring "${needle}". ` +
+                `Got: ${JSON.stringify(interpolatedPrompt)}`,
+            );
+          }
+        }
+        for (const forbidden of testCase.expectNotInPrompt) {
+          if (interpolatedPrompt.includes(forbidden)) {
+            throw new Error(
+              `Interpolated prompt contains forbidden substring "${forbidden}". ` +
+                `Got: ${JSON.stringify(interpolatedPrompt)}`,
+            );
+          }
+        }
+      },
+      score: ({ responseText }) => {
+        const scores: Score[] = [
+          noPlaceholderLeakScore(responseText),
+          notARefusalScore(responseText),
+        ];
+        if (testCase.expectInResponse.length > 0) {
+          scores.push(addressesDataScore(responseText, testCase.expectInResponse));
+        }
+        return scores;
+      },
+      metadata: {
+        case: testCase.id,
+        template: testCase.template,
+        config: testCase.config,
+        model: MODEL_ID,
+      },
+    },
+  }),
+);

--- a/tools/evals/agents/prompt-interpolation/prompt-interpolation.eval.ts
+++ b/tools/evals/agents/prompt-interpolation/prompt-interpolation.eval.ts
@@ -1,22 +1,19 @@
 /**
- * Prompt-interpolation end-to-end eval.
- *
- * Anchors the behavior PR #199 fixes: agent prompts that reference
- * `{{inputs.x}}` (and the Liquid-style `| default: '...'` filter) are resolved
- * by `interpolatePromptPlaceholders` BEFORE being sent to the LLM, so the
- * model sees real data instead of literal mustache syntax.
+ * Prompt-interpolation downstream eval.
  *
  * The unit tests in `packages/fsm-engine/tests/prompt-interpolation.test.ts`
- * pin the substring-substitution contract. This eval pins the downstream
- * effect: an interpolated prompt produces an LLM response that addresses the
- * substituted values, contains no `{{...}}` leakage, and isn't a
- * "missing input" refusal — which is exactly the failure shape the PR cites.
+ * already pin the substring-substitution contract. This eval covers a
+ * complementary, model-side property: when the rendered prompt is sent to a
+ * real LLM, the response addresses the substituted values, doesn't leak
+ * `{{...}}` syntax, and isn't a "missing input" refusal — the failure shape
+ * cited by PR #199.
  *
- * Why a real-LLM eval on top of unit tests: a future refactor that kept the
- * function correct but broke the call ordering (e.g. interpolating after the
- * prompt was sent) would not fail the unit tests but WOULD fail this eval,
- * because the LLM's output would suddenly start echoing `{{inputs.x}}` or
- * refusing.
+ * Scope note: this eval calls `interpolatePromptPlaceholders` directly, NOT
+ * via `runtime.ts:executeAgent`, so a regression that removed the
+ * interpolation call from the agent-action path would not be caught here.
+ * That end-to-end coverage lives in the daemon-side smoke test documented in
+ * the PR. Treat this eval as "given a correctly-rendered prompt, the LLM
+ * behaves," not "the FSM call site is wired correctly."
  */
 
 import { interpolatePromptPlaceholders } from "@atlas/fsm-engine";
@@ -175,19 +172,9 @@ const cases: InterpolationCase[] = [
     expectNotInPrompt: ["{{", "}}", "classic SNES/GBA"],
     expectInResponse: ["knight"],
   },
-  {
-    id: "empty-string-fallback",
-    name: "empty-string input still triggers the default (Liquid convention)",
-    // Forms commonly post "" for unfilled optional fields. Without the
-    // empty-string-as-missing rule, the default would never fire here.
-    template: "Greet the visitor in {{inputs.language | default: 'English'}}. Keep it to one line.",
-    config: { language: "" },
-    input: "greeting: empty language",
-    expectInPrompt: ["English"],
-    expectNotInPrompt: ["{{", "}}"],
-    // Hello / hi / welcome — any common English greeting token.
-    expectInResponse: [],
-  },
+  // Empty-string-as-missing semantics are covered by unit tests in
+  // prompt-interpolation.test.ts; an LLM run adds nothing the no-leak /
+  // no-refusal scorers don't already give us on every other case.
 ];
 
 // ---------------------------------------------------------------------------
@@ -216,6 +203,10 @@ async function runInterpolationCase(testCase: InterpolationCase): Promise<RunOut
       "You follow the user's instruction precisely and respond in plain prose. Keep responses short.",
     prompt: interpolatedPrompt,
     maxOutputTokens: 200,
+    // Determinism: keyword scoring is paraphrase-sensitive. Pinning to 0
+    // doesn't fully eliminate variance (server-side sampling can still
+    // diverge on ties) but materially reduces flake.
+    temperature: 0,
   });
   const latencyMs = performance.now() - start;
 

--- a/tools/evals/package.json
+++ b/tools/evals/package.json
@@ -7,6 +7,7 @@
     "@atlas/agent-sdk": "workspace:*",
     "@atlas/bundled-agents": "workspace:*",
     "@atlas/core": "workspace:*",
+    "@atlas/fsm-engine": "workspace:*",
     "@atlas/llm": "workspace:*",
     "@atlas/logger": "workspace:*",
     "@atlas/utils": "workspace:*",


### PR DESCRIPTION
## Summary
- Friday workspaces use `agent` actions exclusively, but only the `llm` action path ran `interpolatePromptPlaceholders` (in `buildContextPrompt`). Agent action prompts passed `{{inputs.description}}` through to the agent verbatim while the values sat in the appended `## Input` block — the agent then either ignored the placeholders or refused.
- Added the same interpolation to `WorkspaceRuntime.executeAgent` (against `fsmContext.input`) so both action types behave consistently.
- Extended the placeholder regex to support the Liquid/Jinja-style `| default: 'fallback'` filter (`{{inputs.style | default: 'classic SNES/GBA style'}}`), with single- and double-quoted literals; the early-return on missing `prepareResult` is dropped so default-only placeholders still render.
- Exported `interpolatePromptPlaceholders` from `@atlas/fsm-engine` so the workspace runtime can import it.

## Test plan
- [x] `deno task test packages/fsm-engine/tests/prompt-interpolation.test.ts` — 15 passed (5 new cases for the default filter)
- [x] `deno task test packages/fsm-engine/tests/` — 162 passed
- [x] `deno task test packages/workspace/` — 273 passed
- [x] `deno task test apps/atlasd/src/agent-helpers.test.ts` — 22 passed
- [x] `deno check packages/fsm-engine/mod.ts packages/workspace/src/runtime.ts apps/atlasd/src/agent-helpers.ts`
- [x] Manual: trigger a Friday workspace agent prompt that references `{{inputs.description}}` / `{{inputs.style | default: '...'}}` and confirm the values are substituted in the prompt sent to the agent