### PR TITLE
fix(workspace): merge atlas agent config prompt with action prompt

### DIFF
--- a/apps/atlasd/src/agent-helpers.test.ts
+++ b/apps/atlasd/src/agent-helpers.test.ts
@@ -1,14 +1,13 @@
 /**
- * Tests for agent prompt precedence + output validation.
+ * Tests for agent prompt composition + output validation.
  *
  * These tests verify:
- * 1. action.prompt takes priority over agentConfig.prompt
- * 2. If no action.prompt, falls back to agentConfig.prompt
- * 3. If neither exists, returns context only
- * 4. validateAgentOutput hallucination-detection branching
+ * 1. agentConfig.prompt and action.prompt are concatenated (config first) by buildFinalAgentPrompt
+ * 2. composeAgentPrompt wires extract + interpolate + concat in the same order as runtime.executeAgent
+ * 3. validateAgentOutput hallucination-detection branching
  */
 
-import type { AgentResult } from "@atlas/agent-sdk";
+import type { AgentResult, AtlasAgentConfig } from "@atlas/agent-sdk";
 import type { Context } from "@atlas/fsm-engine";
 import {
   ValidationFailedError,
@@ -19,12 +18,43 @@ import type { PlatformModels } from "@atlas/llm";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildFinalAgentPrompt,
+  composeAgentPrompt,
   extractAgentConfigPrompt,
   validateAgentOutput,
 } from "./agent-helpers.ts";
 
