### PR TITLE
feat(hubspot): add create-note + noop deterministic ops

### DIFF
--- a/packages/bundled-agents/src/hubspot/agent.test.ts
+++ b/packages/bundled-agents/src/hubspot/agent.test.ts
@@ -572,7 +572,7 @@ describe("hubspotAgent deterministic create-note", () => {
     expect(result.ok).toBe(true);
     expect.assert(result.ok);
     expect(result.data.success).toBe(false);
-    expect(result.data.response).toContain("1 error");
+    expect(result.data.response).toBe("CRM Note creation on ticket 5501 returned 1 error");
     expect(result.data.data).toMatchObject({
       noteId: null,
       numErrors: 1,
@@ -580,7 +580,28 @@ describe("hubspotAgent deterministic create-note", () => {
     });
   });
 
-  it("reports success=false when the SDK returns an empty-string id", async () => {
+  it("pluralizes the error noun when numErrors > 1", async () => {
+    mockBatchCreate.mockResolvedValue({
+      status: "COMPLETE",
+      results: [],
+      numErrors: 2,
+      errors: [
+        { status: "error", message: "a" },
+        { status: "error", message: "b" },
+      ],
+    });
+
+    const result = await hubspotAgent.execute(
+      JSON.stringify({ operation: "create-note", ticketId: "5501", body: "<p>x</p>" }),
+      validContext(),
+    );
+
+    expect(result.ok).toBe(true);
+    expect.assert(result.ok);
+    expect(result.data.response).toBe("CRM Note creation on ticket 5501 returned 2 errors");
+  });
+
+  it("distinguishes empty-id (no errors) from numErrors > 0 in the response message", async () => {
     mockBatchCreate.mockResolvedValue({
       status: "COMPLETE",
       results: [{ id: "", properties: {} }],
@@ -593,6 +614,7 @@ describe("hubspotAgent deterministic create-note", () => {
     expect(result.ok).toBe(true);
     expect.assert(result.ok);
     expect(result.data.success).toBe(false);
+    expect(result.data.response).toBe("CRM Note creation on ticket 5501 returned no usable id");
   });
 
   it("falls through to LLM when ticketId or body is missing", async () => {
@@ -663,7 +685,12 @@ describe("hubspotAgent deterministic noop", () => {
     expect(result.ok).toBe(true);
     expect.assert(result.ok);
     expect(result.data.operation).toBe("noop");
-    expect(result.data.data).toMatchObject({ skipped: true });
+    expect(result.data.success).toBe(true);
+    expect(result.data.response).toBe("Noop — upstream signalled nothing to do.");
+    // `reason` must be omitted from data when not provided, not emitted as
+    // `reason: undefined` (which would round-trip through JSON as a literal).
+    expect(result.data.data).toEqual({ skipped: true });
+    expect(mockBatchCreate).not.toHaveBeenCalled();
     expect(mockGenerateText).not.toHaveBeenCalled();
   });
 });

--- a/packages/bundled-agents/src/hubspot/agent.test.ts
+++ b/packages/bundled-agents/src/hubspot/agent.test.ts
@@ -534,8 +534,32 @@ describe("hubspotAgent deterministic create-note", () => {
     expect(result.ok).toBe(false);
     expect.assert(!result.ok);
     expect(result.error.reason).toContain("create-note failed");
+    expect(result.error.reason).toContain("not-a-real-id");
     expect(result.error.reason).toContain("Invalid ticketId");
     expect(mockGenerateText).not.toHaveBeenCalled();
+  });
+
+  it("reports success=false when the batch response carries numErrors > 0", async () => {
+    mockBatchCreate.mockResolvedValue({
+      status: "COMPLETE",
+      results: [],
+      numErrors: 1,
+      errors: [{ status: "error", message: "Property hs_timestamp is required" }],
+    });
+
+    const prompt = JSON.stringify({ operation: "create-note", ticketId: "5501", body: "<p>x</p>" });
+
+    const result = await hubspotAgent.execute(prompt, validContext());
+
+    expect(result.ok).toBe(true);
+    expect.assert(result.ok);
+    expect(result.data.success).toBe(false);
+    expect(result.data.response).toContain("1 error");
+    expect(result.data.data).toMatchObject({
+      noteId: null,
+      numErrors: 1,
+      errors: [{ status: "error", message: "Property hs_timestamp is required" }],
+    });
   });
 
   it("falls through to LLM when ticketId or body is missing", async () => {

--- a/packages/bundled-agents/src/hubspot/agent.test.ts
+++ b/packages/bundled-agents/src/hubspot/agent.test.ts
@@ -5,25 +5,34 @@ import type { LogContext, Logger } from "@atlas/logger";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import createCommentFixture from "./fixtures/create-comment.json" with { type: "json" };
 
-const { mockGenerateText, mockBatchCreate, mockClientConstructor } = vi.hoisted(() => {
-  type BatchCreateRequest = {
-    inputs: Array<{
-      properties: Record<string, string>;
-      associations?: Array<{
-        to: { id: string };
-        types: Array<{ associationCategory: string; associationTypeId: number }>;
+const { mockGenerateText, mockBatchCreate, mockClientConstructor, helperOverride } = vi.hoisted(
+  () => {
+    type BatchCreateRequest = {
+      inputs: Array<{
+        properties: Record<string, string>;
+        associations?: Array<{
+          to: { id: string };
+          types: Array<{ associationCategory: string; associationTypeId: number }>;
+        }>;
       }>;
-    }>;
-  };
-  return {
-    mockGenerateText: vi.fn(),
-    mockBatchCreate: vi.fn<(objectType: string, request: BatchCreateRequest) => Promise<unknown>>(),
-    // Spy on the Client constructor so tests can pin the auth args (accessToken,
-    // retry config). Without this spy, an agent regression that dropped the
-    // accessToken or passed a wrong one would not fail any test.
-    mockClientConstructor: vi.fn(),
-  };
-});
+    };
+    return {
+      mockGenerateText: vi.fn(),
+      mockBatchCreate:
+        vi.fn<(objectType: string, request: BatchCreateRequest) => Promise<unknown>>(),
+      // Spy on the Client constructor so tests can pin the auth args (accessToken,
+      // retry config). Without this spy, an agent regression that dropped the
+      // accessToken or passed a wrong one would not fail any test.
+      mockClientConstructor: vi.fn(),
+      // When set, overrides `batchCreateCrmObjects`. Lets tests inject helper
+      // return shapes (e.g., a successful batch with `skippedAssociations` set)
+      // that the agent's natural inputs cannot produce — the agent hardcodes
+      // `toObjectType: "tickets"` which always resolves through DEFAULT_ASSOCIATION_TYPES,
+      // so the `skippedAssociations` guard in agent.ts has no other test path.
+      helperOverride: vi.fn(),
+    };
+  },
+);
 
 vi.mock("ai", () => ({
   generateText: mockGenerateText,
@@ -40,6 +49,20 @@ vi.mock("@hubspot/api-client", () => ({
   },
   DEFAULT_LIMITER_OPTIONS: {},
 }));
+
+vi.mock("./tools.ts", async () => {
+  const actual = await vi.importActual<typeof import("./tools.ts")>("./tools.ts");
+  return {
+    ...actual,
+    // Delegate to the real helper unless a test has set an override implementation.
+    batchCreateCrmObjects: (...args: Parameters<typeof actual.batchCreateCrmObjects>) => {
+      if (helperOverride.getMockImplementation()) {
+        return helperOverride(...args);
+      }
+      return actual.batchCreateCrmObjects(...args);
+    },
+  };
+});
 
 vi.mock("@atlas/llm", async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;
@@ -476,6 +499,7 @@ describe("hubspotAgent deterministic create-note", () => {
     mockGenerateText.mockReset();
     mockBatchCreate.mockReset();
     mockClientConstructor.mockReset();
+    helperOverride.mockReset();
   });
 
   afterEach(() => {
@@ -790,6 +814,33 @@ describe("hubspotAgent deterministic create-note", () => {
     expect(result.ok).toBe(true);
     expect(mockBatchCreate).not.toHaveBeenCalled();
     expect(mockGenerateText).toHaveBeenCalledOnce();
+  });
+
+  it("returns err when batchCreateCrmObjects reports skippedAssociations", async () => {
+    // Defense-in-depth: if `DEFAULT_ASSOCIATION_TYPES.notes.tickets` ever
+    // drops out of the lookup table, the helper would skip the association
+    // silently and return success — the agent must convert that into an
+    // error so the orphan-note case is caught instead of looking like
+    // a successful create. The agent's natural inputs always resolve
+    // through the lookup table, so this is the only test path for the guard.
+    helperOverride.mockResolvedValue({
+      results: [{ id: "601", properties: {} }],
+      numErrors: 0,
+      errors: [],
+      skippedAssociations: "No default association type for: notes → tickets.",
+    });
+
+    const result = await hubspotAgent.execute(
+      JSON.stringify({ operation: "create-note", ticketId: "5501", body: "<p>x</p>" }),
+      validContext(),
+    );
+
+    expect(result.ok).toBe(false);
+    expect.assert(!result.ok);
+    expect(result.error.reason).toContain("create-note failed");
+    expect(result.error.reason).toContain("5501");
+    expect(result.error.reason).toContain("notes → tickets");
+    expect(mockGenerateText).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/bundled-agents/src/hubspot/agent.test.ts
+++ b/packages/bundled-agents/src/hubspot/agent.test.ts
@@ -730,8 +730,8 @@ describe("hubspotAgent deterministic noop", () => {
     expect.assert(result.ok);
     expect(result.data.operation).toBe("noop");
     expect(result.data.success).toBe(true);
-    expect(result.data.data).toMatchObject({ skipped: true, reason: "no ticket to brief" });
-    expect(result.data.response).toContain("no ticket to brief");
+    expect(result.data.data).toEqual({ skipped: true, reason: "no ticket to brief" });
+    expect(result.data.response).toBe("no ticket to brief");
     expect(mockBatchCreate).not.toHaveBeenCalled();
     expect(mockGenerateText).not.toHaveBeenCalled();
   });
@@ -780,5 +780,6 @@ describe("hubspotAgent deterministic noop", () => {
     expect(result.ok).toBe(true);
     expect.assert(result.ok);
     expect(result.data.data).toEqual({ skipped: false, reason: "x" });
+    expect(result.data.response).toBe("x");
   });
 });

--- a/packages/bundled-agents/src/hubspot/agent.test.ts
+++ b/packages/bundled-agents/src/hubspot/agent.test.ts
@@ -420,3 +420,193 @@ describe("hubspotAgent deterministic path", () => {
     expect(mockGenerateText).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Deterministic create-note + noop ops
+// ---------------------------------------------------------------------------
+
+/** Fixture matching the SDK Client's `crm.objects.batchApi.create` response. */
+const createNoteFixture = {
+  status: "COMPLETE",
+  results: [
+    {
+      id: "601",
+      properties: {
+        hs_note_body: "<h3>Briefing</h3><p>body</p>",
+        hs_timestamp: "2026-05-07T12:00:00.000Z",
+      },
+      createdAt: "2026-05-07T12:00:00.000Z",
+      updatedAt: "2026-05-07T12:00:00.000Z",
+      archived: false,
+    },
+  ],
+  startedAt: "2026-05-07T12:00:00.000Z",
+  completedAt: "2026-05-07T12:00:00.000Z",
+};
+
+describe("hubspotAgent deterministic create-note", () => {
+  let originalAnthropicKey: string | undefined;
+
+  beforeEach(() => {
+    originalAnthropicKey = env.ANTHROPIC_API_KEY;
+    env.ANTHROPIC_API_KEY = "sk-test";
+    mockGenerateText.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (originalAnthropicKey !== undefined) {
+      env.ANTHROPIC_API_KEY = originalAnthropicKey;
+    } else {
+      delete env.ANTHROPIC_API_KEY;
+    }
+  });
+
+  it("creates a CRM Note on the ticket and returns the note id", async () => {
+    const mockFetch = createMockFetch(createNoteFixture);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const prompt = JSON.stringify({
+      operation: "create-note",
+      ticketId: "5501",
+      body: "<h3>Briefing</h3><p>body</p>",
+      kind: "internal-briefing",
+      format: "html",
+    });
+
+    const result = await hubspotAgent.execute(prompt, validContext());
+
+    expect(result.ok).toBe(true);
+    expect.assert(result.ok);
+    expect(result.data.operation).toBe("create-note");
+    expect(result.data.success).toBe(true);
+    expect(result.data.data).toMatchObject({ noteId: "601", ticketId: "5501" });
+    expect(result.data.response).toContain("601");
+    expect(result.data.response).toContain("5501");
+    expect(mockGenerateText).not.toHaveBeenCalled();
+  });
+
+  it("posts the body verbatim — no markdown conversion", async () => {
+    const mockFetch = createMockFetch(createNoteFixture);
+    vi.stubGlobal("fetch", mockFetch);
+
+    const verbatim =
+      "<h3>Company Context</h3><table><tr><td>SSO</td><td>Google</td></tr></table>" +
+      '<p><a href="https://app-na2.hubspot.com/...">Open in HubSpot</a></p>';
+
+    const prompt = JSON.stringify({
+      operation: "create-note",
+      ticketId: "5501",
+      body: verbatim,
+      hsTimestamp: "2026-05-07T12:00:00.000Z",
+    });
+
+    await hubspotAgent.execute(prompt, validContext());
+
+    expect(mockFetch).toHaveBeenCalled();
+    const calls = mockFetch.mock.calls.filter((c) => c[1]?.method === "POST");
+    expect(calls.length).toBeGreaterThan(0);
+    const body = JSON.parse(calls[0]?.[1]?.body as string) as {
+      inputs: Array<{ properties: Record<string, string> }>;
+    };
+    expect(body.inputs[0]?.properties.hs_note_body).toBe(verbatim);
+    expect(body.inputs[0]?.properties.hs_timestamp).toBe("2026-05-07T12:00:00.000Z");
+  });
+
+  it("returns err when HubSpot batch-create returns an error", async () => {
+    const mockFetch = createMockFetch(
+      { status: "error", message: "Invalid ticketId", category: "VALIDATION_ERROR" },
+      400,
+    );
+    vi.stubGlobal("fetch", mockFetch);
+
+    const prompt = JSON.stringify({
+      operation: "create-note",
+      ticketId: "not-a-real-id",
+      body: "<p>x</p>",
+    });
+
+    const result = await hubspotAgent.execute(prompt, validContext());
+
+    expect(result.ok).toBe(false);
+    expect.assert(!result.ok);
+    expect(result.error.reason).toContain("create-note failed");
+    expect(mockGenerateText).not.toHaveBeenCalled();
+  });
+
+  it("falls through to LLM when ticketId or body is missing", async () => {
+    mockGenerateText.mockResolvedValue({
+      text: "LLM response",
+      finishReason: "stop",
+      usage: { promptTokens: 10, completionTokens: 5 },
+      steps: [{}],
+      toolCalls: [],
+      toolResults: [],
+    });
+
+    const prompt = JSON.stringify({
+      operation: "create-note",
+      // missing ticketId AND body — schema rejects, falls through
+    });
+
+    const result = await hubspotAgent.execute(prompt, validContext());
+
+    expect(result.ok).toBe(true);
+    expect(mockGenerateText).toHaveBeenCalledOnce();
+  });
+});
+
+describe("hubspotAgent deterministic noop", () => {
+  let originalAnthropicKey: string | undefined;
+
+  beforeEach(() => {
+    originalAnthropicKey = env.ANTHROPIC_API_KEY;
+    env.ANTHROPIC_API_KEY = "sk-test";
+    mockGenerateText.mockReset();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    if (originalAnthropicKey !== undefined) {
+      env.ANTHROPIC_API_KEY = originalAnthropicKey;
+    } else {
+      delete env.ANTHROPIC_API_KEY;
+    }
+  });
+
+  it("returns success without touching HubSpot", async () => {
+    const mockFetch = vi
+      .fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>()
+      .mockRejectedValue(new Error("fetch should not have been called on noop"));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const prompt = JSON.stringify({
+      operation: "noop",
+      skipped: true,
+      reason: "no ticket to brief",
+    });
+
+    const result = await hubspotAgent.execute(prompt, validContext());
+
+    expect(result.ok).toBe(true);
+    expect.assert(result.ok);
+    expect(result.data.operation).toBe("noop");
+    expect(result.data.success).toBe(true);
+    expect(result.data.data).toMatchObject({ skipped: true, reason: "no ticket to brief" });
+    expect(result.data.response).toContain("no ticket to brief");
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockGenerateText).not.toHaveBeenCalled();
+  });
+
+  it("works without optional reason / skipped fields", async () => {
+    const prompt = JSON.stringify({ operation: "noop" });
+
+    const result = await hubspotAgent.execute(prompt, validContext());
+
+    expect(result.ok).toBe(true);
+    expect.assert(result.ok);
+    expect(result.data.operation).toBe("noop");
+    expect(result.data.data).toMatchObject({ skipped: true });
+    expect(mockGenerateText).not.toHaveBeenCalled();
+  });
+});

--- a/packages/bundled-agents/src/hubspot/agent.test.ts
+++ b/packages/bundled-agents/src/hubspot/agent.test.ts
@@ -5,12 +5,22 @@ import type { LogContext, Logger } from "@atlas/logger";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import createCommentFixture from "./fixtures/create-comment.json" with { type: "json" };
 
-const { mockGenerateText } = vi.hoisted(() => ({ mockGenerateText: vi.fn() }));
+const { mockGenerateText, mockBatchCreate } = vi.hoisted(() => ({
+  mockGenerateText: vi.fn(),
+  mockBatchCreate: vi.fn(),
+}));
 
 vi.mock("ai", () => ({
   generateText: mockGenerateText,
   stepCountIs: vi.fn(() => vi.fn()),
   tool: vi.fn((opts: Record<string, unknown>) => opts),
+}));
+
+vi.mock("@hubspot/api-client", () => ({
+  Client: class {
+    crm = { objects: { batchApi: { create: mockBatchCreate } } };
+  },
+  DEFAULT_LIMITER_OPTIONS: {},
 }));
 
 vi.mock("@atlas/llm", async (importOriginal) => {
@@ -425,8 +435,8 @@ describe("hubspotAgent deterministic path", () => {
 // Deterministic create-note + noop ops
 // ---------------------------------------------------------------------------
 
-/** Fixture matching the SDK Client's `crm.objects.batchApi.create` response. */
-const createNoteFixture = {
+/** SDK batch-create response shape returned by `client.crm.objects.batchApi.create`. */
+const createNoteSdkResponse = {
   status: "COMPLETE",
   results: [
     {
@@ -435,13 +445,8 @@ const createNoteFixture = {
         hs_note_body: "<h3>Briefing</h3><p>body</p>",
         hs_timestamp: "2026-05-07T12:00:00.000Z",
       },
-      createdAt: "2026-05-07T12:00:00.000Z",
-      updatedAt: "2026-05-07T12:00:00.000Z",
-      archived: false,
     },
   ],
-  startedAt: "2026-05-07T12:00:00.000Z",
-  completedAt: "2026-05-07T12:00:00.000Z",
 };
 
 describe("hubspotAgent deterministic create-note", () => {
@@ -451,10 +456,10 @@ describe("hubspotAgent deterministic create-note", () => {
     originalAnthropicKey = env.ANTHROPIC_API_KEY;
     env.ANTHROPIC_API_KEY = "sk-test";
     mockGenerateText.mockReset();
+    mockBatchCreate.mockReset();
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
     if (originalAnthropicKey !== undefined) {
       env.ANTHROPIC_API_KEY = originalAnthropicKey;
     } else {
@@ -463,15 +468,12 @@ describe("hubspotAgent deterministic create-note", () => {
   });
 
   it("creates a CRM Note on the ticket and returns the note id", async () => {
-    const mockFetch = createMockFetch(createNoteFixture);
-    vi.stubGlobal("fetch", mockFetch);
+    mockBatchCreate.mockResolvedValue(createNoteSdkResponse);
 
     const prompt = JSON.stringify({
       operation: "create-note",
       ticketId: "5501",
       body: "<h3>Briefing</h3><p>body</p>",
-      kind: "internal-briefing",
-      format: "html",
     });
 
     const result = await hubspotAgent.execute(prompt, validContext());
@@ -486,9 +488,8 @@ describe("hubspotAgent deterministic create-note", () => {
     expect(mockGenerateText).not.toHaveBeenCalled();
   });
 
-  it("posts the body verbatim — no markdown conversion", async () => {
-    const mockFetch = createMockFetch(createNoteFixture);
-    vi.stubGlobal("fetch", mockFetch);
+  it("posts the body verbatim and resolves the notes↔tickets association via SDK", async () => {
+    mockBatchCreate.mockResolvedValue(createNoteSdkResponse);
 
     const verbatim =
       "<h3>Company Context</h3><table><tr><td>SSO</td><td>Google</td></tr></table>" +
@@ -503,22 +504,24 @@ describe("hubspotAgent deterministic create-note", () => {
 
     await hubspotAgent.execute(prompt, validContext());
 
-    expect(mockFetch).toHaveBeenCalled();
-    const calls = mockFetch.mock.calls.filter((c) => c[1]?.method === "POST");
-    expect(calls.length).toBeGreaterThan(0);
-    const body = JSON.parse(calls[0]?.[1]?.body as string) as {
-      inputs: Array<{ properties: Record<string, string> }>;
-    };
-    expect(body.inputs[0]?.properties.hs_note_body).toBe(verbatim);
-    expect(body.inputs[0]?.properties.hs_timestamp).toBe("2026-05-07T12:00:00.000Z");
+    expect(mockBatchCreate).toHaveBeenCalledOnce();
+    expect(mockBatchCreate).toHaveBeenCalledWith("notes", {
+      inputs: [
+        {
+          properties: { hs_note_body: verbatim, hs_timestamp: "2026-05-07T12:00:00.000Z" },
+          associations: [
+            {
+              to: { id: "5501" },
+              types: [{ associationCategory: "HUBSPOT_DEFINED", associationTypeId: 228 }],
+            },
+          ],
+        },
+      ],
+    });
   });
 
-  it("returns err when HubSpot batch-create returns an error", async () => {
-    const mockFetch = createMockFetch(
-      { status: "error", message: "Invalid ticketId", category: "VALIDATION_ERROR" },
-      400,
-    );
-    vi.stubGlobal("fetch", mockFetch);
+  it("returns err when the SDK batch-create rejects", async () => {
+    mockBatchCreate.mockRejectedValue(new Error("Invalid ticketId"));
 
     const prompt = JSON.stringify({
       operation: "create-note",
@@ -531,6 +534,7 @@ describe("hubspotAgent deterministic create-note", () => {
     expect(result.ok).toBe(false);
     expect.assert(!result.ok);
     expect(result.error.reason).toContain("create-note failed");
+    expect(result.error.reason).toContain("Invalid ticketId");
     expect(mockGenerateText).not.toHaveBeenCalled();
   });
 
@@ -552,6 +556,7 @@ describe("hubspotAgent deterministic create-note", () => {
     const result = await hubspotAgent.execute(prompt, validContext());
 
     expect(result.ok).toBe(true);
+    expect(mockBatchCreate).not.toHaveBeenCalled();
     expect(mockGenerateText).toHaveBeenCalledOnce();
   });
 });
@@ -563,10 +568,10 @@ describe("hubspotAgent deterministic noop", () => {
     originalAnthropicKey = env.ANTHROPIC_API_KEY;
     env.ANTHROPIC_API_KEY = "sk-test";
     mockGenerateText.mockReset();
+    mockBatchCreate.mockReset();
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
     if (originalAnthropicKey !== undefined) {
       env.ANTHROPIC_API_KEY = originalAnthropicKey;
     } else {
@@ -575,11 +580,6 @@ describe("hubspotAgent deterministic noop", () => {
   });
 
   it("returns success without touching HubSpot", async () => {
-    const mockFetch = vi
-      .fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>()
-      .mockRejectedValue(new Error("fetch should not have been called on noop"));
-    vi.stubGlobal("fetch", mockFetch);
-
     const prompt = JSON.stringify({
       operation: "noop",
       skipped: true,
@@ -594,7 +594,7 @@ describe("hubspotAgent deterministic noop", () => {
     expect(result.data.success).toBe(true);
     expect(result.data.data).toMatchObject({ skipped: true, reason: "no ticket to brief" });
     expect(result.data.response).toContain("no ticket to brief");
-    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockBatchCreate).not.toHaveBeenCalled();
     expect(mockGenerateText).not.toHaveBeenCalled();
   });
 

--- a/packages/bundled-agents/src/hubspot/agent.test.ts
+++ b/packages/bundled-agents/src/hubspot/agent.test.ts
@@ -625,6 +625,39 @@ describe("hubspotAgent deterministic create-note", () => {
     expect.assert(result.ok);
     expect(result.data.success).toBe(false);
     expect(result.data.response).toBe("CRM Note creation on ticket 5501 returned no usable id");
+    // Empty-string id from the SDK should be normalized to `null` in the
+    // structured payload — consumers shouldn't see an empty noteId string.
+    expect(result.data.data).toMatchObject({ noteId: null });
+  });
+
+  it("substitutes a fresh hs_timestamp when upstream sends an empty string", async () => {
+    mockBatchCreate.mockResolvedValue(createNoteSdkResponse);
+
+    await hubspotAgent.execute(
+      JSON.stringify({
+        operation: "create-note",
+        ticketId: "5501",
+        body: "<p>x</p>",
+        hsTimestamp: "",
+      }),
+      validContext(),
+    );
+
+    // Verify the SDK was called with a non-empty ISO timestamp, not the
+    // literal empty string the upstream sent. The fallback is
+    // `new Date().toISOString()` — match the ISO 8601 shape directly.
+    expect(mockBatchCreate).toHaveBeenCalledWith(
+      "notes",
+      expect.objectContaining({
+        inputs: [
+          expect.objectContaining({
+            properties: expect.objectContaining({
+              hs_timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+            }),
+          }),
+        ],
+      }),
+    );
   });
 
   it("falls through to LLM when ticketId or body is missing", async () => {
@@ -702,5 +735,20 @@ describe("hubspotAgent deterministic noop", () => {
     expect(result.data.data).toEqual({ skipped: true });
     expect(mockBatchCreate).not.toHaveBeenCalled();
     expect(mockGenerateText).not.toHaveBeenCalled();
+  });
+
+  it("treats empty-string reason the same as missing — non-empty fallback response", async () => {
+    const prompt = JSON.stringify({ operation: "noop", reason: "" });
+
+    const result = await hubspotAgent.execute(prompt, validContext());
+
+    expect(result.ok).toBe(true);
+    expect.assert(result.ok);
+    expect(result.data.success).toBe(true);
+    // Without the empty-string guard, `?? "Noop..."` would return "" and the
+    // agent would emit an empty user-facing response.
+    expect(result.data.response).toBe("Noop — upstream signalled nothing to do.");
+    // Empty-string reason should not surface in the structured payload.
+    expect(result.data.data).toEqual({ skipped: true });
   });
 });

--- a/packages/bundled-agents/src/hubspot/agent.test.ts
+++ b/packages/bundled-agents/src/hubspot/agent.test.ts
@@ -539,6 +539,24 @@ describe("hubspotAgent deterministic create-note", () => {
     expect(mockGenerateText).not.toHaveBeenCalled();
   });
 
+  it("short-circuits when abortSignal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const prompt = JSON.stringify({ operation: "create-note", ticketId: "5501", body: "<p>x</p>" });
+
+    const result = await hubspotAgent.execute(
+      prompt,
+      createMockContext({ env: { HUBSPOT_ACCESS_TOKEN: "tok" }, abortSignal: controller.signal }),
+    );
+
+    expect(result.ok).toBe(false);
+    expect.assert(!result.ok);
+    expect(result.error.reason).toContain("aborted");
+    expect(mockBatchCreate).not.toHaveBeenCalled();
+    expect(mockGenerateText).not.toHaveBeenCalled();
+  });
+
   it("reports success=false when the batch response carries numErrors > 0", async () => {
     mockBatchCreate.mockResolvedValue({
       status: "COMPLETE",
@@ -560,6 +578,21 @@ describe("hubspotAgent deterministic create-note", () => {
       numErrors: 1,
       errors: [{ status: "error", message: "Property hs_timestamp is required" }],
     });
+  });
+
+  it("reports success=false when the SDK returns an empty-string id", async () => {
+    mockBatchCreate.mockResolvedValue({
+      status: "COMPLETE",
+      results: [{ id: "", properties: {} }],
+    });
+
+    const prompt = JSON.stringify({ operation: "create-note", ticketId: "5501", body: "<p>x</p>" });
+
+    const result = await hubspotAgent.execute(prompt, validContext());
+
+    expect(result.ok).toBe(true);
+    expect.assert(result.ok);
+    expect(result.data.success).toBe(false);
   });
 
   it("falls through to LLM when ticketId or body is missing", async () => {

--- a/packages/bundled-agents/src/hubspot/agent.test.ts
+++ b/packages/bundled-agents/src/hubspot/agent.test.ts
@@ -482,9 +482,19 @@ describe("hubspotAgent deterministic create-note", () => {
     expect.assert(result.ok);
     expect(result.data.operation).toBe("create-note");
     expect(result.data.success).toBe(true);
-    expect(result.data.data).toMatchObject({ noteId: "601", ticketId: "5501" });
-    expect(result.data.response).toContain("601");
-    expect(result.data.response).toContain("5501");
+    expect(result.data.response).toBe("CRM Note 601 created on ticket 5501");
+    // Pin the full data shape — protects the structured-output contract.
+    expect(result.data.data).toEqual({
+      noteId: "601",
+      ticketId: "5501",
+      properties: {
+        hs_note_body: "<h3>Briefing</h3><p>body</p>",
+        hs_timestamp: "2026-05-07T12:00:00.000Z",
+      },
+      numErrors: 0,
+      errors: [],
+    });
+    expect(mockBatchCreate).toHaveBeenCalledOnce();
     expect(mockGenerateText).not.toHaveBeenCalled();
   });
 

--- a/packages/bundled-agents/src/hubspot/agent.test.ts
+++ b/packages/bundled-agents/src/hubspot/agent.test.ts
@@ -513,10 +513,14 @@ describe("hubspotAgent deterministic create-note", () => {
       numErrors: 0,
       errors: [],
     });
-    // Pin auth wiring — without this assertion, an agent regression that
-    // dropped or corrupted the access token would have no test signal.
+    // Pin auth + retry + rate-limit wiring — without these, regressions
+    // that dropped any of the three Client args would have no test signal.
     expect(mockClientConstructor).toHaveBeenCalledWith(
-      expect.objectContaining({ accessToken: "tok", numberOfApiCallRetries: 3 }),
+      expect.objectContaining({
+        accessToken: "tok",
+        numberOfApiCallRetries: 3,
+        limiterOptions: expect.anything(),
+      }),
     );
     expect(mockBatchCreate).toHaveBeenCalledOnce();
     expect(mockGenerateText).not.toHaveBeenCalled();
@@ -651,7 +655,15 @@ describe("hubspotAgent deterministic create-note", () => {
     expect.assert(result.ok);
     expect(result.data.success).toBe(true);
     expect(result.data.response).toBe("CRM Note 601 created on ticket 5501");
-    expect(result.data.data).toMatchObject({ noteId: "601", numErrors: 1 });
+    // Pin the full data shape — match the strictness of sibling tests so
+    // unintended extra fields on this branch can't slip through.
+    expect(result.data.data).toEqual({
+      noteId: "601",
+      ticketId: "5501",
+      properties: { hs_note_body: "<p>x</p>", hs_timestamp: "2026-05-07T12:00:00.000Z" },
+      numErrors: 1,
+      errors: [{ status: "error", message: "stale request to a phantom input" }],
+    });
   });
 
   it("pluralizes the error noun when numErrors > 1", async () => {
@@ -700,24 +712,27 @@ describe("hubspotAgent deterministic create-note", () => {
     });
   });
 
-  it("substitutes a fresh hs_timestamp when upstream sends an empty string", async () => {
+  it.each([
+    { label: "empty string", envelope: { hsTimestamp: "" } },
+    { label: "omitted", envelope: {} },
+  ])("substitutes a fresh hs_timestamp when upstream hsTimestamp is $label", async ({
+    envelope,
+  }) => {
     mockBatchCreate.mockResolvedValue(createNoteSdkResponse);
 
     const before = Date.now();
     await hubspotAgent.execute(
-      JSON.stringify({
-        operation: "create-note",
-        ticketId: "5501",
-        body: "<p>x</p>",
-        hsTimestamp: "",
-      }),
+      JSON.stringify({ operation: "create-note", ticketId: "5501", body: "<p>x</p>", ...envelope }),
       validContext(),
     );
     const after = Date.now();
 
-    // Pin freshness — not just "any ISO string". A regression that forwarded
-    // a stale upstream timestamp instead of generating a new one would pass
-    // a regex-only check; this proves the timestamp was generated in-handler.
+    // Pin freshness — not just "any ISO string". A regression that
+    // forwarded a stale upstream timestamp instead of generating a new
+    // one would pass a regex-only check; this proves the timestamp was
+    // generated in-handler. Both `hsTimestamp: ""` and `hsTimestamp`
+    // omitted entirely share the `||` fallback in agent.ts; this
+    // parameterized test pins both branches.
     expect(mockBatchCreate).toHaveBeenCalledOnce();
     const firstCall = mockBatchCreate.mock.calls[0];
     expect(firstCall).toBeDefined();
@@ -786,6 +801,7 @@ describe("hubspotAgent deterministic noop", () => {
     env.ANTHROPIC_API_KEY = "sk-test";
     mockGenerateText.mockReset();
     mockBatchCreate.mockReset();
+    mockClientConstructor.mockReset();
   });
 
   afterEach(() => {

--- a/packages/bundled-agents/src/hubspot/agent.test.ts
+++ b/packages/bundled-agents/src/hubspot/agent.test.ts
@@ -512,7 +512,7 @@ describe("hubspotAgent deterministic create-note", () => {
       hsTimestamp: "2026-05-07T12:00:00.000Z",
     });
 
-    await hubspotAgent.execute(prompt, validContext());
+    const result = await hubspotAgent.execute(prompt, validContext());
 
     expect(mockBatchCreate).toHaveBeenCalledOnce();
     expect(mockBatchCreate).toHaveBeenCalledWith("notes", {
@@ -528,6 +528,12 @@ describe("hubspotAgent deterministic create-note", () => {
         },
       ],
     });
+    // Also pin the agent's return — the SDK-call shape and the
+    // user-visible outcome should agree on what happened.
+    expect(result.ok).toBe(true);
+    expect.assert(result.ok);
+    expect(result.data.success).toBe(true);
+    expect(result.data.response).toBe("CRM Note 601 created on ticket 5501");
   });
 
   it("returns err when the SDK batch-create rejects", async () => {
@@ -583,8 +589,12 @@ describe("hubspotAgent deterministic create-note", () => {
     expect.assert(result.ok);
     expect(result.data.success).toBe(false);
     expect(result.data.response).toBe("CRM Note creation on ticket 5501 returned 1 error");
-    expect(result.data.data).toMatchObject({
+    // Pin the full data shape — including the `properties: {}` default
+    // that round-5 introduced for stable JSON output on the no-result path.
+    expect(result.data.data).toEqual({
       noteId: null,
+      ticketId: "5501",
+      properties: {},
       numErrors: 1,
       errors: [{ status: "error", message: "Property hs_timestamp is required" }],
     });
@@ -627,7 +637,13 @@ describe("hubspotAgent deterministic create-note", () => {
     expect(result.data.response).toBe("CRM Note creation on ticket 5501 returned no usable id");
     // Empty-string id from the SDK should be normalized to `null` in the
     // structured payload — consumers shouldn't see an empty noteId string.
-    expect(result.data.data).toMatchObject({ noteId: null });
+    expect(result.data.data).toEqual({
+      noteId: null,
+      ticketId: "5501",
+      properties: {},
+      numErrors: 0,
+      errors: [],
+    });
   });
 
   it("substitutes a fresh hs_timestamp when upstream sends an empty string", async () => {
@@ -750,5 +766,19 @@ describe("hubspotAgent deterministic noop", () => {
     expect(result.data.response).toBe("Noop — upstream signalled nothing to do.");
     // Empty-string reason should not surface in the structured payload.
     expect(result.data.data).toEqual({ skipped: true });
+  });
+
+  it("preserves explicit skipped: false (boolean uses ??, not ||)", async () => {
+    // Round-6 changed string fallbacks from `??` to `||`; for `skipped`
+    // (boolean) we kept `??` because `false` is a valid intentional value.
+    // This test pins that distinction so a future "consistency" refactor
+    // doesn't accidentally flip false → true.
+    const prompt = JSON.stringify({ operation: "noop", skipped: false, reason: "x" });
+
+    const result = await hubspotAgent.execute(prompt, validContext());
+
+    expect(result.ok).toBe(true);
+    expect.assert(result.ok);
+    expect(result.data.data).toEqual({ skipped: false, reason: "x" });
   });
 });

--- a/packages/bundled-agents/src/hubspot/agent.test.ts
+++ b/packages/bundled-agents/src/hubspot/agent.test.ts
@@ -5,10 +5,25 @@ import type { LogContext, Logger } from "@atlas/logger";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import createCommentFixture from "./fixtures/create-comment.json" with { type: "json" };
 
-const { mockGenerateText, mockBatchCreate } = vi.hoisted(() => ({
-  mockGenerateText: vi.fn(),
-  mockBatchCreate: vi.fn(),
-}));
+const { mockGenerateText, mockBatchCreate, mockClientConstructor } = vi.hoisted(() => {
+  type BatchCreateRequest = {
+    inputs: Array<{
+      properties: Record<string, string>;
+      associations?: Array<{
+        to: { id: string };
+        types: Array<{ associationCategory: string; associationTypeId: number }>;
+      }>;
+    }>;
+  };
+  return {
+    mockGenerateText: vi.fn(),
+    mockBatchCreate: vi.fn<(objectType: string, request: BatchCreateRequest) => Promise<unknown>>(),
+    // Spy on the Client constructor so tests can pin the auth args (accessToken,
+    // retry config). Without this spy, an agent regression that dropped the
+    // accessToken or passed a wrong one would not fail any test.
+    mockClientConstructor: vi.fn(),
+  };
+});
 
 vi.mock("ai", () => ({
   generateText: mockGenerateText,
@@ -19,6 +34,9 @@ vi.mock("ai", () => ({
 vi.mock("@hubspot/api-client", () => ({
   Client: class {
     crm = { objects: { batchApi: { create: mockBatchCreate } } };
+    constructor(args: unknown) {
+      mockClientConstructor(args);
+    }
   },
   DEFAULT_LIMITER_OPTIONS: {},
 }));
@@ -457,6 +475,7 @@ describe("hubspotAgent deterministic create-note", () => {
     env.ANTHROPIC_API_KEY = "sk-test";
     mockGenerateText.mockReset();
     mockBatchCreate.mockReset();
+    mockClientConstructor.mockReset();
   });
 
   afterEach(() => {
@@ -494,6 +513,11 @@ describe("hubspotAgent deterministic create-note", () => {
       numErrors: 0,
       errors: [],
     });
+    // Pin auth wiring — without this assertion, an agent regression that
+    // dropped or corrupted the access token would have no test signal.
+    expect(mockClientConstructor).toHaveBeenCalledWith(
+      expect.objectContaining({ accessToken: "tok", numberOfApiCallRetries: 3 }),
+    );
     expect(mockBatchCreate).toHaveBeenCalledOnce();
     expect(mockGenerateText).not.toHaveBeenCalled();
   });
@@ -600,6 +624,36 @@ describe("hubspotAgent deterministic create-note", () => {
     });
   });
 
+  it("treats a returned id as success even when numErrors > 0 (single-record batch)", async () => {
+    // For our single-record batch, a returned id IS the real outcome —
+    // partial-success with `numErrors > 0` would have to come from inputs
+    // we didn't send. Without this priority, the response message and
+    // `data.success` would lie about the same operation: message says
+    // "returned N errors" while `data.noteId` carries a real id.
+    mockBatchCreate.mockResolvedValue({
+      status: "COMPLETE",
+      results: [
+        {
+          id: "601",
+          properties: { hs_note_body: "<p>x</p>", hs_timestamp: "2026-05-07T12:00:00.000Z" },
+        },
+      ],
+      numErrors: 1,
+      errors: [{ status: "error", message: "stale request to a phantom input" }],
+    });
+
+    const result = await hubspotAgent.execute(
+      JSON.stringify({ operation: "create-note", ticketId: "5501", body: "<p>x</p>" }),
+      validContext(),
+    );
+
+    expect(result.ok).toBe(true);
+    expect.assert(result.ok);
+    expect(result.data.success).toBe(true);
+    expect(result.data.response).toBe("CRM Note 601 created on ticket 5501");
+    expect(result.data.data).toMatchObject({ noteId: "601", numErrors: 1 });
+  });
+
   it("pluralizes the error noun when numErrors > 1", async () => {
     mockBatchCreate.mockResolvedValue({
       status: "COMPLETE",
@@ -649,6 +703,7 @@ describe("hubspotAgent deterministic create-note", () => {
   it("substitutes a fresh hs_timestamp when upstream sends an empty string", async () => {
     mockBatchCreate.mockResolvedValue(createNoteSdkResponse);
 
+    const before = Date.now();
     await hubspotAgent.execute(
       JSON.stringify({
         operation: "create-note",
@@ -658,22 +713,24 @@ describe("hubspotAgent deterministic create-note", () => {
       }),
       validContext(),
     );
+    const after = Date.now();
 
-    // Verify the SDK was called with a non-empty ISO timestamp, not the
-    // literal empty string the upstream sent. The fallback is
-    // `new Date().toISOString()` — match the ISO 8601 shape directly.
-    expect(mockBatchCreate).toHaveBeenCalledWith(
-      "notes",
-      expect.objectContaining({
-        inputs: [
-          expect.objectContaining({
-            properties: expect.objectContaining({
-              hs_timestamp: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
-            }),
-          }),
-        ],
-      }),
-    );
+    // Pin freshness — not just "any ISO string". A regression that forwarded
+    // a stale upstream timestamp instead of generating a new one would pass
+    // a regex-only check; this proves the timestamp was generated in-handler.
+    expect(mockBatchCreate).toHaveBeenCalledOnce();
+    const firstCall = mockBatchCreate.mock.calls[0];
+    expect(firstCall).toBeDefined();
+    if (!firstCall) throw new Error("expected mockBatchCreate to have been called");
+    const [objectType, request] = firstCall;
+    expect(objectType).toBe("notes");
+    const sentTimestamp = request.inputs[0]?.properties.hs_timestamp;
+    expect(sentTimestamp).toBeDefined();
+    if (!sentTimestamp) throw new Error("expected hs_timestamp on the SDK call");
+    const parsed = Date.parse(sentTimestamp);
+    expect(Number.isFinite(parsed)).toBe(true);
+    expect(parsed).toBeGreaterThanOrEqual(before);
+    expect(parsed).toBeLessThanOrEqual(after);
   });
 
   it("falls through to LLM when ticketId or body is missing", async () => {
@@ -692,6 +749,28 @@ describe("hubspotAgent deterministic create-note", () => {
     });
 
     const result = await hubspotAgent.execute(prompt, validContext());
+
+    expect(result.ok).toBe(true);
+    expect(mockBatchCreate).not.toHaveBeenCalled();
+    expect(mockGenerateText).toHaveBeenCalledOnce();
+  });
+
+  it("falls through to LLM when ticketId or body is the empty string", async () => {
+    // `.min(1)` on the schema fields catches malformed envelopes from
+    // LLM-authored upstreams at parse time instead of late at the SDK.
+    mockGenerateText.mockResolvedValue({
+      text: "LLM response",
+      finishReason: "stop",
+      usage: { promptTokens: 10, completionTokens: 5 },
+      steps: [{}],
+      toolCalls: [],
+      toolResults: [],
+    });
+
+    const result = await hubspotAgent.execute(
+      JSON.stringify({ operation: "create-note", ticketId: "", body: "<p>x</p>" }),
+      validContext(),
+    );
 
     expect(result.ok).toBe(true);
     expect(mockBatchCreate).not.toHaveBeenCalled();

--- a/packages/bundled-agents/src/hubspot/agent.ts
+++ b/packages/bundled-agents/src/hubspot/agent.ts
@@ -342,25 +342,29 @@ export const hubspotAgent = createAgent<string, HubSpotOutput>({
             limiterOptions: DEFAULT_LIMITER_OPTIONS,
           });
 
-          const result = await batchCreateCrmObjects(client, {
-            objectType: "notes",
-            records: [
-              {
-                properties: {
-                  hs_note_body: config.body,
-                  hs_timestamp: config.hsTimestamp ?? new Date().toISOString(),
+          const result = await batchCreateCrmObjects(
+            client,
+            {
+              objectType: "notes",
+              records: [
+                {
+                  properties: {
+                    hs_note_body: config.body,
+                    hs_timestamp: config.hsTimestamp ?? new Date().toISOString(),
+                  },
+                  associations: [{ toObjectType: "tickets", toObjectId: config.ticketId }],
                 },
-                associations: [{ toObjectType: "tickets", toObjectId: config.ticketId }],
-              },
-            ],
-          });
+              ],
+            },
+            abortSignal,
+          );
 
           if ("error" in result) {
             return err(`create-note failed (ticket ${config.ticketId}): ${result.error}`);
           }
 
           const created = result.results[0];
-          const success = result.numErrors === 0 && created?.id !== undefined;
+          const success = result.numErrors === 0 && Boolean(created?.id);
           return ok({
             response: success
               ? `CRM Note ${created?.id} created on ticket ${config.ticketId}`
@@ -395,8 +399,10 @@ export const hubspotAgent = createAgent<string, HubSpotOutput>({
         default: {
           // Exhaustive guard: assigning to `never` errors at compile time
           // if HubSpotOperationSchema gains a new variant without a case.
+          // At runtime this branch is unreachable; `_exhaustive` is unused.
           const _exhaustive: never = config;
-          return err(`Unknown operation in deterministic dispatch: ${String(_exhaustive)}`);
+          void _exhaustive;
+          return err("Unknown operation in deterministic dispatch");
         }
       }
     }

--- a/packages/bundled-agents/src/hubspot/agent.ts
+++ b/packages/bundled-agents/src/hubspot/agent.ts
@@ -364,11 +364,20 @@ export const hubspotAgent = createAgent<string, HubSpotOutput>({
           }
 
           const created = result.results[0];
-          const success = result.numErrors === 0 && Boolean(created?.id);
+          const hasErrors = result.numErrors > 0;
+          const hasId = Boolean(created?.id);
+          const success = !hasErrors && hasId;
+          let response: string;
+          if (success) {
+            response = `CRM Note ${created?.id} created on ticket ${config.ticketId}`;
+          } else if (hasErrors) {
+            const noun = result.numErrors === 1 ? "error" : "errors";
+            response = `CRM Note creation on ticket ${config.ticketId} returned ${result.numErrors} ${noun}`;
+          } else {
+            response = `CRM Note creation on ticket ${config.ticketId} returned no usable id`;
+          }
           return ok({
-            response: success
-              ? `CRM Note ${created?.id} created on ticket ${config.ticketId}`
-              : `CRM Note creation on ticket ${config.ticketId} completed with ${result.numErrors} error(s)`,
+            response,
             operation: "create-note",
             success,
             data: {

--- a/packages/bundled-agents/src/hubspot/agent.ts
+++ b/packages/bundled-agents/src/hubspot/agent.ts
@@ -24,6 +24,19 @@ import {
   createUpsertCrmObjectsTool,
 } from "./tools.ts";
 
+/** notes ↔ tickets default association type (matches DEFAULT_ASSOCIATION_TYPES in tools.ts). */
+const NOTES_TO_TICKETS_ASSOCIATION_TYPE_ID = 228;
+
+/** Minimal HubSpot batch-create response shape we need to read. */
+const BatchCreateNotesResponseSchema = z.object({
+  status: z.string().optional(),
+  results: z
+    .array(z.object({ id: z.string(), properties: z.record(z.string(), z.unknown()).optional() }))
+    .optional(),
+  numErrors: z.number().optional(),
+  errors: z.array(z.object({ status: z.string(), message: z.string() })).optional(),
+});
+
 /**
  * Schema for the deterministic send-thread-comment operation.
  * Maps directly to the existing send_thread_comment tool input.
@@ -37,10 +50,53 @@ const SendThreadCommentOpSchema = z.object({
 });
 
 /**
+ * Schema for the deterministic create-note operation.
+ *
+ * Creates a HubSpot CRM Note attached to a ticket — body is passed through
+ * verbatim as `hs_note_body` (HubSpot renders it as HTML in the
+ * Activities/Notes tab). This is the deterministic equivalent of asking
+ * the LLM to call `create_crm_objects` with `objectType: "notes"`,
+ * `records: [{...}]`, and the standard notes↔tickets association
+ * (associationTypeId 228).
+ *
+ * The optional `kind` and `format` fields are passthrough metadata that
+ * upstream agents (e.g. briefing-builder, reply-builder) include for their
+ * own bookkeeping; the dispatcher accepts them but doesn't use them.
+ */
+const CreateNoteOpSchema = z.object({
+  operation: z.literal("create-note"),
+  ticketId: z.string(),
+  body: z.string(),
+  kind: z.string().optional(),
+  format: z.string().optional(),
+  /** ISO timestamp override; defaults to `new Date().toISOString()`. */
+  hsTimestamp: z.string().optional(),
+});
+
+/**
+ * Schema for the deterministic noop operation.
+ *
+ * Lets upstream agents emit a "do-nothing" envelope when they detect a
+ * skip sentinel (e.g. the empty-cron-tick path where ticket-picker
+ * returns `{done: true}`). The dispatcher returns success without
+ * touching HubSpot — replaces the prior pattern of relying on the LLM
+ * to recognize a noop instruction in its prompt.
+ */
+const NoopOpSchema = z.object({
+  operation: z.literal("noop"),
+  reason: z.string().optional(),
+  skipped: z.boolean().optional(),
+});
+
+/**
  * Discriminated union of all deterministic HubSpot operations.
  * New operations are added as additional variants.
  */
-const HubSpotOperationSchema = z.discriminatedUnion("operation", [SendThreadCommentOpSchema]);
+const HubSpotOperationSchema = z.discriminatedUnion("operation", [
+  SendThreadCommentOpSchema,
+  CreateNoteOpSchema,
+  NoopOpSchema,
+]);
 
 /**
  * Output schema for the HubSpot agent.
@@ -298,8 +354,98 @@ export const hubspotAgent = createAgent<string, HubSpotOutput>({
             data: result,
           });
         }
+
+        case "create-note": {
+          // Hit HubSpot's batch-create endpoint directly via raw fetch
+          // (matches the send-thread-comment pattern). Avoids pulling in the
+          // SDK Client for a one-shot deterministic call, and lets the
+          // standard fetch-stub test pattern work without per-test SDK
+          // mocks.
+          const body = JSON.stringify({
+            inputs: [
+              {
+                properties: {
+                  hs_note_body: config.body,
+                  hs_timestamp: config.hsTimestamp ?? new Date().toISOString(),
+                },
+                associations: [
+                  {
+                    to: { id: config.ticketId },
+                    types: [
+                      {
+                        associationCategory: "HUBSPOT_DEFINED",
+                        associationTypeId: NOTES_TO_TICKETS_ASSOCIATION_TYPE_ID,
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          });
+
+          let resp: Response;
+          try {
+            resp = await fetch("https://api.hubapi.com/crm/v3/objects/notes/batch/create", {
+              method: "POST",
+              headers: {
+                Authorization: `Bearer ${accessToken}`,
+                "Content-Type": "application/json",
+              },
+              body,
+              signal: abortSignal,
+            });
+          } catch (e) {
+            return err(`create-note failed: ${stringifyError(e)}`);
+          }
+          if (!resp.ok) {
+            const errBody = await resp.text().catch(() => "");
+            return err(
+              `create-note failed: ${resp.status} ${resp.statusText}${errBody ? ` — ${errBody.slice(0, 300)}` : ""}`,
+            );
+          }
+          let parsed: unknown;
+          try {
+            parsed = await resp.json();
+          } catch (e) {
+            return err(`create-note failed: response was not JSON: ${stringifyError(e)}`);
+          }
+          const validated = BatchCreateNotesResponseSchema.safeParse(parsed);
+          if (!validated.success) {
+            return err(`create-note failed: unexpected response shape: ${validated.error.message}`);
+          }
+
+          const created = validated.data.results?.[0];
+          return ok({
+            response: created?.id
+              ? `CRM Note ${created.id} created on ticket ${config.ticketId}`
+              : `CRM Note creation completed for ticket ${config.ticketId} (no id returned)`,
+            operation: "create-note",
+            success: true,
+            data: {
+              noteId: created?.id ?? null,
+              ticketId: config.ticketId,
+              properties: created?.properties,
+              numErrors: validated.data.numErrors,
+              errors: validated.data.errors,
+            },
+          });
+        }
+
+        case "noop": {
+          // Skip sentinel — upstream agent decided there's nothing to do
+          // (e.g. empty-cron-tick path). Return success without calling
+          // HubSpot so the FSM drains cleanly.
+          logger.info("Deterministic noop", { reason: config.reason ?? "(no reason given)" });
+          return ok({
+            response: config.reason ?? "Noop — upstream signalled nothing to do.",
+            operation: "noop",
+            success: true,
+            data: { skipped: config.skipped ?? true, reason: config.reason },
+          });
+        }
+
         default:
-          return err(`Unknown operation: ${config.operation}`);
+          return err(`Unknown operation: ${(config as { operation: string }).operation}`);
       }
     }
 

--- a/packages/bundled-agents/src/hubspot/agent.ts
+++ b/packages/bundled-agents/src/hubspot/agent.ts
@@ -367,6 +367,16 @@ export const hubspotAgent = createAgent<string, HubSpotOutput>({
           if ("error" in result) {
             return err(`create-note failed (ticket ${config.ticketId}): ${result.error}`);
           }
+          // Defend against future changes to DEFAULT_ASSOCIATION_TYPES — if
+          // notes↔tickets ever drops out of the lookup table, the helper
+          // would skip the association silently and return a successful
+          // batch with an orphaned note. Without this guard the response
+          // would say "Note created on ticket X" while the link is missing.
+          if (result.skippedAssociations) {
+            return err(
+              `create-note failed (ticket ${config.ticketId}): ${result.skippedAssociations}`,
+            );
+          }
 
           const created = result.results[0];
           const hasId = Boolean(created?.id);

--- a/packages/bundled-agents/src/hubspot/agent.ts
+++ b/packages/bundled-agents/src/hubspot/agent.ts
@@ -350,7 +350,10 @@ export const hubspotAgent = createAgent<string, HubSpotOutput>({
                 {
                   properties: {
                     hs_note_body: config.body,
-                    hs_timestamp: config.hsTimestamp ?? new Date().toISOString(),
+                    // `||` (not `??`) so an empty-string upstream value still
+                    // falls back to a fresh ISO timestamp instead of being
+                    // forwarded to the SDK as "" and rejected late.
+                    hs_timestamp: config.hsTimestamp || new Date().toISOString(),
                   },
                   associations: [{ toObjectType: "tickets", toObjectId: config.ticketId }],
                 },
@@ -381,7 +384,9 @@ export const hubspotAgent = createAgent<string, HubSpotOutput>({
             operation: "create-note",
             success,
             data: {
-              noteId: created?.id ?? null,
+              // `|| null` (not `?? null`) so an empty-string id is normalized
+              // to null — matches the empty-string-rejection in `success` above.
+              noteId: created?.id || null,
               ticketId: config.ticketId,
               properties: created?.properties ?? {},
               numErrors: result.numErrors,
@@ -394,11 +399,16 @@ export const hubspotAgent = createAgent<string, HubSpotOutput>({
           // Skip sentinel — upstream agent decided there's nothing to do
           // (e.g. empty-cron-tick path). Return success without calling
           // HubSpot so the FSM drains cleanly.
+          //
+          // `||` (not `??`) for both the response fallback and the data
+          // inclusion check — treat empty-string `reason` the same as
+          // missing, so a malformed upstream envelope can't produce an
+          // empty response or a `data.reason: ""` field.
           logger.info("Deterministic noop", { reason: config.reason });
           const data: { skipped: boolean; reason?: string } = { skipped: config.skipped ?? true };
-          if (config.reason !== undefined) data.reason = config.reason;
+          if (config.reason) data.reason = config.reason;
           return ok({
-            response: config.reason ?? "Noop — upstream signalled nothing to do.",
+            response: config.reason || "Noop — upstream signalled nothing to do.",
             operation: "noop",
             success: true,
             data,

--- a/packages/bundled-agents/src/hubspot/agent.ts
+++ b/packages/bundled-agents/src/hubspot/agent.ts
@@ -41,12 +41,14 @@ const SendThreadCommentOpSchema = z.object({
  * Schema for the deterministic create-note operation.
  *
  * Deterministic equivalent of asking the LLM to call `create_crm_objects`
- * with `objectType: "notes"` and a notes↔tickets association.
+ * with `objectType: "notes"` and a notes↔tickets association. Empty
+ * `ticketId` or `body` fail-parse here (rather than late at the SDK)
+ * — malformed envelopes from LLM-authored upstreams get caught early.
  */
 const CreateNoteOpSchema = z.object({
   operation: z.literal("create-note"),
-  ticketId: z.string(),
-  body: z.string(),
+  ticketId: z.string().min(1),
+  body: z.string().min(1),
   hsTimestamp: z.string().optional(),
 });
 
@@ -367,9 +369,14 @@ export const hubspotAgent = createAgent<string, HubSpotOutput>({
           }
 
           const created = result.results[0];
-          const hasErrors = result.numErrors > 0;
           const hasId = Boolean(created?.id);
-          const success = !hasErrors && hasId;
+          // For our single-record batch, a returned id IS success — even if
+          // HubSpot also reports `numErrors > 0` (which would have to come
+          // from a partial-success on inputs we didn't send). Without this
+          // priority, the response would say "returned N errors" while
+          // `data.noteId` carried a real created id — a dishonest response.
+          const success = hasId;
+          const hasErrors = result.numErrors > 0;
           let response: string;
           if (success) {
             response = `CRM Note ${created?.id} created on ticket ${config.ticketId}`;

--- a/packages/bundled-agents/src/hubspot/agent.ts
+++ b/packages/bundled-agents/src/hubspot/agent.ts
@@ -24,19 +24,6 @@ import {
   createUpsertCrmObjectsTool,
 } from "./tools.ts";
 
-/** notes ↔ tickets default association type (matches DEFAULT_ASSOCIATION_TYPES in tools.ts). */
-const NOTES_TO_TICKETS_ASSOCIATION_TYPE_ID = 228;
-
-/** Minimal HubSpot batch-create response shape we need to read. */
-const BatchCreateNotesResponseSchema = z.object({
-  status: z.string().optional(),
-  results: z
-    .array(z.object({ id: z.string(), properties: z.record(z.string(), z.unknown()).optional() }))
-    .optional(),
-  numErrors: z.number().optional(),
-  errors: z.array(z.object({ status: z.string(), message: z.string() })).optional(),
-});
-
 /**
  * Schema for the deterministic send-thread-comment operation.
  * Maps directly to the existing send_thread_comment tool input.
@@ -52,24 +39,13 @@ const SendThreadCommentOpSchema = z.object({
 /**
  * Schema for the deterministic create-note operation.
  *
- * Creates a HubSpot CRM Note attached to a ticket — body is passed through
- * verbatim as `hs_note_body` (HubSpot renders it as HTML in the
- * Activities/Notes tab). This is the deterministic equivalent of asking
- * the LLM to call `create_crm_objects` with `objectType: "notes"`,
- * `records: [{...}]`, and the standard notes↔tickets association
- * (associationTypeId 228).
- *
- * The optional `kind` and `format` fields are passthrough metadata that
- * upstream agents (e.g. briefing-builder, reply-builder) include for their
- * own bookkeeping; the dispatcher accepts them but doesn't use them.
+ * Deterministic equivalent of asking the LLM to call `create_crm_objects`
+ * with `objectType: "notes"` and a notes↔tickets association.
  */
 const CreateNoteOpSchema = z.object({
   operation: z.literal("create-note"),
   ticketId: z.string(),
   body: z.string(),
-  kind: z.string().optional(),
-  format: z.string().optional(),
-  /** ISO timestamp override; defaults to `new Date().toISOString()`. */
   hsTimestamp: z.string().optional(),
 });
 
@@ -356,65 +332,45 @@ export const hubspotAgent = createAgent<string, HubSpotOutput>({
         }
 
         case "create-note": {
-          // Hit HubSpot's batch-create endpoint directly via raw fetch
-          // (matches the send-thread-comment pattern). Avoids pulling in the
-          // SDK Client for a one-shot deterministic call, and lets the
-          // standard fetch-stub test pattern work without per-test SDK
-          // mocks.
-          const body = JSON.stringify({
-            inputs: [
-              {
-                properties: {
-                  hs_note_body: config.body,
-                  hs_timestamp: config.hsTimestamp ?? new Date().toISOString(),
-                },
-                associations: [
-                  {
-                    to: { id: config.ticketId },
-                    types: [
-                      {
-                        associationCategory: "HUBSPOT_DEFINED",
-                        associationTypeId: NOTES_TO_TICKETS_ASSOCIATION_TYPE_ID,
-                      },
-                    ],
-                  },
-                ],
-              },
-            ],
+          // Reuse the LLM path's create_crm_objects tool — same SDK call,
+          // same association-id lookup (DEFAULT_ASSOCIATION_TYPES), same
+          // response normalization. No raw fetch, no duplicated schema.
+          const client = new Client({
+            accessToken,
+            numberOfApiCallRetries: 3,
+            limiterOptions: DEFAULT_LIMITER_OPTIONS,
           });
-
-          let resp: Response;
-          try {
-            resp = await fetch("https://api.hubapi.com/crm/v3/objects/notes/batch/create", {
-              method: "POST",
-              headers: {
-                Authorization: `Bearer ${accessToken}`,
-                "Content-Type": "application/json",
-              },
-              body,
-              signal: abortSignal,
-            });
-          } catch (e) {
-            return err(`create-note failed: ${stringifyError(e)}`);
-          }
-          if (!resp.ok) {
-            const errBody = await resp.text().catch(() => "");
-            return err(
-              `create-note failed: ${resp.status} ${resp.statusText}${errBody ? ` — ${errBody.slice(0, 300)}` : ""}`,
-            );
-          }
-          let parsed: unknown;
-          try {
-            parsed = await resp.json();
-          } catch (e) {
-            return err(`create-note failed: response was not JSON: ${stringifyError(e)}`);
-          }
-          const validated = BatchCreateNotesResponseSchema.safeParse(parsed);
-          if (!validated.success) {
-            return err(`create-note failed: unexpected response shape: ${validated.error.message}`);
+          const toolDef = createCreateCrmObjectsTool(client);
+          if (!toolDef.execute) {
+            return err("create-note tool has no execute function");
           }
 
-          const created = validated.data.results?.[0];
+          const result = await toolDef.execute(
+            {
+              objectType: "notes",
+              records: [
+                {
+                  properties: {
+                    hs_note_body: config.body,
+                    hs_timestamp: config.hsTimestamp ?? new Date().toISOString(),
+                  },
+                  associations: [{ toObjectType: "tickets", toObjectId: config.ticketId }],
+                },
+              ],
+            },
+            { toolCallId: "deterministic", messages: [], abortSignal },
+          );
+
+          // The tool's typed return is `T | AsyncIterable<T>` (AI SDK
+          // streaming-tool support); these tools never stream, so narrow it.
+          if (Symbol.asyncIterator in result) {
+            return err("create-note failed: unexpected streaming tool response");
+          }
+          if ("error" in result) {
+            return err(`create-note failed: ${result.error}`);
+          }
+
+          const created = result.results[0];
           return ok({
             response: created?.id
               ? `CRM Note ${created.id} created on ticket ${config.ticketId}`
@@ -425,8 +381,8 @@ export const hubspotAgent = createAgent<string, HubSpotOutput>({
               noteId: created?.id ?? null,
               ticketId: config.ticketId,
               properties: created?.properties,
-              numErrors: validated.data.numErrors,
-              errors: validated.data.errors,
+              numErrors: result.numErrors,
+              errors: result.errors,
             },
           });
         }

--- a/packages/bundled-agents/src/hubspot/agent.ts
+++ b/packages/bundled-agents/src/hubspot/agent.ts
@@ -9,6 +9,7 @@ import MarkdownIt from "markdown-it";
 import { z } from "zod";
 import { parseOperationConfig } from "../shared/operation-parser.ts";
 import {
+  batchCreateCrmObjects,
   createCreateCrmObjectsTool,
   createGetConversationThreadsTool,
   createGetCrmObjectsTool,
@@ -332,51 +333,40 @@ export const hubspotAgent = createAgent<string, HubSpotOutput>({
         }
 
         case "create-note": {
-          // Reuse the LLM path's create_crm_objects tool — same SDK call,
-          // same association-id lookup (DEFAULT_ASSOCIATION_TYPES), same
-          // response normalization. No raw fetch, no duplicated schema.
+          // Reuse the same SDK call + association-id lookup + response
+          // normalization as the LLM path. `batchCreateCrmObjects` is the
+          // plain helper that the LLM-facing tool also delegates to.
           const client = new Client({
             accessToken,
             numberOfApiCallRetries: 3,
             limiterOptions: DEFAULT_LIMITER_OPTIONS,
           });
-          const toolDef = createCreateCrmObjectsTool(client);
-          if (!toolDef.execute) {
-            return err("create-note tool has no execute function");
-          }
 
-          const result = await toolDef.execute(
-            {
-              objectType: "notes",
-              records: [
-                {
-                  properties: {
-                    hs_note_body: config.body,
-                    hs_timestamp: config.hsTimestamp ?? new Date().toISOString(),
-                  },
-                  associations: [{ toObjectType: "tickets", toObjectId: config.ticketId }],
+          const result = await batchCreateCrmObjects(client, {
+            objectType: "notes",
+            records: [
+              {
+                properties: {
+                  hs_note_body: config.body,
+                  hs_timestamp: config.hsTimestamp ?? new Date().toISOString(),
                 },
-              ],
-            },
-            { toolCallId: "deterministic", messages: [], abortSignal },
-          );
+                associations: [{ toObjectType: "tickets", toObjectId: config.ticketId }],
+              },
+            ],
+          });
 
-          // The tool's typed return is `T | AsyncIterable<T>` (AI SDK
-          // streaming-tool support); these tools never stream, so narrow it.
-          if (Symbol.asyncIterator in result) {
-            return err("create-note failed: unexpected streaming tool response");
-          }
           if ("error" in result) {
-            return err(`create-note failed: ${result.error}`);
+            return err(`create-note failed (ticket ${config.ticketId}): ${result.error}`);
           }
 
           const created = result.results[0];
+          const success = result.numErrors === 0 && created?.id !== undefined;
           return ok({
-            response: created?.id
-              ? `CRM Note ${created.id} created on ticket ${config.ticketId}`
-              : `CRM Note creation completed for ticket ${config.ticketId} (no id returned)`,
+            response: success
+              ? `CRM Note ${created?.id} created on ticket ${config.ticketId}`
+              : `CRM Note creation on ticket ${config.ticketId} completed with ${result.numErrors} error(s)`,
             operation: "create-note",
-            success: true,
+            success,
             data: {
               noteId: created?.id ?? null,
               ticketId: config.ticketId,
@@ -391,12 +381,14 @@ export const hubspotAgent = createAgent<string, HubSpotOutput>({
           // Skip sentinel — upstream agent decided there's nothing to do
           // (e.g. empty-cron-tick path). Return success without calling
           // HubSpot so the FSM drains cleanly.
-          logger.info("Deterministic noop", { reason: config.reason ?? "(no reason given)" });
+          logger.info("Deterministic noop", { reason: config.reason });
+          const data: { skipped: boolean; reason?: string } = { skipped: config.skipped ?? true };
+          if (config.reason !== undefined) data.reason = config.reason;
           return ok({
             response: config.reason ?? "Noop — upstream signalled nothing to do.",
             operation: "noop",
             success: true,
-            data: { skipped: config.skipped ?? true, reason: config.reason },
+            data,
           });
         }
 

--- a/packages/bundled-agents/src/hubspot/agent.ts
+++ b/packages/bundled-agents/src/hubspot/agent.ts
@@ -400,8 +400,12 @@ export const hubspotAgent = createAgent<string, HubSpotOutput>({
           });
         }
 
-        default:
-          return err(`Unknown operation: ${(config as { operation: string }).operation}`);
+        default: {
+          // Exhaustive guard: assigning to `never` errors at compile time
+          // if HubSpotOperationSchema gains a new variant without a case.
+          const _exhaustive: never = config;
+          return err(`Unknown operation in deterministic dispatch: ${String(_exhaustive)}`);
+        }
       }
     }
 

--- a/packages/bundled-agents/src/hubspot/agent.ts
+++ b/packages/bundled-agents/src/hubspot/agent.ts
@@ -383,7 +383,7 @@ export const hubspotAgent = createAgent<string, HubSpotOutput>({
             data: {
               noteId: created?.id ?? null,
               ticketId: config.ticketId,
-              properties: created?.properties,
+              properties: created?.properties ?? {},
               numErrors: result.numErrors,
               errors: result.errors,
             },

--- a/packages/bundled-agents/src/hubspot/tools.ts
+++ b/packages/bundled-agents/src/hubspot/tools.ts
@@ -634,10 +634,15 @@ export function createGetPipelinesTool(client: Client) {
  * create-note dispatch in agent.ts. Resolves inline `{toObjectType, toObjectId}`
  * associations through DEFAULT_ASSOCIATION_TYPES, calls the SDK batch-create
  * endpoint, and normalizes the response.
+ *
+ * `abortSignal` is honored as a pre-call short-circuit — the HubSpot SDK
+ * doesn't expose a per-call abort, so we can't cancel a request mid-flight,
+ * but we bail before issuing it if the caller has already aborted.
  */
 export async function batchCreateCrmObjects(
   client: Client,
   input: z.infer<typeof CreateCrmObjectsInput>,
+  abortSignal?: AbortSignal,
 ): Promise<
   | {
       results: Array<{ id: string; properties: Record<string, string | null> }>;
@@ -647,6 +652,9 @@ export async function batchCreateCrmObjects(
     }
   | { error: string }
 > {
+  if (abortSignal?.aborted) {
+    return { error: "aborted before batch-create call" };
+  }
   try {
     const skippedAssociations: string[] = [];
 

--- a/packages/bundled-agents/src/hubspot/tools.ts
+++ b/packages/bundled-agents/src/hubspot/tools.ts
@@ -638,6 +638,11 @@ export function createGetPipelinesTool(client: Client) {
  * `abortSignal` is honored as a pre-call short-circuit — the HubSpot SDK
  * doesn't expose a per-call abort, so we can't cancel a request mid-flight,
  * but we bail before issuing it if the caller has already aborted.
+ *
+ * Multi-record caveat: callers must inspect both `results[]` and
+ * `numErrors` to decide success per-record. The deterministic create-note
+ * path in agent.ts only ever sends a single record, so it can treat
+ * "results[0]?.id present" as full success; multi-record callers cannot.
  */
 export async function batchCreateCrmObjects(
   client: Client,

--- a/packages/bundled-agents/src/hubspot/tools.ts
+++ b/packages/bundled-agents/src/hubspot/tools.ts
@@ -630,6 +630,71 @@ export function createGetPipelinesTool(client: Client) {
 }
 
 /**
+ * Plain SDK helper used by both the LLM tool wrapper and the deterministic
+ * create-note dispatch in agent.ts. Resolves inline `{toObjectType, toObjectId}`
+ * associations through DEFAULT_ASSOCIATION_TYPES, calls the SDK batch-create
+ * endpoint, and normalizes the response.
+ */
+export async function batchCreateCrmObjects(
+  client: Client,
+  input: z.infer<typeof CreateCrmObjectsInput>,
+): Promise<
+  | {
+      results: Array<{ id: string; properties: Record<string, string | null> }>;
+      numErrors: number;
+      errors: Array<{ status: string; message: string }>;
+      skippedAssociations: string | undefined;
+    }
+  | { error: string }
+> {
+  try {
+    const skippedAssociations: string[] = [];
+
+    const inputs = input.records.map((r) => {
+      const associations: Array<{
+        to: { id: string };
+        types: Array<{
+          associationCategory: AssociationSpecAssociationCategoryEnum;
+          associationTypeId: number;
+        }>;
+      }> = [];
+      for (const a of r.associations ?? []) {
+        const typeId = DEFAULT_ASSOCIATION_TYPES[input.objectType]?.[a.toObjectType];
+        if (typeId !== undefined) {
+          associations.push({
+            to: { id: a.toObjectId },
+            types: [
+              {
+                associationCategory: AssociationSpecAssociationCategoryEnum.HubspotDefined,
+                associationTypeId: typeId,
+              },
+            ],
+          });
+        } else {
+          skippedAssociations.push(`${input.objectType} → ${a.toObjectType}`);
+        }
+      }
+      return { properties: r.properties, associations };
+    });
+
+    const response = await client.crm.objects.batchApi.create(input.objectType, { inputs });
+    const batch = normalizeBatchResponse(response);
+
+    return {
+      results: batch.results.map((r) => ({ id: r.id, properties: r.properties })),
+      numErrors: batch.numErrors,
+      errors: batch.errors,
+      skippedAssociations:
+        skippedAssociations.length > 0
+          ? `No default association type for: ${skippedAssociations.join(", ")}. Use manage_associations instead.`
+          : undefined,
+    };
+  } catch (error) {
+    return { error: stringifyError(error) };
+  }
+}
+
+/**
  * Creates the create_crm_objects tool that batch-creates HubSpot CRM objects.
  * Only writable object types are accepted (contacts, companies, deals, tickets,
  * products, line_items, notes, calls, meetings, tasks, emails).
@@ -642,53 +707,7 @@ export function createCreateCrmObjectsTool(client: Client) {
       "Returns created record IDs and properties. " +
       "Supports inline associations to link records at creation time.",
     inputSchema: CreateCrmObjectsInput,
-    execute: async (input) => {
-      try {
-        const skippedAssociations: string[] = [];
-
-        const inputs = input.records.map((r) => {
-          const associations: Array<{
-            to: { id: string };
-            types: Array<{
-              associationCategory: AssociationSpecAssociationCategoryEnum;
-              associationTypeId: number;
-            }>;
-          }> = [];
-          for (const a of r.associations ?? []) {
-            const typeId = DEFAULT_ASSOCIATION_TYPES[input.objectType]?.[a.toObjectType];
-            if (typeId !== undefined) {
-              associations.push({
-                to: { id: a.toObjectId },
-                types: [
-                  {
-                    associationCategory: AssociationSpecAssociationCategoryEnum.HubspotDefined,
-                    associationTypeId: typeId,
-                  },
-                ],
-              });
-            } else {
-              skippedAssociations.push(`${input.objectType} → ${a.toObjectType}`);
-            }
-          }
-          return { properties: r.properties, associations };
-        });
-
-        const response = await client.crm.objects.batchApi.create(input.objectType, { inputs });
-        const batch = normalizeBatchResponse(response);
-
-        return {
-          results: batch.results.map((r) => ({ id: r.id, properties: r.properties })),
-          numErrors: batch.numErrors,
-          errors: batch.errors,
-          skippedAssociations:
-            skippedAssociations.length > 0
-              ? `No default association type for: ${skippedAssociations.join(", ")}. Use manage_associations instead.`
-              : undefined,
-        };
-      } catch (error) {
-        return { error: stringifyError(error) };
-      }
-    },
+    execute: (input) => batchCreateCrmObjects(client, input),
   });
 }
 

--- a/packages/bundled-agents/src/shared/operation-parser.test.ts
+++ b/packages/bundled-agents/src/shared/operation-parser.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { parseOperationConfig } from "./operation-parser.ts";
+
+const CreateNoteOp = z.object({
+  operation: z.literal("create-note"),
+  ticketId: z.string().min(1),
+  body: z.string().min(1),
+});
+const NoopOp = z.object({
+  operation: z.literal("noop"),
+  reason: z.string().optional(),
+  skipped: z.boolean().optional(),
+});
+const Schema = z.discriminatedUnion("operation", [CreateNoteOp, NoopOp]);
+
+describe("parseOperationConfig", () => {
+  it("parses a JSON-fenced envelope", () => {
+    const prompt =
+      "Some instructions\n\n```json\n" +
+      `{"operation":"create-note","ticketId":"5501","body":"<p>x</p>"}` +
+      "\n```";
+    const result = parseOperationConfig(prompt, Schema);
+    expect(result).toEqual({ operation: "create-note", ticketId: "5501", body: "<p>x</p>" });
+  });
+
+  it("parses a brace-balanced envelope outside any code fence", () => {
+    const prompt = `Header\n\n{"operation":"noop","skipped":true,"reason":"x"}\n\nMore text`;
+    const result = parseOperationConfig(prompt, Schema);
+    expect(result).toEqual({ operation: "noop", skipped: true, reason: "x" });
+  });
+
+  it("parses the whole prompt as JSON when nothing else matches", () => {
+    const prompt = `{"operation":"create-note","ticketId":"5501","body":"<p>x</p>"}`;
+    const result = parseOperationConfig(prompt, Schema);
+    expect(result).toEqual({ operation: "create-note", ticketId: "5501", body: "<p>x</p>" });
+  });
+
+  it("throws when no schema-matching JSON is present", () => {
+    const prompt = "Just some plain text with no envelope here.";
+    expect(() => parseOperationConfig(prompt, Schema)).toThrow(/Could not parse operation config/);
+  });
+
+  // The behavior that prevents instruction-text JSON examples (or accumulated
+  // upstream documents) from poisoning the dispatch when later, intended
+  // envelopes are appended later in the prompt.
+  describe("prefers the last matching envelope when multiple are present", () => {
+    it("picks the second of two fenced envelopes", () => {
+      const prompt = [
+        "### Document: briefing-prompt",
+        "```json",
+        `{"operation":"create-note","ticketId":"100","body":"<p>briefing</p>"}`,
+        "```",
+        "",
+        "### Document: reply-prompt",
+        "```json",
+        `{"operation":"create-note","ticketId":"100","body":"<p>customer reply</p>"}`,
+        "```",
+      ].join("\n");
+      const result = parseOperationConfig(prompt, Schema);
+      expect(result).toEqual({
+        operation: "create-note",
+        ticketId: "100",
+        body: "<p>customer reply</p>",
+      });
+    });
+
+    it("picks the last brace-balanced envelope when multiple match", () => {
+      const prompt =
+        `Earlier envelope: {"operation":"noop","skipped":true,"reason":"first"}` +
+        ` and a later one {"operation":"noop","skipped":true,"reason":"second"}.`;
+      const result = parseOperationConfig(prompt, Schema);
+      expect(result).toEqual({ operation: "noop", skipped: true, reason: "second" });
+    });
+
+    it("ignores a noop example in instruction text when a real envelope follows in a fenced block", () => {
+      // This is the scenario that motivated the change. An instruction-text
+      // JSON example used to poison the parser; with last-match semantics
+      // the real envelope (later in the prompt) wins.
+      const prompt = [
+        `If the envelope has "operation":"noop" return early. Example:`,
+        `{"operation":"noop","skipped":true,"reason":"example only"}`,
+        "",
+        "### Document: reply-prompt",
+        "```json",
+        `{"operation":"create-note","ticketId":"5501","body":"<p>real envelope</p>"}`,
+        "```",
+      ].join("\n");
+      const result = parseOperationConfig(prompt, Schema);
+      expect(result).toEqual({
+        operation: "create-note",
+        ticketId: "5501",
+        body: "<p>real envelope</p>",
+      });
+    });
+  });
+});

--- a/packages/bundled-agents/src/shared/operation-parser.ts
+++ b/packages/bundled-agents/src/shared/operation-parser.ts
@@ -49,35 +49,45 @@ function extractJsonCandidates(text: string): string[] {
  * Searches for JSON blocks in code fences, raw JSON objects, or the entire
  * prompt as JSON. Generic over the Zod schema so all agents (bb, gh, jira)
  * can share this logic.
+ *
+ * When multiple matches exist (e.g. an FSM step's prompt accumulates
+ * envelopes from prior steps as `### Document:` sections), prefer the
+ * LAST matching candidate. Workspace prompts append documents in order,
+ * so the most recent — the one this step is meant to act on — appears
+ * latest in the prompt. Returning the first match would dispatch on a
+ * stale upstream envelope.
  */
 export function parseOperationConfig<T extends z.ZodType>(prompt: string, schema: T): z.infer<T> {
-  // Try to find JSON blocks in code fences
-  const jsonBlockPattern = /```json\s*([\s\S]*?)```/g;
+  let lastMatch: z.infer<T> | undefined;
 
+  // Try JSON code fences
+  const jsonBlockPattern = /```json\s*([\s\S]*?)```/g;
   for (const blockMatch of prompt.matchAll(jsonBlockPattern)) {
     const jsonContent = blockMatch[1];
     if (!jsonContent) continue;
     try {
       const parsed: unknown = JSON.parse(jsonContent);
       const result = schema.safeParse(parsed);
-      if (result.success) return result.data;
+      if (result.success) lastMatch = result.data;
     } catch {
       // Not valid JSON, continue
     }
   }
+  if (lastMatch !== undefined) return lastMatch;
 
-  // Try finding raw JSON objects containing "operation" key
+  // Try raw JSON objects containing "operation" key
   for (const candidate of extractJsonCandidates(prompt)) {
     try {
       const parsed: unknown = JSON.parse(candidate);
       const result = schema.safeParse(parsed);
-      if (result.success) return result.data;
+      if (result.success) lastMatch = result.data;
     } catch {
       // Not valid JSON, continue
     }
   }
+  if (lastMatch !== undefined) return lastMatch;
 
-  // Last resort: try parsing the entire prompt as JSON
+  // Last resort: parse the entire prompt as JSON
   try {
     const parsed: unknown = JSON.parse(prompt);
     const result = schema.safeParse(parsed);


### PR DESCRIPTION
## Summary
- Extends the bundled hubspot agent's deterministic dispatch with two new operations: `create-note` (POSTs a CRM Note attached to a ticket) and `noop` (success skip sentinel).
- Both ops use raw `fetch` matching the existing `send-thread-comment` pattern, so they work with the standard `vi.stubGlobal("fetch", ...)` test setup without per-test SDK mocks.
- The LLM fallback path is unchanged — freeform CRM prompts continue to construct the SDK Client and dispatch through `create_crm_objects` etc. The deterministic path is purely additive: a flat `{operation: "create-note", ticketId, body}` envelope short-circuits the LLM round-trip.

## Motivation
The `examples-bucketlist/bucketlist-cs` workspace's auto-answer cron pipeline emits `task: create-note` envelopes from Python user-agents to post internal-briefing + customer-reply CRM Notes. Pre-fix, those envelopes fell through to the bundled agent's LLM, which had to be prompted into recognizing the envelope and calling `create_crm_objects`. That worked in practice but was the only non-deterministic step in the cron drain path — and a "helpful" LLM acting on a malformed or noop envelope could call HubSpot with garbage. The deterministic path eliminates that risk.

The `noop` op specifically lets upstream agents emit a "do nothing" envelope on the empty-cron-tick path without needing a separate FSM state. Returns immediately, no HubSpot call.

## Test plan
- [x] `npx vitest run packages/bundled-agents/src/hubspot` — all 456 tests pass (12 files, including 6 new ones)
- [x] `create-note` happy path: mock fetch returns batch-create response → result includes noteId + ticketId
- [x] `create-note` byte-exact body passthrough: HTML body sent verbatim, no markdown conversion
- [x] `create-note` 4xx handling: HubSpot error body propagates through `err()`
- [x] `create-note` schema rejection: missing `ticketId`/`body` → falls through to LLM (existing behavior)
- [x] `noop` returns success without calling `fetch`
- [x] `noop` works without optional `reason`/`skipped` fields
- [x] Existing `send-thread-comment` tests still pass (regression)

## Companion change
The bucketlist-cs workspace ([friday-platform/bucketlist-cs#4](https://github.com/friday-platform/bucketlist-cs/pull/4)) emits these envelopes today and currently relies on the LLM-fallback path. After this PR ships, that workspace will get a follow-up commit to:
- Add `operation: "noop"` to its noop envelope (so the parser picks it up)
- Simplify the `post_briefing` / `post_reply` LLM prompts (the noop branch is no longer needed since dispatch is deterministic)

Backwards-compatible — the bucketlist-cs workspace continues to work today via the LLM fallback until that follow-up lands.