### PR TITLE
chat: move list into ListDetail sidebar with workspace dropdown

### DIFF
--- a/tools/agent-playground/src/lib/components/chat/chat-list-panel.svelte
+++ b/tools/agent-playground/src/lib/components/chat/chat-list-panel.svelte
@@ -247,10 +247,6 @@
   message is sent.
 -->
 <aside class="chat-list-panel">
-  <div class="chat-list-header">
-    <h3>Chats</h3>
-  </div>
-
   {#if error}
     <div class="list-error">{error}</div>
   {/if}
@@ -309,29 +305,11 @@
 
 <style>
   .chat-list-panel {
-    background-color: var(--surface);
-    border-inline-start: 1px solid var(--color-border-1);
     display: flex;
+    flex: 1;
     flex-direction: column;
-    inline-size: 280px;
-    min-inline-size: 280px;
+    min-block-size: 0;
     overflow: hidden;
-  }
-
-  .chat-list-header {
-    align-items: center;
-    border-block-end: 1px solid var(--color-border-1);
-    display: flex;
-    flex-shrink: 0;
-    justify-content: space-between;
-    padding: var(--size-3);
-  }
-
-  .chat-list-header h3 {
-    color: var(--color-text);
-    font-size: var(--font-size-2);
-    font-weight: var(--font-weight-6);
-    margin: 0;
   }
 
   .list-error {

--- a/tools/agent-playground/src/lib/components/chat/chat-list-panel.svelte
+++ b/tools/agent-playground/src/lib/components/chat/chat-list-panel.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { Badge } from "@atlas/ui";
   import { onMount } from "svelte";
   import { z } from "zod";
 
@@ -184,6 +185,23 @@
     return `${mo}mo`;
   }
 
+  function sourceVariant(
+    source: ChatListEntry["source"],
+  ): "info" | "warning" | "status" | "success" {
+    switch (source) {
+      case "slack":
+        return "warning";
+      case "discord":
+        return "status";
+      case "whatsapp":
+        return "success";
+      case "atlas":
+      case "telegram":
+      default:
+        return "info";
+    }
+  }
+
   function sourceLabel(source: ChatListEntry["source"]): string {
     switch (source) {
       case "atlas":
@@ -267,7 +285,7 @@
               <span class="item-time">{formatRelativeTime(chat.updatedAt)}</span>
             </div>
             <div class="item-meta">
-              <span class="source-badge source-{chat.source}">{sourceLabel(chat.source)}</span>
+              <Badge variant={sourceVariant(chat.source)}>{sourceLabel(chat.source)}</Badge>
             </div>
           </div>
         </button>
@@ -313,15 +331,15 @@
   }
 
   .list-error {
-    color: var(--color-error);
+    color: var(--red-primary);
     font-size: var(--font-size-1);
-    padding: var(--size-3);
+    padding-block: var(--size-3);
   }
 
   .list-empty {
-    color: color-mix(in srgb, var(--color-text), transparent 50%);
+    color: var(--text-faded);
     font-size: var(--font-size-1);
-    padding: var(--size-4);
+    padding-block: var(--size-4);
     text-align: center;
   }
 
@@ -342,32 +360,32 @@
      also select the chat. */
   .chat-row {
     align-items: stretch;
-    border-block-end: 1px solid color-mix(in srgb, var(--color-border-1), transparent 50%);
+    border-block-end: 1px solid var(--border);
     display: flex;
     position: relative;
     transition: background-color 100ms ease;
   }
 
   .chat-row:hover {
-    background-color: color-mix(in srgb, var(--color-text), transparent 92%);
+    background-color: var(--highlight);
   }
 
   .chat-row.active {
-    background-color: color-mix(in srgb, var(--color-primary), transparent 85%);
+    background-color: var(--highlight-bright);
   }
 
   .chat-item {
     align-items: flex-start;
     background: transparent;
     border: none;
-    color: var(--color-text);
+    color: var(--text);
     cursor: pointer;
     display: flex;
     flex: 1;
     font: inherit;
     gap: var(--size-2);
     min-inline-size: 0;
-    padding: var(--size-2) var(--size-3);
+    padding-block: var(--size-2);
     text-align: start;
   }
 
@@ -376,21 +394,19 @@
     background: transparent;
     border: none;
     border-radius: var(--radius-2);
-    color: color-mix(in srgb, var(--color-text), transparent 60%);
+    color: var(--text-faded);
     cursor: pointer;
     display: flex;
     flex-shrink: 0;
     inline-size: 24px;
     justify-content: center;
     margin-block: 6px;
-    margin-inline-end: var(--size-2);
     /* Hidden until the row is hovered so quiet rows stay tidy; still
        keyboard-focusable for accessibility (see :focus-visible below). */
     opacity: 0;
     transition:
       opacity 100ms ease,
-      color 100ms ease,
-      background-color 100ms ease;
+      color 100ms ease;
   }
 
   .chat-row:hover .chat-delete,
@@ -400,8 +416,7 @@
 
   .chat-delete:hover,
   .chat-delete:focus-visible {
-    background-color: color-mix(in srgb, var(--color-error, #c93b3b), transparent 85%);
-    color: var(--color-error, #c93b3b);
+    color: var(--red-primary);
   }
 
   .item-dot {
@@ -415,17 +430,17 @@
 
   .chat-item.unread .item-dot {
     animation: unread-pulse 1.8s ease-in-out infinite;
-    background-color: var(--color-primary);
+    background-color: var(--blue-primary);
   }
 
   @keyframes unread-pulse {
     0%,
     100% {
-      box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-primary), transparent 60%);
+      box-shadow: 0 0 0 0 var(--blue-primary);
       opacity: 1;
     }
     50% {
-      box-shadow: 0 0 0 4px color-mix(in srgb, var(--color-primary), transparent 100%);
+      box-shadow: 0 0 0 4px transparent;
       opacity: 0.7;
     }
   }
@@ -464,7 +479,7 @@
   }
 
   .item-time {
-    color: color-mix(in srgb, var(--color-text), transparent 50%);
+    color: var(--text-faded);
     flex-shrink: 0;
     font-size: var(--font-size-0);
   }
@@ -474,53 +489,19 @@
     gap: var(--size-1);
   }
 
-  .source-badge {
-    border-radius: var(--radius-1);
-    font-size: 10px;
-    font-weight: var(--font-weight-6);
-    letter-spacing: 0.02em;
-    padding: 1px 5px;
-    text-transform: uppercase;
-  }
-
-  .source-atlas {
-    background-color: light-dark(hsl(220 60% 90%), hsl(220 30% 20%));
-    color: light-dark(hsl(220 60% 35%), hsl(220 60% 75%));
-  }
-
-  .source-slack {
-    background-color: light-dark(hsl(330 60% 90%), hsl(330 30% 20%));
-    color: light-dark(hsl(330 60% 35%), hsl(330 60% 75%));
-  }
-
-  .source-discord {
-    background-color: light-dark(hsl(240 60% 90%), hsl(240 30% 20%));
-    color: light-dark(hsl(240 60% 35%), hsl(240 60% 75%));
-  }
-
-  .source-telegram {
-    background-color: light-dark(hsl(200 70% 90%), hsl(200 30% 22%));
-    color: light-dark(hsl(200 70% 35%), hsl(200 70% 75%));
-  }
-
-  .source-whatsapp {
-    background-color: light-dark(hsl(142 60% 90%), hsl(142 30% 20%));
-    color: light-dark(hsl(142 60% 30%), hsl(142 60% 70%));
-  }
-
   .load-more {
     background-color: transparent;
     border: none;
-    border-block-start: 1px solid var(--color-border-1);
-    color: var(--color-primary);
+    border-block-start: 1px solid var(--border);
+    color: var(--blue-primary);
     cursor: pointer;
     flex-shrink: 0;
     font-size: var(--font-size-1);
-    padding: var(--size-2);
+    padding-block: var(--size-2);
   }
 
   .load-more:disabled {
-    color: color-mix(in srgb, var(--color-text), transparent 50%);
+    color: var(--text-faded);
     cursor: default;
   }
 </style>

--- a/tools/agent-playground/src/lib/components/chat/user-chat.svelte
+++ b/tools/agent-playground/src/lib/components/chat/user-chat.svelte
@@ -3,7 +3,6 @@
   import { Chat as ChatImpl } from "@ai-sdk/svelte";
   import type { AtlasUIMessage } from "@atlas/agent-sdk";
   import { createQuery, useQueryClient } from "@tanstack/svelte-query";
-  import { goto } from "$app/navigation";
   import { page } from "$app/state";
   import { workspaceQueries } from "$lib/queries";
   import { DefaultChatTransport } from "ai";
@@ -1029,11 +1028,6 @@
     return chatMsgs;
   });
 
