### PR TITLE
fix(atlasd): give signal-stream tests headroom over vitest 5s default

### DIFF
--- a/apps/atlasd/src/signal-stream.test.ts
+++ b/apps/atlasd/src/signal-stream.test.ts
@@ -69,7 +69,7 @@ describe("publishSignal + SignalConsumer", () => {
     expect(received[0]?.signalId).toBe("my-signal");
     expect(received[0]?.payload).toEqual({ hello: "world" });
     expect(received[0]?.publishedAt).toBeDefined();
-  });
+  }, 15_000);
 
   it("redelivers on forward failure up to maxDeliver, then dead-letters", async () => {
     let attempts = 0;
@@ -89,7 +89,7 @@ describe("publishSignal + SignalConsumer", () => {
     await consumer.destroy();
 
     expect(attempts).toBeGreaterThanOrEqual(3);
-  });
+  }, 20_000);
 
   it("dedups identical dedupId within the duplicate_window", async () => {
     const dispatched: string[] = [];
@@ -113,7 +113,7 @@ describe("publishSignal + SignalConsumer", () => {
     await consumer.destroy();
 
     expect(dispatched).toEqual(["once"]);
-  });
+  }, 15_000);
 
   it("awaitSignalCompletion times out when nobody publishes a response", async () => {
     const correlationId = crypto.randomUUID();
@@ -140,7 +140,7 @@ describe("publishSignal + SignalConsumer", () => {
     await consumer.destroy();
 
     expect(seen).toEqual(["s-0", "s-1", "s-2", "s-3", "s-4", "s-5"]);
-  });
+  }, 15_000);
 });
 
 async function waitFor(predicate: () => boolean, timeoutMs: number): Promise<void> {


### PR DESCRIPTION
## Summary

CI run [25476527180](https://github.com/friday-platform/friday-studio/actions/runs/25476527180/job/74751098520) failed in `apps/atlasd/src/signal-stream.test.ts` with `Test timed out in 5000ms`. The triggering commit (#213) doesn't touch this code — it's a flaky test.

The inner `waitFor(..., 5000)` deadline exactly matched vitest's default 5000ms test timeout, so under CI load the consumer setup ate the budget and vitest's timer tripped before `waitFor` saw the predicate flip. Local run finished in 4.97s, confirming the test sits right on the edge.

Bumps per-test timeouts above each `waitFor` budget so the framework no longer races the test:
- 5000ms waitFor → 15s test timeout
- 10000ms waitFor → 20s test timeout
- 3000ms waitFor + 500ms wait → 15s test timeout

## Test plan

- [x] `deno task test apps/atlasd/src/signal-stream.test.ts` passes (7/7) locally
- [ ] CI green