### PR TITLE
fix(playground): render CANCELLED badge on runs list

### DIFF
--- a/tools/agent-playground/src/lib/components/session/session-progress-card.svelte
+++ b/tools/agent-playground/src/lib/components/session/session-progress-card.svelte
@@ -79,7 +79,9 @@
         ? ("active" as const)
         : session.status === "failed"
           ? ("failed" as const)
-          : ("completed" as const),
+          : session.status === "cancelled"
+            ? ("cancelled" as const)
+            : ("completed" as const),
   );
 </script>
 


### PR DESCRIPTION
## Summary
- The runs-list session card's `badgeStatus` ternary in `session-progress-card.svelte` had no branch for `cancelled`, so cancelled sessions fell through to `completed` and rendered as a green **COMPLETE** badge while the detail page correctly showed **CANCELLED**.
- Added the missing branch. `StatusBadge` already supports the `cancelled` status (label "Cancelled"), so no other changes needed.

## Test plan
- [ ] Open `http://localhost:5200/platform/<wsId>/sessions` for a workspace with a cancelled run and confirm the badge reads **CANCELLED** (matches the detail page).
- [ ] Confirm completed / failed / active / skipped badges still render correctly.