### PR TITLE
fix(workspace): unblock cancelSession when engine.signal ignores AbortSignal

### DIFF
--- a/packages/workspace/src/runtime-error-propagation.test.ts
+++ b/packages/workspace/src/runtime-error-propagation.test.ts
@@ -139,6 +139,108 @@ describe("session error propagation", () => {
     expect(session.error).toBeUndefined();
   });
 
+  it("cancelSession unblocks the await even when engine.signal ignores AbortSignal", async () => {
+    // Repro: a workspace agent makes a blocking call (e.g. a fetch with no
+    // signal piped through) so `engine.signal` never settles. Without the
+    // `awaitWithAbort` race in processSignalForJob, `cancelSession` aborts
+    // the per-session controller but the await stays pending, the
+    // `activeAbortControllers` entry never clears, and the cascade-stream
+    // in-flight slot stays pinned — so the next trigger of the same signal
+    // hits skipped-duplicate forever. The fix: cancel must complete the
+    // outer await within ~1 tick of `controller.abort()` regardless of
+    // what the engine is doing inside.
+    await withTestRuntime(createSuccessConfig(), async (runtime) => {
+      // Hijack the FSM engine's signal method on the *next* engine the
+      // runtime creates so it returns a never-settling promise but exposes
+      // its onEvent / onStreamEvent callbacks to the test. Wrapping
+      // createJobEngine is the smallest seam — every signal trigger goes
+      // through it once. createJobEngine is private; cast via unknown.
+      const captured: { onEvent?: (e: unknown) => void; onStreamEvent?: (c: unknown) => void } = {};
+      const r = runtime as unknown as {
+        createJobEngine: (
+          ...args: unknown[]
+        ) => Promise<{ engine: { signal: (...args: unknown[]) => unknown } }>;
+      };
+      const original = r.createJobEngine.bind(r);
+      r.createJobEngine = async (...args: unknown[]) => {
+        const result = await original(...args);
+        result.engine.signal = (...args: unknown[]) => {
+          const ctx = args[1] as
+            | { onEvent?: (e: unknown) => void; onStreamEvent?: (c: unknown) => void }
+            | undefined;
+          captured.onEvent = ctx?.onEvent;
+          captured.onStreamEvent = ctx?.onStreamEvent;
+          return new Promise(() => {});
+        };
+        return result;
+      };
+
+      // Capture stream events emitted to the SSE-style outer callback so we
+      // can assert later events from the orphan engine are dropped.
+      const outerEvents: Array<{ type: string }> = [];
+      const sessionPromise = runtime.triggerSignalWithSession(
+        "test-signal",
+        {},
+        undefined,
+        (chunk) => {
+          outerEvents.push(chunk as { type: string });
+        },
+        undefined,
+        undefined,
+      );
+
+      // Wait until the controller is registered, then cancel.
+      const start = Date.now();
+      let activeId: string | undefined;
+      while (Date.now() - start < 5_000) {
+        const ids = (runtime as unknown as { activeAbortControllers: Map<string, unknown> })
+          .activeAbortControllers;
+        const first = ids.keys().next();
+        if (!first.done) {
+          activeId = first.value;
+          break;
+        }
+        await new Promise((r) => setTimeout(r, 5));
+      }
+      expect(activeId).toBeTruthy();
+
+      runtime.cancelSession(activeId as string);
+
+      // The session must finalize promptly despite engine.signal being
+      // wedged — well under the 30s test timeout.
+      const session = await Promise.race([
+        sessionPromise,
+        new Promise<never>((_, reject) =>
+          setTimeout(() => reject(new Error("processSignal did not resolve after cancel")), 5_000),
+        ),
+      ]);
+
+      expect(session.status).toBe("cancelled");
+      // hasActiveSession must clear so subsequent triggers aren't blocked.
+      expect(runtime.hasActiveSession(activeId as string)).toBe(false);
+
+      // Orphan engine.signal is still alive — simulate a late callback as
+      // the underlying work eventually progresses. The `finalized` gate
+      // must drop these so they can't land in JetStream after
+      // `session:complete` was emitted.
+      const eventsBefore = outerEvents.length;
+      captured.onEvent?.({
+        type: "data-fsm-state-transition",
+        data: {
+          sessionId: activeId,
+          workspaceId: "test-workspace-id",
+          jobName: "test-job",
+          fromState: "processing",
+          toState: "complete",
+          triggeringSignal: "test-signal",
+          timestamp: new Date().toISOString(),
+        },
+      });
+      captured.onStreamEvent?.({ type: "text-delta", id: "x", delta: "late" });
+      expect(outerEvents.length).toBe(eventsBefore);
+    });
+  });
+
   it("externally-passed abortSignal cancels the session — closes the cascade-replace abort chain", async () => {
     // Regression: `CascadeConsumer`'s `replace` policy aborts the
     // AbortController it created, then passes that signal through

--- a/packages/workspace/src/runtime.ts
+++ b/packages/workspace/src/runtime.ts
@@ -123,6 +123,48 @@ import { MountedStoreBinding } from "./mounted-store-binding.ts";
 import { interpolateConfig, resolveWorkspaceVariables } from "./variable-interpolation.ts";
 
 /**
+ * Await a promise but reject as soon as `signal` aborts, even when the
+ * underlying promise never settles. The orphaned promise keeps running — the
+ * caller accepts whatever side-effects it produces.
+ *
+ * Why this exists: `engine.signal()` awaits agent work that can include
+ * `fetch()` calls which don't pipe the AbortSignal through. Without this
+ * race, a single non-cooperative call wedges the await forever, leaks the
+ * `activeAbortControllers` entry, and blocks `cascade-stream`'s in-flight
+ * slot — at which point the skipped-duplicate guard rejects every
+ * subsequent trigger of the same signal until the daemon restarts.
+ */
+function awaitWithAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(asAbortError(signal.reason));
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      signal.removeEventListener("abort", onAbort);
+      reject(asAbortError(signal.reason));
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+    promise.then(
+      (value) => {
+        signal.removeEventListener("abort", onAbort);
+        resolve(value);
+      },
+      (err) => {
+        signal.removeEventListener("abort", onAbort);
+        reject(err);
+      },
+    );
+  });
+}
+
+function asAbortError(reason: unknown): Error {
+  if (reason instanceof Error && reason.name === "AbortError") return reason;
+  const err = new Error(
+    reason instanceof Error ? reason.message : typeof reason === "string" ? reason : "Aborted",
+  );
+  err.name = "AbortError";
+  return err;
+}
+
+/**
  * Classify an error to determine session status.
  * UserConfigurationError (OAuth not connected, missing env vars) → "skipped"
  * All other errors → "failed"
@@ -1050,6 +1092,12 @@ export class WorkspaceRuntime {
         /** Tracks the FSM state where a non-agent action (code/emit) failed, so we
          *  can attribute the error to the correct planned step in the catch block. */
         let failedActionStateId: string | undefined;