+// `@atlas/fsm-engine`'s `mod.ts` transitively pulls in Deno-only modules, so
+// `vi.importActual` fails under vitest's Node runtime. Stub the two functions
+// the helpers call: `expandArtifactRefsInDocuments` becomes a passthrough,
+// and `interpolatePromptPlaceholders` does the same `{{path}}` substitution
+// the real implementation does (the substring-substitution contract is pinned
+// in `packages/fsm-engine/tests/prompt-interpolation.test.ts`; this stub
+// just covers enough for `composeAgentPrompt` to round-trip its inputs).
 vi.mock("@atlas/fsm-engine", () => ({
   expandArtifactRefsInDocuments: vi.fn((docs: unknown[]) => Promise.resolve(docs)),
+  interpolatePromptPlaceholders: (
+    prompt: string,
+    prepareResult: { config?: Record<string, unknown> } | undefined,
+  ): string => {
+    const config = prepareResult?.config ?? {};
+    const scopes: Record<string, unknown> = { inputs: config, config, signal: { payload: config } };
+    const re =
+      /\{\{\s*([a-zA-Z_][a-zA-Z0-9_.]*)\s*(?:\|\s*default\s*:\s*(?:'([^']*)'|"([^"]*)"))?\s*\}\}/g;
+    return prompt.replace(re, (original, path, sq, dq) => {
+      const fallback: string | undefined = sq ?? dq;
+      let cursor: unknown = scopes;
+      for (const segment of String(path).split(".")) {
+        if (cursor === null || cursor === undefined || typeof cursor !== "object") {
+          return fallback ?? original;
+        }
+        cursor = (cursor as Record<string, unknown>)[segment];
+      }
+      if (cursor === undefined || cursor === null) return fallback ?? original;
+      if (typeof cursor === "string") return cursor === "" ? (fallback ?? cursor) : cursor;
+      if (typeof cursor === "number" || typeof cursor === "boolean") return String(cursor);
+      return JSON.stringify(cursor);
+    });
+  },
 }));
 
 const mockValidate = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<ValidationVerdict>>());
@@ -121,29 +151,33 @@ describe("extractAgentConfigPrompt", () => {
 describe("buildFinalAgentPrompt", () => {
   const documentContext = "## Context Facts\n- Current Date: Monday, January 26, 2026";
 
-  describe("prompt precedence", () => {
-    it("uses action.prompt when both action.prompt and agentConfig.prompt exist", () => {
+  describe("prompt composition", () => {
+    it("concatenates agentConfig.prompt before action.prompt when both exist", () => {
       const result = buildFinalAgentPrompt(
         "Action task instructions",
-        "Config fallback prompt",
+        "Agent-wide guidance",
         documentContext,
       );
 
+      expect(result).toBe(`Agent-wide guidance\n\nAction task instructions\n\n${documentContext}`);
+    });
+
+    it("uses agentConfig.prompt alone when action.prompt is undefined", () => {
+      const result = buildFinalAgentPrompt(undefined, "Agent-wide guidance", documentContext);
+
+      expect(result).toBe(`Agent-wide guidance\n\n${documentContext}`);
+    });
+
+    it("uses agentConfig.prompt alone when action.prompt is empty string", () => {
+      const result = buildFinalAgentPrompt("", "Agent-wide guidance", documentContext);
+
+      expect(result).toBe(`Agent-wide guidance\n\n${documentContext}`);
+    });
+
+    it("uses action.prompt alone when agentConfig.prompt is empty", () => {
+      const result = buildFinalAgentPrompt("Action task instructions", "", documentContext);
+
       expect(result).toBe(`Action task instructions\n\n${documentContext}`);
-      expect(result).not.toContain("Config fallback prompt");
-    });
-
-    it("falls back to agentConfig.prompt when action.prompt is undefined", () => {
-      const result = buildFinalAgentPrompt(undefined, "Config fallback prompt", documentContext);
-
-      expect(result).toBe(`Config fallback prompt\n\n${documentContext}`);
-    });
-
-    it("falls back to agentConfig.prompt when action.prompt is empty string", () => {
-      // Empty string is falsy, so falls back to config prompt
-      const result = buildFinalAgentPrompt("", "Config fallback prompt", documentContext);
-
-      expect(result).toBe(`Config fallback prompt\n\n${documentContext}`);
     });
 
     it("returns context only when neither action.prompt nor agentConfig.prompt exist", () => {
@@ -175,21 +209,22 @@ describe("buildFinalAgentPrompt", () => {
   });
 
   describe("custom agent scenario", () => {
-    it("custom agent uses action.prompt over agentConfig.prompt", () => {
-      // Custom agents defined in workspace.yml have agentConfig.prompt
-      // But if the FSM action also specifies a prompt, it takes precedence
+    it("agentConfig.prompt is prepended as agent-wide guidance to action.prompt", () => {
+      // Custom agents defined in workspace.yml have agentConfig.prompt — this
+      // is treated as agent-wide guidance (e.g. "always use neon green bg")
+      // and is prepended to the per-step action.prompt so both apply.
       const result = buildFinalAgentPrompt(
-        "Override: specific task for this step",
-        "Default: general purpose for this agent",
+        "Specific task for this step",
+        "Agent-wide: always use neon green background",
         documentContext,
       );
 
-      expect(result).toBe(`Override: specific task for this step\n\n${documentContext}`);
-      expect(result).not.toContain("Default: general purpose");
+      expect(result).toBe(
+        `Agent-wide: always use neon green background\n\nSpecific task for this step\n\n${documentContext}`,
+      );
     });
 
-    it("custom agent uses agentConfig.prompt when no action.prompt", () => {
-      // Custom agent with config prompt, but FSM action doesn't override
+    it("custom agent uses agentConfig.prompt alone when no action.prompt", () => {
       const result = buildFinalAgentPrompt(
         undefined,
         "Default: general purpose for this agent",
@@ -238,6 +273,94 @@ describe("buildFinalAgentPrompt", () => {
       expect(result).toContain("## Available Documents");
       expect(result).toContain("task-plan");
     });
+  });
+});
+
+describe("composeAgentPrompt", () => {
+  // Pins the call-site composition in WorkspaceRuntime.executeAgent. If a
+  // future refactor drops the agent-config prompt from the pipeline (the
+  // exact regression that caused the select_noodle "neon green" bug), these
+  // tests fail.
+
+  const documentContext = "## Context Facts\n- Current Date: 2026-05-06";
+
+  const atlasAgent = (prompt: string): AtlasAgentConfig => ({
+    type: "atlas",
+    agent: "image-generation",
+    description: "test atlas agent",
+    prompt,
+  });
+
+  it("includes BOTH agentConfig.prompt and action.prompt in the final prompt", () => {
+    const prompt = composeAgentPrompt(
+      { prompt: "Generate a sprite of a noodle" },
+      atlasAgent("Background must be solid neon green"),
+      undefined,
+      documentContext,
+    );
+
+    expect(prompt).toContain("Background must be solid neon green");
+    expect(prompt).toContain("Generate a sprite of a noodle");
+    expect(prompt).toContain(documentContext);
+  });
+
+  it("places agentConfig.prompt before action.prompt", () => {
+    const prompt = composeAgentPrompt(
+      { prompt: "ACTION_TASK" },
+      atlasAgent("CONFIG_GUIDANCE"),
+      undefined,
+      documentContext,
+    );
+
+    expect(prompt.indexOf("CONFIG_GUIDANCE")).toBeLessThan(prompt.indexOf("ACTION_TASK"));
+  });
+
+  it("interpolates `{{inputs.x}}` in the action prompt", () => {
+    const prompt = composeAgentPrompt(
+      { prompt: "Describe: {{inputs.subject}}" },
+      atlasAgent("Always be concise"),
+      { config: { subject: "neon mushroom" } },
+      documentContext,
+    );
+
+    expect(prompt).toContain("Describe: neon mushroom");
+    expect(prompt).not.toContain("{{inputs.subject}}");
+  });
+
+  it("interpolates `{{inputs.x}}` in the agentConfig prompt too", () => {
+    const prompt = composeAgentPrompt(
+      { prompt: "Make it pop" },
+      atlasAgent("Use {{inputs.color | default: 'red'}} background"),
+      { config: { color: "neon green" } },
+      documentContext,
+    );
+
+    expect(prompt).toContain("Use neon green background");
+    expect(prompt).not.toContain("{{inputs.color");
+  });
+
+  it("falls back to agentConfig.prompt alone when action.prompt is undefined", () => {
+    const prompt = composeAgentPrompt(
+      { prompt: undefined },
+      atlasAgent("Solo guidance"),
+      undefined,
+      documentContext,
+    );
+
+    expect(prompt).toBe(`Solo guidance\n\n${documentContext}`);
+  });
+
+  it("returns just action.prompt + context when no agent config exists (bundled-agent path)", () => {
+    // Bundled agents invoked without a workspace.yml entry have no agentConfig.
+    // The action prompt must still reach the agent.
+    const prompt = composeAgentPrompt(
+      { prompt: "Bundled task instructions" },
+      undefined,
+      undefined,
+      documentContext,
+    );
+
+    expect(prompt).toBe(`Bundled task instructions\n\n${documentContext}`);
   });
 });
 

--- a/apps/atlasd/src/agent-helpers.test.ts
+++ b/apps/atlasd/src/agent-helpers.test.ts
@@ -24,37 +24,16 @@ import {
 } from "./agent-helpers.ts";
 
 // `@atlas/fsm-engine`'s `mod.ts` transitively pulls in Deno-only modules, so
-// `vi.importActual` fails under vitest's Node runtime. Stub the two functions
-// the helpers call: `expandArtifactRefsInDocuments` becomes a passthrough,
-// and `interpolatePromptPlaceholders` does the same `{{path}}` substitution
-// the real implementation does (the substring-substitution contract is pinned
-// in `packages/fsm-engine/tests/prompt-interpolation.test.ts`; this stub
-// just covers enough for `composeAgentPrompt` to round-trip its inputs).
+// `vi.importActual` fails under vitest's Node runtime. Stub with a sentinel
+// wrapper so tests can check *that* interpolation ran without re-implementing
+// (and drifting from) the real regex. The substitution contract is pinned in
+// `packages/fsm-engine/tests/prompt-interpolation.test.ts`.
+// Pass-through on empty strings so `composeAgentPrompt`'s `extractAgentConfigPrompt() === ""`
+// branches behave the same as with the real impl (which returns "" for input "").
+const INTERPOLATED = (raw: string) => (raw ? `INTERP[${raw}]` : raw);
 vi.mock("@atlas/fsm-engine", () => ({
   expandArtifactRefsInDocuments: vi.fn((docs: unknown[]) => Promise.resolve(docs)),
-  interpolatePromptPlaceholders: (
-    prompt: string,
-    prepareResult: { config?: Record<string, unknown> } | undefined,
-  ): string => {
-    const config = prepareResult?.config ?? {};
-    const scopes: Record<string, unknown> = { inputs: config, config, signal: { payload: config } };
-    const re =
-      /\{\{\s*([a-zA-Z_][a-zA-Z0-9_.]*)\s*(?:\|\s*default\s*:\s*(?:'([^']*)'|"([^"]*)"))?\s*\}\}/g;
-    return prompt.replace(re, (original, path, sq, dq) => {
-      const fallback: string | undefined = sq ?? dq;
-      let cursor: unknown = scopes;
-      for (const segment of String(path).split(".")) {
-        if (cursor === null || cursor === undefined || typeof cursor !== "object") {
-          return fallback ?? original;
-        }
-        cursor = (cursor as Record<string, unknown>)[segment];
-      }
-      if (cursor === undefined || cursor === null) return fallback ?? original;
-      if (typeof cursor === "string") return cursor === "" ? (fallback ?? cursor) : cursor;
-      if (typeof cursor === "number" || typeof cursor === "boolean") return String(cursor);
-      return JSON.stringify(cursor);
-    });
-  },
+  interpolatePromptPlaceholders: (prompt: string): string => INTERPOLATED(prompt),
 }));
 
 const mockValidate = vi.hoisted(() => vi.fn<(...args: unknown[]) => Promise<ValidationVerdict>>());
@@ -315,7 +294,12 @@ describe("composeAgentPrompt", () => {
     expect(prompt.indexOf("CONFIG_GUIDANCE")).toBeLessThan(prompt.indexOf("ACTION_TASK"));
   });
 
-  it("interpolates `{{inputs.x}}` in the action prompt", () => {
+  // The interpolation tests below verify the helper *invokes*
+  // interpolatePromptPlaceholders on each layer. They do NOT verify the
+  // substitution result — that contract is pinned in
+  // `packages/fsm-engine/tests/prompt-interpolation.test.ts`. The mock at the
+  // top of this file is a sentinel wrapper so we can detect "ran".
+  it("invokes interpolatePromptPlaceholders on the action prompt", () => {
     const prompt = composeAgentPrompt(
       { prompt: "Describe: {{inputs.subject}}" },
       atlasAgent("Always be concise"),
@@ -323,11 +307,10 @@ describe("composeAgentPrompt", () => {
       documentContext,
     );
 
-    expect(prompt).toContain("Describe: neon mushroom");
-    expect(prompt).not.toContain("{{inputs.subject}}");
+    expect(prompt).toContain("INTERP[Describe: {{inputs.subject}}]");
   });
 
-  it("interpolates `{{inputs.x}}` in the agentConfig prompt too", () => {
+  it("invokes interpolatePromptPlaceholders on the agentConfig prompt too", () => {
     const prompt = composeAgentPrompt(
       { prompt: "Make it pop" },
       atlasAgent("Use {{inputs.color | default: 'red'}} background"),
@@ -335,8 +318,7 @@ describe("composeAgentPrompt", () => {
       documentContext,
     );
 
-    expect(prompt).toContain("Use neon green background");
-    expect(prompt).not.toContain("{{inputs.color");
+    expect(prompt).toContain("INTERP[Use {{inputs.color | default: 'red'}} background]");
   });
 
   it("falls back to agentConfig.prompt alone when action.prompt is undefined", () => {
@@ -347,7 +329,8 @@ describe("composeAgentPrompt", () => {
       documentContext,
     );
 
-    expect(prompt).toBe(`Solo guidance\n\n${documentContext}`);
+    // Sentinel wrap from the interpolation mock — see top-of-file comment.
+    expect(prompt).toBe(`INTERP[Solo guidance]\n\n${documentContext}`);
   });
 
   it("returns just action.prompt + context when no agent config exists (bundled-agent path)", () => {
@@ -360,7 +343,8 @@ describe("composeAgentPrompt", () => {
       documentContext,
     );
 
-    expect(prompt).toBe(`Bundled task instructions\n\n${documentContext}`);
+    // Sentinel wrap from the interpolation mock — see top-of-file comment.
+    expect(prompt).toBe(`INTERP[Bundled task instructions]\n\n${documentContext}`);
   });
 });
 

--- a/apps/atlasd/src/agent-helpers.ts
+++ b/apps/atlasd/src/agent-helpers.ts
@@ -6,8 +6,8 @@
 import type { AgentResult, AtlasAgentConfig } from "@atlas/agent-sdk";
 import type { LLMAgentConfig, SystemAgentConfig, WorkspaceAgentConfig } from "@atlas/config";
 import type { ArtifactStorageAdapter } from "@atlas/core/artifacts";
-import type { Context, JSONSchema, Signal } from "@atlas/fsm-engine";
-import { expandArtifactRefsInDocuments } from "@atlas/fsm-engine";
+import type { AgentAction, Context, JSONSchema, Signal } from "@atlas/fsm-engine";
+import { expandArtifactRefsInDocuments, interpolatePromptPlaceholders } from "@atlas/fsm-engine";
 import {
   type HallucinationDetectorConfig,
   SupervisionLevel,
@@ -77,12 +77,16 @@ export function extractAgentConfigPrompt(agentConfig: WorkspaceAgentConfig | und
 }
 
 /**
- * Build the final prompt for an agent with correct precedence.
+ * Build the final prompt for an agent.
  *
- * Prompt precedence: action.prompt > agentConfig.prompt > context only
+ * The agent config prompt is treated as a system-style prompt for the agent
+ * (e.g. "always use a neon green background") and is concatenated before the
+ * action prompt (the per-step task). This matches how `type: llm` workspace
+ * agents are expanded in `packages/config/src/expand-agent-actions.ts`, where
+ * `${config.prompt}\n\n${action.prompt}` is built up.
  *
- * @param actionPrompt - Prompt from the FSM AgentAction (highest priority)
- * @param agentConfigPrompt - Prompt from workspace.yml agent config (fallback)
+ * @param actionPrompt - Prompt from the FSM AgentAction (per-step task)
+ * @param agentConfigPrompt - Prompt from workspace.yml agent config (agent-wide)
  * @param documentContext - Built context from FSM documents and signal data
  * @returns Final prompt to send to the agent
  *
@@ -93,9 +97,35 @@ export function buildFinalAgentPrompt(
   agentConfigPrompt: string,
   documentContext: string,
 ): string {
-  // Prompt precedence: action.prompt > agentConfig.prompt > context only
-  const taskPrompt = actionPrompt || agentConfigPrompt;
+  const taskPrompt = [agentConfigPrompt, actionPrompt].filter(Boolean).join("\n\n");
   return taskPrompt ? `${taskPrompt}\n\n${documentContext}` : documentContext;
+}
+
+/**
+ * End-to-end agent prompt composition. Pulls the agent's workspace-config
+ * prompt, interpolates `{{...}}` placeholders against the prepare result on
+ * both the config and action prompts, and concatenates them with the document
+ * context via {@link buildFinalAgentPrompt}.
+ *
+ * Exists as a single helper so the prompt assembled by `WorkspaceRuntime.executeAgent`
+ * can be tested directly — and so a regression that re-routes the call site
+ * around `buildFinalAgentPrompt` (dropping the agent config prompt) is caught
+ * by a unit test, not only by an end-to-end run.
+ *
+ * @internal Exported for testing
+ */
+export function composeAgentPrompt(
+  action: Pick<AgentAction, "prompt">,
+  agentConfig: WorkspaceAgentConfig | undefined,
+  prepareResult: Context["input"],
+  documentContext: string,
+): string {
+  const agentConfigPrompt = extractAgentConfigPrompt(agentConfig);
+  const interpolatedActionPrompt = action.prompt
+    ? interpolatePromptPlaceholders(action.prompt, prepareResult)
+    : action.prompt;
+  const interpolatedConfigPrompt = interpolatePromptPlaceholders(agentConfigPrompt, prepareResult);
+  return buildFinalAgentPrompt(interpolatedActionPrompt, interpolatedConfigPrompt, documentContext);
 }
 
 /**

--- a/packages/fsm-engine/schema.ts
+++ b/packages/fsm-engine/schema.ts
@@ -57,7 +57,7 @@ export const AgentActionSchema = z.object({
   outputTo: z.string().optional(),
   /** Explicit document type name for output schema lookup. Resolves to JSON Schema from documentTypes. */
   outputType: z.string().optional(),
-  /** Task instructions for the agent. Takes precedence over agent config prompt. */
+  /** Per-step task instructions. Concatenated after the workspace agent's config prompt. */
   prompt: z.string().optional(),
   /** @experimental — see LLMActionSchema.skills. Not enforced at runtime today. */
   skills: z.array(z.string()).optional(),

--- a/packages/fsm-engine/types.ts
+++ b/packages/fsm-engine/types.ts
@@ -84,7 +84,7 @@ export interface AgentAction {
   outputTo?: string;
   /** Explicit result type name for schema validation. */
   outputType?: string;
-  /** Task instructions for the agent. Takes precedence over agent config prompt. */
+  /** Per-step task instructions. Concatenated after the workspace agent's config prompt. */
   prompt?: string;
   /**
    * Document id(s) whose `data` becomes the agent's task input. String form

--- a/packages/workspace/src/runtime-agent-prompt-composition.test.ts
+++ b/packages/workspace/src/runtime-agent-prompt-composition.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit test for the agent-prompt composition call site in
+ * `WorkspaceRuntime.executeAgent`.
+ *
+ * `composeAgentPrompt` itself is unit-tested in
+ * `apps/atlasd/src/agent-helpers.test.ts`. That test pins the helper, but it
+ * does NOT pin the call site — a future refactor that re-inlines the
+ * composition logic in `runtime.ts` (the original shape of the bug fixed in
+ * PR #215) would not be caught by helper-only tests.
+ *
+ * This test mocks `AgentOrchestrator.executeAgent` to capture the prompt arg,
+ * configures a workspace whose agent has BOTH a config-level prompt and a
+ * per-step FSM action prompt, and asserts both reach the agent.
+ */
+
+import { rm } from "node:fs/promises";
+import process from "node:process";
+import type { AgentResult } from "@atlas/agent-sdk";
+import type { MergedConfig } from "@atlas/config";
+import { atlasAgent } from "@atlas/config/testing";
+import { createStubPlatformModels } from "@atlas/llm";
+import { makeTempDir } from "@atlas/utils/temp.server";
+import { describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock AgentOrchestrator — captures the prompt arg passed to executeAgent
+// ---------------------------------------------------------------------------
+
+const capturedPrompts = vi.hoisted(() => [] as string[]);
+
+vi.mock("@atlas/core", async (importActual) => {
+  const actual = await importActual<typeof import("@atlas/core")>();
+
+  const successResult: AgentResult = {
+    agentId: "pixel-asset-generator",
+    timestamp: new Date().toISOString(),
+    input: {},
+    ok: true as const,
+    data: "mock agent output",
+    durationMs: 0,
+  };
+
+  class MockAgentOrchestrator {
+    executeAgent(_agentId: string, prompt: string): Promise<AgentResult> {
+      capturedPrompts.push(prompt);
+      return Promise.resolve(successResult);
+    }
+    hasActiveExecutions() {
+      return false;
+    }
+    getActiveExecutions() {
+      return [];
+    }
+    shutdown() {
+      return Promise.resolve();
+    }
+  }
+
+  return { ...actual, AgentOrchestrator: MockAgentOrchestrator };
+});
+
+const { WorkspaceRuntime } = await import("./runtime.ts");
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const CONFIG_PROMPT = "Background must always be solid neon green (#00FF00).";
+const ACTION_PROMPT = "Generate a sprite of a {{inputs.subject}}.";
+
+/**
+ * Workspace with an atlas-typed agent that has its own config-level prompt,
+ * plus an FSM action that sets a per-step prompt with `{{inputs.x}}`.
+ */
+function createConfig(): MergedConfig {
+  return {
+    atlas: null,
+    workspace: {
+      version: "1.0",
+      workspace: { name: "select-noodle-test", description: "Both-layer prompt regression" },
+      agents: {
+        "pixel-asset-generator": atlasAgent({
+          agent: "image-generation",
+          description: "pixel asset generator",
+          prompt: CONFIG_PROMPT,
+        }),
+      },
+      signals: {
+        "test-signal": { provider: "http", description: "Test signal", config: { path: "/test" } },
+      },
+      jobs: {
+        "test-job": {
+          triggers: [{ signal: "test-signal" }],
+          fsm: {
+            id: "test-fsm",
+            initial: "idle",
+            context: { inputs: { subject: "robot chef" } },
+            states: {
+              idle: { on: { "test-signal": { target: "generate" } } },
+              generate: {
+                entry: [
+                  { type: "agent", agentId: "pixel-asset-generator", prompt: ACTION_PROMPT },
+                  { type: "emit", event: "DONE" },
+                ],
+                on: { DONE: { target: "complete" } },
+              },
+              complete: { type: "final" },
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+async function withTestRuntime(
+  fn: (runtime: import("./runtime.ts").WorkspaceRuntime) => Promise<void>,
+): Promise<void> {
+  const testDir = makeTempDir({ prefix: "atlas_agent_prompt_test_" });
+  const originalAtlasHome = process.env.FRIDAY_HOME;
+  process.env.FRIDAY_HOME = testDir;
+
+  try {
+    const runtime = new WorkspaceRuntime({ id: "test-workspace-id" }, createConfig(), {
+      workspacePath: testDir,
+      lazy: true,
+      platformModels: createStubPlatformModels(),
+    });
+
+    await runtime.initialize();
+    await fn(runtime);
+    await runtime.shutdown();
+  } finally {
+    if (originalAtlasHome) {
+      process.env.FRIDAY_HOME = originalAtlasHome;
+    } else {
+      delete process.env.FRIDAY_HOME;
+    }
+    try {
+      await rm(testDir, { recursive: true });
+    } catch {
+      // ignore cleanup errors
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+describe("runtime.executeAgent — agent prompt composition (call site)", () => {
+  it("passes BOTH the agent-config prompt and the (interpolated) action prompt to executeAgent", async () => {
+    capturedPrompts.length = 0;
+
+    await withTestRuntime(async (runtime) => {
+      await runtime.processSignal({
+        id: "test-signal",
+        type: "test-signal",
+        data: { subject: "robot chef" },
+        timestamp: new Date(),
+      });
+    });
+
+    expect(capturedPrompts).toHaveLength(1);
+    const prompt = capturedPrompts[0] ?? "";
+
+    // Config-layer guidance reaches the agent — this is the regression the bug
+    // was about: it used to be silently dropped when the action also set a prompt.
+    expect(prompt).toContain(CONFIG_PROMPT);
+
+    // Action-layer task also reaches the agent, with `{{inputs.x}}` interpolated.
+    expect(prompt).toContain("Generate a sprite of a robot chef.");
+    expect(prompt).not.toContain("{{inputs.subject}}");
+
+    // Order: config (agent-wide) before action (per-step), matching the
+    // contract pinned in apps/atlasd/src/agent-helpers.test.ts.
+    expect(prompt.indexOf(CONFIG_PROMPT)).toBeLessThan(
+      prompt.indexOf("Generate a sprite of a robot chef."),
+    );
+  });
+});

--- a/packages/workspace/src/runtime.ts
+++ b/packages/workspace/src/runtime.ts
@@ -73,7 +73,6 @@ import {
   type FSMEngine,
   type FSMEvent,
   type FSMStateSkippedEvent,
-  interpolatePromptPlaceholders,
   type SignalWithContext,
   validateFSMStructure,
 } from "@atlas/fsm-engine";
@@ -94,9 +93,8 @@ import { parse as parseYAML } from "@std/yaml";
 import { z } from "zod";
 import {
   buildAgentPrompt,
-  buildFinalAgentPrompt,
+  composeAgentPrompt,
   extractAgentConfig,
-  extractAgentConfigPrompt,
   validateAgentOutput,
 } from "../../../apps/atlasd/src/agent-helpers.ts";
 import { generateSessionSummary } from "../../../apps/atlasd/src/session-summarizer.ts";
@@ -1595,8 +1593,6 @@ export class WorkspaceRuntime {
     });
 
     const agentConfig = this.config.workspace.agents?.[agentId];
-
-    const agentConfigPrompt = extractAgentConfigPrompt(agentConfig);
     const agentCustomConfig = extractAgentConfig(agentConfig);
 
     const context = await buildAgentPrompt(
@@ -1608,26 +1604,7 @@ export class WorkspaceRuntime {
       ArtifactStorage,
     );
 
-    // Resolve `{{inputs.x}}` / `{{config.x}}` / `{{signal.payload.x}}` against
-    // the prepare-result payload before composing the final prompt. The LLM
-    // action path does this in `buildContextPrompt`; agent actions skipped it,
-    // so Friday workspaces (which exclusively use agent actions) saw literal
-    // `{{inputs.description}}` and the agent fell back to whatever it could
-    // glean from the appended `## Input` block instead. Interpolating here
-    // makes the convention work uniformly across both action types.
-    const prepareResult = fsmContext.input;
-    const interpolatedActionPrompt = action.prompt
-      ? interpolatePromptPlaceholders(action.prompt, prepareResult)
-      : action.prompt;
-    const interpolatedConfigPrompt = interpolatePromptPlaceholders(
-      agentConfigPrompt,
-      prepareResult,
-    );
-    const prompt = buildFinalAgentPrompt(
-      interpolatedActionPrompt,
-      interpolatedConfigPrompt,
-      context,
-    );
+    const prompt = composeAgentPrompt(action, agentConfig, fsmContext.input, context);
 
     let standingOrdersBlock = "";
     if (process.env.FRIDAY_STANDING_ORDERS_BOOTSTRAP === "1" && this.options.memoryAdapter) {

--- a/tools/evals/agents/agent-config-prompt/agent-config-prompt.eval.ts
+++ b/tools/evals/agents/agent-config-prompt/agent-config-prompt.eval.ts
@@ -11,6 +11,7 @@
  */
 
 import { atlasAgent } from "@atlas/config/testing";
+import { interpolatePromptPlaceholders } from "@atlas/fsm-engine";
 import { registry, traceModel } from "@atlas/llm";
 import { generateText } from "ai";
 import { composeAgentPrompt } from "../../../../apps/atlasd/src/agent-helpers.ts";
@@ -154,22 +155,27 @@ export const evals: EvalRegistration[] = cases.map((testCase) =>
       input: testCase.input,
       run: () => runConfigPromptCase(testCase),
       // Structural sanity: both prompt layers must appear in the composed
-      // prompt before we even ask the model. Catches a regression in
-      // composeAgentPrompt itself — separately from the LLM-side score.
-      // Both layers must appear in the composed prompt before we ask the
-      // model — substring-match the prefix up to the first `{{`, since
-      // composeAgentPrompt interpolates placeholders out.
+      // prompt — fully interpolated — before we ask the model. Catches a
+      // regression in composeAgentPrompt itself, separately from the
+      // LLM-side score. We reconstruct the expected post-interpolation
+      // string by running the SAME interpolatePromptPlaceholders the
+      // helper uses, against `prepareConfig`.
       assert: ({ composedPrompt }) => {
-        const requirePrefix = (label: string, raw: string) => {
-          const prefix = raw.split("{{")[0] ?? "";
-          if (prefix && !composedPrompt.includes(prefix)) {
+        const prepareResult = testCase.prepareConfig
+          ? { config: testCase.prepareConfig }
+          : undefined;
+        const requireLayer = (label: string, raw: string) => {
+          const expected = interpolatePromptPlaceholders(raw, prepareResult);
+          if (!composedPrompt.includes(expected)) {
             throw new Error(
-              `Composed prompt missing ${label} prefix.\nGot: ${JSON.stringify(composedPrompt)}`,
+              `Composed prompt missing ${label} (post-interpolation).\n` +
+                `Expected substring: ${JSON.stringify(expected)}\n` +
+                `Got: ${JSON.stringify(composedPrompt)}`,
             );
           }
         };
-        requirePrefix("agentConfig.prompt", testCase.agentConfigPrompt);
-        if (testCase.actionPrompt) requirePrefix("action.prompt", testCase.actionPrompt);
+        requireLayer("agentConfig.prompt", testCase.agentConfigPrompt);
+        if (testCase.actionPrompt) requireLayer("action.prompt", testCase.actionPrompt);
       },
       score: ({ responseText }) => {
         const scores: Score[] = [honorsConfigPromptScore(responseText, testCase.requiredToken)];

--- a/tools/evals/agents/agent-config-prompt/agent-config-prompt.eval.ts
+++ b/tools/evals/agents/agent-config-prompt/agent-config-prompt.eval.ts
@@ -1,0 +1,190 @@
+/**
+ * Model-side property for `composeAgentPrompt` (in `apps/atlasd/src/agent-helpers.ts`):
+ * when a workspace agent has both a config-level `prompt` and a per-step FSM
+ * action `prompt`, the LLM honors both layers. The structural contract
+ * (config-then-action, both reach the model) is pinned in
+ * `apps/atlasd/src/agent-helpers.test.ts`; this eval verifies the model
+ * actually obeys the config-level guidance once it arrives.
+ *
+ * Scope: calls `composeAgentPrompt` directly. A regression that bypasses the
+ * helper inside `runtime.executeAgent` would not be caught here.
+ */
+
+import { atlasAgent } from "@atlas/config/testing";
+import { registry, traceModel } from "@atlas/llm";
+import { generateText } from "ai";
+import { composeAgentPrompt } from "../../../../apps/atlasd/src/agent-helpers.ts";
+import { AgentContextAdapter } from "../../lib/context.ts";
+import { loadCredentials } from "../../lib/load-credentials.ts";
+import { type BaseEvalCase, defineEval, type EvalRegistration } from "../../lib/registration.ts";
+import { createScore, type Score } from "../../lib/scoring.ts";
+
+await loadCredentials();
+
+const adapter = new AgentContextAdapter();
+
+// Haiku: cheap, fast, and instruction-following enough to make this signal
+// crisp. If Haiku ignores the system-style guidance, that's the bug.
+const MODEL_ID = "anthropic:claude-haiku-4-5";
+
+// ---------------------------------------------------------------------------
+// Scorers
+// ---------------------------------------------------------------------------
+
+/** The config-prompt instruction landed: response contains the required token. */
+function honorsConfigPromptScore(text: string, requiredToken: string): Score {
+  const present = text.includes(requiredToken);
+  return createScore(
+    "HonorsConfigPrompt",
+    present ? 1 : 0,
+    present
+      ? `Response contains required token "${requiredToken}"`
+      : `Response missing required token "${requiredToken}" — config-prompt instruction was likely dropped`,
+  );
+}
+
+/** The action-prompt task also landed: response addresses the per-step task. */
+function addressesActionPromptScore(text: string, keywords: string[]): Score {
+  const lower = text.toLowerCase();
+  const matches = keywords.filter((k) => lower.includes(k.toLowerCase()));
+  const value = matches.length / keywords.length;
+  return createScore(
+    "AddressesActionPrompt",
+    value,
+    `${matches.length}/${keywords.length} action-prompt keywords matched: [${keywords.join(", ")}]`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Test data
+// ---------------------------------------------------------------------------
+
+interface ConfigPromptCase extends BaseEvalCase {
+  /** Workspace-level guidance — this is what the bug used to drop. */
+  agentConfigPrompt: string;
+  /** Per-step task prompt from the FSM action. Omit for the config-only path. */
+  actionPrompt?: string;
+  /** Optional `prepareResult.config` for `{{inputs.x}}` interpolation. */
+  prepareConfig?: Record<string, unknown>;
+  /** Token the config-prompt instructs the model to emit. */
+  requiredToken: string;
+  /** Keywords that prove the action-prompt task was also addressed. */
+  actionPromptKeywords: string[];
+}
+
+const cases: ConfigPromptCase[] = [
+  {
+    id: "marker-token",
+    name: "config prompt instruction (marker token) is honored alongside action prompt",
+    // Marker tokens are the firmest signal we can get: Haiku reproduces a
+    // pinned literal far more faithfully than a paraphrasable directive.
+    agentConfigPrompt:
+      'You are a helpful assistant. Always end every response with the literal token "NEON_GREEN_OK" on its own line. This is a non-negotiable formatting rule.',
+    actionPrompt: "Introduce yourself in one short sentence.",
+    requiredToken: "NEON_GREEN_OK",
+    actionPromptKeywords: ["assistant"],
+    input: "marker-token: introduce yourself",
+  },
+  {
+    id: "interpolated-action-with-config-rule",
+    name: "config prompt is honored when action prompt uses {{inputs.x}} interpolation",
+    agentConfigPrompt:
+      'You answer questions about visual design. Always include the literal token "BG_NEON_GREEN" verbatim somewhere in your response.',
+    actionPrompt: "Describe a {{inputs.subject}} sprite in two sentences.",
+    prepareConfig: { subject: "robot chef" },
+    requiredToken: "BG_NEON_GREEN",
+    actionPromptKeywords: ["robot", "chef"],
+    input: "interpolated: robot chef sprite",
+  },
+  {
+    id: "config-prompt-alone",
+    name: "config prompt drives behavior when no action prompt is set",
+    agentConfigPrompt:
+      'Reply with exactly one short sentence introducing yourself, and append the literal token "SOLO_OK" at the end.',
+    requiredToken: "SOLO_OK",
+    actionPromptKeywords: [],
+    input: "solo: config-only path",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Run helper
+// ---------------------------------------------------------------------------
+
+interface RunOutcome {
+  /** The fully-composed prompt sent to the LLM (config + action + context). */
+  composedPrompt: string;
+  /** The LLM's response text. */
+  responseText: string;
+  /** End-to-end latency in milliseconds. */
+  latencyMs: number;
+}
+
+async function runConfigPromptCase(testCase: ConfigPromptCase): Promise<RunOutcome> {
+  const composedPrompt = composeAgentPrompt(
+    { prompt: testCase.actionPrompt },
+    atlasAgent({ agent: "image-generation", prompt: testCase.agentConfigPrompt }),
+    testCase.prepareConfig ? { config: testCase.prepareConfig } : undefined,
+    "## Context Facts\n- Current Date: 2026-05-06",
+  );
+
+  const start = performance.now();
+  const result = await generateText({
+    model: traceModel(registry.languageModel(MODEL_ID)),
+    // No system message: the whole point is that the agent config prompt acts
+    // as the system-style instruction. Adding one here would mask the bug.
+    prompt: composedPrompt,
+    maxOutputTokens: 200,
+    temperature: 0,
+  });
+  const latencyMs = performance.now() - start;
+
+  return { composedPrompt, responseText: result.text, latencyMs };
+}
+
+// ---------------------------------------------------------------------------
+// Eval registrations
+// ---------------------------------------------------------------------------
+
+export const evals: EvalRegistration[] = cases.map((testCase) =>
+  defineEval<RunOutcome>({
+    name: `agent-config-prompt/${testCase.id}`,
+    adapter,
+    config: {
+      input: testCase.input,
+      run: () => runConfigPromptCase(testCase),
+      // Structural sanity: both prompt layers must appear in the composed
+      // prompt before we even ask the model. Catches a regression in
+      // composeAgentPrompt itself — separately from the LLM-side score.
+      // Both layers must appear in the composed prompt before we ask the
+      // model — substring-match the prefix up to the first `{{`, since
+      // composeAgentPrompt interpolates placeholders out.
+      assert: ({ composedPrompt }) => {
+        const requirePrefix = (label: string, raw: string) => {
+          const prefix = raw.split("{{")[0] ?? "";
+          if (prefix && !composedPrompt.includes(prefix)) {
+            throw new Error(
+              `Composed prompt missing ${label} prefix.\nGot: ${JSON.stringify(composedPrompt)}`,
+            );
+          }
+        };
+        requirePrefix("agentConfig.prompt", testCase.agentConfigPrompt);
+        if (testCase.actionPrompt) requirePrefix("action.prompt", testCase.actionPrompt);
+      },
+      score: ({ responseText }) => {
+        const scores: Score[] = [honorsConfigPromptScore(responseText, testCase.requiredToken)];
+        if (testCase.actionPromptKeywords.length > 0) {
+          scores.push(addressesActionPromptScore(responseText, testCase.actionPromptKeywords));
+        }
+        return scores;
+      },
+      metadata: {
+        case: testCase.id,
+        agentConfigPrompt: testCase.agentConfigPrompt,
+        actionPrompt: testCase.actionPrompt,
+        requiredToken: testCase.requiredToken,
+        model: MODEL_ID,
+      },
+    },
+  }),
+);


### PR DESCRIPTION
## Summary

- Atlas-typed workspace agents had their `prompt:` config silently dropped whenever the calling FSM action also set a `prompt:` — `buildFinalAgentPrompt` used `actionPrompt || configPrompt`, so action always won. (LLM-typed workspace agents already concatenate both via `expand-agent-actions.ts`; atlas-typed agents were inconsistent.)
- Concatenate the two prompts (config first, then action) and extract the inline composition in `WorkspaceRuntime.executeAgent` into a new `composeAgentPrompt` helper so the wiring is unit-testable.
- Add a model-side eval at `tools/evals/agents/agent-config-prompt/` that sends both layers to Haiku and asserts the LLM emits a marker token defined in the config prompt.

## Motivating bug

In the `select_noodle` workspace, the `pixel-asset-generator` (atlas/`image-generation`) had a `prompt:` instructing it to "use neon green (#00FF00) background". The FSM's `generate` state set its own per-step `prompt:` ("Generate a single pixel art game asset. Description: …"). Pre-fix, only the action prompt reached the LLM and the generated images had random backgrounds.

## Test plan

- [x] `npx vitest run apps/atlasd/src/agent-helpers.test.ts` — 29 tests pass (was 23; +6 for `composeAgentPrompt`, +0 net for `buildFinalAgentPrompt` after rewriting precedence cases as composition cases)
- [x] `deno check apps/atlasd/src/agent-helpers.ts packages/workspace/src/runtime.ts tools/evals/agents/agent-config-prompt/agent-config-prompt.eval.ts` clean
- [x] `deno run -A npm:@biomejs/biome check` clean for all touched files
- [x] `deno task evals run -t tools/evals/agents/agent-config-prompt/agent-config-prompt.eval.ts` (run before merging — needs ANTHROPIC creds)

## Files

- `apps/atlasd/src/agent-helpers.ts` — `buildFinalAgentPrompt` now concatenates; new `composeAgentPrompt` helper composes extract → interpolate → concat
- `apps/atlasd/src/agent-helpers.test.ts` — rewrote precedence cases as composition cases; added `composeAgentPrompt` suite
- `packages/workspace/src/runtime.ts` — `executeAgent` delegates to `composeAgentPrompt`
- `packages/fsm-engine/{schema,types}.ts` — doc comments updated to match new behavior
- `tools/evals/agents/agent-config-prompt/` — new eval

## Scope notes

- The eval (and the `composeAgentPrompt` unit tests) cover the helper, not the runtime call site. A regression that bypasses `composeAgentPrompt` inside `runtime.executeAgent` would not be caught — but the helper is now the single delegation point, so any such change would be obvious in code review.
- Backward compatibility: workspaces that intentionally relied on the action prompt overriding the config prompt will now see both. This matches the existing `type: llm` behavior.