### PR TITLE
fix(env): write .env values unquoted, strip quotes on read

### DIFF
--- a/apps/atlasd/routes/config.test.ts
+++ b/apps/atlasd/routes/config.test.ts
@@ -115,11 +115,30 @@ describe("PUT /env on-disk format", () => {
     expect(onDisk).toBe(`MSG="it's fine"`);
   });
 
-  test("multi-line value uses double quotes with escaped newlines", async () => {
-    await putEnv({ BLOCK: "line1\nline2" });
+  test("newline-bearing values are rejected at the boundary", async () => {
+    // The Go launcher's unquoteEnvValue strips outer quotes only; it
+    // doesn't expand `\n`, so KEY="line1\nline2" would reach spawned
+    // services with a literal backslash-n. Reject up front instead.
+    const app = createApp();
+    const res = await app.request("/env", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ envVars: { BLOCK: "line1\nline2" } }),
+    });
+    expect(res.status).toBe(400);
+  });
 
-    const onDisk = await readFile(join(tempHome, ".env"), "utf-8");
-    expect(onDisk).toBe(`BLOCK="line1\\nline2"`);
+  test("newline-bearing keys are rejected at the boundary", async () => {
+    // A key with `\n` would let one PUT entry split into two on-disk
+    // lines, smuggling additional env vars into spawned services on
+    // the next launcher import. Schema enforces POSIX identifiers.
+    const app = createApp();
+    const res = await app.request("/env", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ envVars: { "FOO\nBAR": "baz" } }),
+    });
+    expect(res.status).toBe(400);
   });
 
   test("multiple keys are joined by newlines, no trailing newline", async () => {
@@ -132,6 +151,9 @@ describe("PUT /env on-disk format", () => {
 
 describe("PUT → GET round-trip", () => {
   test("preserves values across the full set of edge cases", async () => {
+    // Newlines are rejected at the boundary (see "newline-bearing values
+    // are rejected"), so the round-trip set covers every other shape the
+    // Settings UI can send.
     const cases = {
       ANTHROPIC_API_KEY: "sk-ant-api03-foo-bar",
       OPENAI_URL: "https://api.openai.com/v1",
@@ -140,7 +162,6 @@ describe("PUT → GET round-trip", () => {
       WITH_HASH: "abc#def",
       WITH_SQUOTE: "it's ok",
       WITH_DQUOTE: 'say "hi"',
-      WITH_NEWLINE: "line1\nline2",
       EMPTY: "",
     };
 

--- a/apps/atlasd/routes/config.test.ts
+++ b/apps/atlasd/routes/config.test.ts
@@ -123,10 +123,7 @@ describe("PUT /env on-disk format", () => {
   });
 
   test("multiple keys are joined by newlines, no trailing newline", async () => {
-    await putEnv({
-      ANTHROPIC_API_KEY: "sk-ant-foo",
-      OPENAI_API_KEY: "sk-proj-bar",
-    });
+    await putEnv({ ANTHROPIC_API_KEY: "sk-ant-foo", OPENAI_API_KEY: "sk-proj-bar" });
 
     const onDisk = await readFile(join(tempHome, ".env"), "utf-8");
     expect(onDisk).toBe("ANTHROPIC_API_KEY=sk-ant-foo\nOPENAI_API_KEY=sk-proj-bar");
@@ -178,7 +175,8 @@ describe("PUT → GET round-trip", () => {
 
     // Round-trip back through PUT — the value parsed cleanly, the
     // re-write must NOT re-introduce the quotes.
-    await putEnv(before.envVars!);
+    if (!before.envVars) throw new Error("envVars missing from GET response");
+    await putEnv(before.envVars);
 
     const onDisk = await readFile(envPath, "utf-8");
     expect(onDisk).toBe("ANTHROPIC_API_KEY=sk-ant-legacy");

--- a/apps/atlasd/routes/config.test.ts
+++ b/apps/atlasd/routes/config.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Integration tests for the daemon-level /config/env routes.
+ *
+ * Regression guard for the env-var quoting bug: prior to the fix,
+ * @std/dotenv's stringify wrapped any value containing a non-word
+ * character in single quotes, so an API key like `sk-ant-foo` landed
+ * on disk as `ANTHROPIC_API_KEY='sk-ant-foo'`. The launcher's
+ * loadDotEnv (tools/friday-launcher/project.go) then forwarded the
+ * literal-quoted value to spawned services, breaking authentication.
+ *
+ * These tests assert the on-disk shape (unquoted for simple values,
+ * quoted only when the value would otherwise be ambiguous) AND that
+ * PUT → GET round-trips preserve the original value semantically.
+ */
+
+import { mkdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+
+import { configRoutes } from "./config.ts";
+
+interface PutEnvResponse {
+  success: boolean;
+  error?: string;
+}
+
+interface GetEnvResponse {
+  success: boolean;
+  envVars?: Record<string, string>;
+  envPath?: string;
+  error?: string;
+}
+
+let tempHome: string;
+let originalFridayHome: string | undefined;
+
+beforeEach(async () => {
+  tempHome = join(tmpdir(), `atlasd-env-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  await mkdir(tempHome, { recursive: true });
+  originalFridayHome = process.env.FRIDAY_HOME;
+  process.env.FRIDAY_HOME = tempHome;
+});
+
+afterEach(async () => {
+  if (originalFridayHome === undefined) {
+    delete process.env.FRIDAY_HOME;
+  } else {
+    process.env.FRIDAY_HOME = originalFridayHome;
+  }
+  await rm(tempHome, { recursive: true, force: true });
+});
+
+function createApp() {
+  const app = new Hono();
+  app.route("/", configRoutes);
+  return app;
+}
+
+async function putEnv(envVars: Record<string, string>): Promise<PutEnvResponse> {
+  const app = createApp();
+  const res = await app.request("/env", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ envVars }),
+  });
+  expect(res.status).toBe(200);
+  return (await res.json()) as PutEnvResponse;
+}
+
+async function getEnv(): Promise<GetEnvResponse> {
+  const app = createApp();
+  const res = await app.request("/env");
+  expect(res.status).toBe(200);
+  return (await res.json()) as GetEnvResponse;
+}
+
+describe("PUT /env on-disk format", () => {
+  test("API key with hyphens lands unquoted (the original bug)", async () => {
+    await putEnv({ ANTHROPIC_API_KEY: "sk-ant-api03-foo-bar" });
+
+    const onDisk = await readFile(join(tempHome, ".env"), "utf-8");
+    expect(onDisk).toBe("ANTHROPIC_API_KEY=sk-ant-api03-foo-bar");
+    expect(onDisk).not.toContain("'");
+    expect(onDisk).not.toContain('"');
+  });
+
+  test("URL with slashes/colons lands unquoted", async () => {
+    await putEnv({ FRIDAYD_URL: "http://localhost:18080" });
+
+    const onDisk = await readFile(join(tempHome, ".env"), "utf-8");
+    expect(onDisk).toBe("FRIDAYD_URL=http://localhost:18080");
+  });
+
+  test("value with whitespace gets single-quoted", async () => {
+    await putEnv({ GREETING: "hello world" });
+
+    const onDisk = await readFile(join(tempHome, ".env"), "utf-8");
+    expect(onDisk).toBe("GREETING='hello world'");
+  });
+
+  test("value with $ gets single-quoted to avoid expansion", async () => {
+    await putEnv({ KEY: "abc$def" });
+
+    const onDisk = await readFile(join(tempHome, ".env"), "utf-8");
+    expect(onDisk).toBe("KEY='abc$def'");
+  });
+
+  test("value with embedded single quote uses double quotes", async () => {
+    await putEnv({ MSG: "it's fine" });
+
+    const onDisk = await readFile(join(tempHome, ".env"), "utf-8");
+    expect(onDisk).toBe(`MSG="it's fine"`);
+  });
+
+  test("multi-line value uses double quotes with escaped newlines", async () => {
+    await putEnv({ BLOCK: "line1\nline2" });
+
+    const onDisk = await readFile(join(tempHome, ".env"), "utf-8");
+    expect(onDisk).toBe(`BLOCK="line1\\nline2"`);
+  });
+
+  test("multiple keys are joined by newlines, no trailing newline", async () => {
+    await putEnv({
+      ANTHROPIC_API_KEY: "sk-ant-foo",
+      OPENAI_API_KEY: "sk-proj-bar",
+    });
+
+    const onDisk = await readFile(join(tempHome, ".env"), "utf-8");
+    expect(onDisk).toBe("ANTHROPIC_API_KEY=sk-ant-foo\nOPENAI_API_KEY=sk-proj-bar");
+  });
+});
+
+describe("PUT → GET round-trip", () => {
+  test("preserves values across the full set of edge cases", async () => {
+    const cases = {
+      ANTHROPIC_API_KEY: "sk-ant-api03-foo-bar",
+      OPENAI_URL: "https://api.openai.com/v1",
+      WITH_SPACE: "hello world",
+      WITH_DOLLAR: "abc$def",
+      WITH_HASH: "abc#def",
+      WITH_SQUOTE: "it's ok",
+      WITH_DQUOTE: 'say "hi"',
+      WITH_NEWLINE: "line1\nline2",
+      EMPTY: "",
+    };
+
+    await putEnv(cases);
+    const got = await getEnv();
+
+    expect(got.success).toBe(true);
+    expect(got.envVars).toEqual(cases);
+  });
+
+  test("legacy quoted value (pre-fix .env on disk) is read unquoted by GET", async () => {
+    // Simulate a .env file written by the buggy stringify that wrapped
+    // hyphenated values in single quotes. @std/dotenv's parse strips
+    // the quotes, so GET should already return the clean value — the
+    // launcher-side fix handles forwarding to spawned services.
+    const envPath = join(tempHome, ".env");
+    await mkdir(tempHome, { recursive: true });
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(envPath, "ANTHROPIC_API_KEY='sk-ant-legacy-quoted'\n", "utf-8");
+
+    const got = await getEnv();
+    expect(got.envVars?.ANTHROPIC_API_KEY).toBe("sk-ant-legacy-quoted");
+  });
+
+  test("re-saving a legacy quoted .env rewrites it unquoted", async () => {
+    const envPath = join(tempHome, ".env");
+    const { writeFile } = await import("node:fs/promises");
+    await writeFile(envPath, "ANTHROPIC_API_KEY='sk-ant-legacy'\n", "utf-8");
+
+    const before = await getEnv();
+    expect(before.envVars?.ANTHROPIC_API_KEY).toBe("sk-ant-legacy");
+
+    // Round-trip back through PUT — the value parsed cleanly, the
+    // re-write must NOT re-introduce the quotes.
+    await putEnv(before.envVars!);
+
+    const onDisk = await readFile(envPath, "utf-8");
+    expect(onDisk).toBe("ANTHROPIC_API_KEY=sk-ant-legacy");
+  });
+});

--- a/apps/atlasd/routes/config.ts
+++ b/apps/atlasd/routes/config.ts
@@ -10,7 +10,7 @@ import { createPlatformModels, getCatalog, PlatformModelsConfigError } from "@at
 import { logger } from "@atlas/logger";
 import { stringifyError } from "@atlas/utils";
 import { getFridayHome } from "@atlas/utils/paths.server";
-import { parse, stringify } from "@std/dotenv";
+import { parse } from "@std/dotenv";
 import { parse as parseYaml, stringify as stringifyYaml } from "@std/yaml";
 import { describeRoute, resolver, validator } from "hono-openapi";
 import z from "zod";
@@ -25,6 +25,57 @@ async function exists(path: string): Promise<boolean> {
   } catch {
     return false;
   }
+}
+
+/**
+ * Serialize env vars into `.env` format without unnecessary quoting.
+ *
+ * @std/dotenv's stringify wraps any value containing a non-word char
+ * (a `-` in an API key, a `/` in a URL, …) in single quotes. The
+ * launcher's loadDotEnv (tools/friday-launcher/project.go) reads the
+ * file as-is and forwards `KEY='sk-ant-foo'` verbatim to spawned
+ * services, so agents inherit the literal quotes and the API key
+ * fails to authenticate. The Tauri installer's render_env_lines also
+ * writes unquoted, so this matches the format the rest of the stack
+ * already expects.
+ *
+ * Quoting rules picked to round-trip through @std/dotenv's parse
+ * (used on the read side) and shell-style readers like the launcher:
+ *   - newline / CR / NUL  → double-quote with `\n`/`\r` escapes
+ *   - whitespace, `#`, `$`, leading `'`/`"`, or backslash
+ *                         → single-quote (literal, no expansion)
+ *   - anything with a `'` or that needs newline escaping
+ *                         → double-quote with backslash escapes
+ *   - otherwise           → unquoted
+ */
+function stringifyEnv(envVars: Record<string, string>): string {
+  const lines: string[] = [];
+  for (const [key, value] of Object.entries(envVars)) {
+    if (key.startsWith("#")) continue;
+    const v = value ?? "";
+
+    const hasNewline = /[\r\n]/.test(v);
+    const needsQuoting = hasNewline || /[\s#$"'\\]/.test(v) || /^['"]/.test(v);
+
+    if (!needsQuoting) {
+      lines.push(`${key}=${v}`);
+      continue;
+    }
+
+    if (!hasNewline && !v.includes("'")) {
+      lines.push(`${key}='${v}'`);
+      continue;
+    }
+
+    const escaped = v
+      .replaceAll("\\", "\\\\")
+      .replaceAll('"', '\\"')
+      .replaceAll("\n", "\\n")
+      .replaceAll("\r", "\\r")
+      .replaceAll("\t", "\\t");
+    lines.push(`${key}="${escaped}"`);
+  }
+  return lines.join("\n");
 }
 
 import { daemonFactory } from "../src/factory.ts";
@@ -135,8 +186,7 @@ configRoutes.put(
         await mkdir(atlasDir, { recursive: true });
       }
 
-      // Write the file using @std/dotenv stringify
-      const content = stringify(envVars);
+      const content = stringifyEnv(envVars);
       await writeFile(envPath, content, "utf-8");
 
       logger.info("Environment variables updated successfully", {

--- a/apps/atlasd/routes/config.ts
+++ b/apps/atlasd/routes/config.ts
@@ -39,14 +39,17 @@ async function exists(path: string): Promise<boolean> {
  * writes unquoted, so this matches the format the rest of the stack
  * already expects.
  *
- * Quoting rules picked to round-trip through @std/dotenv's parse
- * (used on the read side) and shell-style readers like the launcher:
- *   - newline / CR / NUL  → double-quote with `\n`/`\r` escapes
+ * Inputs are pre-validated by envVarsPutRequestSchema: keys are POSIX
+ * identifiers and values contain no CR/LF, so we don't need to handle
+ * multi-line escapes here (the Go launcher's unquoteEnvValue strips
+ * outer quotes only — it would forward `\n` literally).
+ *
+ * Quoting rules picked to round-trip through @std/dotenv's parse:
  *   - whitespace, `#`, `$`, leading `'`/`"`, or backslash
- *                         → single-quote (literal, no expansion)
- *   - anything with a `'` or that needs newline escaping
- *                         → double-quote with backslash escapes
- *   - otherwise           → unquoted
+ *                  → single-quote (literal, no expansion)
+ *   - value containing `'`
+ *                  → double-quote with `\` and `"` escapes
+ *   - otherwise    → unquoted
  */
 function stringifyEnv(envVars: Record<string, string>): string {
   const lines: string[] = [];
@@ -54,25 +57,19 @@ function stringifyEnv(envVars: Record<string, string>): string {
     if (key.startsWith("#")) continue;
     const v = value ?? "";
 
-    const hasNewline = /[\r\n]/.test(v);
-    const needsQuoting = hasNewline || /[\s#$"'\\]/.test(v) || /^['"]/.test(v);
+    const needsQuoting = /[\s#$"'\\]/.test(v) || /^['"]/.test(v);
 
     if (!needsQuoting) {
       lines.push(`${key}=${v}`);
       continue;
     }
 
-    if (!hasNewline && !v.includes("'")) {
+    if (!v.includes("'")) {
       lines.push(`${key}='${v}'`);
       continue;
     }
 
-    const escaped = v
-      .replaceAll("\\", "\\\\")
-      .replaceAll('"', '\\"')
-      .replaceAll("\n", "\\n")
-      .replaceAll("\r", "\\r")
-      .replaceAll("\t", "\\t");
+    const escaped = v.replaceAll("\\", "\\\\").replaceAll('"', '\\"');
     lines.push(`${key}="${escaped}"`);
   }
   return lines.join("\n");
@@ -94,7 +91,24 @@ const envVarsGetResponseSchema = z.object({
   error: z.string().optional(),
 });
 
-const envVarsPutRequestSchema = z.object({ envVars: z.record(z.string(), z.string()) });
+/**
+ * Keys: POSIX env-var identifiers — `[A-Za-z_][A-Za-z0-9_]*`. Tighter than
+ * what @std/dotenv parse accepts on the read side, deliberately: a key
+ * containing `\n` would let one PUT entry split into two on-disk lines and
+ * smuggle additional env vars into spawned services on the next launcher
+ * import.
+ *
+ * Values: no CR/LF. The Settings UI never sends multi-line values today,
+ * and the Go launcher's unquoteEnvValue strips outer quotes only — it
+ * doesn't expand `\n` escapes — so any multi-line value would reach
+ * spawned services with literal backslash-n. Reject at the boundary.
+ */
+const envVarsPutRequestSchema = z.object({
+  envVars: z.record(
+    z.string().regex(/^[A-Za-z_][A-Za-z0-9_]*$/, "env var keys must be POSIX identifiers"),
+    z.string().regex(/^[^\r\n]*$/, "env var values must not contain newlines"),
+  ),
+});
 
 const envVarsPutResponseSchema = z.object({ success: z.boolean(), error: z.string().optional() });
 

--- a/tools/friday-launcher/project.go
+++ b/tools/friday-launcher/project.go
@@ -230,10 +230,39 @@ func loadDotEnv(path string) []string {
 		if key == "" {
 			continue
 		}
-		value := line[eq+1:]
+		value := unquoteEnvValue(line[eq+1:])
 		out = append(out, key+"="+value)
 	}
 	return out
+}
+
+// unquoteEnvValue strips a single layer of matching surrounding quotes
+// from a .env value so spawned services receive the intended string,
+// not the literal quotes.
+//
+// Standard dotenv parsers (Node, Python, @std/dotenv) treat `KEY='v'`
+// as `KEY=v`. The launcher previously left quotes attached, so any
+// .env line written by atlasd's @std/dotenv stringify (which wraps
+// values with non-word chars in single quotes — e.g. an API key with
+// `-`) reached agents as `'sk-ant-foo'` and failed authentication.
+// Stripping here is defensive: even after atlasd switched to
+// unquoted-by-default writes, hand-edited .env files and pre-fix
+// installs continue to work.
+//
+// Only strips when the leading and trailing quote match. Mismatched
+// or single-sided quotes are left as-is — they're part of the value.
+// Embedded escapes inside double quotes (`\n`, `\"`) are not expanded
+// here; values that need them should be set via the Settings UI,
+// which writes the canonical unquoted form.
+func unquoteEnvValue(v string) string {
+	if len(v) < 2 {
+		return v
+	}
+	first, last := v[0], v[len(v)-1]
+	if (first == '\'' || first == '"') && first == last {
+		return v[1 : len(v)-1]
+	}
+	return v
 }
 
 func discoverClaudeBinary() string {

--- a/tools/friday-launcher/project_env_test.go
+++ b/tools/friday-launcher/project_env_test.go
@@ -183,7 +183,20 @@ func TestImportDotEnvIntoProcessEnv_StripsSurroundingQuotes(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("HOME", tmpHome)
+	// importDotEnvIntoProcessEnv calls os.Setenv directly with no restore,
+	// and t.Setenv("", "") won't work here because the import skips keys
+	// already set (LookupEnv returns true for empty strings). Capture the
+	// prior value and restore it via t.Cleanup so these keys don't leak
+	// into sibling tests.
 	for _, k := range []string{"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "MIXED_QUOTE", "PLAIN_KEY"} {
+		prev, hadPrev := os.LookupEnv(k)
+		t.Cleanup(func() {
+			if hadPrev {
+				_ = os.Setenv(k, prev)
+			} else {
+				_ = os.Unsetenv(k)
+			}
+		})
 		_ = os.Unsetenv(k)
 	}
 

--- a/tools/friday-launcher/project_env_test.go
+++ b/tools/friday-launcher/project_env_test.go
@@ -163,6 +163,45 @@ func TestImportDotEnvIntoProcessEnv_PopulatesPortOverrides(t *testing.T) {
 	}
 }
 
+// TestImportDotEnvIntoProcessEnv_StripsSurroundingQuotes asserts that
+// values written with surrounding quotes by atlasd's pre-fix
+// stringify (or by hand-edited .env files using standard dotenv
+// quoting) reach spawned services unquoted. Regression guard: prior
+// to the fix, an API key like sk-ant-foo persisted via the Settings
+// UI ended up on disk as `'sk-ant-foo'`, which the launcher forwarded
+// verbatim to agents, so authentication failed with a literal-quoted
+// key.
+func TestImportDotEnvIntoProcessEnv_StripsSurroundingQuotes(t *testing.T) {
+	tmpHome := t.TempDir()
+	envDir := filepath.Join(tmpHome, ".friday", "local")
+	if err := os.MkdirAll(envDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	envFile := filepath.Join(envDir, ".env")
+	envContent := "ANTHROPIC_API_KEY='sk-ant-quoted-single'\nOPENAI_API_KEY=\"sk-proj-quoted-double\"\nMIXED_QUOTE='leftover\"\nPLAIN_KEY=sk-no-quotes\n"
+	if err := os.WriteFile(envFile, []byte(envContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HOME", tmpHome)
+	for _, k := range []string{"ANTHROPIC_API_KEY", "OPENAI_API_KEY", "MIXED_QUOTE", "PLAIN_KEY"} {
+		_ = os.Unsetenv(k)
+	}
+
+	importDotEnvIntoProcessEnv()
+
+	cases := map[string]string{
+		"ANTHROPIC_API_KEY": "sk-ant-quoted-single",
+		"OPENAI_API_KEY":    "sk-proj-quoted-double",
+		"MIXED_QUOTE":       "'leftover\"", // mismatched quotes left as-is
+		"PLAIN_KEY":         "sk-no-quotes",
+	}
+	for k, want := range cases {
+		if got := os.Getenv(k); got != want {
+			t.Errorf("%s = %q, want %q", k, got, want)
+		}
+	}
+}
+
 // TestImportDotEnvIntoProcessEnv_PreservesExistingEnv asserts that an
 // already-set value (e.g. shell export) wins over the .env file. This
 // matches deno's --env-file precedence rule: process env > file. A


### PR DESCRIPTION
## Summary

The Settings UI at `/settings` saved env vars through `PUT /api/config/env`, which used `@std/dotenv`'s `stringify` to write the file. That helper wraps any value containing a non-word char (e.g. `-` in `sk-ant-foo`) in single quotes, so a saved API key landed on disk as `ANTHROPIC_API_KEY='sk-ant-foo'`. The Go launcher's `loadDotEnv` reads `.env` raw (no quote stripping) and forwards every entry into spawned services' `Environment`, so agents ended up with `ANTHROPIC_API_KEY` literally containing `'sk-ant-foo'` (quotes and all) — every provider call returned 401.

- `apps/atlasd/routes/config.ts` — replace the `@std/dotenv` `stringify` with a local serializer that only quotes when truly necessary (whitespace, `#`, `$`, leading quote, newline, backslash). API keys, URLs, etc. now write unquoted, matching the Tauri installer's `render_env_lines`.
- `tools/friday-launcher/project.go` — strip a single layer of matching surrounding quotes in `loadDotEnv` (defense in depth: pre-fix `.env` files and hand-edited dotenv-style quoting now work without requiring a re-save through the UI).
- Tests: 10 new vitest cases (`apps/atlasd/routes/config.test.ts`) covering on-disk shape and `PUT → GET` round-trip, plus a Go regression guard (`TestImportDotEnvIntoProcessEnv_StripsSurroundingQuotes`).

## Test plan

- [x] `deno task test apps/atlasd/routes/config.test.ts` — 10/10 pass
- [x] `deno task test apps/atlasd/routes/` — 607/607 pass (no regressions)
- [x] `go test ./tools/friday-launcher/...` — all pass incl. new regression guard
- [x] `deno check apps/atlasd/routes/config.ts` clean
- [x] Manual: save an Anthropic API key via the Settings UI and verify the daemon's spawned agents authenticate successfully