+        /** Set true once we've finalized the session (cancellation path). The
+         *  orphan `engine.signal` may keep firing onEvent/onStreamEvent
+         *  callbacks for minutes after; this flag short-circuits them so late
+         *  events don't land in JetStream after `session:complete` has been
+         *  emitted. */
+        let finalized = false;
 
         logger.info("Processing signal via FSM", {
           sessionId: session.id,
@@ -1091,89 +1139,99 @@ export class WorkspaceRuntime {
         // consumer reading the records. Source of truth for "what
         // happened in workspace X" is the SESSIONS JetStream stream.)
 
-        try {
-          await engine.signal(
-            { type: signal.id, data: signal.data || {} },
-            {
-              sessionId: session.id,
-              workspaceId: this.workspace.id,
-              abortSignal: effectiveAbortSignal,
-              skipStates,
-              // FSM lifecycle events only (state transitions, action executions, tool calls/results)
-              onEvent: (event) => {
-                if (onStreamEvent) {
-                  const fsmChunk = fsmEventToStreamChunk(event);
-                  if (fsmChunk) {
-                    onStreamEvent(fsmChunk);
-                  }
+        // Capture the engine.signal promise so we can race it against the
+        // abort signal (see `awaitWithAbort`). If the engine is wedged on
+        // non-cooperative work, the await rejects immediately on cancel,
+        // releasing this session and the cascade-stream slot above it.
+        const enginePromise = engine.signal(
+          { type: signal.id, data: signal.data || {} },
+          {
+            sessionId: session.id,
+            workspaceId: this.workspace.id,
+            abortSignal: effectiveAbortSignal,
+            skipStates,
+            // FSM lifecycle events only (state transitions, action executions, tool calls/results)
+            onEvent: (event) => {
+              // Drop events from an orphaned engine.signal that's still
+              // running after we cancelled and finalized the session.
+              if (finalized) return;
+              if (onStreamEvent) {
+                const fsmChunk = fsmEventToStreamChunk(event);
+                if (fsmChunk) {
+                  onStreamEvent(fsmChunk);
                 }
+              }
 
-                if (
-                  sessionStream &&
-                  event.type === "data-fsm-action-execution" &&
-                  isAgentAction(event as FSMActionExecutionEvent)
+              if (
+                sessionStream &&
+                event.type === "data-fsm-action-execution" &&
+                isAgentAction(event as FSMActionExecutionEvent)
+              ) {
+                const actionEvent = event as FSMActionExecutionEvent;
+                if (actionEvent.data.status === "started") {
+                  stepCounter++;
+                  sessionStream.emit(mapActionToStepStart(actionEvent, stepCounter));
+                } else if (
+                  actionEvent.data.status === "completed" ||
+                  actionEvent.data.status === "failed"
                 ) {
-                  const actionEvent = event as FSMActionExecutionEvent;
-                  if (actionEvent.data.status === "started") {
-                    stepCounter++;
-                    sessionStream.emit(mapActionToStepStart(actionEvent, stepCounter));
-                  } else if (
-                    actionEvent.data.status === "completed" ||
-                    actionEvent.data.status === "failed"
-                  ) {
-                    // LLM actions carry result data directly on the event (populated by FSM engine).
-                    // Agent actions use the side-channel (populated by executeAgent callback).
-                    let agentResult: AgentResultData | undefined;
-                    if (actionEvent.data.llmResult) {
-                      agentResult = actionEvent.data.llmResult;
-                    } else {
-                      // Side-channel key must use job.name (workspace-level key) to match
-                      // what executeAgent stores — NOT actionEvent.data.jobName which is
-                      // the FSM definition's id (may differ from the workspace job key).
-                      const sideChannelKey = `${job.name}/${actionEvent.data.actionId}/${actionEvent.data.state}`;
-                      agentResult = sideChannel.get(sideChannelKey);
-                      sideChannel.delete(sideChannelKey);
-                    }
-                    sessionStream.emit(
-                      mapActionToStepComplete(actionEvent, agentResult, stepCounter),
-                    );
+                  // LLM actions carry result data directly on the event (populated by FSM engine).
+                  // Agent actions use the side-channel (populated by executeAgent callback).
+                  let agentResult: AgentResultData | undefined;
+                  if (actionEvent.data.llmResult) {
+                    agentResult = actionEvent.data.llmResult;
+                  } else {
+                    // Side-channel key must use job.name (workspace-level key) to match
+                    // what executeAgent stores — NOT actionEvent.data.jobName which is
+                    // the FSM definition's id (may differ from the workspace job key).
+                    const sideChannelKey = `${job.name}/${actionEvent.data.actionId}/${actionEvent.data.state}`;
+                    agentResult = sideChannel.get(sideChannelKey);
+                    sideChannel.delete(sideChannelKey);
                   }
+                  sessionStream.emit(
+                    mapActionToStepComplete(actionEvent, agentResult, stepCounter),
+                  );
                 }
+              }
 
-                // Track the state where a non-agent action failed — the catch
-                // block uses this to emit synthetic step events for the agent that
-                // was queued behind the failing code action.
-                if (
-                  event.type === "data-fsm-action-execution" &&
-                  !isAgentAction(event as FSMActionExecutionEvent)
-                ) {
-                  const actionEvent = event as FSMActionExecutionEvent;
-                  if (actionEvent.data.status === "failed") {
-                    failedActionStateId = actionEvent.data.state;
-                  }
+              // Track the state where a non-agent action failed — the catch
+              // block uses this to emit synthetic step events for the agent that
+              // was queued behind the failing code action.
+              if (
+                event.type === "data-fsm-action-execution" &&
+                !isAgentAction(event as FSMActionExecutionEvent)
+              ) {
+                const actionEvent = event as FSMActionExecutionEvent;
+                if (actionEvent.data.status === "failed") {
+                  failedActionStateId = actionEvent.data.state;
                 }
+              }
 
-                // Session history v2: map skipped states to step:skipped events
-                if (sessionStream && event.type === "data-fsm-state-skipped") {
-                  sessionStream.emit(mapStateSkippedToStepSkipped(event as FSMStateSkippedEvent));
-                }
+              // Session history v2: map skipped states to step:skipped events
+              if (sessionStream && event.type === "data-fsm-state-skipped") {
+                sessionStream.emit(mapStateSkippedToStepSkipped(event as FSMStateSkippedEvent));
+              }
 
-                // mapValidationAttemptToStepValidation returns null when the
-                // source event is missing actionId — keeps the wire schema's
-                // actionId required without emitting orphan UI pills.
-                if (sessionStream && event.type === "data-fsm-validation-attempt") {
-                  const stepEvent = mapValidationAttemptToStepValidation(event);
-                  if (stepEvent) sessionStream.emit(stepEvent);
-                }
-              },
-              // Agent UIMessageChunks (text, reasoning, tool-call, etc.) flow through
-              // this separate channel, bypassing the FSMEvent-typed onEvent callback
-              onStreamEvent: (chunk) => {
-                onStreamEvent?.(chunk);
-                sessionStream?.emitEphemeral({ stepNumber: stepCounter, chunk });
-              },
+              // mapValidationAttemptToStepValidation returns null when the
+              // source event is missing actionId — keeps the wire schema's
+              // actionId required without emitting orphan UI pills.
+              if (sessionStream && event.type === "data-fsm-validation-attempt") {
+                const stepEvent = mapValidationAttemptToStepValidation(event);
+                if (stepEvent) sessionStream.emit(stepEvent);
+              }
             },
-          );
+            // Agent UIMessageChunks (text, reasoning, tool-call, etc.) flow through
+            // this separate channel, bypassing the FSMEvent-typed onEvent callback
+            onStreamEvent: (chunk) => {
+              if (finalized) return;
+              onStreamEvent?.(chunk);
+              sessionStream?.emitEphemeral({ stepNumber: stepCounter, chunk });
+            },
+          },
+        );
+
+        try {
+          await awaitWithAbort(enginePromise, effectiveAbortSignal);
 
           session.artifacts = this.extractArtifacts(engine.documents);
           session.completedAt = new Date();
@@ -1203,6 +1261,23 @@ export class WorkspaceRuntime {
           // a downstream `AbortError` isn't always what bubbles up from MCP.
           if (effectiveAbortSignal.aborted) {
             session.status = WorkspaceSessionStatus.CANCELLED;
+            // We bailed before engine.signal settled — attach a tail handler so
+            // the orphan's eventual settlement doesn't surface as an
+            // UnhandledPromiseRejection, and log when it actually unwinds so
+            // operators can spot agents that ignore AbortSignal.
+            enginePromise.then(
+              () => {
+                logger.info("Orphan engine.signal resolved after cancel", {
+                  sessionId: session.id,
+                });
+              },
+              (orphanErr) => {
+                logger.info("Orphan engine.signal rejected after cancel", {
+                  sessionId: session.id,
+                  error: stringifyError(orphanErr),
+                });
+              },
+            );
           } else {
             session.status = classifySessionError(error);
           }
@@ -1285,6 +1360,10 @@ export class WorkspaceRuntime {
             }
           }
         } finally {
+          // Close the gate before emitting terminal events. From this point on
+          // an orphaned engine.signal can't write to the session stream — its
+          // callbacks short-circuit on `finalized`.
+          finalized = true;
           if (onStreamEvent) {
             try {
               await onStreamEvent({


### PR DESCRIPTION
## Summary

A workspace agent that makes a blocking call without piping `AbortSignal` through (e.g. a `fetch` with no `signal:` arg) wedges the await on `engine.signal()` in `processSignalForJob`. `cancelSession` aborts the per-session controller, but the await stays pending forever — so the `finally` never clears `activeAbortControllers`, and `cascade-stream`'s in-flight slot stays pinned. Result: every subsequent trigger of the same signal hits **skipped-duplicate** until the daemon restarts.

Race the `engine.signal()` promise against `effectiveAbortSignal` via a new `awaitWithAbort` helper. On cancel the await rejects within ~1 tick; the catch sets `status=CANCELLED`; finally finalizes the session stream, clears the controller, and returns. Dispatch returns to cascade-stream → in-flight slot releases → skipped-duplicate guard releases → user can retry.

The orphaned `engine.signal` is allowed to keep running in the background. A tail handler swallows its eventual settlement (so it can't surface as an `UnhandledPromiseRejection`) and logs it at info level for visibility into agents that don't honour `AbortSignal`.

A `finalized` flag closed-over by the engine's `onEvent` / `onStreamEvent` callbacks short-circuits late events from the orphan so they can't land in JetStream after `session:complete` has been emitted.

## Test plan

- [x] `deno task typecheck` — 0 errors
- [x] `npx knip` — 0 findings
- [x] `vitest run packages/workspace apps/atlasd` — 1183 passing | 1 skipped (273+1 new in `runtime-error-propagation.test.ts`)
- [x] New regression test in `runtime-error-propagation.test.ts`: monkey-patches `createJobEngine` so `engine.signal` returns a never-settling promise; calls `cancelSession`; asserts `processSignal` resolves to `cancelled` within 5s with `hasActiveSession=false`. Also fires the orphan's captured `onEvent`/`onStreamEvent` after finalize to assert the `finalized` gate drops them. Test would time out at 5s without the fix.
- [x] Live QA (daemon + UI from this branch on 8080/5200):
  - Send chat → completes normally.
  - Send long chat → `DELETE /api/sessions/:id` → status flips to `cancelled` (~6.4s); UI shows "Session cancelled by user" with partial output.
  - Retry after cancel → succeeds (skipped-duplicate guard does not engage).
  - Two rapid back-to-back cancel-cycles (~1.2s, ~1.5s) → both `cancelled` cleanly.
  - Daemon log: cancel routes correctly via `runtime.cancelSession` → catch path classifies as `cancelled`. 0 `Orphan engine.signal` lines (LLM SDK honours AbortSignal — orphan tail handler stays dormant for cooperative aborts; only engages on the genuinely stuck path the unit test pins).