### PR TITLE
docs(readme,setup): rewrite README, expand setup-dev-env.sh into a full bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,38 +3,102 @@
 [![CI](https://github.com/friday-platform/friday-studio/actions/workflows/test.yml/badge.svg)](https://github.com/friday-platform/friday-studio/actions)
 [![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/uczJyp5FMH)
 
-AI agent orchestration platform. Workspaces run autonomous agents triggered by
-signals (HTTP, cron).
+Friday turns natural-language asks into repeatable AI-powered workflows.
+You describe what you want in chat — *"every morning, triage my inbox,
+draft replies, file real asks as Linear tickets"* — and the result is a
+`workspace.yml` you can read, version, share, and run on schedule. Run it
+once, or run it forever.
 
-The daemon manages workspace lifecycles — each workspace defines agents,
-signals, and jobs in a `workspace.yml`. Signals arrive (HTTP, CLI, cron), the
-daemon routes them to the workspace runtime, which spawns sessions where agents
-execute with MCP tool access.
+**Why both a chat and a YAML?** Prompts decay. Run the same prompt tomorrow
+and the output drifts; bump the model and your old contracts shift with
+it. Friday keeps both halves of the loop: **conversation** is how you
+build, **configuration** is how you ship — agents, MCP tools, signals
+(HTTP, cron, Slack, email, webhook), and the jobs that wire them together.
+Read the file. Version it. Hand it to a teammate and it runs the same on
+their machine.
+
+Two surfaces, one runtime:
+
+- **Chat in the playground.** Friday picks up your installed skills, MCP
+  servers, memory, and OAuth credentials, and actually drives your tools
+  instead of describing what it would do.
+- **Run autonomously.** Capture the pattern in a `workspace.yml`, bind it
+  to a signal, and the daemon runs it observably and locally on schedule.
+
+It's for developers and operators who want agents in production —
+reviewing PRs at 3am, draining their inbox before standup, watching
+competitor pricing, summarizing a Fathom call into a Linear ticket —
+without wiring queues, secret stores, schedulers, MCP plumbing, and
+provider clients from scratch every time.
+
+> **Prefer the packaged version?** **[hellofriday.ai](https://hellofriday.ai)**
+> ships the same daemon and playground as a one-click installer for macOS
+> and Windows, with the launcher, dependencies, and tray UI bundled. The
+> rest of this README is for working in-tree.
+
+## Architecture
+
+| | What it is | When you use it |
+| --- | --- | --- |
+| **`atlasd` (daemon)** | Headless runtime — HTTP API on `:8080`, workspace lifecycle, signal router, session state, credentials, JetStream message bus. | Production. CI. Anything you'd `systemd`-ify. |
+| **Agent Playground** | SvelteKit web UI on `:5200` — chat with Friday, author and run agents, inspect every session step-by-step, manage skills/MCP servers/schedules/memory/credentials, browse the workspace marketplace. | Day-to-day. The playground is what you actually look at. |
+
+The desktop installer ships both behind a tray icon. In-tree, `deno task
+dev:playground` runs both side by side with hot reload.
 
 ## Quickstart
 
 ### Prerequisites
 
-| Tool | Version | Why |
-| --- | --- | --- |
-| [Deno](https://deno.com/) | `2.7.0+` | Runs the daemon, CLI, and TypeScript packages |
-| [Go](https://go.dev/) | `1.26+` | Builds the Go services under `tools/` (pty-server, webhook-tunnel, friday-launcher) |
-| [Node.js](https://nodejs.org/) | `24+` | Needed for `npx`, Vite, and the web playground |
-| [uv](https://docs.astral.sh/uv/) | `0.11+` | Provisions the managed Python that user agents run under (auto-installed by `setup-dev-env.sh` if absent) |
-| [git](https://git-scm.com/) | any recent | — |
-| Docker (optional) | any recent | Alternative path: run the full stack with `docker compose up` |
+The daemon orchestrates several runtimes — Friday agents can be authored
+in TypeScript *or* Python, can drive a real browser, and fan out work over
+a message bus. Install the four below yourself, then `scripts/setup-dev-env.sh`
+handles the rest.
 
-You do **not** need Postgres for local development — the daemon uses SQLite by
-default. Postgres is only required when running the `link` credential service
-in production.
+**You install these (we won't touch your version managers):**
+
+| Tool | Min | Why |
+| --- | --- | --- |
+| [Node.js](https://nodejs.org/) | `24+` | Playground runs under Vite via `npx`; `@atlas/ui` builds with `svelte-package`. Manage via fnm/volta/nvm — auto-installing system Node clobbers project pins. |
+| [git](https://git-scm.com/) | any recent | — |
+
+**`setup-dev-env.sh` handles these — installs if missing or below min, otherwise keeps yours:**
+
+| Tool | Min | Why |
+| --- | --- | --- |
+| [Deno](https://deno.com/) | `2.7.0` | Runs the daemon, CLI, link service, and every TS/Svelte package. |
+| [Go](https://go.dev/) | `1.26.0` | Builds the Go services in `tools/`. macOS auto-install via Homebrew; Linux fails with the install URL (no sudo without consent). |
+| [uv](https://docs.astral.sh/uv/) | `0.11.0` | Provisions the managed Python that `type: "user"` agents spawn under. |
+| [`nats-server`](https://nats.io/) | `2.12.0` | Internal message bus the daemon spawns for agent ↔ daemon RPC. Pinned to `v2.12.8` for fresh installs. |
+| [`agent-browser`](https://www.npmjs.com/package/agent-browser) | latest | CLI the bundled `web` agent shells out to for headless browsing. Pulls a Chromium build (~150MB) on first run. |
+| Python 3.12 + `friday-agent-sdk` | pinned | Pre-warmed into uv's cache so the first user-agent spawn isn't a cold start. |
+
+Docker (optional) skips all of the above — `docker compose up` runs the
+whole stack in containers.
+
+You don't need a separate database for local development — the daemon
+persists state through its embedded JetStream bus. Postgres is only needed
+for production deployments of the `link` credential service.
 
 ### 1. Clone and install
 
 ```bash
 git clone https://github.com/friday-platform/friday-studio
 cd friday-studio
-deno install                    # install JS/TS deps (also runs husky via prepare hook)
+bash scripts/setup-dev-env.sh    # bootstraps deno+go+uv+nats+agent-browser, runs deno install, pre-warms Python
 ```
+
+`setup-dev-env.sh` checks each tool's version against the minimums above
+and **keeps your existing toolchain** wherever it satisfies them — auto-
+install only kicks in for missing or stale tools. It also runs `deno
+install`, writes the daemon envfile, and pre-warms the uv cache. Re-run
+it whenever the pinned `friday-agent-sdk` version bumps in
+`tools/friday-launcher/paths.go`.
+
+If the script ends with a `⚠ Skipped:` block, follow the per-tool hint and
+re-run. Common case: `agent-browser` install fails on a system Node — switch
+to a user-scoped Node manager (fnm/volta/nvm) and re-run to enable
+web/browser agents.
 
 ### 2. Configure environment
 
@@ -43,236 +107,238 @@ cp .env.example .env
 # open .env and set ANTHROPIC_API_KEY (or another provider key)
 ```
 
-The example file documents every variable the daemon reads. The minimum to run
-a real agent is one LLM provider key.
+The example file documents every variable the daemon reads — provider keys,
+proxies, OAuth/GitHub App credentials, integration tokens. The minimum to
+run a real agent is one LLM provider key.
 
-### 3. Start the daemon
+### 3. Run the playground (recommended)
 
-```bash
-deno task atlas daemon start --detached
-```
-
-Verify it's up:
-
-```bash
-curl -sf http://localhost:8080/health && echo "  daemon ok"
-deno task atlas daemon status
-```
-
-### 4. Run your first agent
-
-Send a prompt through the CLI — the daemon routes it to the bundled chat
-workspace and returns a chat id you can follow up on.
-
-```bash
-deno task atlas prompt "Write a haiku about TypeScript"
-deno task atlas chat                    # list recent chats
-deno task atlas chat <chatId> --human   # readable transcript
-```
-
-To run a real example workspace, clone the
-[`friday-studio-examples`](https://github.com/friday-platform/friday-studio-examples)
-repo and add one — for instance, the HTTP-triggered GitHub PR reviewer:
-
-```bash
-git clone https://github.com/friday-platform/friday-studio-examples
-deno task atlas workspace add ./friday-studio-examples/github-pr-reviewer
-curl -X POST http://localhost:8080/review-pr \
-  -H "Content-Type: application/json" \
-  -d '{"pr_url": "https://github.com/friday-platform/friday-studio/pull/118"}'
-```
-
-Browse
-[`friday-studio-examples`](https://github.com/friday-platform/friday-studio-examples)
-for more — `github-digest`, `inbox-zero`, `competitive-monitor`,
-`daily-operating-memo`, and others — each is a self-contained
-`workspace.yml` you can copy and edit.
-
-### 5. Stop the daemon
-
-```bash
-deno task atlas daemon stop
-```
-
-### Alternative: Docker
-
-```bash
-docker compose up
-```
-
-This runs the daemon, web UI (Studio), credential service, PTY server, and
-webhook tunnel together. Ports default to `1xxxx` to avoid host collisions —
-see [`docker-compose.yml`](docker-compose.yml).
-
-### Web playground (optional)
-
-For interactive development with the Svelte UI, hot-reload daemon, and webhook
-tunnel running side by side:
+One command, four processes — daemon, link, playground, and webhook tunnel —
+all with hot reload:
 
 ```bash
 deno task dev:playground
 ```
 
-Open http://localhost:5200.
+Open <http://localhost:5200> and the sidebar gives you everything: bundled
+agents under **Agents**, MCP server browser, skills, schedules, memory,
+workspace inspector, settings.
 
-## Local development
+### 4. (Or) just the daemon
 
-Working in-tree (running the daemon out of the repo, not via the desktop
-installer) needs a one-time setup so the daemon's user-agent spawn path
-finds a managed Python with the SDK installed:
+If you only need the API:
 
 ```bash
-bash scripts/setup-dev-env.sh
+deno task atlas daemon start --detached
+curl -sf http://localhost:8080/health && echo "  daemon ok"
+deno task atlas daemon stop
 ```
 
-Idempotent. Safe to re-run after every `friday-agent-sdk` version bump.
+## Examples
 
-What it does:
+### Just chat with it
 
-1. Verifies `uv` is on PATH (installs from astral.sh if not).
-2. Writes the env vars the daemon needs (`FRIDAY_UV_PATH`,
-   `UV_PYTHON_INSTALL_DIR`, `UV_CACHE_DIR`, `FRIDAY_AGENT_SDK_VERSION`)
-   into the daemon's envfile (`~/.atlas/.env` or `~/.friday/local/.env`,
-   matching whichever home holds your live state).
-3. Pre-warms the uv cache — Python 3.12 + the pinned `friday-agent-sdk`
-   wheel — so the first user-agent spawn doesn't pay the download as
-   cold-start latency.
-4. Uninstalls any stale editable `friday-agent-sdk` installs from system
-   Pythons that would otherwise shadow the uv-managed copy.
+Open the playground at <http://localhost:5200>. Type:
 
-Restart your daemon after running it so the new env vars take effect.
+> *Find every unread email from my team that's waiting on a reply, summarize what each is asking, and draft responses.*
 
-The desktop installer handles the same setup automatically; this script is
-for in-tree development only.
+Friday uses your `google-gmail` MCP server to search the inbox, an LLM agent
+to triage, and Gmail's `create_draft` tool to leave the replies in your
+drafts folder — picking tools from what's installed. Same surface as a chat
+product, except the actions actually run. No tools wired up? Add them under
+**MCP** / **Skills** / **Settings** and ask again — the conversation
+continues.
 
-## Commands
+The CLI is the same surface, headless:
+
+```bash
+deno task atlas prompt "summarize the last 10 PRs in friday-platform/friday-studio"
+deno task atlas chat <chatId> --human    # readable transcript
+```
+
+### Promote a chat into a workspace
+
+When a one-off chat is worth re-running on its own, capture the agents and
+tools you used in a `workspace.yml` and bind it to a signal.
+
+**HTTP — review every PR I open:**
+
+```bash
+git clone https://github.com/friday-platform/friday-studio-examples
+deno task atlas workspace add ./friday-studio-examples/github-pr-reviewer
+
+curl -X POST http://localhost:8080/review-pr \
+  -d '{"pr_url": "https://github.com/your-org/your-repo/pull/42"}'
+```
+
+The workspace declares an HTTP signal at `/review-pr`, an LLM agent with
+the `gh` MCP server, and a system prompt scoped to your team's review
+checklist. Wire it to GitHub via `webhook-tunnel` for a public URL.
+
+**Cron — drain my inbox before 9am:**
+
+```yaml
+# workspace.yml
+workspace: { name: inbox-zero }
+signals:
+  - { id: morning, type: cron, schedule: "0 8 * * 1-5" }
+agents:
+  - id: triage
+    type: llm
+    model: claude-sonnet-4-6
+    mcp: [gmail, linear]
+    prompt: |
+      Read unread Gmail. Real asks → file as a Linear ticket tagged `inbox`.
+      Newsletters → archive. Reply to anything from <my-team>.
+jobs:
+  - { on: morning, run: triage }
+```
+
+`deno task atlas workspace add ./inbox-zero` and the cron is live. Each
+morning's run lands in **Platform → inbox-zero → Sessions**.
+
+**Web — watch competitor pricing:** the bundled `web` agent shells out to
+the `agent-browser` CLI, so any agent (chat or workspace) can drive a real
+Chromium. Install once with `npm i -g agent-browser && agent-browser install`,
+then bind it to an hourly cron and have it post to Slack on price changes.
+
+### Skip the YAML — write Python
+
+For mechanical work where an LLM is overkill, an agent declared
+`type: "user"` is a Python file the daemon spawns under uv. The agent
+calls LLM, HTTP, and MCP capabilities through `friday-agent-sdk` —
+authoring guide, full API, and ten runnable examples live in
+[`friday-platform/agent-sdk`](https://github.com/friday-platform/agent-sdk).
+
+> **Rule of thumb:** use `type: "user"` only when each call's decision is
+> mechanical (regex / schema / fixed routing). For LLM-judgment work, use
+> `type: "llm"` with MCP tools.
+
+Browse [`friday-studio-examples`](https://github.com/friday-platform/friday-studio-examples)
+for `github-digest`, `competitive-monitor`, `daily-operating-memo`,
+`jira-bugfix-bitbucket`, and others.
+
+## Agent Playground
+
+`deno task dev:playground` opens the playground at <http://localhost:5200>.
+It's the same Svelte app the desktop installer ships — production UI, not
+a debug widget.
+
+**What's in there:**
+
+- **Agents** — bundled agents (claude-code, gh, jira, hubspot, web, csv,
+  knowledge, image-generation, …) with one-click execute and live SSE
+  streaming. Build a custom one-shot agent (provider, model, system prompt,
+  MCP tools) from the same screen.
+- **Workspaces / Inspector** — load a `workspace.yml`, see the parsed
+  signals/agents/jobs graph, run the full pipeline (prompt → blueprint →
+  FSM compile → execute), and replay every step from disk.
+- **Platform → \<workspace\>** — sessions per workspace, FSM state,
+  per-step transcripts, tool calls, costs.
+- **MCP** — every MCP server registered with the daemon, with tool schemas
+  and a "test call" panel.
+- **Skills** — author and edit the markdown skills agents load on demand.
+- **Memory** — narrative memory each workspace has accumulated.
+- **Schedules** — every cron-bound job, last/next fire, manual trigger.
+- **Discover** — workspace marketplace (browse and install community
+  workspaces).
+- **Settings** — model chains, OAuth, provider keys, environment.
+
+**CLI mode** (workspace generation, no UI):
+
+```bash
+deno task sim "build a daily competitor-pricing digest"          # full pipeline
+deno task sim "..." --stop-at=plan       # blueprint only
+deno task sim "..." --stop-at=fsm        # blueprint + FSM compile
+deno task sim "..." --real               # execute with real MCP agents
+```
+
+Artifacts land in `runs/workspaces/<timestamp>-<slug>/` — replay them in the
+playground's **Workspaces / History** tab.
+
+## Common commands
 
 ```bash
 # Daemon lifecycle
-deno task atlas daemon start --detached   # start (background)
-deno task atlas:dev daemon start          # start with auto-restart (session-aware)
-deno task atlas daemon status             # health check
-deno task atlas daemon stop               # stop
+deno task atlas daemon start --detached   # background
+deno task atlas:dev daemon start          # auto-restart on file change
+deno task atlas daemon status             # health
+deno task atlas daemon stop
 
-# Interact
-deno task atlas prompt "your prompt"      # send a one-shot prompt
+# Talk to it
+deno task atlas prompt "your prompt"      # one-shot prompt → bundled chat workspace
 deno task atlas chat                      # list recent chats
-deno task atlas chat <chatId> --human     # show transcript
+deno task atlas chat <chatId> --human     # readable transcript
 
 # Develop
 deno task typecheck                       # deno check + svelte-check
 deno task lint                            # deno lint + biome check --write
 deno task fmt                             # biome format --write
-deno task test $file                      # run a vitest file
-
-# Go services
-go test -race ./...
-golangci-lint run
+deno task test <file>                     # vitest single file
 ```
 
-## Project Structure
+## Docker
+
+Want it all in containers?
+
+```bash
+docker compose up
+```
+
+Brings up the daemon, playground, link credential service, PTY server, and
+webhook tunnel. Ports default to `1xxxx` to avoid host collisions — see
+[`docker-compose.yml`](docker-compose.yml).
+
+## Project structure
 
 ```
 apps/
-  atlasd/             # Daemon — HTTP API, workspace lifecycle (TS/Deno)
-  atlas-cli/          # CLI entry point — `deno task atlas` (TS/Deno)
-  link/               # Credential / OAuth service (TS/Deno)
-  ledger/             # Resource & activity storage service (TS/Deno)
-  studio-installer/   # Friday Studio launcher app — tray, daemon
-                      # supervisor, autostart (Tauri/Rust)
+  atlasd/             # Daemon — HTTP API, workspace lifecycle, signal router
+  atlas-cli/          # CLI entry point — `deno task atlas`
+  link/               # Credential / OAuth service
+  ledger/             # Resource & activity storage service
+  studio-installer/   # Tauri desktop app — tray, daemon supervisor,
+                      # autostart. The hellofriday.ai download.
 packages/             # @atlas/* libraries — core, agent-sdk, config,
                       # fsm-engine, llm, logger, mcp, memory, skills,
-                      # storage, workspace, signals, …
+                      # storage, workspace, signals, jetstream, …
 tools/
-  agent-playground/   # Web client (SvelteKit) — dev tool and the
-                      # production UI bundled in Friday Studio
-  evals/              # Agent eval harness CLI
+  agent-playground/   # Web client (SvelteKit) — production UI
+  evals/              # Agent eval harness
   friday-launcher/    # System tray launcher + daemon supervisor (Go)
   pty-server/         # WebSocket → PTY shell bridge (Go)
   webhook-tunnel/     # Cloudflare tunnel → daemon webhook forwarder (Go)
 ```
 
 Config: `friday.yml` (platform-wide) · `workspace.yml` (per-workspace) ·
-[`CONTRIBUTING.md`](CONTRIBUTING.md) (dev guidelines + code style)
-
-## Python user agents
-
-A workspace agent declared `type: "user"` is a Python file the daemon spawns
-as a subprocess. The agent code calls capabilities (LLM, HTTP, MCP tools,
-streaming) over NATS through the [`friday-agent-sdk`](https://pypi.org/project/friday-agent-sdk/)
-package — no provider keys, no MCP plumbing in your code.
-
-Minimal agent:
-
-```python
-from friday_agent_sdk import AgentContext, agent, ok
-
-@agent(id="hello", version="1.0.0", description="Reverses input.")
-def execute(prompt: str, ctx: AgentContext):
-    return ok({"reversed": prompt[::-1]})
-
-if __name__ == "__main__":
-    from friday_agent_sdk import run
-    run()
-```
-
-Register and run:
-
-```bash
-curl -X POST http://localhost:8080/api/agents/register \
-  -H "Content-Type: application/json" \
-  -d '{"entrypoint":"/abs/path/to/agent.py"}'
-
-curl -X POST "http://localhost:8080/api/agents/hello/run?workspaceId=user" \
-  -H "Content-Type: application/json" \
-  -d '{"input":"hello"}'
-```
-
-The daemon spawns `uv run --python 3.12 --with friday-agent-sdk==<pinned> agent.py`
-under the hood — the version is pinned in
-[`tools/friday-launcher/paths.go`](tools/friday-launcher/paths.go)
-(`bundledAgentSDKVersion`) and threaded through to the daemon via the
-launcher (or `setup-dev-env.sh` for in-tree work). Bumping the SDK is a
-deliberate change in three pin sites: that constant, the same value in the
-[`Dockerfile`](Dockerfile), and `BUNDLED_AGENT_SDK_VERSION` in
-[`apps/studio-installer/src-tauri/src/commands/prewarm_agent_sdk.rs`](apps/studio-installer/src-tauri/src/commands/prewarm_agent_sdk.rs).
-
-**Rule of thumb:** use `type: "user"` only when each call's decision is
-mechanical (regex / schema / fixed routing). For any LLM-judgment work
-(classifying, summarizing, choosing among options), use `type: "llm"` with
-MCP tools — that's faster to author and easier to maintain.
-
-Reference:
-
-- **SDK:** [`friday-platform/agent-sdk`](https://github.com/friday-platform/agent-sdk)
-  · authoring guide vendored at
-  [`packages/system/skills/writing-friday-python-agents`](packages/system/skills/writing-friday-python-agents/SKILL.md)
-- **Memory access from agents:** narrative is the only supported strategy
-  today — see
-  [`packages/system/skills/writing-to-memory`](packages/system/skills/writing-to-memory/SKILL.md)
-- **Spawn resolution:**
-  [`apps/atlasd/src/agent-spawn.ts`](apps/atlasd/src/agent-spawn.ts) —
-  three-tier fallback (uv-run → `FRIDAY_AGENT_PYTHON` → bare `python3`)
+[`CONTRIBUTING.md`](CONTRIBUTING.md) (dev guidelines + code style).
 
 ## Learn more
 
-- [docs.hellofriday.ai](https://docs.hellofriday.ai) — full documentation
-- [`friday-studio-examples`](https://github.com/friday-platform/friday-studio-examples)
-  — ready-to-import workspace examples
-- [`CONTRIBUTING.md`](CONTRIBUTING.md) — how to send patches, code style, hard
-  rules (CLA required)
+- **[hellofriday.ai](https://hellofriday.ai)** — desktop installer (macOS, Windows)
+- **[docs.hellofriday.ai](https://docs.hellofriday.ai)** — full documentation
+- **[`friday-studio-examples`](https://github.com/friday-platform/friday-studio-examples)** —
+  ready-to-import workspaces
+- **[`friday-platform/agent-sdk`](https://github.com/friday-platform/agent-sdk)** —
+  Python SDK for `type: "user"` agents
+- [AI Drift: the hidden cost of building with AI](https://blog.hellofriday.ai/ai-drift-the-hidden-cost-of-building-with-ai-e2b51415b3b0)
+  — why prompt-only automations stop holding up
+- [Building a personal fitness tracker in one conversation](https://blog.hellofriday.ai/building-a-personal-fitness-tracker-in-one-conversation-1ae2696a89f7)
+  — chat → workspace, end to end
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — patches, code style, hard rules (CLA required)
 - [`SECURITY.md`](SECURITY.md) — vulnerability disclosure
+- [Discord](https://discord.gg/uczJyp5FMH) — questions, show-and-tell
 
 ## License
 
 Friday is **source-available** under the [Business Source License 1.1](LICENSE).
 You can read, modify, and self-host the code under the
-[Additional Use Grant](LICENSE), which permits free production use for personal
-use, organizations under 5 people, and businesses with under $1M ARR.
-Production use outside those bounds, or that competes with Tempest Labs'
-offering, requires a commercial license. Each released version converts
-automatically to **Apache-2.0 one year after that version is first
-distributed** (so the current version's Change Date is **2027-04-30**; later
+[Additional Use Grant](LICENSE), which permits free production use for
+personal use, organizations under 5 people, and businesses with under $1M
+ARR. Production use outside those bounds, or that competes with Tempest
+Labs' offering, requires a commercial license. Each released version
+converts automatically to **Apache-2.0 one year after that version is first
+distributed** (current version's Change Date: **2027-04-30**; later
 versions get their own date).
 
 For commercial-license inquiries: legal@tempest.team.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ provider clients from scratch every time.
 
 | | What it is | When you use it |
 | --- | --- | --- |
-| **`atlasd` (daemon)** | Headless runtime — HTTP API on `:8080`, workspace lifecycle, signal router, session state, credentials, JetStream message bus. | Production. CI. Anything you'd `systemd`-ify. |
+| **`atlasd` (daemon)** | Headless runtime — HTTP API on `:8080`, workspace lifecycle, signal router, session state, JetStream message bus. | Production. CI. Anything you'd `systemd`-ify. |
 | **Agent Playground** | SvelteKit web UI on `:5200` — chat with Friday, author and run agents, inspect every session step-by-step, manage skills/MCP servers/schedules/memory/credentials, browse the workspace marketplace. | Day-to-day. The playground is what you actually look at. |
 
 The desktop installer ships both behind a tray icon. In-tree, `deno task

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -1,33 +1,51 @@
 #!/usr/bin/env bash
 #
-# Friday-studio dev-environment setup. Run once after cloning, and again
-# whenever the pinned friday-agent-sdk version bumps in
+# Friday-studio dev-environment bootstrap. Run once after cloning, and
+# again whenever the pinned friday-agent-sdk version bumps in
 # tools/friday-launcher/paths.go (`bundledAgentSDKVersion`).
 #
 # What this does:
-#   1. Verifies `uv` is on PATH (or installs it from astral.sh).
-#   2. Writes FRIDAY_UV_PATH / UV_PYTHON_INSTALL_DIR / UV_CACHE_DIR /
-#      FRIDAY_AGENT_SDK_VERSION into the daemon's .env so the spawn-resolution
-#      path in apps/atlasd/src/agent-spawn.ts picks up uv-run.
-#   3. Pre-warms the uv cache so the first user-agent spawn doesn't pay
-#      the Python 3.12 download + SDK wheel fetch as cold-start.
-#   4. Uninstalls any editable / system-Python `friday-agent-sdk` installs
-#      that would shadow the uv-managed one. (See plans/user-agent-sdk-cohesion.md
+#   0. Preflight: verifies `node` (>= MIN) and `git` are on PATH. We do
+#      not auto-install these — Node has too many version-manager flavors
+#      (nvm/fnm/volta/asdf/system) to clobber safely, and git on macOS
+#      triggers an interactive xcode-select GUI prompt that would stall
+#      the script.
+#   1. Installs Deno if missing or below MIN (user-scoped curl install)
+#      and runs `deno install` for JS/TS workspace deps.
+#   2. Installs Go if missing or below MIN — Homebrew on macOS only; Linux
+#      tarball installs need sudo / PATH wiring we don't assume.
+#   3. Installs uv if missing or below MIN (curl from astral.sh).
+#   4. Installs nats-server if missing or below MIN (Homebrew on macOS,
+#      otherwise `go install` from the pinned tag — used by the daemon's
+#      JetStream bus, see packages/jetstream/src/spawn.ts).
+#   5. Installs agent-browser CLI if missing (npm + `agent-browser install`
+#      to fetch its Chromium — used by the bundled `web` agent).
+#   6. Uninstalls editable / system-Python `friday-agent-sdk` installs that
+#      would shadow the uv-managed one. (See plans/user-agent-sdk-cohesion.md
 #      § E1 — historical local installs from before the PyPI release have
 #      been silently masking install gaps for in-tree dev.)
+#   7. Writes daemon envfile (FRIDAY_UV_PATH, UV_*, FRIDAY_AGENT_SDK_VERSION,
+#      FRIDAY_JETSTREAM_STORE_DIR).
+#   8. Pre-warms the uv cache (Python 3.12 + pinned SDK).
+#
+# Each tool's existing install is **preferred** if it satisfies the
+# minimum version — we never replace a working toolchain. Auto-install
+# only triggers on missing or stale.
 #
 # This is NOT part of the installer flow. The installer's launcher emits
-# the same env vars at runtime. This script is in-tree dev only.
+# the same env vars at runtime and bundles its own nats-server + Chromium.
+# This script is in-tree dev only.
 #
 # Usage:  bash scripts/setup-dev-env.sh
-# Idempotent: safe to re-run.
+# Idempotent.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# ── Pinned SDK version (must match tools/friday-launcher/paths.go) ──────────
+# ── Pinned versions ─────────────────────────────────────────────────────────
+# Pinned (must match repo state):
 PINNED_SDK_VERSION=$(
     grep -E '^const bundledAgentSDKVersion' \
         "$REPO_ROOT/tools/friday-launcher/paths.go" \
@@ -37,6 +55,111 @@ if [[ -z "${PINNED_SDK_VERSION:-}" ]]; then
     echo "✗ could not parse bundledAgentSDKVersion from tools/friday-launcher/paths.go" >&2
     exit 1
 fi
+# nats-server pin — keep aligned with the `nats:<version>-alpine` line in
+# the repo's Dockerfile. Bump together when upgrading.
+PINNED_NATS_VERSION="v2.12.8"
+
+# Minimum versions (mirror the README's prerequisites table). When a tool
+# is already on PATH at >= MIN, we keep it and don't reinstall.
+DENO_MIN="2.7.0"
+NODE_MIN="24.0.0"
+GO_MIN="1.26.0"
+UV_MIN="0.11.0"
+NATS_MIN="2.12.0"
+
+# ── Version helpers ─────────────────────────────────────────────────────────
+# version_ge "1.2.3" "1.2.0" → returns 0 (true) iff first >= second.
+# Uses `sort -V` (POSIX-portable on macOS BSD coreutils + GNU coreutils).
+version_ge() {
+    [[ "$(printf '%s\n%s\n' "$2" "$1" | sort -V | head -1)" == "$2" ]]
+}
+
+# Extract a tool's version string. Returns empty if it can't parse, which
+# `check_min_version` below treats as "assume OK" (don't punish edge formats).
+get_tool_version() {
+    case "$1" in
+        deno)        deno --version 2>/dev/null | head -1 | awk '{print $2}' ;;
+        node)        node --version 2>/dev/null | sed 's/^v//' ;;
+        go)          go version 2>/dev/null | awk '{print $3}' | sed 's/^go//' ;;
+        uv)          uv --version 2>/dev/null | awk '{print $2}' ;;
+        nats-server) nats-server --version 2>/dev/null | awk '{print $NF}' | sed 's/^v//' ;;
+    esac
+}
+
+# Returns 0 if installed and >= min; 1 if installed but too old; 2 if missing.
+check_min_version() {
+    local tool="$1" min="$2"
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        return 2
+    fi
+    local v
+    v="$(get_tool_version "$tool")"
+    if [[ -z "$v" ]]; then
+        # Couldn't parse — assume OK rather than reinstalling something
+        # that's working. Surface a hint in case it's actually broken.
+        echo "  ⚠ $tool present but couldn't parse version — keeping as-is" >&2
+        return 0
+    fi
+    if version_ge "$v" "$min"; then
+        return 0
+    fi
+    return 1
+}
+
+# brew_install_or_upgrade <formula>: returns 0 on success, 1 if Homebrew
+# isn't usable on this platform. Picks `upgrade` for an already-installed
+# formula (since `brew install` on an existing formula is a no-op, not an
+# upgrade — the script's stale branches need explicit `upgrade`). This
+# also lets the deno/uv stale paths avoid `deno upgrade` / `uv self update`,
+# which fail on Homebrew-managed installs.
+brew_install_or_upgrade() {
+    [[ "$OSTYPE" == "darwin"* ]] || return 1
+    command -v brew >/dev/null 2>&1 || return 1
+    if brew list "$1" >/dev/null 2>&1; then
+        brew upgrade "$1"
+    else
+        brew install "$1"
+    fi
+}
+
+# Tools that this run elected to skip rather than fail. Surfaced in the
+# final summary so the user knows which functionality won't work yet.
+declare -a SKIPPED_TOOLS=()
+
+# ── 0. Preflight: tools we do not auto-install ──────────────────────────────
+# macOS-only: Xcode Command Line Tools provide git, make, and the toolchain
+# Homebrew itself depends on. Without CLT, `git --version` triggers an
+# interactive GUI install prompt via the xcrun shim — we'd rather catch
+# that here with a clear message than mid-flight.
+if [[ "$OSTYPE" == "darwin"* ]] && ! xcode-select -p >/dev/null 2>&1; then
+    echo "✗ Xcode Command Line Tools not installed" >&2
+    echo "  macOS requires CLT for git, make, and the Homebrew toolchain." >&2
+    echo "  Install: xcode-select --install" >&2
+    echo "  (a GUI prompt will appear; complete it and re-run this script)" >&2
+    exit 1
+fi
+
+preflight_failed=0
+case "$(check_min_version node "$NODE_MIN"; echo $?)" in
+    0) echo "→ node:          $(command -v node) ($(get_tool_version node))" ;;
+    1) echo "✗ node $(get_tool_version node) is below minimum $NODE_MIN" >&2
+       echo "  upgrade via your Node manager (fnm/volta/nvm) — we don't auto-install Node" >&2
+       preflight_failed=1 ;;
+    2) echo "✗ node not found on PATH" >&2
+       echo "  install: Node.js $NODE_MIN+ — recommended via fnm/volta/nvm (https://nodejs.org/)" >&2
+       preflight_failed=1 ;;
+esac
+if ! command -v git >/dev/null 2>&1; then
+    echo "✗ git not found on PATH" >&2
+    echo "  install: git via your system package manager (https://git-scm.com/)" >&2
+    preflight_failed=1
+fi
+if [[ $preflight_failed -eq 1 ]]; then
+    echo "" >&2
+    echo "Install the missing tools above and re-run this script." >&2
+    exit 1
+fi
+echo "→ git:           $(command -v git)"
 
 # ── Resolve Friday home ─────────────────────────────────────────────────────
 # Two possible homes — match the daemon's resolution:
@@ -52,7 +175,6 @@ declare -a FRIDAY_HOMES=()
 detect_home() {
     local candidate="$1"
     [[ -d "$candidate" ]] || return 1
-    # Live state markers — daemon writes these
     for marker in agents chats sessions activity.db skills.db storage.db; do
         if [[ -e "$candidate/$marker" ]]; then return 0; fi
     done
@@ -62,12 +184,8 @@ detect_home() {
 if [[ -n "${FRIDAY_HOME:-}" ]]; then
     FRIDAY_HOMES=("$FRIDAY_HOME")
 else
-    # Both candidates can be active (launcher run + out-of-tree run on
-    # the same machine). Write to whichever has live state; if both, write
-    # to both — keeps env vars coherent across both daemon launch modes.
     detect_home "$HOME/.atlas" && FRIDAY_HOMES+=("$HOME/.atlas")
     detect_home "$HOME/.friday/local" && FRIDAY_HOMES+=("$HOME/.friday/local")
-    # Neither has state? Use canonical new path.
     if [[ ${#FRIDAY_HOMES[@]} -eq 0 ]]; then
         FRIDAY_HOMES=("$HOME/.friday/local")
         mkdir -p "${FRIDAY_HOMES[0]}"
@@ -75,19 +193,139 @@ else
 fi
 
 echo "→ Friday home(s): ${FRIDAY_HOMES[*]}"
-echo "→ Pinned SDK:    friday-agent-sdk==$PINNED_SDK_VERSION"
+echo "→ Pinned SDK:     friday-agent-sdk==$PINNED_SDK_VERSION"
+echo "→ Pinned NATS:    nats-server $PINNED_NATS_VERSION"
 
-# ── 1. Ensure uv is on PATH ─────────────────────────────────────────────────
-if ! command -v uv >/dev/null 2>&1; then
-    echo "→ uv not found — installing from astral.sh"
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-    # The installer adds to ~/.local/bin; pick it up for this script's session.
-    export PATH="$HOME/.local/bin:$PATH"
-fi
+# ── 1. Ensure Deno + workspace deps ─────────────────────────────────────────
+case "$(check_min_version deno "$DENO_MIN"; echo $?)" in
+    0) echo "→ deno:          $(command -v deno) ($(get_tool_version deno))" ;;
+    1) if brew_install_or_upgrade deno; then
+           echo "→ deno (homebrew) upgraded to $(get_tool_version deno)"
+       else
+           echo "→ deno $(get_tool_version deno) is below $DENO_MIN — upgrading via deno upgrade"
+           deno upgrade
+       fi ;;
+    2) echo "→ deno not found — installing user-scoped from deno.land"
+       curl -fsSL https://deno.land/install.sh | sh
+       export PATH="$HOME/.deno/bin:$PATH"
+       if ! command -v deno >/dev/null 2>&1; then
+           echo "✗ deno install completed but \`deno\` still not on PATH." >&2
+           echo "  Add to your shell profile: export PATH=\"\$HOME/.deno/bin:\$PATH\"" >&2
+           exit 1
+       fi
+       echo "→ deno:          $(command -v deno) ($(get_tool_version deno))" ;;
+esac
+echo "→ Running deno install (idempotent — fast on re-runs)"
+( cd "$REPO_ROOT" && deno install )
+
+# ── 2. Ensure Go ────────────────────────────────────────────────────────────
+# Used to build apps/atlas-cli's Go services and (below, fallback path) to
+# `go install` nats-server. Auto-install only on macOS via brew — Linux
+# tarball installs to /usr/local/go need sudo we don't want to assume,
+# and shadowing an asdf/gvm-managed Go is a common footgun.
+install_go_via_brew_or_fail() {
+    if brew_install_or_upgrade go; then
+        return 0
+    fi
+    echo "✗ Go $1 — install or upgrade manually: https://go.dev/dl/" >&2
+    echo "  (auto-install on Linux skipped to avoid sudo / asdf clobber)" >&2
+    exit 1
+}
+case "$(check_min_version go "$GO_MIN"; echo $?)" in
+    0) echo "→ go:            $(command -v go) ($(get_tool_version go))" ;;
+    1) echo "→ go $(get_tool_version go) is below $GO_MIN — upgrading"
+       install_go_via_brew_or_fail "$(get_tool_version go) below $GO_MIN" ;;
+    2) echo "→ go not found — installing"
+       install_go_via_brew_or_fail "missing" ;;
+esac
+
+# ── 3. Ensure uv ────────────────────────────────────────────────────────────
+case "$(check_min_version uv "$UV_MIN"; echo $?)" in
+    0) echo "→ uv:            $(command -v uv) ($(get_tool_version uv))" ;;
+    1) if brew_install_or_upgrade uv; then
+           echo "→ uv (homebrew) upgraded to $(get_tool_version uv)"
+       else
+           echo "→ uv $(get_tool_version uv) is below $UV_MIN — upgrading via uv self update"
+           uv self update
+       fi ;;
+    2) echo "→ uv not found — installing from astral.sh"
+       curl -LsSf https://astral.sh/uv/install.sh | sh
+       export PATH="$HOME/.local/bin:$PATH"
+       echo "→ uv:            $(command -v uv) ($(get_tool_version uv))" ;;
+esac
 UV_PATH="$(command -v uv)"
-echo "→ uv:          $UV_PATH"
 
-# ── 2. Uninstall stale editable / system-Python friday-agent-sdk installs ───
+# ── 4. Ensure nats-server ───────────────────────────────────────────────────
+# Daemon spawns nats-server for the JetStream bus
+# (packages/jetstream/src/spawn.ts).
+install_nats_server() {
+    if brew_install_or_upgrade nats-server; then
+        return 0
+    fi
+    echo "  via: go install github.com/nats-io/nats-server/v2@$PINNED_NATS_VERSION"
+    go install "github.com/nats-io/nats-server/v2@$PINNED_NATS_VERSION"
+    # go install writes to $(go env GOBIN) or $(go env GOPATH)/bin. The
+    # daemon's `which nats-server` won't find it unless that's on PATH.
+    local gobin
+    gobin="$(go env GOBIN)"
+    [[ -z "$gobin" ]] && gobin="$(go env GOPATH)/bin"
+    # Prefer symlinking into ~/.local/bin if it's writable and on PATH —
+    # the uv installer adds ~/.local/bin to PATH for most users, so this
+    # makes the install idempotent across fresh-shell re-runs without
+    # requiring the user to edit their shell profile for $gobin.
+    if [[ -x "$gobin/nats-server" ]] && [[ -d "$HOME/.local/bin" ]] \
+        && echo ":$PATH:" | grep -q ":$HOME/.local/bin:"; then
+        ln -sf "$gobin/nats-server" "$HOME/.local/bin/nats-server"
+        echo "  → symlinked $gobin/nats-server → $HOME/.local/bin/nats-server"
+    elif ! echo ":$PATH:" | grep -q ":$gobin:"; then
+        export PATH="$gobin:$PATH"
+        echo "  ⚠ $gobin is not on your PATH — add this to your shell profile:"
+        echo "      export PATH=\"$gobin:\$PATH\""
+    fi
+}
+case "$(check_min_version nats-server "$NATS_MIN"; echo $?)" in
+    0) echo "→ nats-server:   $(command -v nats-server) ($(get_tool_version nats-server))" ;;
+    1) echo "→ nats-server $(get_tool_version nats-server) is below $NATS_MIN — installing $PINNED_NATS_VERSION"
+       install_nats_server ;;
+    2) echo "→ nats-server not found — installing $PINNED_NATS_VERSION"
+       install_nats_server ;;
+esac
+if ! command -v nats-server >/dev/null 2>&1; then
+    echo "✗ nats-server still not on PATH after install attempt" >&2
+    echo "  fix manually: brew install nats-server  (or download from" >&2
+    echo "  https://github.com/nats-io/nats-server/releases)" >&2
+    exit 1
+fi
+
+# ── 5. Ensure agent-browser CLI ─────────────────────────────────────────────
+# The bundled `web` agent (packages/bundled-agents/src/web/) shells out to
+# the agent-browser CLI to drive Chromium. The install pulls a Chromium
+# build (~150MB) on first run; soft-failure if npm rejects (system Node
+# permissions) — daemon doesn't hard-depend on this, only web agents do.
+# No min version — agent-browser releases fast and we want latest.
+if ! command -v agent-browser >/dev/null 2>&1; then
+    echo "→ agent-browser not found — installing globally via npm"
+    if ! npm i -g agent-browser; then
+        echo "  ⚠ npm install failed (likely a permissions issue on a system Node)." >&2
+        echo "    Re-run with sudo, or use a user-scoped Node manager (nvm/fnm/volta)." >&2
+        echo "    Skipping agent-browser — web/browser agents will not work until installed." >&2
+    fi
+fi
+if command -v agent-browser >/dev/null 2>&1; then
+    # `agent-browser install` is idempotent: re-runs verify the cached
+    # Chromium and exit fast if already present.
+    if ! agent-browser install >/dev/null 2>&1; then
+        echo "  ⚠ agent-browser install failed — run manually to debug:" >&2
+        echo "      agent-browser install" >&2
+        SKIPPED_TOOLS+=("agent-browser install (Chromium fetch) — re-run \`agent-browser install\` to debug")
+    fi
+    echo "→ agent-browser: $(command -v agent-browser)"
+else
+    echo "→ agent-browser: SKIPPED (web/browser agents disabled until installed)"
+    SKIPPED_TOOLS+=("agent-browser — web/browser agents disabled. Switch to a user-scoped Node manager (fnm/volta/nvm) and re-run.")
+fi
+
+# ── 6. Uninstall stale editable / system-Python friday-agent-sdk installs ───
 # Historic editable installs (e.g. /Users/<you>/tempest/agent-sdk/packages/python)
 # silently shadow the uv-managed SDK and have caused real "works on my
 # machine" divergence. Strip them.
@@ -95,28 +333,35 @@ declare -a STALE_PYTHONS=()
 if command -v python3 >/dev/null 2>&1; then
     STALE_PYTHONS+=("$(command -v python3)")
 fi
-# Common Homebrew-installed alternates that may also have it editable.
 for v in 3.12 3.13 3.14; do
     if command -v "python$v" >/dev/null 2>&1; then
         STALE_PYTHONS+=("$(command -v "python$v")")
     fi
 done
+# Dedup: python3 and python3.12 commonly resolve to the same binary on
+# Homebrew. `[[ a -ef b ]]` tests same-inode (POSIX-ish, supported in bash).
+if [[ ${#STALE_PYTHONS[@]} -gt 1 ]]; then
+    declare -a _deduped=()
+    for p in "${STALE_PYTHONS[@]}"; do
+        _seen=0
+        for d in "${_deduped[@]:-}"; do
+            [[ -n "$d" && "$p" -ef "$d" ]] && { _seen=1; break; }
+        done
+        [[ $_seen -eq 0 ]] && _deduped+=("$p")
+    done
+    STALE_PYTHONS=("${_deduped[@]}")
+fi
 
 for py in "${STALE_PYTHONS[@]}"; do
     if "$py" -c "import friday_agent_sdk" >/dev/null 2>&1; then
         installed=$("$py" -c "import friday_agent_sdk; print(friday_agent_sdk.__file__)" 2>/dev/null || echo "<unknown>")
         echo "→ Removing stale install at $installed (was importable from $py)"
-        # Homebrew/system Pythons are PEP 668 "externally managed" and refuse
+        # PEP 668 "externally managed" Pythons (Homebrew, system) refuse
         # `pip uninstall` without --break-system-packages. We're explicitly
-        # uninstalling a stale dev install we own, so the flag is the
-        # correct tool here. Suppress success/failure noise but capture for
-        # the post-loop verification.
+        # uninstalling a stale dev install we own, so the flag is correct.
         "$py" -m pip uninstall -y --break-system-packages friday-agent-sdk \
             >/dev/null 2>&1 || \
             "$py" -m pip uninstall -y friday-agent-sdk >/dev/null 2>&1 || true
-        # Verify and warn if it didn't take. uv-run in step 4 still
-        # produces the clean SDK so the daemon's primary path is fine —
-        # but bare-python3 fallback would still hit the stale path.
         if "$py" -c "import friday_agent_sdk" >/dev/null 2>&1; then
             still_at=$("$py" -c "import friday_agent_sdk; print(friday_agent_sdk.__file__)" 2>/dev/null || echo "<unknown>")
             echo "  ⚠ uninstall did not take — $py still resolves friday_agent_sdk at $still_at"
@@ -125,12 +370,11 @@ for py in "${STALE_PYTHONS[@]}"; do
     fi
 done
 
-# ── 3. Write env vars to the daemon's .env (idempotent upsert) ──────────────
+# ── 7. Write env vars to the daemon's .env (idempotent upsert) ──────────────
 upsert_env() {
     local key="$1"
     local value="$2"
     if [[ -f "$ENV_FILE" ]] && grep -qE "^${key}=" "$ENV_FILE"; then
-        # Replace existing line in-place (BSD sed compatible: provide -i '' on macOS).
         if [[ "$OSTYPE" == "darwin"* ]]; then
             sed -i '' -E "s|^${key}=.*$|${key}=${value}|" "$ENV_FILE"
         else
@@ -144,19 +388,30 @@ upsert_env() {
 for home in "${FRIDAY_HOMES[@]}"; do
     ENV_FILE="$home/.env"
     touch "$ENV_FILE"
-    upsert_env "FRIDAY_UV_PATH"            "$UV_PATH"
-    upsert_env "UV_PYTHON_INSTALL_DIR"     "$home/uv/python"
-    upsert_env "UV_CACHE_DIR"              "$home/uv/cache"
-    upsert_env "FRIDAY_AGENT_SDK_VERSION"  "$PINNED_SDK_VERSION"
+    upsert_env "FRIDAY_UV_PATH"               "$UV_PATH"
+    upsert_env "UV_PYTHON_INSTALL_DIR"        "$home/uv/python"
+    upsert_env "UV_CACHE_DIR"                 "$home/uv/cache"
+    upsert_env "FRIDAY_AGENT_SDK_VERSION"     "$PINNED_SDK_VERSION"
+    # JetStream store dir: identical to the daemon's current default
+    # (apps/atlasd/src/nats-manager.ts → join(getFridayHome(), "jetstream")),
+    # but pinned in .env so the value is immune to default-changes in the
+    # daemon and visible in `cat ~/.atlas/.env` for operators debugging.
+    # @ljagiello — the studio-installer launcher should emit this same env
+    # var at runtime so installer-mode and dev-mode keep JetStream data
+    # under friday_home rather than $TMPDIR. Pair this with the existing
+    # uv path emission in the launcher.
+    upsert_env "FRIDAY_JETSTREAM_STORE_DIR"   "$home/jetstream"
     echo "→ Wrote env vars to $ENV_FILE"
 done
 
-# ── 4. Pre-warm uv cache ────────────────────────────────────────────────────
-# Triggers Python 3.12 download (if missing) and friday-agent-sdk wheel fetch.
-# First run: ~5–30s depending on network. Subsequent runs: noop.
-# Warm the *first* home — uv's cache is content-addressed, so warming
-# either path effectively warms shared wheel storage; pre-warming both is
-# wasteful. Use the first detected home (preferring live state).
+# ── 8. Pre-warm uv cache ────────────────────────────────────────────────────
+# `uv run --python 3.12` auto-fetches the interpreter on first use — no
+# separate `uv python install` is needed. This step pre-pays that download
+# plus the friday-agent-sdk wheel fetch so the daemon's first user-agent
+# spawn isn't a cold start.
+# First run: ~5–30s. Subsequent runs: noop. uv's cache is content-addressed,
+# so warming either FRIDAY_HOME shares wheel storage; pre-warm only the
+# first detected home.
 PRIMARY_HOME="${FRIDAY_HOMES[0]}"
 echo "→ Pre-warming uv cache at $PRIMARY_HOME/uv/ (Python 3.12 + friday-agent-sdk==$PINNED_SDK_VERSION)"
 UV_PYTHON_INSTALL_DIR="$PRIMARY_HOME/uv/python" \
@@ -169,3 +424,11 @@ echo ""
 echo "✓ Dev environment ready."
 echo "  Daemon will spawn user agents via:"
 echo "    $UV_PATH run --python 3.12 --with friday-agent-sdk==$PINNED_SDK_VERSION agent.py"
+
+if [[ ${#SKIPPED_TOOLS[@]} -gt 0 ]]; then
+    echo ""
+    echo "⚠ Skipped (re-run after fixing to enable):"
+    for t in "${SKIPPED_TOOLS[@]}"; do
+        echo "  - $t"
+    done
+fi

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -122,6 +122,33 @@ brew_install_or_upgrade() {
     fi
 }
 
+# is_brew_managed <tool-name>: returns 0 iff the tool currently on PATH
+# resolves into Homebrew's prefix. Used to gate stale-branch upgrades:
+# without this check, a curl-installed (e.g. ~/.deno/bin/deno) tool that's
+# below MIN would trigger `brew install <tool>`, dropping a second copy
+# alongside the first and leaving PATH order to pick the winner. With it,
+# we only route through brew when brew already owns the binary — otherwise
+# fall through to the tool's own self-upgrade (or, for tools without one,
+# a clear fail-fast asking the user to upgrade via their existing manager).
+is_brew_managed() {
+    [[ "$OSTYPE" == "darwin"* ]] || return 1
+    command -v brew >/dev/null 2>&1 || return 1
+    local p prefix resolved
+    p="$(command -v "$1" 2>/dev/null)"
+    [[ -n "$p" ]] || return 1
+    prefix="$(brew --prefix 2>/dev/null)"
+    [[ -n "$prefix" ]] || return 1
+    # Resolve symlinks. macOS BSD `readlink` lacks `-f`, so use `realpath`
+    # if present, else fall back to comparing the symlink path itself —
+    # which still hits brew's prefix for the canonical /opt/homebrew/bin
+    # entries that brew installs.
+    resolved="$p"
+    if command -v realpath >/dev/null 2>&1; then
+        resolved="$(realpath "$p" 2>/dev/null || echo "$p")"
+    fi
+    [[ "$resolved" == "$prefix"/* || "$p" == "$prefix"/* ]]
+}
+
 # Tools that this run elected to skip rather than fail. Surfaced in the
 # final summary so the user knows which functionality won't work yet.
 declare -a SKIPPED_TOOLS=()
@@ -199,8 +226,9 @@ echo "→ Pinned NATS:    nats-server $PINNED_NATS_VERSION"
 # ── 1. Ensure Deno + workspace deps ─────────────────────────────────────────
 case "$(check_min_version deno "$DENO_MIN"; echo $?)" in
     0) echo "→ deno:          $(command -v deno) ($(get_tool_version deno))" ;;
-    1) if brew_install_or_upgrade deno; then
-           echo "→ deno (homebrew) upgraded to $(get_tool_version deno)"
+    1) if is_brew_managed deno; then
+           echo "→ deno (homebrew) is below $DENO_MIN — upgrading via brew"
+           brew_install_or_upgrade deno
        else
            echo "→ deno $(get_tool_version deno) is below $DENO_MIN — upgrading via deno upgrade"
            deno upgrade
@@ -233,8 +261,18 @@ install_go_via_brew_or_fail() {
 }
 case "$(check_min_version go "$GO_MIN"; echo $?)" in
     0) echo "→ go:            $(command -v go) ($(get_tool_version go))" ;;
-    1) echo "→ go $(get_tool_version go) is below $GO_MIN — upgrading"
-       install_go_via_brew_or_fail "$(get_tool_version go) below $GO_MIN" ;;
+    1) # Stale: only auto-upgrade if the existing binary is brew-managed.
+       # Otherwise (asdf/gvm/manual install, system tarball) we'd shadow
+       # their toolchain with a brew copy — defer to their installer.
+       if is_brew_managed go; then
+           echo "→ go (homebrew) is below $GO_MIN — upgrading via brew"
+           brew_install_or_upgrade go
+       else
+           echo "✗ go $(get_tool_version go) is below $GO_MIN" >&2
+           echo "  Upgrade via your existing installer (asdf/gvm/system) and re-run." >&2
+           echo "  Auto-upgrade skipped to avoid shadowing the existing Go with a brew copy." >&2
+           exit 1
+       fi ;;
     2) echo "→ go not found — installing"
        install_go_via_brew_or_fail "missing" ;;
 esac
@@ -242,8 +280,9 @@ esac
 # ── 3. Ensure uv ────────────────────────────────────────────────────────────
 case "$(check_min_version uv "$UV_MIN"; echo $?)" in
     0) echo "→ uv:            $(command -v uv) ($(get_tool_version uv))" ;;
-    1) if brew_install_or_upgrade uv; then
-           echo "→ uv (homebrew) upgraded to $(get_tool_version uv)"
+    1) if is_brew_managed uv; then
+           echo "→ uv (homebrew) is below $UV_MIN — upgrading via brew"
+           brew_install_or_upgrade uv
        else
            echo "→ uv $(get_tool_version uv) is below $UV_MIN — upgrading via uv self update"
            uv self update
@@ -285,8 +324,18 @@ install_nats_server() {
 }
 case "$(check_min_version nats-server "$NATS_MIN"; echo $?)" in
     0) echo "→ nats-server:   $(command -v nats-server) ($(get_tool_version nats-server))" ;;
-    1) echo "→ nats-server $(get_tool_version nats-server) is below $NATS_MIN — installing $PINNED_NATS_VERSION"
-       install_nats_server ;;
+    1) # Stale: same shadow-avoidance logic as Go. If the existing binary
+       # came from `go install` or a manual download, brew-installing
+       # would put a second copy alongside; defer to whoever owns it.
+       if is_brew_managed nats-server; then
+           echo "→ nats-server (homebrew) is below $NATS_MIN — upgrading via brew"
+           brew_install_or_upgrade nats-server
+       else
+           echo "✗ nats-server $(get_tool_version nats-server) is below $NATS_MIN" >&2
+           echo "  Upgrade via wherever it came from (go install, GitHub release, etc.) and re-run." >&2
+           echo "  Auto-upgrade skipped to avoid shadowing with a brew copy." >&2
+           exit 1
+       fi ;;
     2) echo "→ nats-server not found — installing $PINNED_NATS_VERSION"
        install_nats_server ;;
 esac


### PR DESCRIPTION
## Summary

- **README rewrite.** Chat-first framing — workspaces are how you ship a chat pattern, not the only way in. `hellofriday.ai` repositioned as the packaged distribution of the same daemon + playground (not "the offering" the README is about). Prereq table split into "you install" (Node, git) and "the setup script handles" (Deno, Go, uv, nats-server, agent-browser, Python + SDK), with explicit min versions matching `*_MIN` constants in the script. Outdated SQLite/Postgres phrasing corrected to JetStream now that `storage.db` / `activity.db` / `skills.db` have been migrated/deleted.
- **`scripts/setup-dev-env.sh` expanded into a one-shot bootstrap with version detection.** Keeps your existing toolchain wherever it satisfies the min; only auto-installs missing or stale tools.

## What the script does now

1. **Preflight** — Xcode CLT (macOS), Node ≥ 24, git. Fails fast with install hints if missing.
2. **Deno** — curl install (or `brew upgrade deno` for Homebrew installs).
3. **Go** — Homebrew on macOS; hard-fail on Linux (no sudo / asdf clobber).
4. **uv** — astral.sh curl (or `brew upgrade uv` for Homebrew installs).
5. **nats-server** — pinned to `v2.12.8` (matches Dockerfile). Homebrew on macOS, otherwise `go install` + `~/.local/bin` symlink so re-runs are idempotent without shell-profile edits.
6. **agent-browser** — `npm i -g agent-browser` + Chromium fetch. Soft-fails to a `SKIPPED_TOOLS` summary so users see what's disabled rather than aborting the whole bootstrap on a system-Node permissions issue.
7. **Stale Python `friday-agent-sdk` cleanup** — strips editable installs that shadow the uv-managed SDK; deduped to avoid double-uninstalling when `python3` and `python3.12` resolve to the same brew binary.
8. **Daemon envfile** — writes `FRIDAY_UV_PATH`, `UV_PYTHON_INSTALL_DIR`, `UV_CACHE_DIR`, `FRIDAY_AGENT_SDK_VERSION`, and now `FRIDAY_JETSTREAM_STORE_DIR=$home/jetstream` (identical to the daemon's current default in `apps/atlasd/src/nats-manager.ts`, pinned for parity with the studio-installer launcher).
9. **Pre-warm uv cache** — Python 3.12 + pinned `friday-agent-sdk` wheel so the first user-agent spawn isn't a cold start.

## For @ljagiello

The script now writes `FRIDAY_JETSTREAM_STORE_DIR=<friday_home>/jetstream` to the daemon `.env`. The studio-installer launcher should emit the same env var at runtime so installer-mode and dev-mode agree on JetStream data location (rather than falling through to nats-server's `$TMPDIR/nats/jetstream` default). Pair this with the existing uv path emission in `apps/studio-installer/src-tauri/src/commands/prewarm_agent_sdk.rs`. There's an inline `@ljagiello` comment at the env-write site as a reminder.

## Test plan

- [x] `bash -n scripts/setup-dev-env.sh` — clean
- [x] `version_ge` correctness verified against six pairs (`2.7.4 vs 2.7.0`, `2.6.0 vs 2.7.0`, `2.7.0 vs 2.7.0`, `1.26.1 vs 1.26.0`, `1.25.0 vs 1.26.0`, `0.11.5 vs 0.11.0`) — all pass
- [x] `STALE_PYTHONS` dedup verified with synthetic `(python3, python3, python3.12)` — collapses to two
- [x] `deno task typecheck` — 0 errors (8230 files)
- [x] `deno run -A npm:knip` — clean
- [ ] `deno task test` — 5109 pass / 2 fail (3 test files). Failures are unrelated to this change: `apps/link/src/routes/communicator.test.ts` and `apps/atlasd/src/chat-sdk/chat-sdk-instance.test.ts` are NATS test-server flakes (network race in `packages/core/src/test-utils/nats-test-server.ts:52`); `packages/workspace/src/__tests__/standing-orders-bootstrap.test.ts` is a separate workspace test. This PR only touches `README.md` and `scripts/setup-dev-env.sh` — no TS code changed.
- [ ] Manual: fresh-machine run on macOS to confirm no-op on a tool-complete laptop (please test before merge)
- [ ] Manual: confirm Linux dev path still surfaces clear errors when Go / brew unavailable