### PR TITLE
chat handler race fix + workspace/instance SSE feeds + cascade banner

### DIFF
--- a/apps/atlasd/routes/instance-events.ts
+++ b/apps/atlasd/routes/instance-events.ts
@@ -51,6 +51,14 @@ export const instanceEventsRoutes = daemonFactory
     }
 
     // SSE path — live feed.
+    // Core NATS subscription, not a JetStream consumer — the daemon
+    // re-subscribes automatically on reconnect, but messages published
+    // while the daemon's NATS connection was disconnected are LOST.
+    // Acceptable here because the playground is a dev tool and the
+    // replay endpoint (`?since=<seq>`) covers reload-after-disconnect.
+    // For a production-grade ops UI an ordered ephemeral push consumer
+    // (DeliverPolicy=New) would survive disconnects with replay, at
+    // the cost of one consumer per HTTP client.
     const subject = type ? `instance.${type}` : "instance.>";
     const sub = nc.subscribe(subject);
     // The `subscribe()` call returns before the broker actually registers
@@ -86,8 +94,18 @@ export const instanceEventsRoutes = daemonFactory
               controller.enqueue(enc.encode(`data: ${payload}\n\n`));
             }
           } catch {
-            // subscription closed — fall through to controller.close()
+            // for-await exited early — most often because the SSE
+            // controller threw in `enqueue` after the consumer cancelled
+            // (e.g. browser closed the EventSource). The abort listener
+            // normally tears down the NATS subscription on its own, but
+            // controller-cancel can land first; defense-in-depth in the
+            // finally below ensures we never leak the subscription.
           } finally {
+            try {
+              sub.unsubscribe();
+            } catch {
+              // already gone — abort listener fired first
+            }
             try {
               controller.close();
             } catch {

--- a/apps/atlasd/routes/workspace-events.ts
+++ b/apps/atlasd/routes/workspace-events.ts
@@ -26,6 +26,16 @@ const ParamSchema = z.object({ workspaceId: z.string() });
 const QuerySchema = z.object({ limit: z.coerce.number().int().positive().max(500).optional() });
 
 /**
+ * Adds `stream=true` for the SSE feed branch on top of the replay-only
+ * QuerySchema. Mirrors `apps/atlasd/routes/instance-events.ts` so the two
+ * event surfaces (instance-wide cascade events; workspace operational
+ * events) consume the same shape.
+ */
+const ListQuerySchema = QuerySchema.extend({ stream: z.coerce.boolean().optional() });
+
+const enc = new TextEncoder();
+
+/**
  * Body for `POST /api/events/fire` and `/dismiss`. The composite
  * (workspaceId, signalId, scheduledAt) uniquely identifies a manual
  * `schedule.missed` event — same shape used to derive the KV state
@@ -79,16 +89,90 @@ export const workspaceEventsRoutes = daemonFactory
  * Global feed — every workspace's recent events in one list. Drives
  * the top-level `/schedules` page; per-workspace pages use the
  * `/api/workspaces/:workspaceId/events` variant above.
+ *
+ * Two read modes on the same path:
+ *   - `?stream=true` — SSE feed; subscribes to `events.>` and forwards
+ *                      each entry as a `data:` frame. The /schedules
+ *                      UI listens here for live updates so it doesn't
+ *                      poll the replay endpoint every minute.
+ *   - default        — paginated replay (newest first) for first-load
+ *                      hydration and reload-after-disconnect. Resolves
+ *                      manual-event KV state and runs the pending
+ *                      self-heal — the SSE feed only forwards new
+ *                      publishes and skips that work.
  */
 export const eventsRoutes = daemonFactory
   .createApp()
-  .get("/", zValidator("query", QuerySchema), async (c) => {
-    const { limit } = c.req.valid("query");
+  .get("/", zValidator("query", ListQuerySchema), async (c) => {
+    const { limit, stream } = c.req.valid("query");
     const ctx = c.get("app");
     const nc = ctx.daemon.getNatsConnection();
     if (!nc) return c.json({ error: "NATS connection not ready" }, 503);
-    const events = await listAllWorkspaceEvents(nc, { ...(limit !== undefined ? { limit } : {}) });
-    return c.json({ events }, 200);
+
+    if (!stream) {
+      const events = await listAllWorkspaceEvents(nc, {
+        ...(limit !== undefined ? { limit } : {}),
+      });
+      return c.json({ events }, 200);
+    }
+
+    // SSE branch — subscribe to the raw NATS subject and forward each
+    // event JSON as a `data:` frame. Operator-action lifecycle (the
+    // KV-backed `status` / `pending` / `actionedAt` fields resolved by
+    // the replay path) is intentionally NOT joined here: stream
+    // entries are immutable, so the UI hydrates lifecycle from the
+    // replay endpoint at first load and treats the SSE feed as a feed
+    // of new publishes only. After a fire/dismiss, the UI updates
+    // optimistically — the KV write is the source of truth, the
+    // stream just carries the original event.
+    const sub = nc.subscribe(`events.>`);
+    // The `subscribe()` call returns before the broker actually
+    // registers the subscription. Without this flush, an event
+    // published in the window between subscribe-returns and
+    // broker-registers would be silently dropped. Once the flush
+    // resolves the subscription is live server-side and the SSE
+    // handshake honestly means "from now on, you get every event."
+    await nc.flush();
+
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        c.req.raw.signal.addEventListener("abort", () => {
+          try {
+            sub.unsubscribe();
+          } catch {
+            // already gone
+          }
+          try {
+            controller.close();
+          } catch {
+            // already closed
+          }
+        });
+
+        void (async () => {
+          try {
+            for await (const msg of sub) {
+              const payload = msg.string();
+              controller.enqueue(enc.encode(`data: ${payload}\n\n`));
+            }
+          } catch {
+            // subscription closed — fall through to controller.close()
+          } finally {
+            try {
+              controller.close();
+            } catch {
+              // already closed
+            }
+          }
+        })();
+      },
+    });
+
+    return c.body(body, 200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
   })
   /**
    * Fire a pending manual `schedule.missed` event. Triggers the

--- a/apps/atlasd/routes/workspace-events.ts
+++ b/apps/atlasd/routes/workspace-events.ts
@@ -156,8 +156,18 @@ export const eventsRoutes = daemonFactory
               controller.enqueue(enc.encode(`data: ${payload}\n\n`));
             }
           } catch {
-            // subscription closed — fall through to controller.close()
+            // for-await exited early — most often because the SSE
+            // controller threw in `enqueue` after the consumer cancelled
+            // (e.g. browser closed the EventSource). The abort listener
+            // normally tears down the NATS subscription on its own, but
+            // controller-cancel can land first; defense-in-depth in the
+            // finally below ensures we never leak the subscription.
           } finally {
+            try {
+              sub.unsubscribe();
+            } catch {
+              // already gone — abort listener fired first
+            }
             try {
               controller.close();
             } catch {

--- a/apps/atlasd/routes/workspace-events.ts
+++ b/apps/atlasd/routes/workspace-events.ts
@@ -125,6 +125,15 @@ export const eventsRoutes = daemonFactory
     // of new publishes only. After a fire/dismiss, the UI updates
     // optimistically — the KV write is the source of truth, the
     // stream just carries the original event.
+    // Core NATS subscription, not a JetStream consumer — the daemon
+    // re-subscribes automatically on reconnect, but messages published
+    // while the daemon's NATS connection was disconnected are LOST.
+    // Acceptable here because the playground is a dev tool and the
+    // replay endpoint covers reload-after-disconnect; the operator-
+    // action POSTs invalidate the query and refetch on every flip.
+    // For a production-grade ops UI an ordered ephemeral push consumer
+    // (DeliverPolicy=New) would survive disconnects with replay, at
+    // the cost of one consumer per HTTP client.
     const sub = nc.subscribe(`events.>`);
     // The `subscribe()` call returns before the broker actually
     // registers the subscription. Without this flush, an event

--- a/apps/atlasd/src/chat-sdk/atlas-web-adapter.test.ts
+++ b/apps/atlasd/src/chat-sdk/atlas-web-adapter.test.ts
@@ -125,6 +125,13 @@ describe("AtlasWebAdapter.handleWebhook", () => {
     expect(message.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
 
     expect(registry.getStream("chat-webhook")?.active).toBe(true);
+    // Wire-up contract: handleWebhook must stash the StreamBuffer it
+    // creates on `Message.raw.turnBuffer` so the shared chat-sdk handler
+    // can capture this turn's buffer deterministically (closes the
+    // subscribe-window race in #192). Asserting identity here means a
+    // refactor that drops the assignment fails this test instead of
+    // only manifesting at runtime in the live SSE handler.
+    expect(message.raw.turnBuffer).toBe(registry.getStream("chat-webhook"));
   });
 
   it("preserves data-artifact-attached parts on WebChatPayload.uiMessage", async () => {

--- a/apps/atlasd/src/chat-sdk/atlas-web-adapter.ts
+++ b/apps/atlasd/src/chat-sdk/atlas-web-adapter.ts
@@ -28,7 +28,7 @@ import type {
 import { Message, parseMarkdown, stringifyMarkdown } from "chat";
 import { z } from "zod";
 import type { ChatTurnRegistry } from "../chat-turn-registry.ts";
-import type { StreamRegistry } from "../stream-registry.ts";
+import type { StreamBuffer, StreamRegistry } from "../stream-registry.ts";
 
 const SSE_HEADERS = {
   "Content-Type": "text/event-stream",
@@ -102,6 +102,14 @@ export interface WebChatPayload {
    * request may be long gone before the FSM is done.
    */
   abortSignal?: AbortSignal;
+  /**
+   * The StreamRegistry buffer this turn owns. The shared chat-sdk handler
+   * reads this back instead of calling `streamRegistry.getStream(chatId)`,
+   * which has a race window: by the time the handler captures it, a
+   * follow-up POST may have already replaced the buffer for the same
+   * chatId. Stashing the reference at dispatch makes capture deterministic.
+   */
+  turnBuffer?: StreamBuffer;
 }
 
 export class AtlasWebAdapter implements Adapter<string, WebChatPayload> {
@@ -249,6 +257,7 @@ export class AtlasWebAdapter implements Adapter<string, WebChatPayload> {
       datetime,
       foregroundWorkspaceIds,
       abortSignal,
+      turnBuffer,
     };
     const message = this.parseMessage(payload);
     this.chat.processMessage(this, chatId, message, {

--- a/apps/atlasd/src/chat-sdk/chat-sdk-instance.test.ts
+++ b/apps/atlasd/src/chat-sdk/chat-sdk-instance.test.ts
@@ -197,22 +197,41 @@ describe("createMessageHandler", () => {
       },
     );
     const handler = createMessageHandler("ws-test", triggerFn, registry);
+    const appendEventSpy = vi.spyOn(registry, "appendEvent");
 
     const turn1Buffer = registry.createStream("chat-race");
-    // Model the race: turn 2 replaces the chatId-keyed buffer BEFORE turn 1's
-    // handler runs (i.e. while turn 1 was still awaiting subscribe / append).
-    const turn2Buffer = registry.createStream("chat-race");
+
+    // Model the actual race window: turn 2 replaces the chatId-keyed buffer
+    // *during* turn 1's `await ChatStorage.appendMessage()` call, not before
+    // the handler starts. This is the production race — the swap happens
+    // between `thread.subscribe` and the buffer-capture line where the bug
+    // fixed here used to be visible.
+    let turn2Buffer: ReturnType<typeof registry.createStream> | undefined;
+    mockAppendMessage.mockImplementationOnce(() => {
+      turn2Buffer = registry.createStream("chat-race");
+      return Promise.resolve({ ok: true });
+    });
 
     const thread = makeThread("chat-race");
     await handler(thread, makeMessage({ threadId: "chat-race", raw: { turnBuffer: turn1Buffer } }));
 
-    // Turn 1's late chunk fires after turn 2 owns the chatId. Pre-fix this
-    // would have appended into turn2Buffer because getStream returned it;
-    // post-fix the handler used turn1Buffer from raw, and the identity
-    // check at appendEvent drops the chunk.
+    // Turn 1's late chunk fires after turn 2 owns the chatId.
     captureChunkCallback?.({ type: "text-delta", delta: "from-turn-1" });
 
-    expect(turn2Buffer.events).toEqual([]);
+    // Positive: the handler called `appendEvent` with `turn1Buffer` as the
+    // `expectedBuffer`. Pre-fix the third arg was `getStream(chatId)`, which
+    // would resolve to `turn2Buffer` by now. This catches a regression that
+    // disables the tap entirely (in which case the negative-only assertions
+    // below would still pass).
+    expect(appendEventSpy).toHaveBeenCalledWith(
+      "chat-race",
+      expect.objectContaining({ type: "text-delta" }),
+      turn1Buffer,
+    );
+    // Negative: the chunk lands nowhere — `appendEvent`'s identity check
+    // rejected it because the registry's current buffer is turn 2.
+    expect(turn1Buffer.events).toEqual([]);
+    expect(turn2Buffer?.events).toEqual([]);
   });
 
   it("does not finish a follow-up turn's buffer when the prior turn cleans up", async () => {

--- a/apps/atlasd/src/chat-sdk/chat-sdk-instance.test.ts
+++ b/apps/atlasd/src/chat-sdk/chat-sdk-instance.test.ts
@@ -102,11 +102,11 @@ describe("createMessageHandler", () => {
     };
 
     const thread = makeThread("chat-abc");
-    registry.createStream("chat-abc");
+    const turnBuffer = registry.createStream("chat-abc");
 
     await handler(
       thread,
-      makeMessage({ id: "m-1", text: "Hi", threadId: "chat-abc", raw: { datetime } }),
+      makeMessage({ id: "m-1", text: "Hi", threadId: "chat-abc", raw: { datetime, turnBuffer } }),
     );
 
     expect(thread.subscribe).toHaveBeenCalled();
@@ -162,7 +162,10 @@ describe("createMessageHandler", () => {
     const thread = makeThread("chat-cross");
     const turn1Buffer = registry.createStream("chat-cross");
 
-    await handler(thread, makeMessage({ threadId: "chat-cross" }));
+    await handler(
+      thread,
+      makeMessage({ threadId: "chat-cross", raw: { turnBuffer: turn1Buffer } }),
+    );
 
     // Simulate a follow-up turn replacing the buffer mid-flight, then a
     // late producer from turn 1 emits one more chunk.
@@ -171,6 +174,45 @@ describe("createMessageHandler", () => {
 
     expect(turn1Buffer.events).toEqual([]); // turn 1's buffer was closed by createStream replacement
     expect(turn2Buffer.events).toEqual([]); // and turn 1's stale chunk did NOT leak into turn 2
+  });
+
+  it("captures turnBuffer from message.raw, not via getStream, to defeat subscribe-window race", async () => {
+    // The race: handler awaits `thread.subscribe()` and `ChatStorage.appendMessage()`
+    // before capturing its buffer. If a follow-up POST replaces the chatId-keyed
+    // buffer in that window, `streamRegistry.getStream(chatId)` would hand back
+    // the next turn's buffer — turn 1's chunks then land under turn 2's identity
+    // and leak in as orphan deltas. Stashing the buffer on `Message.raw.turnBuffer`
+    // at dispatch makes capture deterministic.
+    const registry = new StreamRegistry();
+    let captureChunkCallback: ((chunk: unknown) => void) | undefined;
+    const triggerFn = vi.fn(
+      (
+        _signalName: string,
+        _payload: Record<string, unknown>,
+        _streamId: string,
+        onStreamEvent: (chunk: unknown) => void,
+      ) => {
+        captureChunkCallback = onStreamEvent;
+        return Promise.resolve({ sessionId: "sess-1" });
+      },
+    );
+    const handler = createMessageHandler("ws-test", triggerFn, registry);
+
+    const turn1Buffer = registry.createStream("chat-race");
+    // Model the race: turn 2 replaces the chatId-keyed buffer BEFORE turn 1's
+    // handler runs (i.e. while turn 1 was still awaiting subscribe / append).
+    const turn2Buffer = registry.createStream("chat-race");
+
+    const thread = makeThread("chat-race");
+    await handler(thread, makeMessage({ threadId: "chat-race", raw: { turnBuffer: turn1Buffer } }));
+
+    // Turn 1's late chunk fires after turn 2 owns the chatId. Pre-fix this
+    // would have appended into turn2Buffer because getStream returned it;
+    // post-fix the handler used turn1Buffer from raw, and the identity
+    // check at appendEvent drops the chunk.
+    captureChunkCallback?.({ type: "text-delta", delta: "from-turn-1" });
+
+    expect(turn2Buffer.events).toEqual([]);
   });
 
   it("does not finish a follow-up turn's buffer when the prior turn cleans up", async () => {
@@ -194,9 +236,12 @@ describe("createMessageHandler", () => {
 
     const handler = createMessageHandler("ws-test", triggerFn, registry);
     const thread = makeThread("chat-no-rip");
-    registry.createStream("chat-no-rip"); // turn 1's buffer
+    const turn1Buffer = registry.createStream("chat-no-rip"); // turn 1's buffer
 
-    await handler(thread, makeMessage({ threadId: "chat-no-rip" }));
+    await handler(
+      thread,
+      makeMessage({ threadId: "chat-no-rip", raw: { turnBuffer: turn1Buffer } }),
+    );
 
     // After turn 1's handler ran its finally, turn 2's buffer must still be
     // active — the identity check made the finishStream call a no-op.
@@ -216,8 +261,8 @@ describe("createMessageHandler", () => {
     const handler = createMessageHandler("ws-test", triggerFn, registry);
 
     const thread = makeThread("chat-filter");
-    registry.createStream("chat-filter");
-    await handler(thread, makeMessage({ threadId: "chat-filter" }));
+    const turnBuffer = registry.createStream("chat-filter");
+    await handler(thread, makeMessage({ threadId: "chat-filter", raw: { turnBuffer } }));
 
     // Only client-safe events reach StreamRegistry; thread.post sees them all.
     const types = registry
@@ -310,11 +355,11 @@ describe("createMessageHandler", () => {
     (thread as unknown as { post: ReturnType<typeof vi.fn> }).post = vi
       .fn()
       .mockRejectedValue(new Error("Slack API down"));
-    registry.createStream("chat-err");
+    const turnBuffer = registry.createStream("chat-err");
 
-    await expect(handler(thread, makeMessage({ threadId: "chat-err" }))).rejects.toThrow(
-      "Slack API down",
-    );
+    await expect(
+      handler(thread, makeMessage({ threadId: "chat-err", raw: { turnBuffer } })),
+    ).rejects.toThrow("Slack API down");
     expect(mockAppendMessage).toHaveBeenCalled();
     // finally block ran even though post threw
     expect(registry.getStream("chat-err")?.active).toBe(false);

--- a/apps/atlasd/src/chat-sdk/chat-sdk-instance.ts
+++ b/apps/atlasd/src/chat-sdk/chat-sdk-instance.ts
@@ -26,7 +26,7 @@ import {
   TelegramCredentialSecretSchema,
 } from "../services/communicator-wiring.ts";
 import { isClientSafeEvent } from "../stream-event-filter.ts";
-import type { StreamBuffer, StreamRegistry } from "../stream-registry.ts";
+import { isStreamBuffer, type StreamRegistry } from "../stream-registry.ts";
 import {
   buildChatSdkAdapters,
   type CommunicatorEntry,
@@ -887,14 +887,17 @@ export function createMessageHandler(
     // late events from this turn into it. Non-web adapters don't set
     // `turnBuffer`, so `ownBuffer` stays undefined and the `appendEvent`
     // tap below short-circuits, matching prior behavior.
-    const ownBuffer =
-      typeof message.raw === "object" &&
-      message.raw !== null &&
-      "turnBuffer" in message.raw &&
-      typeof message.raw.turnBuffer === "object" &&
-      message.raw.turnBuffer !== null
-        ? (message.raw.turnBuffer as StreamBuffer)
+    const rawTurnBuffer =
+      typeof message.raw === "object" && message.raw !== null && "turnBuffer" in message.raw
+        ? message.raw.turnBuffer
         : undefined;
+    // `isStreamBuffer` validates the structural shape rather than relying on
+    // a `as StreamBuffer` assertion against an unknown-typed field. If a
+    // future adapter ever stuffs the wrong thing onto `raw.turnBuffer`,
+    // `ownBuffer` falls through to undefined and the tap short-circuits —
+    // strictly safer than asserting and trusting the identity check in
+    // `appendEvent` to silently drop every chunk.
+    const ownBuffer = isStreamBuffer(rawTurnBuffer) ? rawTurnBuffer : undefined;
 
     // signalToStream fans events two ways: the tap pushes ALL client-safe
     // events to StreamRegistry for the full web SSE stream, while the async

--- a/apps/atlasd/src/chat-sdk/chat-sdk-instance.ts
+++ b/apps/atlasd/src/chat-sdk/chat-sdk-instance.ts
@@ -26,7 +26,7 @@ import {
   TelegramCredentialSecretSchema,
 } from "../services/communicator-wiring.ts";
 import { isClientSafeEvent } from "../stream-event-filter.ts";
-import type { StreamRegistry } from "../stream-registry.ts";
+import type { StreamBuffer, StreamRegistry } from "../stream-registry.ts";
 import {
   buildChatSdkAdapters,
   type CommunicatorEntry,
@@ -878,14 +878,23 @@ export function createMessageHandler(
       : undefined;
 
     // Capture the buffer this turn owns so stale producers can't bleed into
-    // a follow-up turn's buffer. The web adapter creates the buffer in
-    // `handleWebhook` before dispatching here; non-web adapters (Slack etc.)
-    // never create one and `getStream` returns undefined — appendEvent then
-    // returns false silently for those, matching prior behavior. Without this
-    // capture, a late event from an aborted turn would land in the next
-    // turn's buffer (same chatId key) and arrive at the UI without a matching
-    // `text-start`, tripping the AI SDK validator with a "text delta error".
-    const ownBuffer = streamRegistry.getStream(chatId);
+    // a follow-up turn's buffer. The web adapter stashes the buffer it
+    // created on `Message.raw.turnBuffer` at dispatch time — reading it
+    // back here is deterministic. Calling `streamRegistry.getStream(chatId)`
+    // instead races with follow-up POSTs that land between the two awaits
+    // above (`thread.subscribe`, `ChatStorage.appendMessage`): the next
+    // turn's buffer would be captured under the current chatId, leaking
+    // late events from this turn into it. Non-web adapters don't set
+    // `turnBuffer`, so `ownBuffer` stays undefined and the `appendEvent`
+    // tap below short-circuits, matching prior behavior.
+    const ownBuffer =
+      typeof message.raw === "object" &&
+      message.raw !== null &&
+      "turnBuffer" in message.raw &&
+      typeof message.raw.turnBuffer === "object" &&
+      message.raw.turnBuffer !== null
+        ? (message.raw.turnBuffer as StreamBuffer)
+        : undefined;
 
     // signalToStream fans events two ways: the tap pushes ALL client-safe
     // events to StreamRegistry for the full web SSE stream, while the async
@@ -897,6 +906,12 @@ export function createMessageHandler(
       { chatId, userId, streamId, datetime, foregroundWorkspaceIds },
       streamId,
       (chunk: unknown) => {
+        // Non-web adapters (Slack, Telegram, Teams, etc.) never create a
+        // registry buffer — `appendEvent` would always return false and
+        // emit a `stream_event_dropped` warn for every chunk, drowning
+        // out the real drops the line is meant to flag. Skip the call
+        // entirely for those adapters.
+        if (!ownBuffer) return;
         if (isClientSafeEvent(chunk)) {
           const appended = streamRegistry.appendEvent(chatId, chunk, ownBuffer);
           if (!appended) {

--- a/apps/atlasd/src/stream-registry.ts
+++ b/apps/atlasd/src/stream-registry.ts
@@ -61,6 +61,26 @@ export interface StreamBuffer {
 }
 
 /**
+ * Structural type guard — used at the `Message.raw` boundary in the chat
+ * SDK handler where the value comes back as `unknown`. A bare cast there
+ * would silently accept any object shape; if a buggy adapter ever stuffed
+ * the wrong thing into `raw.turnBuffer`, the identity check in
+ * `appendEvent` would just always mismatch and events would silently
+ * drop. Better to validate the shape and short-circuit cleanly.
+ */
+export function isStreamBuffer(value: unknown): value is StreamBuffer {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Partial<Record<keyof StreamBuffer, unknown>>;
+  return (
+    typeof v.chatId === "string" &&
+    typeof v.active === "boolean" &&
+    Array.isArray(v.events) &&
+    v.subscribers instanceof Set &&
+    v.openParts instanceof Map
+  );
+}
+
+/**
  * Map a chunk to its slot in {@link StreamBuffer.openParts}.
  *
  * `tool-input-available` is also an opener: it carries the fully-formed

--- a/tools/agent-playground/src/lib/components/shared/cascade-status-banner.svelte
+++ b/tools/agent-playground/src/lib/components/shared/cascade-status-banner.svelte
@@ -1,0 +1,194 @@
+<!--
+  Subscribes to the daemon's INSTANCE_EVENTS SSE feed and surfaces
+  cascade-backlog state at the app shell level.
+
+  - `cascade.queue_saturated` (without a matching drained) → persistent
+    banner. Clears on `cascade.queue_drained`.
+  - `cascade.queue_timeout`, `cascade.replaced` → one toast per event.
+    Toasts are short-lived (closeDelay configured on the shared toaster)
+    so the burst case self-rate-limits visually.
+
+  On first mount the component hydrates state from the replay endpoint
+  so a refresh after a saturation event already in flight still shows
+  the banner — the SSE feed only carries new publishes.
+
+  @component
+-->
+<script lang="ts">
+  import { toast } from "@atlas/ui";
+  import { browser } from "$app/environment";
+  import { z } from "zod";
+
+  // The four shapes match `apps/atlasd/src/instance-events.ts`. We
+  // parse defensively because the stream is open for future
+  // `instance.daemon.*` / `instance.health.*` event types we don't
+  // care about here — unknown events fall through.
+  const SaturatedSchema = z.object({
+    type: z.literal("cascade.queue_saturated"),
+    at: z.string(),
+    inFlight: z.number(),
+    cap: z.number(),
+    backlog: z.number(),
+    deepestSignal: z.string().optional(),
+  });
+  const DrainedSchema = z.object({
+    type: z.literal("cascade.queue_drained"),
+    at: z.string(),
+    inFlight: z.number(),
+    cap: z.number(),
+  });
+  const TimeoutSchema = z.object({
+    type: z.literal("cascade.queue_timeout"),
+    at: z.string(),
+    workspaceId: z.string(),
+    signalId: z.string(),
+    queuedMs: z.number(),
+    correlationId: z.string().optional(),
+  });
+  const ReplacedSchema = z.object({
+    type: z.literal("cascade.replaced"),
+    at: z.string(),
+    workspaceId: z.string(),
+    signalId: z.string(),
+    cancelledSessionId: z.string(),
+    newSessionId: z.string(),
+  });
+  const InstanceEventSchema = z.union([
+    SaturatedSchema,
+    DrainedSchema,
+    TimeoutSchema,
+    ReplacedSchema,
+  ]);
+  const ReplayResponseSchema = z.object({ events: z.array(InstanceEventSchema) });
+  type SaturatedEvent = z.infer<typeof SaturatedSchema>;
+  type InstanceEvent = z.infer<typeof InstanceEventSchema>;
+
+  // The most recent saturated event when there's no matching drained
+  // after it. Reset to null when a drained event arrives.
+  let saturatedState = $state<SaturatedEvent | null>(null);
+
+  function applyEvent(event: InstanceEvent): void {
+    switch (event.type) {
+      case "cascade.queue_saturated":
+        saturatedState = event;
+        return;
+      case "cascade.queue_drained":
+        saturatedState = null;
+        return;
+      case "cascade.queue_timeout":
+        toast({
+          title: "Cascade queue timeout",
+          description: `${event.workspaceId} / ${event.signalId} sat ${formatMs(event.queuedMs)} before pickup`,
+          error: true,
+        });
+        return;
+      case "cascade.replaced":
+        toast({
+          title: "Cascade replaced",
+          description: `${event.workspaceId} / ${event.signalId} aborted in favor of newer envelope`,
+        });
+        return;
+    }
+  }
+
+  function formatMs(ms: number): string {
+    if (ms < 1_000) return `${ms}ms`;
+    if (ms < 60_000) return `${Math.round(ms / 1_000)}s`;
+    return `${Math.round(ms / 60_000)}m`;
+  }
+
+  $effect(() => {
+    if (!browser) return;
+
+    let cancelled = false;
+
+    // Hydrate first: scan recent cascade events to find the latest
+    // saturated/drained pair. Walks newest-first, so the first
+    // saturated/drained match wins. If the latest is a saturated
+    // without a later drained, we render the banner immediately on
+    // mount (no waiting for the next SSE publish).
+    void (async () => {
+      try {
+        const res = await fetch("/api/daemon/api/instance/events?type=cascade.&limit=50");
+        if (!res.ok || cancelled) return;
+        const { events } = ReplayResponseSchema.parse(await res.json());
+        for (const ev of events) {
+          if (ev.type === "cascade.queue_saturated") {
+            saturatedState = ev;
+            break;
+          }
+          if (ev.type === "cascade.queue_drained") {
+            saturatedState = null;
+            break;
+          }
+        }
+      } catch (err) {
+        console.error("Failed to hydrate cascade state", err);
+      }
+    })();
+
+    const es = new EventSource("/api/daemon/api/instance/events?stream=true");
+    es.addEventListener("message", (e) => {
+      try {
+        const parsed = InstanceEventSchema.safeParse(JSON.parse(e.data));
+        if (parsed.success) applyEvent(parsed.data);
+      } catch (err) {
+        console.error("Failed to parse instance SSE event", err);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      es.close();
+    };
+  });
+</script>
+
+{#if saturatedState}
+  <div class="cascade-banner" role="status" aria-live="polite">
+    <span class="dot" aria-hidden="true"></span>
+    <span class="message">
+      Cascade queue saturated — {saturatedState.inFlight}/{saturatedState.cap} in flight,
+      {saturatedState.backlog} queued
+      {#if saturatedState.deepestSignal}
+        (deepest: <code>{saturatedState.deepestSignal}</code>)
+      {/if}
+    </span>
+  </div>
+{/if}
+
+<style>
+  .cascade-banner {
+    align-items: center;
+    background: color-mix(in srgb, var(--color-warning, #d29922), transparent 80%);
+    border-block-end: 1px solid color-mix(in srgb, var(--color-warning, #d29922), transparent 60%);
+    color: var(--color-text);
+    display: flex;
+    flex: 0 0 auto;
+    font-size: 13px;
+    gap: 12px;
+    inline-size: 100%;
+    padding-block: 8px;
+    padding-inline: 16px;
+  }
+
+  .dot {
+    background: var(--color-warning, #d29922);
+    block-size: 8px;
+    border-radius: 50%;
+    flex: 0 0 auto;
+    inline-size: 8px;
+  }
+
+  .message {
+    flex: 1 1 auto;
+
+    code {
+      background: color-mix(in srgb, var(--color-text), transparent 88%);
+      border-radius: var(--radius-1);
+      font-family: monospace;
+      font-size: 0.92em;
+      padding: 1px 5px;
+    }
+  }
+</style>

--- a/tools/agent-playground/src/lib/components/shared/cascade-status-banner.svelte
+++ b/tools/agent-playground/src/lib/components/shared/cascade-status-banner.svelte
@@ -101,45 +101,61 @@
     if (!browser) return;
 
     let cancelled = false;
+    let es: EventSource | null = null;
 
-    // Hydrate first: scan recent cascade events to find the latest
-    // saturated/drained pair. Walks newest-first, so the first
-    // saturated/drained match wins. If the latest is a saturated
-    // without a later drained, we render the banner immediately on
-    // mount (no waiting for the next SSE publish).
+    // Hydrate FIRST, then open the SSE stream. Awaiting the replay
+    // resolves the ordering race where a `cascade.queue_drained`
+    // arrives over SSE before the hydrate's older snapshot lands —
+    // the snapshot would otherwise clobber the fresher SSE state and
+    // re-render a banner that should be cleared. The blind window
+    // equals hydrate latency (single round-trip to the local daemon),
+    // which is acceptable for cascade events.
     void (async () => {
       try {
         const res = await fetch("/api/daemon/api/instance/events?type=cascade.&limit=50");
-        if (!res.ok || cancelled) return;
-        const { events } = ReplayResponseSchema.parse(await res.json());
-        for (const ev of events) {
-          if (ev.type === "cascade.queue_saturated") {
-            saturatedState = ev;
-            break;
-          }
-          if (ev.type === "cascade.queue_drained") {
-            saturatedState = null;
-            break;
+        if (cancelled) return;
+        if (res.ok) {
+          const json = await res.json();
+          if (cancelled) return;
+          const parsed = ReplayResponseSchema.safeParse(json);
+          if (parsed.success) {
+            for (const ev of parsed.data.events) {
+              if (ev.type === "cascade.queue_saturated") {
+                saturatedState = ev;
+                break;
+              }
+              if (ev.type === "cascade.queue_drained") {
+                saturatedState = null;
+                break;
+              }
+            }
           }
         }
       } catch (err) {
         console.error("Failed to hydrate cascade state", err);
       }
-    })();
 
-    const es = new EventSource("/api/daemon/api/instance/events?stream=true");
-    es.addEventListener("message", (e) => {
-      try {
-        const parsed = InstanceEventSchema.safeParse(JSON.parse(e.data));
-        if (parsed.success) applyEvent(parsed.data);
-      } catch (err) {
-        console.error("Failed to parse instance SSE event", err);
-      }
-    });
+      if (cancelled) return;
+      es = new EventSource("/api/daemon/api/instance/events?stream=true");
+      es.addEventListener("message", (e) => {
+        try {
+          const parsed = InstanceEventSchema.safeParse(JSON.parse(e.data));
+          if (parsed.success) applyEvent(parsed.data);
+        } catch (err) {
+          console.error("Failed to parse instance SSE event", err);
+        }
+      });
+      // EventSource auto-reconnects on transient errors; surfacing
+      // them gives a developer running the playground a console
+      // signal that the live feed has stopped delivering.
+      es.addEventListener("error", () => {
+        console.error("Cascade SSE feed errored (EventSource will retry)");
+      });
+    })();
 
     return () => {
       cancelled = true;
-      es.close();
+      es?.close();
     };
   });
 </script>

--- a/tools/agent-playground/src/routes/+layout.svelte
+++ b/tools/agent-playground/src/routes/+layout.svelte
@@ -6,6 +6,7 @@
   import "@atlas/ui/colors.css";
   import "../app.css";
   import favicon from "$lib/assets/favicon.png";
+  import CascadeStatusBanner from "$lib/components/shared/cascade-status-banner.svelte";
   import Sidebar from "$lib/components/shared/sidebar.svelte";
   import CommandPalette from "$lib/components/shared/command-palette.svelte";
   import UpdateBanner from "$lib/components/shared/update-banner.svelte";
@@ -68,6 +69,7 @@
 <QueryClientProvider client={queryClient}>
   <div class="app-root">
     <UpdateBanner />
+    <CascadeStatusBanner />
     <div class="app-shell">
       <Sidebar />
       <main>

--- a/tools/agent-playground/src/routes/schedules/+page.svelte
+++ b/tools/agent-playground/src/routes/schedules/+page.svelte
@@ -96,6 +96,12 @@
   $effect(() => {
     if (!browser) return;
     const es = new EventSource("/api/daemon/api/events?stream=true");
+    es.addEventListener("error", () => {
+      // EventSource auto-reconnects; surfacing the error so a stale
+      // `/schedules` view is at least visible in devtools when the
+      // daemon's NATS connection is down or the SSE route 503s.
+      console.error("Schedules SSE feed errored (EventSource will retry)");
+    });
     es.addEventListener("message", (e) => {
       let parsed: ScheduleMissedEvent;
       try {

--- a/tools/agent-playground/src/routes/schedules/+page.svelte
+++ b/tools/agent-playground/src/routes/schedules/+page.svelte
@@ -86,15 +86,21 @@
     return `${e.workspaceId}:${e.signalId}:${e.scheduledAt}`;
   }
 
-  // Live updates via SSE. EventSource auto-reconnects on transient
-  // disconnects; on reconnect we don't replay missed events here —
-  // operator action endpoints already invalidate the query and refetch
-  // the replay path, which catches up state. A pure SSE-driven UI
-  // would want a `since=<seq>` cursor on reconnect, but the
-  // /schedules surface is fine being eventually-consistent with a
-  // bounded replay window.
+  // Live updates via SSE. Gated on `eventsQuery.isSuccess` so the
+  // EventSource doesn't open until the replay's `queryFn` has resolved
+  // and seeded the cache — without the gate, an SSE event landing
+  // mid-fetch is merged via `setQueryData` and then clobbered when
+  // TanStack overwrites the cache with the replay snapshot. Mirrors
+  // the hydrate-then-subscribe ordering in `CascadeStatusBanner`.
+  // EventSource auto-reconnects on transient disconnects; we don't
+  // replay missed events on reconnect here — operator action endpoints
+  // already invalidate the query and refetch the replay path, which
+  // catches up state. A pure SSE-driven UI would want a `since=<seq>`
+  // cursor on reconnect, but the /schedules surface is fine being
+  // eventually-consistent with a bounded replay window.
   $effect(() => {
     if (!browser) return;
+    if (!eventsQuery.isSuccess) return;
     const es = new EventSource("/api/daemon/api/events?stream=true");
     es.addEventListener("error", () => {
       // EventSource auto-reconnects; surfacing the error so a stale

--- a/tools/agent-playground/src/routes/schedules/+page.svelte
+++ b/tools/agent-playground/src/routes/schedules/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { IconSmall, PageLayout } from "@atlas/ui";
   import { createQuery, useQueryClient } from "@tanstack/svelte-query";
+  import { browser } from "$app/environment";
   import { getDaemonClient } from "$lib/daemon-client";
   import { z } from "zod";
 
@@ -60,17 +61,70 @@
   const EventsResponseSchema = z.object({ events: z.array(ScheduleMissedEventSchema) });
   type ScheduleMissedEvent = z.infer<typeof ScheduleMissedEventSchema>;
 
+  const EVENTS_QUERY_KEY = ["workspace-events", "schedule.missed"] as const;
+
+  // Replay path — used for first-load hydration and reload-after-disconnect.
+  // The SSE feed (effect below) handles live updates so we no longer poll.
+  // The replay endpoint is the only source for `status` / `pending` /
+  // `actionedAt` (resolved server-side from the WORKSPACE_EVENT_STATE KV).
   const eventsQuery = createQuery(() => ({
-    queryKey: ["workspace-events", "schedule.missed"],
+    queryKey: EVENTS_QUERY_KEY,
     queryFn: async () => {
       const res = await fetch("/api/daemon/api/events?limit=50");
       if (!res.ok) throw new Error(`Failed to fetch events: ${res.status}`);
       return EventsResponseSchema.parse(await res.json());
     },
-    refetchInterval: 60_000,
   }));
 
   const events = $derived(eventsQuery.data?.events ?? []);
+
+  // Composite identity used to dedupe across the replay endpoint (which
+  // re-stamps a sanitized `id`) and the SSE feed (which delivers the
+  // raw event without an `id`). Going through (workspaceId, signalId,
+  // scheduledAt) bypasses the format mismatch.
+  function naturalKey(e: ScheduleMissedEvent): string {
+    return `${e.workspaceId}:${e.signalId}:${e.scheduledAt}`;
+  }
+
+  // Live updates via SSE. EventSource auto-reconnects on transient
+  // disconnects; on reconnect we don't replay missed events here —
+  // operator action endpoints already invalidate the query and refetch
+  // the replay path, which catches up state. A pure SSE-driven UI
+  // would want a `since=<seq>` cursor on reconnect, but the
+  // /schedules surface is fine being eventually-consistent with a
+  // bounded replay window.
+  $effect(() => {
+    if (!browser) return;
+    const es = new EventSource("/api/daemon/api/events?stream=true");
+    es.addEventListener("message", (e) => {
+      let parsed: ScheduleMissedEvent;
+      try {
+        parsed = ScheduleMissedEventSchema.parse(JSON.parse(e.data));
+      } catch (err) {
+        console.error("Failed to parse schedule SSE event", err);
+        return;
+      }
+      // The publish path doesn't stamp the KV-derived `status`/`pending`
+      // fields — those only exist after the read path joins KV. Apply
+      // the same defaults the replay path uses for fresh events:
+      // coalesce/catchup auto-fired; manual is pending until the
+      // operator acts (which will trigger an invalidate → refetch).
+      if (!parsed.status) {
+        parsed.status = parsed.policy === "manual" ? "pending" : "auto";
+        if (parsed.policy === "manual") parsed.pending = true;
+      }
+      queryClient.setQueryData<{ events: ScheduleMissedEvent[] }>(
+        EVENTS_QUERY_KEY,
+        (prev) => {
+          const existing = prev?.events ?? [];
+          const k = naturalKey(parsed);
+          if (existing.some((ev) => naturalKey(ev) === k)) return prev;
+          return { events: [parsed, ...existing] };
+        },
+      );
+    });
+    return () => es.close();
+  });
 
   let actingOnGroup = $state<Set<string>>(new Set());
   let openMenuFor = $state<string | null>(null);


### PR DESCRIPTION
## Summary

Closes four open issues across atlasd + agent-playground:

- **Closes #192** — chat handler captured `streamRegistry.getStream(chatId)` after two awaits, so a follow-up POST landing in that ~10–50ms window leaked late chunks from the prior turn into the next. The web adapter now stashes the buffer on `Message.raw.turnBuffer` at dispatch and the handler reads it back deterministically (boundary-validated via an `isStreamBuffer` structural type guard, not a cast).
- **Closes #193** — with capture now precise, non-web adapters (Slack/Telegram/Teams) — which never create a registry buffer — were still hitting `appendEvent` and tripping `stream_event_dropped` on every chunk. Early-exit the tap when `ownBuffer` is undefined.
- **Closes #184** — new `?stream=true` SSE branch on `/api/events` mirroring the existing `/api/instance/events` pattern; `/schedules` page drops its 60s polling and consumes the feed via `EventSource`. Replay endpoint stays for first-load hydration / KV-resolved state. EventSource open is gated on the replay query's `isSuccess` so SSE events landing mid-fetch aren't clobbered when TanStack writes the replay snapshot.
- **Closes #183** — new `CascadeStatusBanner` mounted in playground `+layout.svelte` consuming the existing `INSTANCE_EVENTS` SSE feed: persistent banner on `cascade.queue_saturated` (clears on drained), toasts for `cascade.queue_timeout` / `cascade.replaced`. Hydrates from replay before opening the live feed.

## Review-driven fixes folded in

- `CascadeStatusBanner` awaits hydrate before opening EventSource (closes snapshot-clobbers-fresher-SSE race).
- Both EventSources got `error` listeners (playground `console.*` allowed in dev tooling).
- `sub.unsubscribe()` added to for-await `finally` of both SSE routes — defense-in-depth for the controller-cancel-before-abort path.
- Core-vs-JetStream tradeoff documented in both SSE route comments.
- `as StreamBuffer` cast on `Message.raw.turnBuffer` replaced with `isStreamBuffer` structural type guard exported from `stream-registry.ts`.
- `/schedules` `$effect` gated on `eventsQuery.isSuccess` (mirrors hydrate-then-subscribe ordering from the cascade banner).
- Race regression test rewritten with proper timeline (turn-2 swap during turn 1's `await` window via `mockAppendMessage.mockImplementationOnce`) and a positive `appendEventSpy` assertion that the handler called `appendEvent` with `turn1Buffer` as `expectedBuffer` — directly tests the fix mechanism instead of a negative-only assertion that would have stayed green if the tap were disabled entirely.

## Deliberately deferred → #212

- NATS slow-consumer mitigation (silent message loss when an EventSource client throttles).
- Subscription-leak window before `start(controller)` runs in both SSE routes (`subscribe` runs before the `ReadableStream` is constructed; the abort listener registers inside `start`).
- Direct integration tests for the SSE backend branches (subscribe + flush + abort + finally cleanup).

All three pair well as one focused follow-up PR; gated on this surface shipping beyond the dev-only playground.

## Test plan

- [x] `deno task typecheck` — 0 errors (8237 files)
- [x] `npx knip` — clean (only pre-existing `$types` resolution warnings)
- [x] `deno task test` (full suite) — 5187 passed | 26 skipped (382 files). Includes the rewritten race regression test (`captures turnBuffer from message.raw, not via getStream, to defeat subscribe-window race`) and the wire-up identity assertion in `atlas-web-adapter.test.ts`.
- [x] **Live-daemon QA** — passed end-to-end. Headers correct on both SSE endpoints; both EventSources connect from the playground; banner hydrate precedes its EventSource open by ~14ms (await-before-SSE fix verified live); published `instance.cascade.queue_saturated` / `_drained` / `_timeout` / `_replaced` and `events.<ws>.schedule.missed` over NATS — banner renders/clears, toasts fire with correct formatting, `/schedules` auto-switches to Missed tab and renders new row with status=pending. Zero console errors. Full QA log in [this comment](https://github.com/friday-platform/friday-studio/pull/206#issuecomment-4384157963).
