### PR TITLE
fix(core/session): make event reducer fully idempotent so duplicate publishes don't unstick finalized sessions

### DIFF
--- a/packages/core/src/session/jetstream-session-history-adapter.test.ts
+++ b/packages/core/src/session/jetstream-session-history-adapter.test.ts
@@ -143,6 +143,51 @@ describe("JetStreamSessionHistoryAdapter", () => {
     expect(view?.task).toBe("do the thing");
   });
 
+  it("get() prefers metadata KV summary when events stream is missing terminal events", async () => {
+    // Repro for the long-running-session bug: a session whose
+    // `step:complete` and `session:complete` events failed to publish
+    // (or were dropped) would leave `adapter.get()`'s event-derived view
+    // stuck at `status: active` with `running` blocks even after the
+    // metadata summary was correctly written by `save()`. Cross-referencing
+    // the metadata KV in `get()` lets the consumer reach the right
+    // terminal state without depending on the event stream being complete.
+    const adapter = new JetStreamSessionHistoryAdapter(nc);
+    const sid = `s-${crypto.randomUUID()}`;
+    const start = startEvent(sid, "ws-stale");
+    const stepStart: SessionStreamEvent = {
+      type: "step:start",
+      sessionId: sid,
+      stepNumber: 1,
+      agentName: "knowledge",
+      stateId: "build",
+      actionType: "agent",
+      task: "Build the corpus.",
+      timestamp: new Date().toISOString(),
+    };
+    // Append start + step:start, but DELIBERATELY skip step:complete and
+    // session:complete to simulate the stuck-event-stream condition.
+    await adapter.appendEvent(sid, start);
+    await adapter.appendEvent(sid, stepStart);
+
+    // Without the summary fallback, get() would return status=active.
+    // We finalize via save() with a summary that says completed.
+    await adapter.save(
+      sid,
+      [start, stepStart], // events array intentionally missing terminal events
+      summaryFor(sid, "ws-stale", "completed"),
+    );
+
+    const view = await adapter.get(sid);
+    expect(view).not.toBeNull();
+    // Summary's terminal fields must override the event-derived view.
+    expect(view?.status).toBe("completed");
+    expect(view?.completedAt).toBeDefined();
+    // Per-block sweep: running/pending blocks become `skipped` (matches
+    // the reducer's pending→skipped behavior on session:complete).
+    const knowledgeBlock = view?.agentBlocks.find((b) => b.agentName === "knowledge");
+    expect(knowledgeBlock?.status).toBe("skipped");
+  });
+
   it("save() then markInterruptedSessions() does not double-finalize", async () => {
     const adapter = new JetStreamSessionHistoryAdapter(nc);
     const sid = `s-${crypto.randomUUID()}`;

--- a/packages/core/src/session/jetstream-session-history-adapter.test.ts
+++ b/packages/core/src/session/jetstream-session-history-adapter.test.ts
@@ -222,44 +222,6 @@ describe("JetStreamSessionHistoryAdapter", () => {
     expect(view?.workspaceId).toBe("ws-kv-fail");
   });
 
-  it("ensureStream upgrades duplicate_window on existing streams (2m → 30m)", async () => {
-    // Stream config drift is the most likely deployed-environment
-    // regression: a daemon upgrade lands the new DEDUP_WINDOW_NS but
-    // the broker already has the SESSION_EVENTS stream with the 2m
-    // default. ensureStream must `streams.update` it on next access.
-    // This was not exercised by other tests because beforeAll always
-    // creates a fresh server — none had a pre-existing stream with the
-    // OLD config. We construct that condition explicitly here.
-    const TWO_MINUTES_NS = 2 * 60 * 1_000_000_000;
-    const THIRTY_MINUTES_NS = 30 * 60 * 1_000_000_000;
-
-    // Delete any existing SESSION_EVENTS so we can re-create with the
-    // old config (the per-suite adapters left one with the new
-    // duplicate_window during prior tests).
-    const jsm = await nc.jetstreamManager();
-    try {
-      await jsm.streams.delete("SESSION_EVENTS");
-    } catch {
-      // stream didn't exist — fine
-    }
-    await jsm.streams.add({
-      name: "SESSION_EVENTS",
-      subjects: ["sessions.>"],
-      duplicate_window: TWO_MINUTES_NS,
-    });
-
-    const before = await jsm.streams.info("SESSION_EVENTS");
-    expect(Number(before.config.duplicate_window)).toBe(TWO_MINUTES_NS);
-
-    // Trigger ensureStream via any adapter call.
-    const adapter = new JetStreamSessionHistoryAdapter(nc);
-    const sid = `s-${crypto.randomUUID()}`;
-    await adapter.appendEvent(sid, startEvent(sid, "ws-upgrade"));
-
-    const after = await jsm.streams.info("SESSION_EVENTS");
-    expect(Number(after.config.duplicate_window)).toBe(THIRTY_MINUTES_NS);
-  });
-
   it("save() then markInterruptedSessions() does not double-finalize", async () => {
     const adapter = new JetStreamSessionHistoryAdapter(nc);
     const sid = `s-${crypto.randomUUID()}`;

--- a/packages/core/src/session/jetstream-session-history-adapter.test.ts
+++ b/packages/core/src/session/jetstream-session-history-adapter.test.ts
@@ -151,6 +151,13 @@ describe("JetStreamSessionHistoryAdapter", () => {
     // metadata summary was correctly written by `save()`. Cross-referencing
     // the metadata KV in `get()` lets the consumer reach the right
     // terminal state without depending on the event stream being complete.
+    //
+    // NB: `startNatsTestServer` runs single-node, so KV reads are served
+    // by the leader and read-your-writes holds. On clustered (R≥3)
+    // deployments the immediate `metadata.get()` after `save()` could be
+    // served by a follower that hasn't replicated yet — the production
+    // adapter handles that by falling through to the event-derived view
+    // (see `jetstream-session-history-adapter.ts:get`).
     const adapter = new JetStreamSessionHistoryAdapter(nc);
     const sid = `s-${crypto.randomUUID()}`;
     const start = startEvent(sid, "ws-stale");
@@ -185,7 +192,72 @@ describe("JetStreamSessionHistoryAdapter", () => {
     // Per-block sweep: running/pending blocks become `skipped` (matches
     // the reducer's pending→skipped behavior on session:complete).
     const knowledgeBlock = view?.agentBlocks.find((b) => b.agentName === "knowledge");
-    expect(knowledgeBlock?.status).toBe("skipped");
+    expect.assert(knowledgeBlock !== undefined);
+    expect(knowledgeBlock.status).toBe("skipped");
+  });
+
+  it("get() degrades to event-derived view when metadata KV lookup throws", async () => {
+    // The production adapter wraps `metadata.get()` in try/catch so a
+    // transient KV failure (broker hiccup, bucket race during init)
+    // logs a warning and falls back to the event-derived view rather
+    // than propagating a 5xx. Without this branch a future regression
+    // that re-throws would silently revert to the original "stuck at
+    // status: active" symptom and we'd never know.
+    const adapter = new JetStreamSessionHistoryAdapter(nc);
+    const sid = `s-${crypto.randomUUID()}`;
+    // Append events but don't save() — no summary in KV at all yet.
+    await adapter.appendEvent(sid, startEvent(sid, "ws-kv-fail"));
+
+    // Force the KV lookup path to throw. The adapter caches the KV
+    // handle in `metadataKV`; we replace it with a stub whose `get()`
+    // rejects. No `as any` — narrow the cast to the property we touch.
+    const stubKV = { get: () => Promise.reject(new Error("simulated KV failure")) };
+    Object.defineProperty(adapter, "metadataKV", { value: stubKV, writable: true });
+
+    const view = await adapter.get(sid);
+    // Event-derived view returned (status from `session:start` reducer
+    // is "active"); we did NOT throw despite the KV failure.
+    expect(view).not.toBeNull();
+    expect(view?.status).toBe("active");
+    expect(view?.workspaceId).toBe("ws-kv-fail");
+  });
+
+  it("ensureStream upgrades duplicate_window on existing streams (2m → 30m)", async () => {
+    // Stream config drift is the most likely deployed-environment
+    // regression: a daemon upgrade lands the new DEDUP_WINDOW_NS but
+    // the broker already has the SESSION_EVENTS stream with the 2m
+    // default. ensureStream must `streams.update` it on next access.
+    // This was not exercised by other tests because beforeAll always
+    // creates a fresh server — none had a pre-existing stream with the
+    // OLD config. We construct that condition explicitly here.
+    const TWO_MINUTES_NS = 2 * 60 * 1_000_000_000;
+    const THIRTY_MINUTES_NS = 30 * 60 * 1_000_000_000;
+
+    // Delete any existing SESSION_EVENTS so we can re-create with the
+    // old config (the per-suite adapters left one with the new
+    // duplicate_window during prior tests).
+    const jsm = await nc.jetstreamManager();
+    try {
+      await jsm.streams.delete("SESSION_EVENTS");
+    } catch {
+      // stream didn't exist — fine
+    }
+    await jsm.streams.add({
+      name: "SESSION_EVENTS",
+      subjects: ["sessions.>"],
+      duplicate_window: TWO_MINUTES_NS,
+    });
+
+    const before = await jsm.streams.info("SESSION_EVENTS");
+    expect(Number(before.config.duplicate_window)).toBe(TWO_MINUTES_NS);
+
+    // Trigger ensureStream via any adapter call.
+    const adapter = new JetStreamSessionHistoryAdapter(nc);
+    const sid = `s-${crypto.randomUUID()}`;
+    await adapter.appendEvent(sid, startEvent(sid, "ws-upgrade"));
+
+    const after = await jsm.streams.info("SESSION_EVENTS");
+    expect(Number(after.config.duplicate_window)).toBe(THIRTY_MINUTES_NS);
   });
 
   it("save() then markInterruptedSessions() does not double-finalize", async () => {

--- a/packages/core/src/session/jetstream-session-history-adapter.ts
+++ b/packages/core/src/session/jetstream-session-history-adapter.ts
@@ -52,6 +52,18 @@ const INFLIGHT_BUCKET = "SESSION_INFLIGHT";
 
 const NINETY_DAYS_NS = 90 * 24 * 60 * 60 * 1_000_000_000;
 
+// Defense-in-depth dedup window for `save()` republishes. Default JetStream
+// dedup is 2 minutes, which is shorter than many real sessions — a 9-min
+// reindex's start events fall outside it, so `save()`'s republish (intended
+// to be a no-op via Nats-Msg-Id dedup) becomes a duplicate publish, which
+// the reducer used to fold in as a state reset. The reducer is now
+// idempotent (see session-reducer.ts), but a 24-hour dedup window also
+// closes the gap at the broker layer for any plausible session lifetime
+// (cron jobs, slow LLM runs, batch reindex of large corpora). Cost: in-memory
+// dedup table grows linearly with traffic; 24h × ~10k events/day × ~64B
+// per entry ≈ ~6 MB even at high-volume single-instance deployments.
+const DEDUP_WINDOW_NS = 24 * 60 * 60 * 1_000_000_000;
+
 const SAFE_TOKEN_RE = /[^A-Za-z0-9_-]/g;
 function sanitize(s: string): string {
   return s.replace(SAFE_TOKEN_RE, "_");
@@ -69,7 +81,16 @@ export class JetStreamSessionHistoryAdapter implements SessionHistoryAdapter {
     if (this.streamReady) return;
     const jsm = await this.nc.jetstreamManager();
     try {
-      await jsm.streams.info(STREAM_NAME);
+      const info = await jsm.streams.info(STREAM_NAME);
+      // Bump dedup_window on existing streams that were created before
+      // DEDUP_WINDOW_NS landed (default 2m too short for long sessions).
+      // Update is idempotent — broker accepts the same value as a no-op.
+      if (Number(info.config.duplicate_window) !== DEDUP_WINDOW_NS) {
+        await jsm.streams.update(STREAM_NAME, {
+          ...info.config,
+          duplicate_window: DEDUP_WINDOW_NS,
+        });
+      }
     } catch {
       await jsm.streams.add({
         name: STREAM_NAME,
@@ -77,6 +98,7 @@ export class JetStreamSessionHistoryAdapter implements SessionHistoryAdapter {
         retention: RetentionPolicy.Limits,
         storage: StorageType.File,
         max_age: NINETY_DAYS_NS,
+        duplicate_window: DEDUP_WINDOW_NS,
       });
     }
     this.streamReady = true;

--- a/packages/core/src/session/jetstream-session-history-adapter.ts
+++ b/packages/core/src/session/jetstream-session-history-adapter.ts
@@ -52,29 +52,13 @@ const INFLIGHT_BUCKET = "SESSION_INFLIGHT";
 
 const NINETY_DAYS_NS = 90 * 24 * 60 * 60 * 1_000_000_000;
 
-// Dedup window for `save()` republishes. Default JetStream dedup is 2
-// minutes, which is shorter than many real sessions — a 9-min reindex's
-// start events fall outside it, so `save()`'s republish (intended to be a
-// no-op via Nats-Msg-Id dedup) becomes a duplicate publish, which the
-// reducer used to fold in as a state reset.
-//
-// **Correctness is now in the reducer, not the broker.** session:start
-// and step:start are idempotent (see session-reducer.ts) — duplicate
-// landings reduce to the same view. The dedup window is purely an
-// optimization to avoid broker churn (network, disk, dedup-table writes)
-// from re-publishing events the broker already stored.
-//
-// 30 minutes is a measured bump from the 2m default: 15× more headroom,
-// covers normal cron / LLM / mid-size reindex sessions cleanly, and stays
-// well below "huge global change" territory. Sessions longer than 30 min
-// will see save() re-publishes hit the broker as new messages — that's
-// fine, the reducer still produces a correct view.
-//
-// Memory cost (broker holds active dedup table in memory, ~64 bytes/entry):
-//   - 10k events/day with 30m window → ~13 KB
-//   - 100k events/day → ~130 KB
-// Trivial at every plausible deployment scale.
-const DEDUP_WINDOW_NS = 30 * 60 * 1_000_000_000;
+// We use JetStream's default `duplicate_window` (2 minutes). Long-running
+// sessions whose `save()` republishes land outside that window will see
+// the duplicates pass dedup and reach the reducer — that's fine, because
+// the reducer is fully idempotent for ALL session events (session:start,
+// step:start, step:complete, step:skipped, session:complete; see
+// session-reducer.ts). Correctness lives in the reducer; broker dedup is
+// just an optimization for the common in-window case.
 
 const SAFE_TOKEN_RE = /[^A-Za-z0-9_-]/g;
 function sanitize(s: string): string {
@@ -93,16 +77,7 @@ export class JetStreamSessionHistoryAdapter implements SessionHistoryAdapter {
     if (this.streamReady) return;
     const jsm = await this.nc.jetstreamManager();
     try {
-      const info = await jsm.streams.info(STREAM_NAME);
-      // Bump dedup_window on existing streams that were created before
-      // DEDUP_WINDOW_NS landed (default 2m too short for long sessions).
-      // Use partial update — `streams.update` accepts `Partial<StreamUpdateConfig>`,
-      // so we send only the field we want to change. Spreading `info.config`
-      // would re-send server-managed fields (e.g. `created`) and risks
-      // breakage on future broker version bumps that tighten validation.
-      if (Number(info.config.duplicate_window) !== DEDUP_WINDOW_NS) {
-        await jsm.streams.update(STREAM_NAME, { duplicate_window: DEDUP_WINDOW_NS });
-      }
+      await jsm.streams.info(STREAM_NAME);
     } catch {
       await jsm.streams.add({
         name: STREAM_NAME,
@@ -110,7 +85,6 @@ export class JetStreamSessionHistoryAdapter implements SessionHistoryAdapter {
         retention: RetentionPolicy.Limits,
         storage: StorageType.File,
         max_age: NINETY_DAYS_NS,
-        duplicate_window: DEDUP_WINDOW_NS,
       });
     }
     this.streamReady = true;
@@ -161,14 +135,15 @@ export class JetStreamSessionHistoryAdapter implements SessionHistoryAdapter {
     await this.ensureStream();
     const js = this.nc.jetstream();
     // Idempotent backfill: republish each event with a stable
-    // `Nats-Msg-Id`. The broker silently rejects duplicates within its
-    // dedup window (default 2m, plenty for "appendEvent → save" in the
-    // same handler), so the common case where appendEvent already
-    // streamed every event becomes a no-op at the stream layer.
-    // Without this, the reducer would see two `step:start` events for
-    // every step on a save() that follows appendEvent (the reducer
-    // matches step:start by agentName+pending, so a re-publish appends
-    // a duplicate block instead of merging — verified in repro).
+    // `Nats-Msg-Id`. Two layers protect correctness:
+    //   1. Broker dedup (default 2m window) silently rejects duplicates
+    //      whose stable msgID is still in the in-memory dedup table —
+    //      the common case for "appendEvent → save" in the same handler.
+    //   2. Reducer idempotency (session-reducer.ts) guarantees that any
+    //      duplicates that DO slip past the broker (e.g. a session that
+    //      runs longer than the dedup window) reduce to the same view
+    //      as the originals. Correctness does not depend on dedup
+    //      window size.
     if (events.length > 0) {
       for (const e of events) {
         await js.publish(this.subject(sessionId), enc.encode(JSON.stringify(e)), {
@@ -240,21 +215,31 @@ export class JetStreamSessionHistoryAdapter implements SessionHistoryAdapter {
 
     // Cross-reference the SESSION_METADATA KV. The metadata summary is
     // written by `save()` and is the source of truth for finalization
-    // (status, completedAt, durationMs). The events stream is best-effort:
-    // long-running sessions or transient publish failures can drop terminal
-    // events (`step:complete`, `session:complete`), leaving the
-    // event-derived view stuck at `status: active` with running/pending
-    // blocks even though the session was correctly finalized. If a summary
-    // exists, prefer its terminal fields and sweep any non-terminal
-    // per-block status to `skipped` (matches the reducer's pending→skipped
-    // sweep on session:complete).
+    // (status, completedAt, durationMs). With the reducer's idempotency
+    // guards on session:start / step:start / step:complete /
+    // session:complete (see session-reducer.ts), the event-derived view
+    // is correct for any session whose events were all published — even
+    // when `save()`'s republish lands outside the broker's
+    // `duplicate_window`. The KV fallback is still required because:
+    //
+    // 1. `markInterruptedSessions()` writes a summary directly into the
+    //    KV (status `interrupted`) without publishing terminal events —
+    //    the event stream has session:start but no session:complete. The
+    //    summary is the only source of truth for these sessions.
+    // 2. Genuine event-loss scenarios (publish failure during a daemon
+    //    crash, broker storage corruption) leave the event-derived view
+    //    stuck at `status: active`. Preferring the summary recovers the
+    //    correct terminal state.
+    // 3. Defense-in-depth: if a future regression breaks reducer
+    //    idempotency, the fallback still serves a finalized view rather
+    //    than a corrupted one.
     //
     // Caveats:
     // 1. JetStream KV does NOT guarantee read-your-writes on clustered (R>1)
     //    deployments — a `get()` immediately after `save()` may be served by
-    //    a follower that hasn't replicated yet, returning undefined. The
-    //    fallback then silently uses the event-derived view, which may still
-    //    show `status: active`. On single-node deployments (our default) the
+    //    a follower that hasn't replicated yet, returning null. The fallback
+    //    then silently uses the event-derived view (now correct because of
+    //    reducer idempotency). On single-node deployments (our default) the
     //    leader serves all reads, so this isn't a concern.
     // 2. We treat any KV read error as "no summary" rather than propagating
     //    a 5xx — the caller still gets the event-derived view, which is at

--- a/packages/core/src/session/jetstream-session-history-adapter.ts
+++ b/packages/core/src/session/jetstream-session-history-adapter.ts
@@ -202,7 +202,34 @@ export class JetStreamSessionHistoryAdapter implements SessionHistoryAdapter {
     }
 
     if (events.length === 0) return null;
-    return buildSessionView(events);
+    const view = buildSessionView(events);
+
+    // Cross-reference the SESSION_METADATA KV. The metadata summary is
+    // written by `save()` and is the source of truth for finalization
+    // (status, completedAt, durationMs). The events stream is best-effort:
+    // long-running sessions or transient publish failures can drop terminal
+    // events (`step:complete`, `session:complete`), leaving the
+    // event-derived view stuck at `status: active` with running/pending
+    // blocks even though the session was correctly finalized. If a summary
+    // exists, prefer its terminal fields and sweep any non-terminal
+    // per-block status to `skipped` (matches the reducer's pending→skipped
+    // sweep on session:complete).
+    const metadata = await this.getMetadataKV();
+    const summary = await metadata.get<SessionSummary>([sessionId]);
+    if (summary) {
+      const reconciledBlocks = view.agentBlocks.map((b) =>
+        b.status === "running" || b.status === "pending" ? { ...b, status: "skipped" as const } : b,
+      );
+      return {
+        ...view,
+        agentBlocks: reconciledBlocks,
+        status: summary.status,
+        completedAt: summary.completedAt,
+        durationMs: summary.durationMs ?? view.durationMs,
+        error: summary.error ?? view.error,
+      };
+    }
+    return view;
   }
 
   async listByWorkspace(workspaceId?: string): Promise<SessionSummary[]> {

--- a/packages/core/src/session/jetstream-session-history-adapter.ts
+++ b/packages/core/src/session/jetstream-session-history-adapter.ts
@@ -52,17 +52,29 @@ const INFLIGHT_BUCKET = "SESSION_INFLIGHT";
 
 const NINETY_DAYS_NS = 90 * 24 * 60 * 60 * 1_000_000_000;
 
-// Defense-in-depth dedup window for `save()` republishes. Default JetStream
-// dedup is 2 minutes, which is shorter than many real sessions — a 9-min
-// reindex's start events fall outside it, so `save()`'s republish (intended
-// to be a no-op via Nats-Msg-Id dedup) becomes a duplicate publish, which
-// the reducer used to fold in as a state reset. The reducer is now
-// idempotent (see session-reducer.ts), but a 24-hour dedup window also
-// closes the gap at the broker layer for any plausible session lifetime
-// (cron jobs, slow LLM runs, batch reindex of large corpora). Cost: in-memory
-// dedup table grows linearly with traffic; 24h × ~10k events/day × ~64B
-// per entry ≈ ~6 MB even at high-volume single-instance deployments.
-const DEDUP_WINDOW_NS = 24 * 60 * 60 * 1_000_000_000;
+// Dedup window for `save()` republishes. Default JetStream dedup is 2
+// minutes, which is shorter than many real sessions — a 9-min reindex's
+// start events fall outside it, so `save()`'s republish (intended to be a
+// no-op via Nats-Msg-Id dedup) becomes a duplicate publish, which the
+// reducer used to fold in as a state reset.
+//
+// **Correctness is now in the reducer, not the broker.** session:start
+// and step:start are idempotent (see session-reducer.ts) — duplicate
+// landings reduce to the same view. The dedup window is purely an
+// optimization to avoid broker churn (network, disk, dedup-table writes)
+// from re-publishing events the broker already stored.
+//
+// 30 minutes is a measured bump from the 2m default: 15× more headroom,
+// covers normal cron / LLM / mid-size reindex sessions cleanly, and stays
+// well below "huge global change" territory. Sessions longer than 30 min
+// will see save() re-publishes hit the broker as new messages — that's
+// fine, the reducer still produces a correct view.
+//
+// Memory cost (broker holds active dedup table in memory, ~64 bytes/entry):
+//   - 10k events/day with 30m window → ~13 KB
+//   - 100k events/day → ~130 KB
+// Trivial at every plausible deployment scale.
+const DEDUP_WINDOW_NS = 30 * 60 * 1_000_000_000;
 
 const SAFE_TOKEN_RE = /[^A-Za-z0-9_-]/g;
 function sanitize(s: string): string {
@@ -84,12 +96,12 @@ export class JetStreamSessionHistoryAdapter implements SessionHistoryAdapter {
       const info = await jsm.streams.info(STREAM_NAME);
       // Bump dedup_window on existing streams that were created before
       // DEDUP_WINDOW_NS landed (default 2m too short for long sessions).
-      // Update is idempotent — broker accepts the same value as a no-op.
+      // Use partial update — `streams.update` accepts `Partial<StreamUpdateConfig>`,
+      // so we send only the field we want to change. Spreading `info.config`
+      // would re-send server-managed fields (e.g. `created`) and risks
+      // breakage on future broker version bumps that tighten validation.
       if (Number(info.config.duplicate_window) !== DEDUP_WINDOW_NS) {
-        await jsm.streams.update(STREAM_NAME, {
-          ...info.config,
-          duplicate_window: DEDUP_WINDOW_NS,
-        });
+        await jsm.streams.update(STREAM_NAME, { duplicate_window: DEDUP_WINDOW_NS });
       }
     } catch {
       await jsm.streams.add({
@@ -247,7 +259,7 @@ export class JetStreamSessionHistoryAdapter implements SessionHistoryAdapter {
     // 2. We treat any KV read error as "no summary" rather than propagating
     //    a 5xx — the caller still gets the event-derived view, which is at
     //    least consistent with what the events show.
-    let summary: SessionSummary | undefined;
+    let summary: SessionSummary | null = null;
     try {
       const metadata = await this.getMetadataKV();
       summary = await metadata.get<SessionSummary>([sessionId]);

--- a/packages/core/src/session/jetstream-session-history-adapter.ts
+++ b/packages/core/src/session/jetstream-session-history-adapter.ts
@@ -236,8 +236,27 @@ export class JetStreamSessionHistoryAdapter implements SessionHistoryAdapter {
     // exists, prefer its terminal fields and sweep any non-terminal
     // per-block status to `skipped` (matches the reducer's pending→skipped
     // sweep on session:complete).
-    const metadata = await this.getMetadataKV();
-    const summary = await metadata.get<SessionSummary>([sessionId]);
+    //
+    // Caveats:
+    // 1. JetStream KV does NOT guarantee read-your-writes on clustered (R>1)
+    //    deployments — a `get()` immediately after `save()` may be served by
+    //    a follower that hasn't replicated yet, returning undefined. The
+    //    fallback then silently uses the event-derived view, which may still
+    //    show `status: active`. On single-node deployments (our default) the
+    //    leader serves all reads, so this isn't a concern.
+    // 2. We treat any KV read error as "no summary" rather than propagating
+    //    a 5xx — the caller still gets the event-derived view, which is at
+    //    least consistent with what the events show.
+    let summary: SessionSummary | undefined;
+    try {
+      const metadata = await this.getMetadataKV();
+      summary = await metadata.get<SessionSummary>([sessionId]);
+    } catch (err) {
+      logger.warn("Metadata KV lookup failed; using event-derived view", {
+        sessionId,
+        error: String(err),
+      });
+    }
     if (summary) {
       const reconciledBlocks = view.agentBlocks.map((b) =>
         b.status === "running" || b.status === "pending" ? { ...b, status: "skipped" as const } : b,

--- a/packages/core/src/session/session-reducer.test.ts
+++ b/packages/core/src/session/session-reducer.test.ts
@@ -808,11 +808,22 @@ describe("buildSessionView", () => {
 
     const view = buildSessionView(events);
 
+    // The pre-fix bug produced TWO agentBlocks of the same agent — the
+    // duplicate `step:start` fell through to the "no matching pending
+    // block" branch and APPENDED a second running block on top of the
+    // already-completed one. Pin both `length === 1` AND `agentName` so
+    // a regression that brings back the duplicate-append path fails loud.
     expect(view.status).toBe("completed");
     expect(view.agentBlocks).toHaveLength(1);
     const block = view.agentBlocks[0];
     expect.assert(block !== undefined);
+    expect(block.agentName).toBe("researcher");
     expect(block.status).toBe("completed");
+    // The duplicate `step:start` carries the same NOW timestamp as the
+    // original; without idempotency it would overwrite startedAt. Pin it
+    // to catch the case where step:start partially overwrites a running
+    // block instead of being a clean no-op.
+    expect(block.startedAt).toBe(NOW);
     expect(view.completedAt).toBe(LATER);
     expect(view.durationMs).toBe(5000);
   });

--- a/packages/core/src/session/session-reducer.test.ts
+++ b/packages/core/src/session/session-reducer.test.ts
@@ -824,7 +824,100 @@ describe("buildSessionView", () => {
     // to catch the case where step:start partially overwrites a running
     // block instead of being a clean no-op.
     expect(block.startedAt).toBe(NOW);
+    // Pin the completed-block fields populated by stepComplete: a
+    // regression that lets the duplicate `step:start` clobber the merged
+    // block (e.g. drops output/toolCalls back to defaults) would still
+    // pass the length/status assertions but would corrupt the view that
+    // ships to the client.
+    expect(block.output).toEqual({ answer: 42 });
+    expect(block.toolCalls).toEqual([{ toolName: "search", args: { q: "test" } }]);
+    expect(block.durationMs).toBe(1234);
     expect(view.completedAt).toBe(LATER);
+    expect(view.durationMs).toBe(5000);
+  });
+
+  test("idempotent on duplicate step:start with planned-steps path", () => {
+    // Variant of the long-running-session bug for the realistic
+    // production path: sessions usually have plannedSteps, so the
+    // pending block is pre-seeded by session:start (stepNumber=undefined,
+    // status="pending") and the FIRST step:start transitions it
+    // pending→running. The duplicate step:start must hit the idempotency
+    // guard against the now-running (or completed) block, NOT fall
+    // through to the pending-finder (which would be a no-op anyway since
+    // the block is no longer pending) and NOT append a second block.
+    const events = [
+      sessionStart({
+        plannedSteps: [{ agentName: "researcher", task: "research", actionType: "agent" }],
+      }),
+      stepStart(), // transitions pending → running
+      stepComplete(),
+      sessionComplete(),
+      // Duplicate step:start arriving after dedup window expired:
+      stepStart(),
+    ];
+
+    const view = buildSessionView(events);
+
+    expect(view.status).toBe("completed");
+    expect(view.agentBlocks).toHaveLength(1);
+    const block = view.agentBlocks[0];
+    expect.assert(block !== undefined);
+    expect(block.agentName).toBe("researcher");
+    expect(block.status).toBe("completed");
+    expect(block.startedAt).toBe(NOW);
+    expect(block.output).toEqual({ answer: 42 });
+  });
+
+  test("idempotent on duplicate step:complete (terminal-status guard)", () => {
+    // Repro for the pre-fix gap that round-2 review surfaced: a duplicate
+    // step:complete republished by `save()` outside the broker's
+    // duplicate_window would re-apply to the already-completed block,
+    // re-stamping durationMs/output/toolCalls. Identical-payload
+    // duplicates would no-op effectively, but a payload-divergent
+    // re-publish would corrupt the block. The reducer now short-circuits
+    // when the block is already in a terminal status.
+    const events = [
+      sessionStart(),
+      stepStart(),
+      stepComplete({ durationMs: 1234, output: { answer: 42 } }),
+      // Duplicate with payload-divergent values to prove first-wins:
+      stepComplete({ durationMs: 9999, output: { answer: "wrong" } }),
+    ];
+
+    const view = buildSessionView(events);
+
+    expect(view.agentBlocks).toHaveLength(1);
+    const block = view.agentBlocks[0];
+    expect.assert(block !== undefined);
+    // First-wins: the original durationMs/output stand, the duplicate is
+    // dropped.
+    expect(block.status).toBe("completed");
+    expect(block.durationMs).toBe(1234);
+    expect(block.output).toEqual({ answer: 42 });
+  });
+
+  test("idempotent on duplicate session:complete (terminal-status guard)", () => {
+    // Repro for the pre-fix gap that round-2 review surfaced: a duplicate
+    // session:complete republished outside the broker's duplicate_window
+    // would re-stamp completedAt/durationMs and re-run the
+    // pending→skipped sweep. The reducer now short-circuits when
+    // view.status is already terminal AND completedAt is set.
+    const FIRST_TS = "2026-02-13T10:00:05.000Z";
+    const SECOND_TS = "2026-02-13T10:30:00.000Z";
+    const events = [
+      sessionStart(),
+      stepStart(),
+      stepComplete(),
+      sessionComplete({ timestamp: FIRST_TS, durationMs: 5000, status: "completed" }),
+      // Payload-divergent duplicate to prove first-wins:
+      sessionComplete({ timestamp: SECOND_TS, durationMs: 9999, status: "failed" }),
+    ];
+
+    const view = buildSessionView(events);
+
+    // First-wins: original completedAt/durationMs/status stand.
+    expect(view.status).toBe("completed");
+    expect(view.completedAt).toBe(FIRST_TS);
     expect(view.durationMs).toBe(5000);
   });
 });

--- a/packages/core/src/session/session-reducer.test.ts
+++ b/packages/core/src/session/session-reducer.test.ts
@@ -779,4 +779,41 @@ describe("buildSessionView", () => {
     const view = buildSessionView([]);
     expect(view).toEqual(initialSessionView());
   });
+
+  test("idempotent on duplicate session:start + step:start (long-running session bug)", () => {
+    // Repro for the production bug: a 9-min reindex session has 7 events
+    // in JetStream — the full lifecycle (start, step:start, step:complete,
+    // session:complete, session:summary) PLUS duplicates of the start and
+    // step:start. The duplicates are emitted by `save()`'s republish (with
+    // Nats-Msg-Id dedup) when the original publish lands outside JetStream's
+    // dedup_window (default 2m, our reindex took 9m).
+    //
+    // Pre-fix: the duplicate session:start RESET the view to status="active"
+    // and wiped agentBlocks; the duplicate step:start APPENDED a fresh
+    // running block on top of the already-completed one. Final view:
+    // status=active, two knowledge blocks, the second one stuck running.
+    //
+    // Post-fix: the reducer detects same-sessionId / same-stepNumber+agent
+    // and treats the duplicates as no-ops. View is identical to the
+    // duplicate-free reduction.
+    const events = [
+      sessionStart(),
+      stepStart(),
+      stepComplete(),
+      sessionComplete(),
+      // Duplicates that arrive at end-of-stream after dedup window expired:
+      sessionStart(),
+      stepStart(),
+    ];
+
+    const view = buildSessionView(events);
+
+    expect(view.status).toBe("completed");
+    expect(view.agentBlocks).toHaveLength(1);
+    const block = view.agentBlocks[0];
+    expect.assert(block !== undefined);
+    expect(block.status).toBe("completed");
+    expect(view.completedAt).toBe(LATER);
+    expect(view.durationMs).toBe(5000);
+  });
 });

--- a/packages/core/src/session/session-reducer.ts
+++ b/packages/core/src/session/session-reducer.ts
@@ -246,18 +246,18 @@ function reduceStepComplete(
   const existing = view.agentBlocks[idx];
   if (!existing) return view;
 
-  // Idempotent: if the block is already in a terminal status, this is a
-  // duplicate `step:complete` (e.g. `save()` republish landing outside
-  // JetStream's `duplicate_window`). Re-applying would re-stamp
-  // `durationMs`/`output`/`toolCalls`. Identical-payload duplicates would
-  // overwrite to the same values (no-op), but a payload-divergent
-  // re-publish (which shouldn't happen with Nats-Msg-Id dedup but defends
-  // against upstream bugs) would corrupt the block. First-wins.
+  // Idempotent: if the block is already in a terminal status (completed /
+  // failed / skipped), this is a duplicate `step:complete` (e.g. `save()`
+  // republish landing outside JetStream's `duplicate_window`). Re-applying
+  // would re-stamp `durationMs`/`output`/`toolCalls`. Identical-payload
+  // duplicates would overwrite to the same values (no-op), but a
+  // payload-divergent re-publish (which shouldn't happen with Nats-Msg-Id
+  // dedup but defends against upstream bugs) would corrupt the block.
+  // First-wins.
   if (
     existing.status === "completed" ||
     existing.status === "failed" ||
-    existing.status === "skipped" ||
-    existing.status === "cancelled"
+    existing.status === "skipped"
   ) {
     return view;
   }

--- a/packages/core/src/session/session-reducer.ts
+++ b/packages/core/src/session/session-reducer.ts
@@ -47,6 +47,16 @@ export function reduceSessionEvent(
 
   switch (event.type) {
     case "session:start":
+      // Idempotent: if a session:start has already been folded in for this
+      // sessionId, treat duplicates as no-ops. Without this guard a
+      // republished session:start (e.g. when `save()` re-publishes events
+      // that fell outside JetStream's `duplicate_window`) RESETS the view
+      // back to status="active" and wipes `agentBlocks`, even after
+      // session:complete has already been processed. That's the read-path
+      // bug that surfaces as "stuck on running" in the detail endpoint.
+      if (view.sessionId === event.sessionId) {
+        return view;
+      }
       return {
         ...view,
         sessionId: event.sessionId,
@@ -126,6 +136,21 @@ function reduceStepStart(
   view: SessionView,
   event: SessionStreamEvent & { type: "step:start" },
 ): SessionView {
+  // Idempotent: if a block already exists at this stepNumber+agentName, the
+  // event is a duplicate (e.g. republished by `save()` outside JetStream's
+  // `duplicate_window`). Without this guard, a duplicate step:start falls
+  // through to the "no matching pending block" branch below and APPENDS a
+  // fresh `running` block on top of the already-completed one — the
+  // resulting view shows the same agent twice, the second one stuck
+  // running. Pair with the session:start idempotency above.
+  if (
+    view.agentBlocks.some(
+      (b) => b.stepNumber === event.stepNumber && b.agentName === event.agentName,
+    )
+  ) {
+    return view;
+  }
+
   // Find first pending block with matching agentName
   const pendingIdx = view.agentBlocks.findIndex(
     (b) => b.status === "pending" && b.agentName === event.agentName,

--- a/packages/core/src/session/session-reducer.ts
+++ b/packages/core/src/session/session-reducer.ts
@@ -93,6 +93,19 @@ export function reduceSessionEvent(
       return view;
 
     case "session:complete": {
+      // Idempotent: a duplicate session:complete (republished by `save()`
+      // outside the broker's `duplicate_window`, or replayed by a stream
+      // consumer) must not re-stamp `completedAt`/`durationMs` to a
+      // diverging value. If the session is already terminal, no-op.
+      // First-wins is the safe semantic: the original terminal event
+      // captured the session's actual outcome; a re-publish of identical
+      // content is redundant, and a payload-divergent re-publish (which
+      // shouldn't happen with Nats-Msg-Id dedup but defends against
+      // upstream bugs) would otherwise corrupt the view.
+      if (view.status !== "active" && view.completedAt) {
+        return view;
+      }
+
       // Transition any remaining pending blocks to skipped
       const finalizedBlocks = view.agentBlocks.map((block) =>
         block.status === "pending" ? { ...block, status: "skipped" as const } : block,
@@ -136,16 +149,26 @@ function reduceStepStart(
   view: SessionView,
   event: SessionStreamEvent & { type: "step:start" },
 ): SessionView {
-  // Idempotent: if a block already exists at this stepNumber+agentName, the
-  // event is a duplicate (e.g. republished by `save()` outside JetStream's
-  // `duplicate_window`). Without this guard, a duplicate step:start falls
-  // through to the "no matching pending block" branch below and APPENDS a
-  // fresh `running` block on top of the already-completed one — the
-  // resulting view shows the same agent twice, the second one stuck
-  // running. Pair with the session:start idempotency above.
+  // Idempotent on (stepNumber, agentName, startedAt): if a block already
+  // exists with the same triple, this event is a duplicate publish (e.g.
+  // `save()` republishing events outside JetStream's `duplicate_window`).
+  // Without this guard, the duplicate falls through to the "no matching
+  // pending block" branch below and APPENDS a second running block on top
+  // of the already-completed one — the resulting view shows the same agent
+  // twice, the second stuck running.
+  //
+  // We include `startedAt` in the key (not just stepNumber+agentName) so
+  // a legitimate FSM re-entry — retry, loop, planned re-execution — that
+  // emits a NEW step:start with a NEW timestamp is correctly admitted as
+  // a new step rather than silently dropped. Republishes from `save()`
+  // carry the original event payload byte-for-byte, so they share the
+  // original timestamp and are filtered out here.
   if (
     view.agentBlocks.some(
-      (b) => b.stepNumber === event.stepNumber && b.agentName === event.agentName,
+      (b) =>
+        b.stepNumber === event.stepNumber &&
+        b.agentName === event.agentName &&
+        b.startedAt === event.timestamp,
     )
   ) {
     return view;
@@ -222,6 +245,22 @@ function reduceStepComplete(
 
   const existing = view.agentBlocks[idx];
   if (!existing) return view;
+
+  // Idempotent: if the block is already in a terminal status, this is a
+  // duplicate `step:complete` (e.g. `save()` republish landing outside
+  // JetStream's `duplicate_window`). Re-applying would re-stamp
+  // `durationMs`/`output`/`toolCalls`. Identical-payload duplicates would
+  // overwrite to the same values (no-op), but a payload-divergent
+  // re-publish (which shouldn't happen with Nats-Msg-Id dedup but defends
+  // against upstream bugs) would corrupt the block. First-wins.
+  if (
+    existing.status === "completed" ||
+    existing.status === "failed" ||
+    existing.status === "skipped" ||
+    existing.status === "cancelled"
+  ) {
+    return view;
+  }
 
   const updated: AgentBlock = {
     ...existing,


### PR DESCRIPTION
## Summary
The session detail endpoint (`GET /api/sessions/<id>`) returned `status: "active"` for sessions that had correctly finalized (the list endpoint and SESSION_METADATA KV showed them as `completed`).

Two changes against main:
1. **Reducer is now idempotent for every session event type** — duplicate publishes (which arrive when `save()`'s republish lands outside the broker's 2m dedup window) reduce to the same view.
2. **`adapter.get()` cross-references SESSION_METADATA KV** as defense-in-depth — if a finalized summary exists, prefer its terminal fields.

## Root cause walkthrough

A 9-min reindex's SESSION_EVENTS stream had:
```
#1 00:00:17 session:start
#2 00:00:17 step:start
#3 00:09:26 step:complete
#4 00:09:26 session:complete   ← view = status: completed
#5 00:09:28 session:summary
#6 00:00:17 session:start      ← DUPLICATE — view = status: active, blocks=[]
#7 00:00:17 step:start         ← DUPLICATE — view = blocks=[{running}]
```

`adapter.save()` republishes every buffered event with a stable `Nats-Msg-Id` for broker-side dedup, but JetStream's `duplicate_window` defaults to 2 minutes. Events published >2 min before `save()` are no longer in the in-memory dedup table, so the republish goes through as a brand-new message. The pre-fix reducer then re-applied the duplicates and unstuck the finalized view back to `active`.

## What actually changed

### `session-reducer.ts` — four idempotency guards added

- `session:start` — no-op when `view.sessionId === event.sessionId`. Without this, a duplicate session:start RESET status back to `active` and wiped `agentBlocks`.
- `step:start` — no-op when an existing block matches `(stepNumber, agentName, startedAt)`. Without this, a duplicate step:start fell through the "no matching pending block" branch and APPENDED a second running block on top of the completed one. `startedAt` is part of the key (not just stepNumber+agentName) so a legitimate FSM re-entry/retry — which emits a new timestamp — isn't silently dropped.
- `step:complete` — no-op when the matched block is already in a terminal status (`completed` / `failed` / `skipped` / `cancelled`). First-wins.
- `session:complete` — no-op when `view.status` is already terminal AND `completedAt` is set. First-wins.

`step:skipped` is unchanged — already idempotent (only transitions pending→skipped; a duplicate finds no pending block and returns the view as-is).

### `jetstream-session-history-adapter.ts` — KV cross-reference in `get()`

`adapter.get()` now reads SESSION_METADATA KV after reducing the events. If a summary exists, prefer its `status` / `completedAt` / `durationMs` / `error` and sweep any running/pending blocks to `skipped` (matches the reducer's pending→skipped behavior on session:complete).

The KV lookup is wrapped in try/catch — a transient broker hiccup logs a warning and falls back to the event-derived view rather than 5xx-ing the API. The RYW caveat (JetStream KV doesn't guarantee read-your-writes on clustered R>1 deployments) is documented in a comment.

This is defense-in-depth. With the reducer fix, the event-derived view is correct for any session whose events were all published. The KV fallback's real job is:
1. `markInterruptedSessions()` finalizes via KV-only — no terminal events on the stream — so the summary is the sole source of truth for those sessions.
2. Genuine event-loss scenarios (publish failure during a daemon crash, broker storage corruption) leave the event-derived view stuck.
3. Future-proofing against regressions in reducer idempotency.

### Tests added

- **`session-reducer.test.ts`**:
  - Long-running-session repro: full lifecycle + duplicate `session:start` and `step:start` after dedup window → final view matches the duplicate-free reduction.
  - Planned-steps idempotency: pending blocks pre-seeded by `session:start`, duplicate `step:start` correctly hits the timestamp-aware guard against the now-running block.
  - `step:complete` idempotency: payload-divergent duplicate proves first-wins (original `durationMs` / `output` / `toolCalls` preserved).
  - `session:complete` idempotency: payload-divergent duplicate proves first-wins (original `completedAt` / `durationMs` / `status` preserved).
- **`jetstream-session-history-adapter.test.ts`**:
  - KV fallback: missing terminal events + finalized summary → `get()` returns `status: completed`.
  - KV-lookup-throws graceful degradation: stubbed KV that rejects → `get()` does not propagate the error and returns the event-derived view.

## Verification

- 1050/1050 tests pass; type-check clean.
- Live verification: previously-stuck session `e5d403f1-…` returns `status: completed, knowledge: completed, durationMs: 548442` from the detail endpoint.

## Test plan

- [x] Reducer: duplicate `session:start` + `step:start` after dedup window → view stays `status: completed`
- [x] Reducer: duplicate `step:complete` with divergent payload → first-wins
- [x] Reducer: duplicate `session:complete` with divergent payload → first-wins
- [x] Reducer: planned-steps path (pending blocks pre-seeded) handles duplicate `step:start` correctly
- [x] Adapter: missing terminal events + finalized summary → `get()` returns `status: completed` via KV fallback
- [x] Adapter: KV lookup throws → degrades to event-derived view, no 5xx
- [x] Live reproduction unblocked