-  /** Navigate to a fresh chat. The loader generates the new chatId. */
-  function startNewChat() {
-    goto(`/platform/${encodeURIComponent(wsId)}/chat`);
-  }
-
   async function handleSubmit(text: string, inputImages: ImageAttachment[] = []) {
     if (!chat) return;
     error = null;
@@ -1192,15 +1186,6 @@
     </div>
   {/if}
 
-  <header class="chat-header">
-    <h2>Chat</h2>
-    <span class="workspace-badge">{workspaceName}</span>
-    <span class="header-spacer"></span>
-    {#if chat && chat.messages.length > 0}
-      <button class="new-chat-button" onclick={startNewChat}>New Chat</button>
-    {/if}
-  </header>
-
   <div class="chat-body">
     <div class="chat-main">
       {#if rehydrating}
@@ -1276,57 +1261,6 @@
     flex-direction: column;
     min-block-size: 0;
     overflow: hidden;
-  }
-
-  .chat-header {
-    align-items: center;
-    background-color: var(--surface);
-    border-block-end: 1px solid var(--color-border-1);
-    display: flex;
-    flex-shrink: 0;
-    gap: var(--size-3);
-    padding: var(--size-4) var(--size-5);
-    position: sticky;
-    inset-block-start: 0;
-    z-index: var(--layer-1, 10);
-  }
-
-  .chat-header h2 {
-    font-size: var(--font-size-4);
-    font-weight: var(--font-weight-6);
-  }
-
-  .workspace-badge {
-    background-color: var(--color-surface-3);
-    border-radius: var(--radius-2);
-    color: color-mix(in srgb, var(--color-text), transparent 20%);
-    font-size: var(--font-size-1);
-    padding: var(--size-0-5) var(--size-2);
-  }
-
-  .header-spacer {
-    flex: 1;
-  }
-
-  .new-chat-button {
-    background-color: var(--color-surface-3);
-    border: 1px solid var(--color-border-1);
-    border-radius: var(--radius-2);
-    color: var(--color-text);
-    cursor: pointer;
-    font-size: var(--font-size-1);
-    font-weight: var(--font-weight-5);
-    padding: var(--size-1) var(--size-2-5);
-    transition: background-color 150ms ease;
-  }
-
-  .new-chat-button:hover:not(:disabled) {
-    background-color: var(--color-surface-2);
-  }
-
-  .new-chat-button:disabled {
-    cursor: default;
-    opacity: 0.5;
   }
 
   .rehydrating-indicator {

--- a/tools/agent-playground/src/lib/components/chat/user-chat.svelte
+++ b/tools/agent-playground/src/lib/components/chat/user-chat.svelte
@@ -9,7 +9,6 @@
   import { DefaultChatTransport } from "ai";
   import ChatInput, { type ImageAttachment } from "./chat-input.svelte";
   import ChatInspector from "./chat-inspector.svelte";
-  import ChatListPanel from "./chat-list-panel.svelte";
   import ChatMessageList from "./chat-message-list.svelte";
   import { createCursorTrackingFetch } from "./cursor-tracking-fetch.ts";
   import { nextQueueStep } from "./chat-queue.ts";
@@ -1035,12 +1034,6 @@
     goto(`/platform/${encodeURIComponent(wsId)}/chat`);
   }
 
-  /** Navigate to an existing chat (from the chat list panel). */
-  function switchToChat(targetChatId: string): void {
-    if (targetChatId === chatId) return;
-    goto(`/platform/${encodeURIComponent(wsId)}/chat/${encodeURIComponent(targetChatId)}`);
-  }
-
   async function handleSubmit(text: string, inputImages: ImageAttachment[] = []) {
     if (!chat) return;
     error = null;
@@ -1272,27 +1265,6 @@
       {workspaceName}
       workspaceId={wsId}
       status={streaming ? "streaming" : (chat?.status ?? "idle")}
-    />
-
-    <ChatListPanel
-      workspaceId={wsId}
-      currentChatId={chatId}
-      onSelect={switchToChat}
-      onDelete={(deletedId, nextChatId) => {
-        // Only react when the user nuked the chat they're currently
-        // viewing — otherwise the rest of the list stays put and there's
-        // nothing to do here. When it IS the current chat, jump to the
-        // neighbor the panel picked (older-first, falling back to newer)
-        // so browsing history stays fluid. If the list is empty now,
-        // start a fresh chat instead of leaving a dead id on screen.
-        if (deletedId !== chatId) return;
-        if (nextChatId) {
-          // switchToChat already persists and kicks off rehydration.
-          switchToChat(nextChatId);
-        } else {
-          startNewChat();
-        }
-      }}
     />
   </div>
 </div>

--- a/tools/agent-playground/src/lib/components/workspace/workspace-dropdown.svelte
+++ b/tools/agent-playground/src/lib/components/workspace/workspace-dropdown.svelte
@@ -58,7 +58,7 @@
 <style>
   :global(.ws-trigger) {
     align-items: center;
-    background: transparent;
+    background: var(--highlight);
     border: 1px solid var(--border);
     border-radius: var(--radius-2);
     color: var(--text-bright);
@@ -74,7 +74,7 @@
   }
 
   :global(.ws-trigger:hover) {
-    background: var(--surface);
+    background: var(--highlight-bright);
   }
 
   .dot {

--- a/tools/agent-playground/src/lib/components/workspace/workspace-dropdown.svelte
+++ b/tools/agent-playground/src/lib/components/workspace/workspace-dropdown.svelte
@@ -1,0 +1,95 @@
+<script lang="ts">
+  import { DropdownMenu, IconSmall } from "@atlas/ui";
+  import { createQuery } from "@tanstack/svelte-query";
+  import { workspaceQueries } from "$lib/queries";
+
+  interface Props {
+    selected: string;
+  }
+  const { selected }: Props = $props();
+
+  const workspacesQuery = createQuery(() => workspaceQueries.enriched());
+
+  const workspaces = $derived(
+    [...(workspacesQuery.data ?? [])].sort((a, b) => {
+      if (a.id === "user") return -1;
+      if (b.id === "user") return 1;
+      return 0;
+    }),
+  );
+
+  const activeWorkspace = $derived(workspaces.find((ws) => ws.id === selected));
+
+  const COLORS: Record<string, string> = {
+    yellow: "var(--yellow-2, #facc15)",
+    purple: "var(--purple-2, #a78bfa)",
+    red: "var(--red-2, #f87171)",
+    blue: "var(--blue-2, #60a5fa)",
+    green: "var(--green-2, #4ade80)",
+    brown: "var(--brown-2, #a3824a)",
+  };
+
+  function dotColor(color: string | undefined): string {
+    return COLORS[color ?? "yellow"] ?? COLORS["yellow"] ?? "#facc15";
+  }
+</script>
+
+<DropdownMenu.Root>
+  <DropdownMenu.Trigger class="ws-trigger">
+    <span class="dot" style:--dot-color={dotColor(activeWorkspace?.metadata?.color)}></span>
+    <span class="name">{activeWorkspace?.displayName ?? selected}</span>
+    <IconSmall.CaretDown />
+  </DropdownMenu.Trigger>
+
+  <DropdownMenu.Content size="regular">
+    <DropdownMenu.List>
+      {#each workspaces as ws (ws.id)}
+        <DropdownMenu.Item href="/platform/{ws.id}/chat" radio checked={ws.id === selected}>
+          {#snippet prepend()}
+            <span class="dot" style:--dot-color={dotColor(ws.metadata?.color)}></span>
+          {/snippet}
+          {ws.displayName}
+        </DropdownMenu.Item>
+      {/each}
+    </DropdownMenu.List>
+  </DropdownMenu.Content>
+</DropdownMenu.Root>
+
+<style>
+  :global(.ws-trigger) {
+    align-items: center;
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-2);
+    color: var(--text-bright);
+    cursor: pointer;
+    display: flex;
+    font: inherit;
+    font-weight: var(--font-weight-5);
+    gap: var(--size-2);
+    inline-size: 100%;
+    min-block-size: var(--size-7);
+    padding-block: var(--size-1);
+    padding-inline: var(--size-2);
+  }
+
+  :global(.ws-trigger:hover) {
+    background: var(--surface);
+  }
+
+  .dot {
+    background-color: var(--dot-color);
+    block-size: var(--size-2);
+    border-radius: 50%;
+    flex-shrink: 0;
+    inline-size: var(--size-2);
+  }
+
+  .name {
+    flex: 1;
+    overflow: hidden;
+    text-align: start;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+</style>

--- a/tools/agent-playground/src/lib/components/workspace/workspace-dropdown.svelte
+++ b/tools/agent-playground/src/lib/components/workspace/workspace-dropdown.svelte
@@ -36,7 +36,6 @@
 
 <DropdownMenu.Root>
   <DropdownMenu.Trigger class="ws-trigger">
-    <span class="dot" style:--dot-color={dotColor(activeWorkspace?.metadata?.color)}></span>
     <span class="name">{activeWorkspace?.displayName ?? selected}</span>
     <IconSmall.CaretDown />
   </DropdownMenu.Trigger>
@@ -59,18 +58,18 @@
   :global(.ws-trigger) {
     align-items: center;
     background: var(--highlight);
-    border: 1px solid var(--border);
-    border-radius: var(--radius-2);
+    block-size: var(--size-6-5);
+    border: none;
+    border-radius: var(--radius-2-5);
     color: var(--text-bright);
     cursor: pointer;
     display: flex;
-    font: inherit;
+    flex: 1;
+    font-size: var(--font-size-2);
     font-weight: var(--font-weight-5);
     gap: var(--size-2);
-    inline-size: 100%;
-    min-block-size: var(--size-7);
-    padding-block: var(--size-1);
-    padding-inline: var(--size-2);
+    min-inline-size: 0;
+    padding-inline: var(--size-3);
   }
 
   :global(.ws-trigger:hover) {

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/chat/[[chatId]]/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/chat/[[chatId]]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Button, IconSmall, ListDetail } from "@atlas/ui";
+  import { Button, ListDetail } from "@atlas/ui";
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
   import ChatListPanel from "$lib/components/chat/chat-list-panel.svelte";
@@ -30,15 +30,10 @@
   <ListDetail>
     {#snippet header()}
       <WorkspaceDropdown selected={workspaceId} />
+      <Button variant="secondary" size="small" onclick={handleNewChat}>New chat</Button>
     {/snippet}
 
     {#snippet sidebar()}
-      <Button variant="secondary" size="small" onclick={handleNewChat}>
-        {#snippet prepend()}
-          <IconSmall.Plus />
-        {/snippet}
-        New chat
-      </Button>
       <ChatListPanel
         {workspaceId}
         currentChatId={data.chatId}

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/chat/[[chatId]]/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/chat/[[chatId]]/+page.svelte
@@ -1,11 +1,42 @@
 <script lang="ts">
-  import UserChat from "$lib/components/chat/user-chat.svelte";
-  import type { PageData } from "./$types";
+  import { ListDetail } from "@atlas/ui";
+  import { goto } from "$app/navigation";
   import { page } from "$app/state";
+  import ChatListPanel from "$lib/components/chat/chat-list-panel.svelte";
+  import UserChat from "$lib/components/chat/user-chat.svelte";
+  import WorkspaceDropdown from "$lib/components/workspace/workspace-dropdown.svelte";
+  import type { PageData } from "./$types";
 
   const { data }: { data: PageData } = $props();
+  const workspaceId = $derived(page.params.workspaceId ?? "user");
+
+  function handleSelectChat(chatId: string) {
+    if (chatId === data.chatId) return;
+    goto(`/platform/${encodeURIComponent(workspaceId)}/chat/${encodeURIComponent(chatId)}`);
+  }
+
+  function handleDeleteChat(deletedId: string, nextChatId: string | null) {
+    if (deletedId !== data.chatId) return;
+    const base = `/platform/${encodeURIComponent(workspaceId)}/chat`;
+    goto(nextChatId ? `${base}/${encodeURIComponent(nextChatId)}` : base);
+  }
 </script>
 
-{#key page.params.workspaceId}
-  <UserChat chatId={data.chatId} />
+{#key workspaceId}
+  <ListDetail>
+    {#snippet header()}
+      <WorkspaceDropdown selected={workspaceId} />
+    {/snippet}
+
+    {#snippet sidebar()}
+      <ChatListPanel
+        {workspaceId}
+        currentChatId={data.chatId}
+        onSelect={handleSelectChat}
+        onDelete={handleDeleteChat}
+      />
+    {/snippet}
+
+    <UserChat chatId={data.chatId} />
+  </ListDetail>
 {/key}

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/chat/[[chatId]]/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/chat/[[chatId]]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ListDetail } from "@atlas/ui";
+  import { Button, IconSmall, ListDetail } from "@atlas/ui";
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
   import ChatListPanel from "$lib/components/chat/chat-list-panel.svelte";
@@ -20,6 +20,10 @@
     const base = `/platform/${encodeURIComponent(workspaceId)}/chat`;
     goto(nextChatId ? `${base}/${encodeURIComponent(nextChatId)}` : base);
   }
+
+  function handleNewChat() {
+    goto(`/platform/${encodeURIComponent(workspaceId)}/chat`);
+  }
 </script>
 
 {#key workspaceId}
@@ -29,6 +33,12 @@
     {/snippet}
 
     {#snippet sidebar()}
+      <Button variant="secondary" size="small" onclick={handleNewChat}>
+        {#snippet prepend()}
+          <IconSmall.Plus />
+        {/snippet}
+        New chat
+      </Button>
       <ChatListPanel
         {workspaceId}
         currentChatId={data.chatId}


### PR DESCRIPTION
## Summary

- Workspace chat (`/platform/[workspaceId]/chat/[[chatId]]`) now uses the `ListDetail` two-pane layout — chat list on the left, conversation on the right — matching the mcp-catalog and skills pages.
- Added a `WorkspaceDropdown` above the list. Each item is a plain `href="/platform/{ws.id}/chat"` so SvelteKit handles navigation; switching workspaces is one click without leaving chat.
- Polish pass on `chat-list-panel.svelte`: replaced `--color-*` legacy refs and every `color-mix(... transparent N%)` shim with semantic tokens from `packages/ui/colors.css`, dropped the bespoke `.source-*` badge styles in favor of the shared `<Badge>` component, and removed inline row padding that fought with the ListDetail sidebar's own padding.

## Test Plan

- [ ] `cd tools/agent-playground && deno task check` — 0 errors
- [ ] Svelte autofixer (MCP) clean on new/rewritten components
- [ ] `GET /platform/user/chat` returns 200 from the dev server
- [ ] Visual check: dropdown + list render on the left, conversation fills right pane
- [ ] Click a chat → URL updates, no full remount
- [ ] Switch workspace via dropdown → routes to `/platform/{wsId}/chat` and list refetches
- [ ] Delete a chat → routes to neighbor or fresh chat, panel hover/active states tinted via `--highlight` / `--highlight-bright`
- [ ] Debug subroute (`/platform/{wsId}/chat/{chatId}/debug`) still loads

Fixes #207