### PR TITLE
Fix Activity HITL streams and daemon connection cleanup

### DIFF
--- a/apps/atlasd/routes/elicitations/index.test.ts
+++ b/apps/atlasd/routes/elicitations/index.test.ts
@@ -526,4 +526,71 @@ describe("GET /stream — SSE", () => {
       controller.abort();
     }
   });
+
+  test("global stream emits sanitized metadata only", async () => {
+    const wsId = `ws-global-${crypto.randomUUID().slice(0, 8)}`;
+    const app = createSseTestApp(nc);
+
+    const controller = new AbortController();
+    try {
+      const res = await app.request("/stream/global", { signal: controller.signal });
+      expect(res.status).toBe(200);
+      expect(res.headers.get("Content-Type")).toBe("text/event-stream");
+
+      const envelope = makeElicitation({
+        id: "elc_global_1",
+        workspaceId: wsId,
+        sessionId: "sess_global",
+        actionId: "ask-human",
+        kind: "open-question",
+        question: "Sensitive question text?",
+        options: [{ label: "Secret", value: "secret-value" }],
+        pendingTool: { name: "send_email", args: { body: "private" } },
+        status: "answered",
+        answer: {
+          value: "private answer",
+          note: "sensitive note",
+          answeredAt: "2026-05-05T00:30:00.000Z",
+        },
+      });
+      nc.publish(`elicitations.${wsId}.sess_global.elc_global_1`, JSON.stringify(envelope));
+
+      const buf = await readUntil(res, (b) => b.includes("elc_global_1"));
+      const frame = buf.split("\n\n").find((f) => f.length > 0);
+      expect(frame?.startsWith("data: ")).toBe(true);
+      const payload = JSON.parse(frame?.slice("data: ".length) ?? "{}") as Record<string, unknown>;
+
+      expect(payload).toEqual({
+        id: "elc_global_1",
+        workspaceId: wsId,
+        sessionId: "sess_global",
+        actionId: "ask-human",
+        kind: "open-question",
+        createdAt: "2026-05-05T00:00:00.000Z",
+        expiresAt: "2026-05-05T01:00:00.000Z",
+        status: "answered",
+      });
+      expect(payload).not.toHaveProperty("question");
+      expect(payload).not.toHaveProperty("options");
+      expect(payload).not.toHaveProperty("pendingTool");
+      expect(payload).not.toHaveProperty("answer");
+    } finally {
+      controller.abort();
+    }
+  });
+
+  test("global stream abort unsubscribes from NATS", async () => {
+    const app = createSseTestApp(nc);
+    const baseline = activeSubs(nc);
+    const controller = new AbortController();
+
+    const res = await app.request("/stream/global", { signal: controller.signal });
+    expect(res.status).toBe(200);
+    expect(activeSubs(nc)).toBe(baseline + 1);
+
+    controller.abort();
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(activeSubs(nc)).toBe(baseline);
+  });
 });

--- a/apps/atlasd/routes/elicitations/index.ts
+++ b/apps/atlasd/routes/elicitations/index.ts
@@ -9,6 +9,8 @@
  *   - GET /stream        Workspace-scoped SSE feed; subscribes to NATS
  *                        `elicitations.<wsid>.>` and forwards each envelope
  *                        as a `data:` frame
+ *   - GET /stream/global Sanitized global SSE feed; subscribes to NATS
+ *                        `elicitations.>` but strips sensitive fields
  *   - POST /:id/answer   { value, note?, answeredBy? } — server fills
  *                        `answeredAt`; flips status to `answered`
  *   - POST /:id/decline  { note? } — flips status to `declined`
@@ -19,6 +21,7 @@ import {
   ElicitationSchema,
   ElicitationStatusSchema,
   ElicitationStorage,
+  ElicitationSummarySchema,
   ToolAccessGrants,
 } from "@atlas/core";
 import { createLogger } from "@atlas/logger";
@@ -168,6 +171,102 @@ elicitationApp.get(
             // for-await exited early — controller cancel can land before
             // the abort listener fires. Fall through to the finally
             // teardown so we never leak the NATS subscription.
+          } finally {
+            try {
+              sub.unsubscribe();
+            } catch {
+              // already gone
+            }
+            try {
+              controller.close();
+            } catch {
+              // already closed
+            }
+          }
+        })();
+      },
+    });
+
+    return c.body(body, 200, {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache",
+      Connection: "keep-alive",
+    });
+  },
+);
+
+// ---------------------------------------------------------------------------
+// GET /stream/global — sanitized global SSE feed
+// ---------------------------------------------------------------------------
+
+elicitationApp.get(
+  "/stream/global",
+  describeRoute({
+    tags: ["Elicitations"],
+    summary: "Subscribe to sanitized global elicitation updates (SSE)",
+    description:
+      "Server-sent events feed for global Activity/sidebar invalidation. " +
+      "Subscribes to all elicitation subjects but emits only metadata fields " +
+      "and never includes question text, pendingTool.args, options, or answers.",
+    responses: {
+      200: {
+        description:
+          "SSE stream (text/event-stream). Each frame is a JSON-encoded ElicitationSummary.",
+      },
+      503: {
+        description: "NATS connection not ready",
+        content: { "application/json": { schema: resolver(errorResponseSchema) } },
+      },
+    },
+  }),
+  async (c) => {
+    const ctx = c.get("app");
+    const nc = ctx.daemon.getNatsConnection();
+    if (!nc) return c.json({ error: "NATS connection not ready" }, 503);
+
+    const sub = nc.subscribe("elicitations.>");
+    await nc.flush();
+
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        c.req.raw.signal.addEventListener("abort", () => {
+          try {
+            sub.unsubscribe();
+          } catch {
+            // already gone
+          }
+          try {
+            controller.close();
+          } catch {
+            // already closed
+          }
+        });
+
+        void (async () => {
+          try {
+            for await (const msg of sub) {
+              let raw: unknown;
+              try {
+                raw = JSON.parse(msg.string());
+              } catch (error) {
+                logger.warn("Dropping non-JSON elicitation event from global stream", {
+                  error: stringifyError(error),
+                });
+                continue;
+              }
+              const parsed = ElicitationSchema.safeParse(raw);
+              if (!parsed.success) {
+                logger.warn("Dropping invalid elicitation event from global stream", {
+                  error: parsed.error.message,
+                });
+                continue;
+              }
+              const safe = ElicitationSummarySchema.parse(parsed.data);
+              controller.enqueue(enc.encode(`data: ${JSON.stringify(safe)}\n\n`));
+            }
+          } catch {
+            // for-await exited early — controller cancel can land before
+            // the abort listener fires. Fall through to teardown.
           } finally {
             try {
               sub.unsubscribe();

--- a/apps/atlasd/routes/workspaces/index.ts
+++ b/apps/atlasd/routes/workspaces/index.ts
@@ -1711,7 +1711,22 @@ const workspacesRoutes = daemonFactory
     // worker publishes; the response subscription delivers the terminal
     // {ok, result} envelope and triggers SSE close.
     const streamSub = nc.subscribe(`signals.stream.${correlationId}`);
-    const responsePromise = awaitSignalCompletion(nc, correlationId, 600_000);
+    const clientAbort = c.req.raw.signal;
+    const signalStreamAbort = new AbortController();
+    const responsePromise = awaitSignalCompletion(
+      nc,
+      correlationId,
+      600_000,
+      signalStreamAbort.signal,
+    );
+    void responsePromise.catch(() => undefined);
+    let subscriptionsClosed = false;
+    const closeSignalSubscriptions = () => {
+      if (subscriptionsClosed) return;
+      subscriptionsClosed = true;
+      signalStreamAbort.abort();
+      streamSub.unsubscribe();
+    };
 
     // Capture the spawned session's id from the live stream so we can cancel
     // it on client disconnect. Without this, an aborted chat-tool fetch only
@@ -1720,10 +1735,7 @@ const workspacesRoutes = daemonFactory
     // etc.) finish anyway. Caused observed email storms when chat follow-ups
     // aborted prior turns mid-job.
     let spawnedSessionId: string | undefined;
-    // The Hono request's underlying AbortSignal fires when the client
-    // disconnects (browser navigates away, fetch is aborted, etc.).
-    const clientAbort = c.req.raw.signal;
-    const onClientAbort = () => {
+    const cancelSpawnedSession = () => {
       if (!spawnedSessionId) return;
       try {
         const runtime = ctx.getWorkspaceRuntime(workspaceId);
@@ -1737,10 +1749,26 @@ const workspacesRoutes = daemonFactory
         });
       }
     };
-    clientAbort.addEventListener("abort", onClientAbort, { once: true });
+    // The Hono request's underlying AbortSignal fires when the client
+    // disconnects (browser navigates away, fetch is aborted, etc.).
+    const onClientAbort = () => {
+      closeSignalSubscriptions();
+      cancelSpawnedSession();
+    };
+    if (clientAbort.aborted) {
+      onClientAbort();
+    } else {
+      clientAbort.addEventListener("abort", onClientAbort, { once: true });
+    }
 
     const sseStream = new ReadableStream({
       async start(controller) {
+        let clientGone = false;
+        const markClientGone = () => {
+          clientGone = true;
+          closeSignalSubscriptions();
+          cancelSpawnedSession();
+        };
         const safeEnqueue = (bytes: Uint8Array) => {
           try {
             controller.enqueue(bytes);
@@ -1751,6 +1779,7 @@ const workspacesRoutes = daemonFactory
               signalId,
               error: err,
             });
+            markClientGone();
             return false;
           }
         };
@@ -1781,6 +1810,10 @@ const workspacesRoutes = daemonFactory
         })();
 
         try {
+          if (clientAbort.aborted || signalStreamAbort.signal.aborted) {
+            return;
+          }
+
           await ctx.daemon.publishSignalToJetStream({
             workspaceId,
             signalId,
@@ -1839,19 +1872,27 @@ const workspacesRoutes = daemonFactory
           }
           safeEnqueue(encoder.encode("data: [DONE]\n\n"));
         } catch (error) {
-          const errorMessage = stringifyError(error);
-          logger.error("Signal trigger SSE error", { error: errorMessage, workspaceId, signalId });
-          safeEnqueue(
-            encoder.encode(
-              `data: ${JSON.stringify({ type: "job-error", data: { error: errorMessage } })}\n\n`,
-            ),
-          );
-          safeEnqueue(encoder.encode("data: [DONE]\n\n"));
+          if (clientGone || signalStreamAbort.signal.aborted || clientAbort.aborted) {
+            logger.debug("Signal trigger SSE aborted by client", { workspaceId, signalId });
+          } else {
+            const errorMessage = stringifyError(error);
+            logger.error("Signal trigger SSE error", {
+              error: errorMessage,
+              workspaceId,
+              signalId,
+            });
+            safeEnqueue(
+              encoder.encode(
+                `data: ${JSON.stringify({ type: "job-error", data: { error: errorMessage } })}\n\n`,
+              ),
+            );
+            safeEnqueue(encoder.encode("data: [DONE]\n\n"));
+          }
         } finally {
-          streamSub.unsubscribe();
+          closeSignalSubscriptions();
           await forward.catch(() => undefined);
-          // SSE finished cleanly — the session has already terminated, so
-          // there's nothing to cancel on client abort. Drop the listener.
+          // This response path owns subscription cleanup/cancellation now;
+          // drop the request-abort listener before closing the stream.
           clientAbort.removeEventListener("abort", onClientAbort);
           try {
             controller.close();
@@ -1859,6 +1900,11 @@ const workspacesRoutes = daemonFactory
             /* already closed */
           }
         }
+      },
+      cancel() {
+        closeSignalSubscriptions();
+        cancelSpawnedSession();
+        clientAbort.removeEventListener("abort", onClientAbort);
       },
     });
 
@@ -1935,6 +1981,14 @@ const workspacesRoutes = daemonFactory
       // discovery), and cancel on `c.req.raw.signal` abort.
       let spawnedSessionId: string | undefined;
       const discoverySub = nc.subscribe(`signals.stream.${correlationId}`);
+      const signalResponseAbort = new AbortController();
+      let subscriptionsClosed = false;
+      const closeSignalSubscriptions = () => {
+        if (subscriptionsClosed) return;
+        subscriptionsClosed = true;
+        signalResponseAbort.abort();
+        discoverySub.unsubscribe();
+      };
       const discovery = (async () => {
         for await (const msg of discoverySub) {
           if (spawnedSessionId) break;
@@ -1945,6 +1999,7 @@ const workspacesRoutes = daemonFactory
             };
             if (parsed.type === "data-session-start" && parsed.data?.sessionId) {
               spawnedSessionId = parsed.data.sessionId;
+              discoverySub.unsubscribe();
               break;
             }
           } catch {
@@ -1954,7 +2009,7 @@ const workspacesRoutes = daemonFactory
       })();
       discovery.catch(() => undefined);
       const clientAbort = c.req.raw.signal;
-      const onClientAbort = () => {
+      const cancelSpawnedSession = () => {
         if (!spawnedSessionId) return;
         try {
           const runtime = ctx.getWorkspaceRuntime(workspaceId);
@@ -1968,12 +2023,30 @@ const workspacesRoutes = daemonFactory
           });
         }
       };
-      clientAbort.addEventListener("abort", onClientAbort, { once: true });
+      const onClientAbort = () => {
+        closeSignalSubscriptions();
+        cancelSpawnedSession();
+      };
+      if (clientAbort.aborted) {
+        onClientAbort();
+      } else {
+        clientAbort.addEventListener("abort", onClientAbort, { once: true });
+      }
 
       try {
+        if (clientAbort.aborted || signalResponseAbort.signal.aborted) {
+          return c.json({ error: "Client disconnected" }, 408);
+        }
+
         // Subscribe BEFORE publishing — a fast consumer could otherwise
         // beat us to the response subject and we'd miss the reply.
-        const responsePromise = awaitSignalCompletion(nc, correlationId, 600_000);
+        const responsePromise = awaitSignalCompletion(
+          nc,
+          correlationId,
+          600_000,
+          signalResponseAbort.signal,
+        );
+        void responsePromise.catch(() => undefined);
         await ctx.daemon.publishSignalToJetStream({
           workspaceId,
           signalId,
@@ -2007,6 +2080,11 @@ const workspacesRoutes = daemonFactory
           summary: result.summary ?? "",
         });
       } catch (error) {
+        if (clientAbort.aborted || signalResponseAbort.signal.aborted) {
+          logger.debug("Signal trigger aborted by client", { workspaceId, signalId });
+          return c.json({ error: "Client disconnected" }, 408);
+        }
+
         const errorMessage = stringifyError(error);
         if (error instanceof SessionFailedError) {
           logger.warn("Signal session failed", { error });
@@ -2053,7 +2131,7 @@ const workspacesRoutes = daemonFactory
         return c.json({ error: `Failed to process signal: ${errorMessage}` }, 500);
       } finally {
         clientAbort.removeEventListener("abort", onClientAbort);
-        discoverySub.unsubscribe();
+        closeSignalSubscriptions();
         await discovery.catch(() => undefined);
       }
     },

--- a/apps/atlasd/routes/workspaces/index.ts
+++ b/apps/atlasd/routes/workspaces/index.ts
@@ -62,7 +62,7 @@ import {
   setCommunicatorMutation,
   wireCommunicator,
 } from "../../src/services/communicator-wiring.ts";
-import { awaitSignalCompletion } from "../../src/signal-stream.ts";
+import { awaitSignalCompletion, publishSignalCancellation } from "../../src/signal-stream.ts";
 import { getCurrentUser } from "../me/adapter.ts";
 import {
   buildWorkspaceBundleBytes,
@@ -1727,6 +1727,19 @@ const workspacesRoutes = daemonFactory
       signalStreamAbort.abort();
       streamSub.unsubscribe();
     };
+    let cancellationPublished = false;
+    const cancelCorrelatedSignal = () => {
+      if (cancellationPublished) return;
+      cancellationPublished = true;
+      void publishSignalCancellation(nc, correlationId, "Client disconnected").catch((error) => {
+        logger.warn("Failed to publish signal cancellation", {
+          workspaceId,
+          signalId,
+          correlationId,
+          error: stringifyError(error),
+        });
+      });
+    };
 
     // Capture the spawned session's id from the live stream so we can cancel
     // it on client disconnect. Without this, an aborted chat-tool fetch only
@@ -1752,6 +1765,7 @@ const workspacesRoutes = daemonFactory
     // The Hono request's underlying AbortSignal fires when the client
     // disconnects (browser navigates away, fetch is aborted, etc.).
     const onClientAbort = () => {
+      cancelCorrelatedSignal();
       closeSignalSubscriptions();
       cancelSpawnedSession();
     };
@@ -1766,6 +1780,7 @@ const workspacesRoutes = daemonFactory
         let clientGone = false;
         const markClientGone = () => {
           clientGone = true;
+          cancelCorrelatedSignal();
           closeSignalSubscriptions();
           cancelSpawnedSession();
         };
@@ -1810,6 +1825,11 @@ const workspacesRoutes = daemonFactory
         })();
 
         try {
+          if (clientAbort.aborted || signalStreamAbort.signal.aborted) {
+            return;
+          }
+
+          await nc.flush();
           if (clientAbort.aborted || signalStreamAbort.signal.aborted) {
             return;
           }
@@ -1902,6 +1922,7 @@ const workspacesRoutes = daemonFactory
         }
       },
       cancel() {
+        cancelCorrelatedSignal();
         closeSignalSubscriptions();
         cancelSpawnedSession();
         clientAbort.removeEventListener("abort", onClientAbort);
@@ -1989,6 +2010,19 @@ const workspacesRoutes = daemonFactory
         signalResponseAbort.abort();
         discoverySub.unsubscribe();
       };
+      let cancellationPublished = false;
+      const cancelCorrelatedSignal = () => {
+        if (cancellationPublished) return;
+        cancellationPublished = true;
+        void publishSignalCancellation(nc, correlationId, "Client disconnected").catch((error) => {
+          logger.warn("Failed to publish signal cancellation", {
+            workspaceId,
+            signalId,
+            correlationId,
+            error: stringifyError(error),
+          });
+        });
+      };
       const discovery = (async () => {
         for await (const msg of discoverySub) {
           if (spawnedSessionId) break;
@@ -2024,6 +2058,7 @@ const workspacesRoutes = daemonFactory
         }
       };
       const onClientAbort = () => {
+        cancelCorrelatedSignal();
         closeSignalSubscriptions();
         cancelSpawnedSession();
       };
@@ -2047,6 +2082,10 @@ const workspacesRoutes = daemonFactory
           signalResponseAbort.signal,
         );
         void responsePromise.catch(() => undefined);
+        await nc.flush();
+        if (clientAbort.aborted || signalResponseAbort.signal.aborted) {
+          return c.json({ error: "Client disconnected" }, 408);
+        }
         await ctx.daemon.publishSignalToJetStream({
           workspaceId,
           signalId,

--- a/apps/atlasd/src/atlas-daemon.test.ts
+++ b/apps/atlasd/src/atlas-daemon.test.ts
@@ -278,6 +278,163 @@ describe("AtlasDaemon idle/session cleanup", () => {
     expect(idleStop).toHaveBeenCalledOnce();
   });
 
+  it("keeps agent MCP requests active until streaming response bodies close", async () => {
+    const daemon = new AtlasDaemon({ port: 0 });
+    const sessions = (daemon as unknown as { agentSessions: Map<string, Record<string, unknown>> })
+      .agentSessions;
+    sessions.set("streaming-agent", {
+      server: { stop: vi.fn().mockResolvedValue(undefined) },
+      transport: {},
+      createdAt: Date.now(),
+      lastUsed: Date.now(),
+      activeRequests: 0,
+    });
+
+    const transport = {
+      handleRequest: vi.fn().mockResolvedValue(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new Uint8Array([1]));
+            },
+          }),
+          { headers: { "Content-Type": "text/event-stream" } },
+        ),
+      ),
+    };
+
+    const response = await (
+      daemon as unknown as {
+        handleAgentMcpRequest: (
+          sessionId: string,
+          transportArg: { handleRequest: () => Promise<Response> },
+          context: unknown,
+        ) => Promise<Response | undefined>;
+      }
+    ).handleAgentMcpRequest("streaming-agent", transport, {});
+
+    expect(sessions.get("streaming-agent")?.activeRequests).toBe(1);
+
+    await response?.body?.cancel();
+
+    expect(sessions.get("streaming-agent")?.activeRequests).toBe(0);
+  });
+
+  it("keeps platform MCP requests active until streaming response bodies close", async () => {
+    const daemon = new AtlasDaemon({ port: 0 });
+    const sessions = (
+      daemon as unknown as { platformMcpSessions: Map<string, Record<string, unknown>> }
+    ).platformMcpSessions;
+    sessions.set("streaming-platform", {
+      server: {},
+      transport: {},
+      createdAt: Date.now(),
+      lastUsed: Date.now(),
+      activeRequests: 0,
+    });
+
+    const transport = {
+      handleRequest: vi.fn().mockResolvedValue(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new Uint8Array([1]));
+            },
+          }),
+          { headers: { "Content-Type": "text/event-stream" } },
+        ),
+      ),
+    };
+
+    const response = await (
+      daemon as unknown as {
+        handlePlatformMcpRequest: (
+          sessionId: string,
+          transportArg: { handleRequest: () => Promise<Response> },
+          context: unknown,
+        ) => Promise<Response | undefined>;
+      }
+    ).handlePlatformMcpRequest("streaming-platform", transport, {});
+
+    expect(sessions.get("streaming-platform")?.activeRequests).toBe(1);
+
+    await response?.body?.cancel();
+
+    expect(sessions.get("streaming-platform")?.activeRequests).toBe(0);
+  });
+
+  it("releases MCP request tracking when streaming response bodies finish", async () => {
+    const daemon = new AtlasDaemon({ port: 0 });
+    const sessions = (daemon as unknown as { agentSessions: Map<string, Record<string, unknown>> })
+      .agentSessions;
+    sessions.set("closing-agent", {
+      server: { stop: vi.fn().mockResolvedValue(undefined) },
+      transport: {},
+      createdAt: Date.now(),
+      lastUsed: Date.now(),
+      activeRequests: 0,
+    });
+
+    const transport = {
+      handleRequest: vi.fn().mockResolvedValue(
+        new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new Uint8Array([1]));
+              controller.close();
+            },
+          }),
+          { headers: { "Content-Type": "text/event-stream" } },
+        ),
+      ),
+    };
+
+    const response = await (
+      daemon as unknown as {
+        handleAgentMcpRequest: (
+          sessionId: string,
+          transportArg: { handleRequest: () => Promise<Response> },
+          context: unknown,
+        ) => Promise<Response | undefined>;
+      }
+    ).handleAgentMcpRequest("closing-agent", transport, {});
+
+    expect(sessions.get("closing-agent")?.activeRequests).toBe(1);
+
+    await response?.arrayBuffer();
+
+    expect(sessions.get("closing-agent")?.activeRequests).toBe(0);
+  });
+
+  it("releases MCP request tracking immediately for no-body responses", async () => {
+    const daemon = new AtlasDaemon({ port: 0 });
+    const sessions = (daemon as unknown as { agentSessions: Map<string, Record<string, unknown>> })
+      .agentSessions;
+    sessions.set("empty-response-agent", {
+      server: { stop: vi.fn().mockResolvedValue(undefined) },
+      transport: {},
+      createdAt: Date.now(),
+      lastUsed: Date.now(),
+      activeRequests: 0,
+    });
+
+    const transport = {
+      handleRequest: vi.fn().mockResolvedValue(new Response(null, { status: 202 })),
+    };
+
+    await (
+      daemon as unknown as {
+        handleAgentMcpRequest: (
+          sessionId: string,
+          transportArg: { handleRequest: () => Promise<Response> },
+          context: unknown,
+        ) => Promise<Response | undefined>;
+      }
+    ).handleAgentMcpRequest("empty-response-agent", transport, {});
+
+    expect(sessions.get("empty-response-agent")?.activeRequests).toBe(0);
+  });
+
   it("closes agent and platform MCP transports during explicit cleanup", async () => {
     const daemon = new AtlasDaemon({ port: 0 });
     const agentClose = vi.fn().mockResolvedValue(undefined);

--- a/apps/atlasd/src/atlas-daemon.test.ts
+++ b/apps/atlasd/src/atlas-daemon.test.ts
@@ -205,35 +205,118 @@ describe("AtlasDaemon idle/session cleanup", () => {
     expect(resetIdleTimeout).toHaveBeenCalledWith("ws-1");
   });
 
-  it("does not clean up stale platform MCP sessions while a request is in flight", () => {
+  it("does not clean up stale platform MCP sessions while a request is in flight", async () => {
     const daemon = new AtlasDaemon({ port: 0 });
     const now = Date.now();
     const stale = now - 16 * 60 * 1000;
     const sessions = (
       daemon as unknown as { platformMcpSessions: Map<string, Record<string, unknown>> }
     ).platformMcpSessions;
+    const activeClose = vi.fn().mockResolvedValue(undefined);
+    const idleClose = vi.fn().mockResolvedValue(undefined);
 
     sessions.set("active-hitl", {
       server: {},
-      transport: {},
+      transport: { close: activeClose },
       createdAt: stale,
       lastUsed: stale,
       activeRequests: 1,
     });
     sessions.set("idle-old", {
       server: {},
-      transport: {},
+      transport: { close: idleClose },
       createdAt: stale,
       lastUsed: stale,
       activeRequests: 0,
     });
 
-    (
-      daemon as unknown as { performPlatformSessionCleanup: () => void }
+    await (
+      daemon as unknown as { performPlatformSessionCleanup: () => Promise<void> }
     ).performPlatformSessionCleanup();
 
     expect(sessions.has("active-hitl")).toBe(true);
     expect(sessions.has("idle-old")).toBe(false);
+    expect(activeClose).not.toHaveBeenCalled();
+    expect(idleClose).toHaveBeenCalledOnce();
+  });
+
+  it("does not clean up stale agent MCP sessions while a request is in flight", async () => {
+    const daemon = new AtlasDaemon({ port: 0 });
+    const now = Date.now();
+    const stale = now - 16 * 60 * 1000;
+    const sessions = (daemon as unknown as { agentSessions: Map<string, Record<string, unknown>> })
+      .agentSessions;
+    const activeClose = vi.fn().mockResolvedValue(undefined);
+    const activeStop = vi.fn().mockResolvedValue(undefined);
+    const idleClose = vi.fn().mockResolvedValue(undefined);
+    const idleStop = vi.fn().mockResolvedValue(undefined);
+
+    sessions.set("active-agent", {
+      server: { stop: activeStop },
+      transport: { close: activeClose },
+      createdAt: stale,
+      lastUsed: stale,
+      activeRequests: 1,
+    });
+    sessions.set("idle-agent", {
+      server: { stop: idleStop },
+      transport: { close: idleClose },
+      createdAt: stale,
+      lastUsed: stale,
+      activeRequests: 0,
+    });
+
+    await (
+      daemon as unknown as { performAgentSessionCleanup: () => Promise<void> }
+    ).performAgentSessionCleanup();
+
+    expect(sessions.has("active-agent")).toBe(true);
+    expect(sessions.has("idle-agent")).toBe(false);
+    expect(activeClose).not.toHaveBeenCalled();
+    expect(activeStop).not.toHaveBeenCalled();
+    expect(idleClose).toHaveBeenCalledOnce();
+    expect(idleStop).toHaveBeenCalledOnce();
+  });
+
+  it("closes agent and platform MCP transports during explicit cleanup", async () => {
+    const daemon = new AtlasDaemon({ port: 0 });
+    const agentClose = vi.fn().mockResolvedValue(undefined);
+    const agentStop = vi.fn().mockResolvedValue(undefined);
+    const platformClose = vi.fn().mockResolvedValue(undefined);
+    const agentSessions = (
+      daemon as unknown as { agentSessions: Map<string, Record<string, unknown>> }
+    ).agentSessions;
+    const platformSessions = (
+      daemon as unknown as { platformMcpSessions: Map<string, Record<string, unknown>> }
+    ).platformMcpSessions;
+
+    agentSessions.set("agent-session", {
+      server: { stop: agentStop },
+      transport: { close: agentClose, onclose: () => undefined },
+      createdAt: Date.now(),
+      lastUsed: Date.now(),
+      activeRequests: 0,
+    });
+    platformSessions.set("platform-session", {
+      server: {},
+      transport: { close: platformClose, onclose: () => undefined },
+      createdAt: Date.now(),
+      lastUsed: Date.now(),
+      activeRequests: 0,
+    });
+
+    await (
+      daemon as unknown as { cleanupAgentSession: (sessionId: string) => Promise<void> }
+    ).cleanupAgentSession("agent-session");
+    await (
+      daemon as unknown as { cleanupPlatformSession: (sessionId: string) => Promise<void> }
+    ).cleanupPlatformSession("platform-session");
+
+    expect(agentClose).toHaveBeenCalledOnce();
+    expect(agentStop).toHaveBeenCalledOnce();
+    expect(platformClose).toHaveBeenCalledOnce();
+    expect(agentSessions.has("agent-session")).toBe(false);
+    expect(platformSessions.has("platform-session")).toBe(false);
   });
 });
 

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -290,6 +290,7 @@ export class AtlasDaemon {
       transport: StreamableHTTPTransport;
       createdAt: number;
       lastUsed: number;
+      activeRequests: number;
     }
   >();
   // Track active SSE connections per session
@@ -984,15 +985,37 @@ export class AtlasDaemon {
       transport,
       createdAt: Date.now(),
       lastUsed: Date.now(),
+      activeRequests: 0,
     });
 
     // Set up cleanup
     transport.onclose = () => {
       logger.info("[Daemon] Agent session closed", { sessionId });
-      this.cleanupAgentSession(sessionId);
+      void this.cleanupAgentSession(sessionId);
     };
 
     return { server, transport };
+  }
+
+  private async handleAgentMcpRequest(
+    sessionId: string,
+    transport: StreamableHTTPTransport,
+    c: Context,
+  ): Promise<Response | undefined> {
+    const session = this.agentSessions.get(sessionId);
+    if (session) {
+      session.activeRequests++;
+      session.lastUsed = Date.now();
+    }
+    try {
+      return await transport.handleRequest(c);
+    } finally {
+      const current = this.agentSessions.get(sessionId);
+      if (current) {
+        current.activeRequests = Math.max(0, current.activeRequests - 1);
+        current.lastUsed = Date.now();
+      }
+    }
   }
 
   /**
@@ -1000,12 +1023,25 @@ export class AtlasDaemon {
    */
   private async cleanupAgentSession(sessionId: string): Promise<void> {
     const session = this.agentSessions.get(sessionId);
-    if (session) {
-      await session.server.stop();
-      this.agentSessions.delete(sessionId);
-      this.agentSSEConnections.delete(sessionId);
-      logger.info("[Daemon] Agent session cleaned up", { sessionId });
+    if (!session) return;
+
+    this.agentSessions.delete(sessionId);
+    this.agentSSEConnections.delete(sessionId);
+    session.transport.onclose = undefined;
+
+    try {
+      await session.transport.close();
+    } catch (error) {
+      logger.debug("Error closing agent MCP transport", { error, sessionId });
     }
+
+    try {
+      await session.server.stop();
+    } catch (error) {
+      logger.debug("Error stopping agent MCP server", { error, sessionId });
+    }
+
+    logger.info("[Daemon] Agent session cleaned up", { sessionId });
   }
 
   /**
@@ -1078,7 +1114,7 @@ export class AtlasDaemon {
     // Set up cleanup
     transport.onclose = () => {
       logger.info("[Daemon] Platform session closed", { sessionId });
-      this.cleanupPlatformSession(sessionId);
+      void this.cleanupPlatformSession(sessionId);
     };
 
     return { server, transport };
@@ -1108,13 +1144,20 @@ export class AtlasDaemon {
   /**
    * Clean up platform session
    */
-  private cleanupPlatformSession(sessionId: string): void {
+  private async cleanupPlatformSession(sessionId: string): Promise<void> {
     const session = this.platformMcpSessions.get(sessionId);
-    if (session) {
-      // Platform MCP Server doesn't have explicit stop() - just remove from map
-      this.platformMcpSessions.delete(sessionId);
-      logger.info("[Daemon] Platform session cleaned up", { sessionId });
+    if (!session) return;
+
+    this.platformMcpSessions.delete(sessionId);
+    session.transport.onclose = undefined;
+
+    try {
+      await session.transport.close();
+    } catch (error) {
+      logger.debug("Error closing platform MCP transport", { error, sessionId });
     }
+
+    logger.info("[Daemon] Platform session cleaned up", { sessionId });
   }
 
   /** Get the NATS connection (available after initialize()). */
@@ -1292,7 +1335,7 @@ export class AtlasDaemon {
             if (c.req.method === "DELETE") {
               logger.info("Terminating Platform MCP session", { sessionId });
               const response = await this.handlePlatformMcpRequest(sessionId, transport, c);
-              this.cleanupPlatformSession(sessionId);
+              await this.cleanupPlatformSession(sessionId);
               return response;
             }
 
@@ -1350,7 +1393,7 @@ export class AtlasDaemon {
             const { transport } = await this.getOrCreateAgentSession(newSessionId);
 
             // Handle the request - this will set the Mcp-Session-Id header
-            const response = await transport.handleRequest(c);
+            const response = await this.handleAgentMcpRequest(newSessionId, transport, c);
 
             // The transport now has the session ID set
             if (transport.sessionId) {
@@ -1374,13 +1417,13 @@ export class AtlasDaemon {
             // Handle DELETE specially - clean up after processing
             if (c.req.method === "DELETE") {
               logger.info("Terminating Agent Server SSE session", { sessionId });
-              const response = await transport.handleRequest(c);
+              const response = await this.handleAgentMcpRequest(sessionId, transport, c);
               await this.cleanupAgentSession(sessionId);
               return response;
             }
 
             // Handle the request
-            return transport.handleRequest(c);
+            return this.handleAgentMcpRequest(sessionId, transport, c);
           } else {
             // No session ID and not a POST request - this is an error
             logger.error("[Daemon] Invalid request - no session ID for non-POST", {
@@ -2715,13 +2758,11 @@ export class AtlasDaemon {
     this.agentSessions.clear();
     this.agentSSEConnections.clear();
 
-    for (const sessionId of this.platformMcpSessions.keys()) {
-      try {
-        this.cleanupPlatformSession(sessionId);
-      } catch (error) {
-        logger.debug("Error cleaning up platform session", { error, sessionId });
-      }
-    }
+    await Promise.allSettled(
+      Array.from(this.platformMcpSessions.keys()).map((sessionId) =>
+        this.cleanupPlatformSession(sessionId),
+      ),
+    );
     this.platformMcpSessions.clear();
 
     if (this.capabilityRegistry) {
@@ -2840,7 +2881,7 @@ export class AtlasDaemon {
 
     // Check every minute for stale sessions
     this.agentSessionCleanupInterval = setInterval(() => {
-      this.performAgentSessionCleanup();
+      void this.performAgentSessionCleanup();
     }, 60000);
 
     logger.info("Agent session cleanup started", {
@@ -2857,8 +2898,11 @@ export class AtlasDaemon {
     const now = Date.now();
     const sessionsToCleanup: string[] = [];
 
-    // Find stale sessions
+    // Find stale sessions. A workspace-chat/agent call can legitimately
+    // hold the MCP response stream open for many minutes, so never reap a
+    // session while an HTTP request is still in flight.
     for (const [sessionId, session] of this.agentSessions) {
+      if (session.activeRequests > 0) continue;
       if (now - session.lastUsed > this.AGENT_SESSION_TIMEOUT_MS) {
         sessionsToCleanup.push(sessionId);
       }
@@ -2878,9 +2922,9 @@ export class AtlasDaemon {
 
     // Enforce session limit (LRU eviction)
     if (this.agentSessions.size > this.MAX_AGENT_SESSIONS) {
-      const sortedSessions = Array.from(this.agentSessions.entries()).sort(
-        (a, b) => a[1].lastUsed - b[1].lastUsed,
-      );
+      const sortedSessions = Array.from(this.agentSessions.entries())
+        .filter(([, session]) => session.activeRequests === 0)
+        .sort((a, b) => a[1].lastUsed - b[1].lastUsed);
 
       const toEvict = sortedSessions.slice(0, this.agentSessions.size - this.MAX_AGENT_SESSIONS);
 
@@ -2906,7 +2950,7 @@ export class AtlasDaemon {
 
     // Check every minute for stale sessions
     this.platformSessionCleanupInterval = setInterval(() => {
-      this.performPlatformSessionCleanup();
+      void this.performPlatformSessionCleanup();
     }, 60000);
 
     logger.info("Platform session cleanup started", {
@@ -2919,7 +2963,7 @@ export class AtlasDaemon {
   /**
    * Clean up stale platform sessions
    */
-  private performPlatformSessionCleanup(): void {
+  private async performPlatformSessionCleanup(): Promise<void> {
     const now = Date.now();
     const sessionsToCleanup: string[] = [];
 
@@ -2941,7 +2985,7 @@ export class AtlasDaemon {
       });
 
       for (const sessionId of sessionsToCleanup) {
-        this.cleanupPlatformSession(sessionId);
+        await this.cleanupPlatformSession(sessionId);
       }
     }
 
@@ -2963,7 +3007,7 @@ export class AtlasDaemon {
       });
 
       for (const [sessionId] of toEvict) {
-        this.cleanupPlatformSession(sessionId);
+        await this.cleanupPlatformSession(sessionId);
       }
     }
   }

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -997,6 +997,13 @@ export class AtlasDaemon {
     return { server, transport };
   }
 
+  private releaseAgentMcpRequest(sessionId: string): void {
+    const current = this.agentSessions.get(sessionId);
+    if (!current) return;
+    current.activeRequests = Math.max(0, current.activeRequests - 1);
+    current.lastUsed = Date.now();
+  }
+
   private async handleAgentMcpRequest(
     sessionId: string,
     transport: StreamableHTTPTransport,
@@ -1008,13 +1015,11 @@ export class AtlasDaemon {
       session.lastUsed = Date.now();
     }
     try {
-      return await transport.handleRequest(c);
-    } finally {
-      const current = this.agentSessions.get(sessionId);
-      if (current) {
-        current.activeRequests = Math.max(0, current.activeRequests - 1);
-        current.lastUsed = Date.now();
-      }
+      const response = await transport.handleRequest(c);
+      return this.trackMcpResponseLifetime(response, () => this.releaseAgentMcpRequest(sessionId));
+    } catch (error) {
+      this.releaseAgentMcpRequest(sessionId);
+      throw error;
     }
   }
 
@@ -1120,6 +1125,13 @@ export class AtlasDaemon {
     return { server, transport };
   }
 
+  private releasePlatformMcpRequest(sessionId: string): void {
+    const current = this.platformMcpSessions.get(sessionId);
+    if (!current) return;
+    current.activeRequests = Math.max(0, current.activeRequests - 1);
+    current.lastUsed = Date.now();
+  }
+
   private async handlePlatformMcpRequest(
     sessionId: string,
     transport: StreamableHTTPTransport,
@@ -1131,14 +1143,75 @@ export class AtlasDaemon {
       session.lastUsed = Date.now();
     }
     try {
-      return await transport.handleRequest(c);
-    } finally {
-      const current = this.platformMcpSessions.get(sessionId);
-      if (current) {
-        current.activeRequests = Math.max(0, current.activeRequests - 1);
-        current.lastUsed = Date.now();
-      }
+      const response = await transport.handleRequest(c);
+      return this.trackMcpResponseLifetime(response, () =>
+        this.releasePlatformMcpRequest(sessionId),
+      );
+    } catch (error) {
+      this.releasePlatformMcpRequest(sessionId);
+      throw error;
     }
+  }
+
+  private trackMcpResponseLifetime(
+    response: Response | undefined,
+    releaseRequest: () => void,
+  ): Response | undefined {
+    let released = false;
+    const releaseOnce = () => {
+      if (released) return;
+      released = true;
+      releaseRequest();
+    };
+
+    if (!response?.body) {
+      releaseOnce();
+      return response;
+    }
+
+    const reader = response.body.getReader();
+    const releaseReaderLock = () => {
+      try {
+        reader.releaseLock();
+      } catch {
+        // The reader may already be released after cancellation.
+      }
+    };
+
+    const trackedBody = new ReadableStream<Uint8Array>({
+      async pull(controller) {
+        try {
+          const { done, value } = await reader.read();
+          if (done) {
+            controller.close();
+            releaseOnce();
+            releaseReaderLock();
+            return;
+          }
+          controller.enqueue(value);
+        } catch (error) {
+          releaseOnce();
+          releaseReaderLock();
+          controller.error(error);
+        }
+      },
+      async cancel(reason) {
+        try {
+          await reader.cancel(reason);
+        } catch {
+          // The upstream body may already be closed/cancelled.
+        } finally {
+          releaseOnce();
+          releaseReaderLock();
+        }
+      },
+    });
+
+    return new Response(trackedBody, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: response.headers,
+    });
   }
 
   /**

--- a/apps/atlasd/src/cascade-stream.test.ts
+++ b/apps/atlasd/src/cascade-stream.test.ts
@@ -11,6 +11,7 @@ import {
 import { ensureInstanceEventsStream, listInstanceEvents } from "./instance-events.ts";
 import {
   awaitSignalCompletion,
+  publishSignalCancellation,
   type SignalEnvelope,
   signalStreamSubject,
 } from "./signal-stream.ts";
@@ -259,6 +260,7 @@ describe("CascadeConsumer correlated callers", () => {
 
     const correlationId = crypto.randomUUID();
     const responsePromise = awaitSignalCompletion(nc, correlationId, 5000);
+    await nc.flush();
     await publishCascade(nc, envelope("ws", "ping", { correlationId }));
     const reply = await responsePromise;
     await consumer.destroy();
@@ -282,6 +284,7 @@ describe("CascadeConsumer correlated callers", () => {
 
     const correlationId = crypto.randomUUID();
     const responsePromise = awaitSignalCompletion(nc, correlationId, 2000);
+    await nc.flush();
     await publishCascade(
       nc,
       envelope("ws", "ping", {
@@ -320,6 +323,7 @@ describe("CascadeConsumer correlated callers", () => {
     await consumer.start();
 
     const responsePromise = awaitSignalCompletion(nc, correlationId, 5000);
+    await nc.flush();
     await publishCascade(nc, envelope("ws", "stream-test", { correlationId }));
     const reply = await responsePromise;
     await reader;
@@ -328,6 +332,89 @@ describe("CascadeConsumer correlated callers", () => {
 
     expect(seenChunks).toHaveLength(3);
     expect(reply.ok).toBe(true);
+  });
+
+  it("honors correlation cancellation published before cascade dispatch starts", async () => {
+    let dispatched = false;
+    const consumer = new CascadeConsumer(
+      nc,
+      () => {
+        dispatched = true;
+        return Promise.resolve({
+          sessionId: "s-cancelled",
+          output: [],
+          artifactIds: [],
+          summary: "",
+        });
+      },
+      () => Promise.resolve("concurrent" as ConcurrencyPolicy),
+      { expiresMs: 1000 },
+    );
+    await consumer.start();
+
+    const correlationId = crypto.randomUUID();
+    await publishSignalCancellation(nc, correlationId, "client stopped");
+    const responsePromise = awaitSignalCompletion(nc, correlationId, 5000);
+    await nc.flush();
+    await publishCascade(nc, envelope("ws", "cancel-before-start", { correlationId }));
+
+    const reply = await responsePromise;
+    await consumer.destroy();
+
+    expect(dispatched).toBe(false);
+    expect(reply.ok).toBe(false);
+    if (!reply.ok) expect(reply.error).toContain("client stopped");
+  });
+
+  it("aborts in-flight cascades by correlation id", async () => {
+    let sawAbort = false;
+    let markStarted!: () => void;
+    const started = new Promise<void>((resolve) => {
+      markStarted = resolve;
+    });
+
+    const consumer = new CascadeConsumer(
+      nc,
+      (_env, ctx) => {
+        markStarted();
+        return new Promise<{
+          sessionId: string;
+          output: never[];
+          artifactIds: string[];
+          summary: string;
+        }>((_, reject) => {
+          if (ctx.abortSignal.aborted) {
+            sawAbort = true;
+            reject(new Error("aborted before listener"));
+            return;
+          }
+          ctx.abortSignal.addEventListener(
+            "abort",
+            () => {
+              sawAbort = true;
+              reject(new Error("aborted by correlation cancellation"));
+            },
+            { once: true },
+          );
+        });
+      },
+      () => Promise.resolve("concurrent" as ConcurrencyPolicy),
+      { expiresMs: 1000 },
+    );
+    await consumer.start();
+
+    const correlationId = crypto.randomUUID();
+    const responsePromise = awaitSignalCompletion(nc, correlationId, 5000);
+    await nc.flush();
+    await publishCascade(nc, envelope("ws", "cancel-running", { correlationId }));
+    await started;
+    await publishSignalCancellation(nc, correlationId, "client stopped");
+
+    const reply = await responsePromise;
+    await consumer.destroy();
+
+    expect(sawAbort).toBe(true);
+    expect(reply.ok).toBe(false);
   });
 });
 

--- a/apps/atlasd/src/cascade-stream.ts
+++ b/apps/atlasd/src/cascade-stream.ts
@@ -52,6 +52,7 @@ import {
   type NatsConnection,
   RetentionPolicy,
   StorageType,
+  type Subscription,
 } from "nats";
 import {
   type CascadeQueueDrainedEvent,
@@ -61,6 +62,7 @@ import {
   publishInstanceEvent,
 } from "./instance-events.ts";
 import {
+  SignalCancellationSchema,
   type SignalEnvelope,
   SignalEnvelopeSchema,
   type SignalResponse,
@@ -80,6 +82,7 @@ const DEFAULT_MAX_AGE_NS = 60 * 60 * 1_000_000_000; // 1h
 const DEFAULT_DUPLICATE_WINDOW_NS = 5 * 60 * 1_000_000_000; // 5min
 const DEFAULT_QUEUE_TIMEOUT_MS = 5 * 60 * 1000; // 5min
 const DEFAULT_MAX_ACK_PENDING = 32;
+const CANCELLED_CORRELATION_MAX_AGE_MS = 60 * 60 * 1000; // matches CASCADES max_age
 
 const enc = new TextEncoder();
 const dec = new TextDecoder();
@@ -252,6 +255,10 @@ export class CascadeConsumer {
    */
   private readonly policyLocks = new Map<string, Promise<void>>();
   private saturated = false;
+  private cancelSub: Subscription | null = null;
+  private cancelLoop: Promise<void> | null = null;
+  private readonly cancelledCorrelations = new Map<string, { reason?: string; at: number }>();
+  private readonly correlatedInFlight = new Map<string, InFlightCascade>();
 
   /**
    * Cascade-execution semaphore. Distinct from JetStream's
@@ -290,6 +297,66 @@ export class CascadeConsumer {
     this.cascadeInFlight--;
     const next = this.cascadeWaiters.shift();
     if (next) next();
+  }
+
+  private pruneStaleCancellations(): void {
+    const cutoff = Date.now() - CANCELLED_CORRELATION_MAX_AGE_MS;
+    for (const [correlationId, cancellation] of this.cancelledCorrelations) {
+      if (cancellation.at < cutoff) this.cancelledCorrelations.delete(correlationId);
+    }
+  }
+
+  private recordCorrelationCancellation(correlationId: string, reason?: string): void {
+    this.pruneStaleCancellations();
+    this.cancelledCorrelations.set(correlationId, { reason, at: Date.now() });
+    const cascade = this.correlatedInFlight.get(correlationId);
+    if (cascade && !cascade.controller.signal.aborted) {
+      cascade.controller.abort(reason ?? "correlation cancelled");
+    }
+  }
+
+  private cancellationForCorrelation(
+    correlationId: string | undefined,
+  ): { reason?: string; at: number } | undefined {
+    if (!correlationId) return undefined;
+    this.pruneStaleCancellations();
+    return this.cancelledCorrelations.get(correlationId);
+  }
+
+  private startCancelSubscription(): void {
+    if (this.cancelSub) return;
+    const sub = this.nc.subscribe("signals.cancel.>");
+    this.cancelSub = sub;
+    this.cancelLoop = (async () => {
+      for await (const msg of sub) {
+        const correlationId = msg.subject.slice("signals.cancel.".length);
+        let reason: string | undefined;
+        try {
+          const parsed = SignalCancellationSchema.safeParse(JSON.parse(dec.decode(msg.data)));
+          if (parsed.success) reason = parsed.data.reason;
+        } catch {
+          // Malformed cancellation payloads still cancel by subject correlation id.
+        }
+        this.recordCorrelationCancellation(correlationId, reason);
+      }
+    })();
+    this.cancelLoop.catch((error) => {
+      logger.debug("Cascade cancellation subscription ended", { error: stringifyError(error) });
+    });
+  }
+
+  private stopCancelSubscription(): Promise<void> {
+    const sub = this.cancelSub;
+    const loop = this.cancelLoop;
+    this.cancelSub = null;
+    this.cancelLoop = null;
+    if (!sub) return Promise.resolve();
+    try {
+      sub.unsubscribe();
+    } catch {
+      // Already gone.
+    }
+    return loop?.catch(() => undefined) ?? Promise.resolve();
   }
 
   /**
@@ -366,6 +433,9 @@ export class CascadeConsumer {
       });
       logger.info("Created CASCADES consumer", { name: this.name });
     }
+    this.startCancelSubscription();
+    await this.nc.flush();
+
     this.running = true;
     this.loop = this.runLoop();
 
@@ -390,6 +460,7 @@ export class CascadeConsumer {
 
   async stop(): Promise<void> {
     this.running = false;
+    await this.stopCancelSubscription();
     if (this.loop) {
       try {
         await this.loop;
@@ -405,6 +476,7 @@ export class CascadeConsumer {
         cascade.controller.abort("daemon shutdown");
       }
     }
+    this.correlatedInFlight.clear();
   }
 
   /** Test-only — drop the durable consumer entry from the broker. */
@@ -586,6 +658,13 @@ export class CascadeConsumer {
       this.inFlight.set(key, set);
     }
     set.add(cascade);
+    if (envelope.correlationId) {
+      this.correlatedInFlight.set(envelope.correlationId, cascade);
+      const cancellation = this.cancellationForCorrelation(envelope.correlationId);
+      if (cancellation) {
+        cascade.controller.abort(cancellation.reason ?? "correlation cancelled");
+      }
+    }
     this.maybeEmitSaturated();
 
     const onStreamEvent = envelope.correlationId
@@ -615,6 +694,10 @@ export class CascadeConsumer {
       try {
         await this.acquireSlot();
         slotHeld = true;
+        if (controller.signal.aborted) {
+          const reason = stringifyError(controller.signal.reason ?? "correlation cancelled");
+          throw new Error(`cascade cancelled before dispatch: ${reason}`);
+        }
         const result = await this.dispatch(envelope, {
           onStreamEvent,
           abortSignal: controller.signal,
@@ -660,6 +743,13 @@ export class CascadeConsumer {
         if (liveSet) {
           liveSet.delete(cascade);
           if (liveSet.size === 0) this.inFlight.delete(key);
+        }
+        if (
+          envelope.correlationId &&
+          this.correlatedInFlight.get(envelope.correlationId) === cascade
+        ) {
+          this.correlatedInFlight.delete(envelope.correlationId);
+          this.cancelledCorrelations.delete(envelope.correlationId);
         }
         this.maybeEmitDrained();
       }

--- a/apps/atlasd/src/signal-stream.test.ts
+++ b/apps/atlasd/src/signal-stream.test.ts
@@ -1,12 +1,13 @@
 import { startNatsTestServer, type TestNatsServer } from "@atlas/core/test-utils/nats-test-server";
 import { connect, type NatsConnection } from "nats";
-import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import {
   awaitSignalCompletion,
   ensureSignalsStream,
   publishSignal,
   SignalConsumer,
   type SignalEnvelope,
+  signalResponseSubject,
   signalSubject,
 } from "./signal-stream.ts";
 
@@ -118,6 +119,26 @@ describe("publishSignal + SignalConsumer", () => {
   it("awaitSignalCompletion times out when nobody publishes a response", async () => {
     const correlationId = crypto.randomUUID();
     await expect(awaitSignalCompletion(nc, correlationId, 200)).rejects.toThrow(/timeout/);
+  });
+
+  it("awaitSignalCompletion unsubscribes promptly when aborted", async () => {
+    const correlationId = crypto.randomUUID();
+    const unsubscribe = vi.fn();
+    const pendingNext = new Promise<IteratorResult<unknown>>(() => {});
+    const subscription = {
+      unsubscribe,
+      [Symbol.asyncIterator]: () => ({ next: () => pendingNext }),
+    };
+    const subscribe = vi.fn(() => subscription);
+    const fakeNc = { subscribe } as unknown as NatsConnection;
+    const controller = new AbortController();
+
+    const responsePromise = awaitSignalCompletion(fakeNc, correlationId, 60_000, controller.signal);
+    controller.abort();
+
+    await expect(responsePromise).rejects.toThrow(/aborted/);
+    expect(subscribe).toHaveBeenCalledWith(signalResponseSubject(correlationId), { max: 1 });
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 
   it("forwards a burst of published signals in arrival order", async () => {

--- a/apps/atlasd/src/signal-stream.ts
+++ b/apps/atlasd/src/signal-stream.ts
@@ -365,29 +365,54 @@ export async function awaitSignalCompletion(
   nc: NatsConnection,
   correlationId: string,
   timeoutMs = 30_000,
+  signal?: AbortSignal,
 ): Promise<SignalResponse> {
   const subject = signalResponseSubject(correlationId);
   const sub = nc.subscribe(subject, { max: 1 });
 
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let abortHandler: (() => void) | undefined;
+  let subscriptionClosed = false;
+  const closeSubscription = () => {
+    if (subscriptionClosed) return;
+    subscriptionClosed = true;
+    sub.unsubscribe();
+  };
+
   const timeout = new Promise<never>((_, reject) => {
     timer = setTimeout(() => {
-      sub.unsubscribe();
+      closeSubscription();
       reject(new Error(`awaitSignalCompletion: timeout after ${timeoutMs}ms`));
     }, timeoutMs);
   });
 
+  const abort = signal
+    ? new Promise<never>((_, reject) => {
+        abortHandler = () => {
+          closeSubscription();
+          reject(new Error("awaitSignalCompletion: aborted"));
+        };
+        if (signal.aborted) {
+          abortHandler();
+          return;
+        }
+        signal.addEventListener("abort", abortHandler, { once: true });
+      })
+    : undefined;
+
   try {
     const iter = sub[Symbol.asyncIterator]();
-    const winner = await Promise.race([iter.next(), timeout]);
+    const pending = abort ? [iter.next(), timeout, abort] : [iter.next(), timeout];
+    const winner = await Promise.race(pending);
     if (winner.done || !winner.value) {
       throw new Error("awaitSignalCompletion: subscription closed without a response");
     }
     return SignalResponseSchema.parse(JSON.parse(dec.decode(winner.value.data)));
   } finally {
     if (timer) clearTimeout(timer);
+    if (abortHandler) signal?.removeEventListener("abort", abortHandler);
     try {
-      sub.unsubscribe();
+      closeSubscription();
     } catch {
       // Already gone
     }

--- a/apps/atlasd/src/signal-stream.ts
+++ b/apps/atlasd/src/signal-stream.ts
@@ -93,6 +93,28 @@ export function signalStreamSubject(correlationId: string): string {
   return `signals.stream.${correlationId}`;
 }
 
+export function signalCancelSubject(correlationId: string): string {
+  return `signals.cancel.${correlationId}`;
+}
+
+export const SignalCancellationSchema = z.object({
+  reason: z.string().optional(),
+  requestedAt: z.string().datetime(),
+});
+export type SignalCancellation = z.infer<typeof SignalCancellationSchema>;
+
+export async function publishSignalCancellation(
+  nc: NatsConnection,
+  correlationId: string,
+  reason = "Client disconnected",
+): Promise<void> {
+  const cancellation: SignalCancellation = { reason, requestedAt: new Date().toISOString() };
+  nc.publish(signalCancelSubject(correlationId), enc.encode(JSON.stringify(cancellation)));
+  // Core NATS publish is buffered; flush so abort/cancel callers know the
+  // cancellation frame reached the server before they tear down local state.
+  await nc.flush();
+}
+
 export async function ensureSignalsStream(
   nc: NatsConnection,
   limits: SignalsStreamLimits = {},
@@ -358,8 +380,9 @@ export class SignalConsumer {
 /**
  * Subscribe to a correlationId's response subject and resolve with the
  * first reply (or reject on timeout). Caller must subscribe BEFORE
- * publishing the request envelope, otherwise a fast response could be
- * missed.
+ * publishing the request envelope. If publish follows immediately, call
+ * `nc.flush()` after constructing this promise so the broker has registered
+ * interest before a fast worker can reply.
  */
 export async function awaitSignalCompletion(
   nc: NatsConnection,

--- a/deno.json
+++ b/deno.json
@@ -15,6 +15,8 @@
   },
   "exclude": [
     "!integration-tests/**/*.test.ts",
+    ".claude/worktrees",
+    ".claude/projects",
     "tools/agent-playground/.svelte-kit",
     "tools/agent-playground/src/routes/**",
     "tools/agent-playground/src/**/*.svelte.ts",

--- a/packages/core/mod.ts
+++ b/packages/core/mod.ts
@@ -43,6 +43,7 @@ export type {
   ElicitationPendingTool,
   ElicitationStatus,
   ElicitationStorageAdapter,
+  ElicitationSummary,
   ExpireSweepResult,
   ToolAccessGrant,
 } from "./src/elicitations/mod.ts";
@@ -55,6 +56,7 @@ export {
   ElicitationSchema,
   ElicitationStatusSchema,
   ElicitationStorage,
+  ElicitationSummarySchema,
   initElicitationStorage,
   ToolAccessGrantSchema,
   ToolAccessGrants,

--- a/packages/core/src/elicitations/mod.ts
+++ b/packages/core/src/elicitations/mod.ts
@@ -16,6 +16,7 @@ export type {
   ElicitationOption,
   ElicitationPendingTool,
   ElicitationStatus,
+  ElicitationSummary,
 } from "./model.ts";
 export {
   CreateElicitationSchema,
@@ -25,6 +26,7 @@ export {
   ElicitationPendingToolSchema,
   ElicitationSchema,
   ElicitationStatusSchema,
+  ElicitationSummarySchema,
 } from "./model.ts";
 // Storage facade + initializer
 export {

--- a/packages/core/src/elicitations/model.ts
+++ b/packages/core/src/elicitations/model.ts
@@ -84,6 +84,24 @@ export const ElicitationSchema = z.object({
 export type Elicitation = z.infer<typeof ElicitationSchema>;
 
 /**
+ * Safe live-update shape for global UI surfaces. Deliberately excludes
+ * question text, selectable options, pending tool arguments, and answers so a
+ * global stream can drive counts/cache invalidation without leaking HITL
+ * content across workspaces.
+ */
+export const ElicitationSummarySchema = ElicitationSchema.pick({
+  id: true,
+  workspaceId: true,
+  sessionId: true,
+  actionId: true,
+  kind: true,
+  createdAt: true,
+  expiresAt: true,
+  status: true,
+});
+export type ElicitationSummary = z.infer<typeof ElicitationSummarySchema>;
+
+/**
  * Input shape for `ElicitationStorage.create`. The adapter fills in
  * `id`, `status`, and `createdAt`; everything else the caller provides.
  */

--- a/packages/core/src/orchestrator/agent-orchestrator.test.ts
+++ b/packages/core/src/orchestrator/agent-orchestrator.test.ts
@@ -10,9 +10,11 @@ import { AgentOrchestrator } from "./agent-orchestrator.ts";
 let capturedTransportOnerror: ((error: Error) => void) | undefined;
 // Capture the onclose handler that Protocol.connect() wraps
 let capturedTransportOnclose: (() => void) | undefined;
+let capturedTransportOptions: { requestInit?: { headers?: Record<string, string> } } | undefined;
 
 const mockTransport = {
   close: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
+  terminateSession: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
   get sessionId() {
     return "mock-session-id";
   },
@@ -37,7 +39,8 @@ const mockTransport = {
 
 vi.mock("@modelcontextprotocol/sdk/client/streamableHttp.js", () => ({
   StreamableHTTPClientTransport: class {
-    constructor() {
+    constructor(_url: URL, options?: { requestInit?: { headers?: Record<string, string> } }) {
+      capturedTransportOptions = options;
       // biome-ignore lint/correctness/noConstructorReturn: mock must return exact object for vi.fn tracking
       return mockTransport;
     }
@@ -138,6 +141,7 @@ describe("AgentOrchestrator - MCP transport fatal error handling", () => {
     vi.clearAllMocks();
     capturedTransportOnerror = undefined;
     capturedTransportOnclose = undefined;
+    capturedTransportOptions = undefined;
     callToolResolve = undefined;
     callToolReject = undefined;
 
@@ -187,7 +191,9 @@ describe("AgentOrchestrator - MCP transport fatal error handling", () => {
     capturedTransportOnerror(new Error("Maximum reconnection attempts (2) exceeded."));
 
     // The onerror handler should have called transport.close()
-    expect(mockTransport.close).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(mockTransport.close).toHaveBeenCalled();
+    });
 
     // transport.close() triggers onclose, which rejects callTool via Protocol._onclose
     // Simulate the close callback chain
@@ -289,7 +295,9 @@ describe("AgentOrchestrator - MCP transport fatal error handling", () => {
     assertOnerrorCaptured(capturedTransportOnerror);
     capturedTransportOnerror(new Error("Failed to reconnect SSE stream: ECONNREFUSED"));
 
-    expect(mockTransport.close).toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(mockTransport.close).toHaveBeenCalled();
+    });
 
     capturedTransportOnclose?.();
 
@@ -297,7 +305,23 @@ describe("AgentOrchestrator - MCP transport fatal error handling", () => {
     expect(result.ok).toBe(false);
   });
 
-  it("releaseSession closes the MCP transport and removes server-assigned session aliases", async () => {
+  it("creates MCP transports with connection-close requests", async () => {
+    const executionPromise = orchestrator.executeAgent("test-agent", "hello", {
+      sessionId: "session-1",
+      workspaceId: "workspace-1",
+    });
+
+    await vi.waitFor(() => {
+      expect(mockClient.callTool).toHaveBeenCalled();
+    });
+
+    expect(capturedTransportOptions?.requestInit?.headers?.Connection).toBe("close");
+
+    resolveSuccessfulCall();
+    await executionPromise;
+  });
+
+  it("releaseSession terminates the server MCP session, closes the transport, and removes server-assigned session aliases", async () => {
     const executionPromise = orchestrator.executeAgent("test-agent", "hello", {
       sessionId: "session-1",
       workspaceId: "workspace-1",
@@ -318,9 +342,11 @@ describe("AgentOrchestrator - MCP transport fatal error handling", () => {
     expect(orchestrator["mcpSessions"].has("mock-session-id")).toBe(true);
 
     mockTransport.close.mockClear();
+    mockTransport.terminateSession.mockClear();
 
     await orchestrator.releaseSession("session-1");
 
+    expect(mockTransport.terminateSession).toHaveBeenCalledTimes(1);
     expect(mockTransport.close).toHaveBeenCalledTimes(1);
     // biome-ignore lint/complexity/useLiteralKeys: accessing private property in test
     expect(orchestrator["mcpSessions"].has("session-1")).toBe(false);

--- a/packages/core/src/orchestrator/agent-orchestrator.test.ts
+++ b/packages/core/src/orchestrator/agent-orchestrator.test.ts
@@ -78,6 +78,7 @@ const mockClient = {
       callToolReject = reject;
     });
   }),
+  notification: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
   setNotificationHandler: vi.fn(),
   close: vi.fn<() => Promise<void>>().mockResolvedValue(undefined),
 };
@@ -103,6 +104,28 @@ function assertResolverCaptured(
   if (!resolver) throw new Error("Expected callToolResolve to be set");
 }
 
+function resolveSuccessfulCall(agentId = "test-agent", input = "hello") {
+  assertResolverCaptured(callToolResolve);
+  callToolResolve({
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          type: "completed",
+          result: {
+            agentId,
+            timestamp: new Date().toISOString(),
+            input,
+            ok: true,
+            durationMs: 100,
+            data: {},
+          },
+        }),
+      },
+    ],
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -126,6 +149,23 @@ describe("AgentOrchestrator - MCP transport fatal error handling", () => {
 
   afterEach(async () => {
     await orchestrator.shutdown();
+  });
+
+  it("does not open an MCP session when the workspace session is already cancelled", async () => {
+    const abortController = new AbortController();
+    abortController.abort();
+
+    const result = await orchestrator.executeAgent("test-agent", "hello", {
+      sessionId: "session-1",
+      workspaceId: "workspace-1",
+      abortSignal: abortController.signal,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(mockClient.connect).not.toHaveBeenCalled();
+    expect(mockClient.callTool).not.toHaveBeenCalled();
+    // biome-ignore lint/complexity/useLiteralKeys: accessing private property in test
+    expect(orchestrator["mcpSessions"].size).toBe(0);
   });
 
   it("closes transport and rejects pending callTool on max reconnection attempts exceeded", async () => {
@@ -182,8 +222,10 @@ describe("AgentOrchestrator - MCP transport fatal error handling", () => {
     capturedTransportOnclose?.();
 
     // Session should be cleaned up
-    // biome-ignore lint/complexity/useLiteralKeys: accessing private property in test
-    expect(orchestrator["mcpSessions"].has("session-1")).toBe(false);
+    await vi.waitFor(() => {
+      // biome-ignore lint/complexity/useLiteralKeys: accessing private property in test
+      expect(orchestrator["mcpSessions"].has("session-1")).toBe(false);
+    });
 
     await executionPromise;
   });
@@ -253,5 +295,66 @@ describe("AgentOrchestrator - MCP transport fatal error handling", () => {
 
     const result = await executionPromise;
     expect(result.ok).toBe(false);
+  });
+
+  it("releaseSession closes the MCP transport and removes server-assigned session aliases", async () => {
+    const executionPromise = orchestrator.executeAgent("test-agent", "hello", {
+      sessionId: "session-1",
+      workspaceId: "workspace-1",
+    });
+
+    await vi.waitFor(() => {
+      expect(mockClient.callTool).toHaveBeenCalled();
+    });
+
+    resolveSuccessfulCall();
+    await executionPromise;
+
+    // The transport mock exposes a different server-side session id, so the
+    // orchestrator stores the same setup under both keys.
+    // biome-ignore lint/complexity/useLiteralKeys: accessing private property in test
+    expect(orchestrator["mcpSessions"].has("session-1")).toBe(true);
+    // biome-ignore lint/complexity/useLiteralKeys: accessing private property in test
+    expect(orchestrator["mcpSessions"].has("mock-session-id")).toBe(true);
+
+    mockTransport.close.mockClear();
+
+    await orchestrator.releaseSession("session-1");
+
+    expect(mockTransport.close).toHaveBeenCalledTimes(1);
+    // biome-ignore lint/complexity/useLiteralKeys: accessing private property in test
+    expect(orchestrator["mcpSessions"].has("session-1")).toBe(false);
+    // biome-ignore lint/complexity/useLiteralKeys: accessing private property in test
+    expect(orchestrator["mcpSessions"].has("mock-session-id")).toBe(false);
+  });
+
+  it("releaseSession removes active stream handlers and request bookkeeping for all aliases", async () => {
+    const executionPromise = orchestrator.executeAgent("test-agent", "hello", {
+      sessionId: "session-1",
+      workspaceId: "workspace-1",
+      onStreamEvent: () => undefined,
+    });
+
+    await vi.waitFor(() => {
+      expect(mockClient.callTool).toHaveBeenCalled();
+    });
+
+    // biome-ignore lint/complexity/useLiteralKeys: accessing private property in test
+    expect(orchestrator["activeStreamHandlers"].has("session-1:test-agent")).toBe(true);
+    // biome-ignore lint/complexity/useLiteralKeys: accessing private property in test
+    expect(orchestrator["activeMCPRequests"].has("session-1:test-agent")).toBe(true);
+
+    mockTransport.close.mockClear();
+    await orchestrator.releaseSession("mock-session-id");
+
+    expect(mockTransport.close).toHaveBeenCalledTimes(1);
+    // biome-ignore lint/complexity/useLiteralKeys: accessing private property in test
+    expect(orchestrator["activeStreamHandlers"].has("session-1:test-agent")).toBe(false);
+    // biome-ignore lint/complexity/useLiteralKeys: accessing private property in test
+    expect(orchestrator["activeMCPRequests"].has("session-1:test-agent")).toBe(false);
+
+    // Let the in-flight executeAgent promise settle cleanly.
+    capturedTransportOnclose?.();
+    await executionPromise;
   });
 });

--- a/packages/core/src/orchestrator/agent-orchestrator.ts
+++ b/packages/core/src/orchestrator/agent-orchestrator.ts
@@ -458,7 +458,9 @@ export class AgentOrchestrator implements IAgentOrchestrator {
       const client = new Client({ name: "atlas-agent-orchestrator", version: "1.0.0" });
 
       const transport = new StreamableHTTPClientTransport(new URL(this.config.agentsServerUrl), {
-        requestInit: { headers: { ...this.config.headers, "mcp-session-id": sessionId } },
+        requestInit: {
+          headers: { ...this.config.headers, "mcp-session-id": sessionId, Connection: "close" },
+        },
       });
 
       // Workaround for MCP SDK bug (typescript-sdk#731): when the SSE stream
@@ -582,6 +584,18 @@ export class AgentOrchestrator implements IAgentOrchestrator {
   ): Promise<void> {
     const sessionIds = this.sessionIdsForSetup(sessionId, setup);
     this.removeSessionBookkeeping(sessionIds);
+
+    try {
+      await setup.transport.terminateSession();
+    } catch (error) {
+      this.logger.warn("Error terminating MCP server session", {
+        sessionId,
+        sessionIds,
+        reason,
+        error,
+      });
+    }
+
     try {
       await setup.transport.close();
       this.logger.info("Closed MCP transport for session", { sessionId, sessionIds, reason });

--- a/packages/core/src/orchestrator/agent-orchestrator.ts
+++ b/packages/core/src/orchestrator/agent-orchestrator.ts
@@ -2,7 +2,8 @@
  * Routes agent execution to MCP services (distributed).
  *
  * Session lifecycle: Each user session gets its own MCP client with SSE streaming.
- * Sessions auto-cleanup after 30min inactivity.
+ * Sessions release on terminal workspace-session completion, with idle cleanup
+ * as a fallback for abandoned sessions.
  */
 
 import {
@@ -23,6 +24,8 @@ import {
   type CancellationNotification,
   StreamContentNotificationSchema,
 } from "../streaming/stream-emitters.ts";
+
+const INACTIVE_SESSION_MAX_AGE_MS = 5 * 60 * 1000;
 
 // TODO(structured-output): Replace with proper agent result schema once agents produce structured output
 const MCPToolResultSchema = z.object({
@@ -113,6 +116,7 @@ export interface IAgentOrchestrator {
     prompt: string,
     context: AgentExecutionContext,
   ): Promise<AgentResult>;
+  releaseSession(sessionId: string): Promise<void>;
   shutdown(): Promise<void>;
 }
 
@@ -250,6 +254,17 @@ export class AgentOrchestrator implements IAgentOrchestrator {
     const startTime = Date.now();
     const logger = this.logger.child({ agentId, sessionId: context.sessionId });
 
+    let abortListener: (() => void) | undefined;
+    const buildCancelledResult = () =>
+      ({
+        agentId,
+        timestamp: new Date().toISOString(),
+        input: prompt,
+        ok: false,
+        error: { reason: "Session cancelled by user" },
+        durationMs: Date.now() - startTime,
+      }) satisfies AgentExecutionError<string>;
+
     const executionKey = `${context.sessionId}:${agentId}`;
     this.activeAgentExecutions.set(executionKey, {
       agentId,
@@ -285,7 +300,18 @@ export class AgentOrchestrator implements IAgentOrchestrator {
         };
       }
 
+      if (context.abortSignal?.aborted) {
+        logger.info("Skipping agent execution because session is already cancelled");
+        return buildCancelledResult();
+      }
+
       const mcpSetup = await this.getOrCreateSessionClient(context.sessionId, context.workspaceId);
+
+      if (context.abortSignal?.aborted) {
+        logger.info("Closing MCP client created during session cancellation");
+        await this.releaseSession(context.sessionId);
+        return buildCancelledResult();
+      }
 
       logger.debug("Executing agent via MCP", {
         agentId,
@@ -300,18 +326,27 @@ export class AgentOrchestrator implements IAgentOrchestrator {
         sessionId: context.sessionId,
       });
 
+      const sendCancellationNotification = async () => {
+        const notification: CancellationNotification = {
+          method: "notifications/cancelled",
+          params: { requestId, reason: "Session cancelled by user" },
+        };
+        try {
+          await mcpSetup.client.notification(notification);
+        } catch (error) {
+          logger.warn("Failed to send cancellation notification", { error, requestId });
+        }
+      };
+
       if (context.abortSignal) {
-        context.abortSignal.addEventListener("abort", async () => {
-          const notification: CancellationNotification = {
-            method: "notifications/cancelled",
-            params: { requestId, reason: "Session cancelled by user" },
-          };
-          try {
-            await mcpSetup.client.notification(notification);
-          } catch (error) {
-            logger.warn("Failed to send cancellation notification", { error, requestId });
-          }
-        });
+        abortListener = () => {
+          void sendCancellationNotification();
+        };
+        if (context.abortSignal.aborted) {
+          await sendCancellationNotification();
+        } else {
+          context.abortSignal.addEventListener("abort", abortListener, { once: true });
+        }
       }
 
       const toolCallArgs: AgentToolParams = {
@@ -387,6 +422,10 @@ export class AgentOrchestrator implements IAgentOrchestrator {
         durationMs: Date.now() - startTime,
       } satisfies AgentExecutionError<string>;
     } finally {
+      if (abortListener) {
+        context.abortSignal?.removeEventListener("abort", abortListener);
+      }
+
       // Must cleanup here to avoid race with late-arriving notifications after finish
       if (context.onStreamEvent) {
         const handlerKey = this.getStreamHandlerKey(context.sessionId, agentId);
@@ -441,13 +480,7 @@ export class AgentOrchestrator implements IAgentOrchestrator {
             sessionId,
             error: message,
           });
-          this.mcpSessions.delete(sessionId);
-          for (const key of this.activeStreamHandlers.keys()) {
-            if (key.startsWith(`${sessionId}:`)) {
-              this.activeStreamHandlers.delete(key);
-            }
-          }
-          transport.close().catch(() => {});
+          void this.releaseSession(sessionId);
         }
       };
 
@@ -504,29 +537,90 @@ export class AgentOrchestrator implements IAgentOrchestrator {
     return setup;
   }
 
-  /** Cleans up sessions inactive for >30 minutes. */
+  private sessionIdsForSetup(primarySessionId: string, setup: MCPSessionSetup): string[] {
+    const ids = new Set([primarySessionId]);
+    for (const [sessionId, candidate] of this.mcpSessions.entries()) {
+      if (candidate === setup) ids.add(sessionId);
+    }
+    return [...ids];
+  }
+
+  private removeSessionBookkeeping(sessionIds: string[]): void {
+    for (const sessionId of sessionIds) {
+      this.mcpSessions.delete(sessionId);
+    }
+
+    for (const key of this.activeStreamHandlers.keys()) {
+      if (sessionIds.some((sessionId) => key.startsWith(`${sessionId}:`))) {
+        this.activeStreamHandlers.delete(key);
+      }
+    }
+
+    for (const key of this.activeMCPRequests.keys()) {
+      if (sessionIds.some((sessionId) => key.startsWith(`${sessionId}:`))) {
+        this.activeMCPRequests.delete(key);
+      }
+    }
+  }
+
+  private hasActiveSessionWork(sessionIds: string[]): boolean {
+    for (const sessionId of sessionIds) {
+      for (const execution of this.activeAgentExecutions.values()) {
+        if (execution.sessionId === sessionId) return true;
+      }
+      for (const request of this.activeMCPRequests.values()) {
+        if (request.sessionId === sessionId) return true;
+      }
+    }
+    return false;
+  }
+
+  private async closeSessionSetup(
+    sessionId: string,
+    setup: MCPSessionSetup,
+    reason: "release" | "idle-cleanup" | "shutdown",
+  ): Promise<void> {
+    const sessionIds = this.sessionIdsForSetup(sessionId, setup);
+    this.removeSessionBookkeeping(sessionIds);
+    try {
+      await setup.transport.close();
+      this.logger.info("Closed MCP transport for session", { sessionId, sessionIds, reason });
+    } catch (error) {
+      this.logger.error("Error closing MCP transport for session", {
+        sessionId,
+        sessionIds,
+        reason,
+        error,
+      });
+    }
+  }
+
+  /** Release a session-scoped MCP client once its workspace session reaches a terminal state. */
+  async releaseSession(sessionId: string): Promise<void> {
+    const setup = this.mcpSessions.get(sessionId);
+    if (!setup) {
+      this.removeSessionBookkeeping([sessionId]);
+      return;
+    }
+    await this.closeSessionSetup(sessionId, setup, "release");
+  }
+
+  /** Cleans up abandoned sessions inactive for >5 minutes. */
   private async cleanupInactiveSessions(): Promise<void> {
     const now = Date.now();
-    const maxAge = 30 * 60 * 1000;
+    const closed = new Set<MCPSessionSetup>();
 
-    for (const [sessionId, setup] of this.mcpSessions.entries()) {
-      if (now - setup.lastActivity > maxAge) {
+    for (const [sessionId, setup] of Array.from(this.mcpSessions.entries())) {
+      if (closed.has(setup)) continue;
+      const sessionIds = this.sessionIdsForSetup(sessionId, setup);
+      if (this.hasActiveSessionWork(sessionIds)) {
+        setup.lastActivity = now;
+        continue;
+      }
+      if (now - setup.lastActivity > INACTIVE_SESSION_MAX_AGE_MS) {
         this.logger.info("Cleaning up inactive session", { sessionId });
-
-        try {
-          await setup.transport.close();
-        } catch (error) {
-          this.logger.error("Error closing transport for session", { sessionId, error });
-        }
-
-        this.mcpSessions.delete(sessionId);
-
-        // Clean up stream handlers for this session
-        for (const key of this.activeStreamHandlers.keys()) {
-          if (key.startsWith(`${sessionId}:`)) {
-            this.activeStreamHandlers.delete(key);
-          }
-        }
+        closed.add(setup);
+        await this.closeSessionSetup(sessionId, setup, "idle-cleanup");
       }
     }
   }
@@ -539,13 +633,11 @@ export class AgentOrchestrator implements IAgentOrchestrator {
       this.sessionCleanupInterval = undefined;
     }
 
-    for (const [sessionId, setup] of this.mcpSessions.entries()) {
-      try {
-        await setup.transport.close();
-        this.logger.info("Closed MCP transport for session", { sessionId });
-      } catch (error) {
-        this.logger.error("Error closing MCP transport for session", { sessionId, error });
-      }
+    const closed = new Set<MCPSessionSetup>();
+    for (const [sessionId, setup] of Array.from(this.mcpSessions.entries())) {
+      if (closed.has(setup)) continue;
+      closed.add(setup);
+      await this.closeSessionSetup(sessionId, setup, "shutdown");
     }
 
     this.mcpSessions.clear();

--- a/packages/utils/src/sse.test.ts
+++ b/packages/utils/src/sse.test.ts
@@ -168,6 +168,51 @@ describe("parseSSEStream", () => {
     }
     expect(messages).toEqual([{ data: "one" }, { data: "two" }, { data: "three" }]);
   });
+
+  it("cancels the underlying stream when iteration stops early", async () => {
+    const encoder = new TextEncoder();
+    let cancelled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("data: first\n\n"));
+        controller.enqueue(encoder.encode("data: second\n\n"));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+
+    const messages = [];
+    for await (const msg of parseSSEStream(stream)) {
+      messages.push(msg);
+      break;
+    }
+
+    expect(messages).toEqual([{ data: "first" }]);
+    expect(cancelled).toBe(true);
+  });
+
+  it("does not cancel the underlying stream after natural completion", async () => {
+    const encoder = new TextEncoder();
+    let cancelled = false;
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode("data: only\n\n"));
+        controller.close();
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+
+    const messages = [];
+    for await (const msg of parseSSEStream(stream)) {
+      messages.push(msg);
+    }
+
+    expect(messages).toEqual([{ data: "only" }]);
+    expect(cancelled).toBe(false);
+  });
 });
 
 describe("parseSSEEvents", () => {

--- a/packages/utils/src/sse.ts
+++ b/packages/utils/src/sse.ts
@@ -48,11 +48,15 @@ export async function* parseSSEStream(
   const reader = body.getReader();
   const decoder = new TextDecoder();
   let buffer = "";
+  let completed = false;
 
   try {
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        completed = true;
+        break;
+      }
 
       buffer += normalizeLineEndings(decoder.decode(value, { stream: true }));
 
@@ -70,6 +74,13 @@ export async function* parseSSEStream(
       }
     }
   } finally {
+    if (!completed) {
+      try {
+        await reader.cancel();
+      } catch {
+        // The stream may already have been cancelled by the caller.
+      }
+    }
     reader.releaseLock();
   }
 }

--- a/packages/workspace/src/__tests__/standing-orders-bootstrap.test.ts
+++ b/packages/workspace/src/__tests__/standing-orders-bootstrap.test.ts
@@ -38,6 +38,9 @@ vi.mock("@atlas/core", async (importActual) => {
     getActiveExecutions() {
       return [];
     }
+    releaseSession() {
+      return Promise.resolve();
+    }
     shutdown() {
       return Promise.resolve();
     }

--- a/packages/workspace/src/runtime-agent-prompt-composition.test.ts
+++ b/packages/workspace/src/runtime-agent-prompt-composition.test.ts
@@ -27,6 +27,7 @@ import { describe, expect, it, vi } from "vitest";
 // ---------------------------------------------------------------------------
 
 const capturedPrompts = vi.hoisted(() => [] as string[]);
+const releasedSessions = vi.hoisted(() => [] as string[]);
 
 vi.mock("@atlas/core", async (importActual) => {
   const actual = await importActual<typeof import("@atlas/core")>();
@@ -50,6 +51,10 @@ vi.mock("@atlas/core", async (importActual) => {
     }
     getActiveExecutions() {
       return [];
+    }
+    releaseSession(sessionId: string) {
+      releasedSessions.push(sessionId);
+      return Promise.resolve();
     }
     shutdown() {
       return Promise.resolve();
@@ -151,6 +156,7 @@ async function withTestRuntime(
 describe("runtime.executeAgent — agent prompt composition (call site)", () => {
   it("passes BOTH the agent-config prompt and the (interpolated) action prompt to executeAgent", async () => {
     capturedPrompts.length = 0;
+    releasedSessions.length = 0;
 
     await withTestRuntime(async (runtime) => {
       await runtime.processSignal({
@@ -177,5 +183,22 @@ describe("runtime.executeAgent — agent prompt composition (call site)", () => 
     expect(prompt.indexOf(CONFIG_PROMPT)).toBeLessThan(
       prompt.indexOf("Generate a sprite of a robot chef."),
     );
+  });
+
+  it("releases the orchestrator session when the workspace session completes", async () => {
+    releasedSessions.length = 0;
+
+    let sessionId: string | undefined;
+    await withTestRuntime(async (runtime) => {
+      const session = await runtime.processSignal({
+        id: "test-signal",
+        type: "test-signal",
+        data: { subject: "robot chef" },
+        timestamp: new Date(),
+      });
+      sessionId = session.id;
+    });
+
+    expect(releasedSessions).toEqual([sessionId]);
   });
 });

--- a/packages/workspace/src/runtime-bootstrap-injection.test.ts
+++ b/packages/workspace/src/runtime-bootstrap-injection.test.ts
@@ -45,6 +45,9 @@ vi.mock("@atlas/core", async (importActual) => {
     getActiveExecutions() {
       return [];
     }
+    releaseSession() {
+      return Promise.resolve();
+    }
     shutdown() {
       return Promise.resolve();
     }

--- a/packages/workspace/src/runtime-session-summary.test.ts
+++ b/packages/workspace/src/runtime-session-summary.test.ts
@@ -61,6 +61,9 @@ vi.mock("@atlas/core", async (importActual) => {
     getActiveExecutions() {
       return [];
     }
+    releaseSession() {
+      return Promise.resolve();
+    }
     shutdown() {
       return Promise.resolve();
     }

--- a/packages/workspace/src/runtime.ts
+++ b/packages/workspace/src/runtime.ts
@@ -2470,6 +2470,7 @@ export class WorkspaceRuntime {
     this.sessions.set(sessionResult.id, activeSession);
 
     if (sessionResult.status !== WorkspaceSessionStatus.ACTIVE) {
+      await this.orchestrator.releaseSession(sessionResult.id);
       await this.persistSessionToHistory(sessionResult, job, signal);
     }
 

--- a/tools/agent-playground/src/lib/components/chat/human-input-tool-card.svelte
+++ b/tools/agent-playground/src/lib/components/chat/human-input-tool-card.svelte
@@ -95,12 +95,23 @@
   const inFlight = $derived(answerMutation.isPending || declineMutation.isPending);
   const canAnswer = $derived(Boolean(matched) && isPending && !inFlight && hasAnswerValue);
   const canDecline = $derived(Boolean(matched) && isPending && !inFlight);
+  const controlsDisabled = $derived(inFlight);
+  const formId = $derived(matched?.id ?? call.toolCallId);
 
-  const activityHref = $derived(
-    routeWorkspaceId
+  const activityHref = $derived.by(() => {
+    const base = routeWorkspaceId
       ? resolve("/platform/[workspaceId]/activity", { workspaceId: routeWorkspaceId })
-      : resolve("/activity", {}),
-  );
+      : resolve("/activity", {});
+    return matched?.id ? `${base}?elicitationId=${encodeURIComponent(matched.id)}` : base;
+  });
+
+  let lastRefetchedForCall = "";
+  $effect(() => {
+    if (!request || matched || listQuery.isFetching) return;
+    if (lastRefetchedForCall === call.toolCallId) return;
+    lastRefetchedForCall = call.toolCallId;
+    void listQuery.refetch();
+  });
 
   let actionsEl: HTMLDivElement | undefined = $state();
   let lastScrolledPendingId = "";
@@ -167,7 +178,7 @@
         <p>{matched.answer.note}</p>
       {/if}
     </div>
-  {:else if matched && isPending && request}
+  {:else if request && (!matched || isPending)}
     <div class="response-form">
       {#if groupedOptionPrompt}
         <div class="nested-choice-list" aria-label="Choose an action for each item">
@@ -185,10 +196,10 @@
                     <label class="choice-button" class:active={nestedChoices[String(item.index)] === action.value}>
                       <input
                         type="radio"
-                        name="human-input-{matched.id}-{item.index}"
+                        name="human-input-{formId}-{item.index}"
                         value={action.value}
                         checked={nestedChoices[String(item.index)] === action.value}
-                        disabled={inFlight}
+                        disabled={controlsDisabled}
                         onchange={(event) => {
                           if (!event.currentTarget.checked) return;
                           nestedChoices = {
@@ -205,7 +216,7 @@
                   class="choice-comment"
                   type="text"
                   value={choiceComments[String(item.index)] ?? ""}
-                  disabled={inFlight}
+                  disabled={controlsDisabled}
                   placeholder="Comment for this item…"
                   oninput={(event) => {
                     choiceComments = {
@@ -227,10 +238,10 @@
             <label class="option" class:active={selectedValue === opt.value}>
               <input
                 type="radio"
-                name="human-input-{matched.id}"
+                name="human-input-{formId}"
                 value={opt.value}
                 bind:group={selectedValue}
-                disabled={inFlight}
+                disabled={controlsDisabled}
               />
               <span>{opt.label}</span>
             </label>
@@ -248,7 +259,7 @@
               </div>
               <div class="nested-choice-controls">
                 <select
-                  disabled={inFlight}
+                  disabled={controlsDisabled}
                   value={nestedChoices[String(item.index)] ?? ""}
                   onchange={(event) => {
                     nestedChoices = {
@@ -266,7 +277,7 @@
                   class="choice-comment"
                   type="text"
                   value={choiceComments[String(item.index)] ?? ""}
-                  disabled={inFlight}
+                  disabled={controlsDisabled}
                   placeholder="Comment for this item…"
                   oninput={(event) => {
                     choiceComments = {
@@ -288,7 +299,7 @@
           <input
             type="text"
             bind:value={freeText}
-            disabled={inFlight}
+            disabled={controlsDisabled}
             placeholder="Type your response…"
           />
         </label>
@@ -296,12 +307,16 @@
 
       <label class="field">
         <span>Note <em>(optional)</em></span>
-        <textarea bind:value={note} disabled={inFlight} rows="2" placeholder="Add context…"></textarea>
+        <textarea bind:value={note} disabled={controlsDisabled} rows="2" placeholder="Add context…"></textarea>
       </label>
+
+      {#if !matched}
+        <p class="hint">Syncing with Activity…</p>
+      {/if}
 
       <div class="actions" bind:this={actionsEl}>
         <Button onclick={onAnswer} disabled={!canAnswer}>
-          {answerMutation.isPending ? "Answering…" : "Answer"}
+          {!matched ? "Syncing…" : answerMutation.isPending ? "Answering…" : "Answer"}
         </Button>
         <Button variant="destructive" onclick={onDecline} disabled={!canDecline}>
           {declineMutation.isPending ? "Declining…" : "Decline"}
@@ -319,10 +334,7 @@
   {:else if matched && effectiveStatus && effectiveStatus !== "pending"}
     <p class="hint">This request is {effectiveStatus}. The run will resume only for answered requests.</p>
   {:else}
-    <p class="hint">
-      The run is waiting for a matching Activity item. If it does not appear here, open Activity.
-    </p>
-    <Button href={activityHref} variant="none">Open Activity</Button>
+    <p class="hint">Preparing the inline question…</p>
   {/if}
 </div>
 

--- a/tools/agent-playground/src/lib/components/chat/user-chat.svelte
+++ b/tools/agent-playground/src/lib/components/chat/user-chat.svelte
@@ -4,7 +4,10 @@
   import type { AtlasUIMessage } from "@atlas/agent-sdk";
   import { createQuery, useQueryClient } from "@tanstack/svelte-query";
   import { page } from "$app/state";
+  import { browser } from "$app/environment";
+  import { ElicitationSchema, type Elicitation } from "@atlas/core/elicitations/model";
   import { workspaceQueries } from "$lib/queries";
+  import { mergeElicitationIntoCache } from "$lib/queries/elicitation-queries.ts";
   import { DefaultChatTransport } from "ai";
   import ChatInput, { type ImageAttachment } from "./chat-input.svelte";
   import ChatInspector from "./chat-inspector.svelte";
@@ -144,6 +147,36 @@
     onUnrecoverable: () => {
       unrecoverableStream = true;
     },
+  });
+
+  /**
+   * Keep the inline HITL cards in sync with Activity.  The card itself
+   * queries the replay list, but newly-created elicitations are delivered via
+   * NATS/SSE; without this subscription a fresh cached list can briefly render
+   * the "open Activity" fallback instead of the inline answer form.
+   */
+  $effect(() => {
+    if (!browser || !wsId) return;
+
+    const url = new URL("/api/daemon/api/elicitations/stream", globalThis.location.origin);
+    url.searchParams.set("workspaceId", wsId);
+
+    const es = new EventSource(url.toString());
+    es.addEventListener("message", (e) => {
+      let parsed: Elicitation;
+      try {
+        parsed = ElicitationSchema.parse(JSON.parse(e.data));
+      } catch (err) {
+        console.error("Failed to parse elicitation SSE event", err);
+        return;
+      }
+      mergeElicitationIntoCache(queryClient, parsed);
+    });
+    es.addEventListener("error", () => {
+      console.warn("Elicitations SSE feed errored (EventSource will retry)");
+    });
+
+    return () => es.close();
   });
 
   /**

--- a/tools/agent-playground/src/lib/components/chat/user-chat.svelte
+++ b/tools/agent-playground/src/lib/components/chat/user-chat.svelte
@@ -382,6 +382,17 @@
       : null,
   );
 
+  // Route changes and component teardown must abort any active AI SDK stream.
+  // Otherwise a chat left waiting on HITL can keep its fetch/SSE connection
+  // alive behind the dev-server proxy after the UI moved elsewhere.
+  $effect(() => {
+    const instance = chat;
+    if (!instance) return;
+    return () => {
+      void instance.stop().catch(() => {});
+    };
+  });
+
   // Pick up an in-flight turn the user navigated away from. 204 = no live
   // stream; if the last loaded message was an unanswered user turn, surface
   // the interrupted banner so they can resend.

--- a/tools/agent-playground/src/lib/components/shared/daemon-gate.svelte
+++ b/tools/agent-playground/src/lib/components/shared/daemon-gate.svelte
@@ -10,11 +10,11 @@
   }
 </script>
 
-{#if daemonHealth.loading}
+{#if daemonHealth.loading && !daemonHealth.hasConnected}
   <div class="gate-state">
     <p class="gate-message">Connecting to daemon...</p>
   </div>
-{:else if !daemonHealth.connected}
+{:else if !daemonHealth.connected && !daemonHealth.hasConnected}
   <div class="gate-state">
     <p class="gate-icon">!</p>
     <p class="gate-title">Reconnecting to Friday Studio…</p>
@@ -25,7 +25,15 @@
     <Button size="small" variant="secondary" onclick={retry}>Retry Now</Button>
   </div>
 {:else}
-  {@render children()}
+  <div class="gate-content">
+    {#if !daemonHealth.connected}
+      <div class="gate-banner" role="status">
+        <span>Reconnecting to Friday Studio…</span>
+        <Button size="small" variant="secondary" onclick={retry}>Retry Now</Button>
+      </div>
+    {/if}
+    {@render children()}
+  </div>
 {/if}
 
 <style>
@@ -37,6 +45,21 @@
     gap: var(--size-3);
     justify-content: center;
     padding: var(--size-10);
+  }
+
+  .gate-content {
+    display: contents;
+  }
+
+  .gate-banner {
+    align-items: center;
+    background: color-mix(in srgb, var(--color-warning), transparent 85%);
+    border-block-end: 1px solid color-mix(in srgb, var(--color-warning), transparent 60%);
+    color: var(--color-text);
+    display: flex;
+    gap: var(--size-3);
+    justify-content: center;
+    padding: var(--size-2) var(--size-4);
   }
 
   .gate-icon {
@@ -62,15 +85,4 @@
     font-size: var(--font-size-3);
   }
 
-  .gate-command {
-    color: color-mix(in srgb, var(--color-text), transparent 30%);
-    font-size: var(--font-size-2);
-
-    code {
-      background-color: var(--color-surface-2);
-      border-radius: var(--radius-1);
-      font-size: var(--font-size-2);
-      padding: var(--size-0-5) var(--size-1);
-    }
-  }
 </style>

--- a/tools/agent-playground/src/lib/components/shared/elicitation-global-stream.svelte
+++ b/tools/agent-playground/src/lib/components/shared/elicitation-global-stream.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+  import { browser } from "$app/environment";
+  import {
+    applyElicitationSummaryEvent,
+    ElicitationSummarySchema,
+  } from "$lib/queries/elicitation-queries.ts";
+  import type { QueryClient } from "@tanstack/svelte-query";
+
+  let { queryClient }: { queryClient: QueryClient } = $props();
+
+  $effect(() => {
+    if (!browser) return;
+
+    const es = new EventSource("/api/daemon/api/elicitations/stream/global");
+    es.addEventListener("message", (event) => {
+      let raw: unknown;
+      try {
+        raw = JSON.parse(event.data);
+      } catch (error) {
+        console.error("Failed to parse global elicitation SSE event", error);
+        return;
+      }
+      const parsed = ElicitationSummarySchema.safeParse(raw);
+      if (!parsed.success) {
+        console.error("Failed to parse global elicitation SSE event", parsed.error);
+        return;
+      }
+      applyElicitationSummaryEvent(queryClient, parsed.data);
+    });
+    es.addEventListener("error", () => {
+      console.warn("Global elicitations SSE feed errored (EventSource will retry)");
+    });
+
+    return () => es.close();
+  });
+</script>

--- a/tools/agent-playground/src/lib/daemon-health.svelte.ts
+++ b/tools/agent-playground/src/lib/daemon-health.svelte.ts
@@ -9,25 +9,53 @@
  * @module
  */
 
-type DaemonHealthState = { connected: boolean; loading: boolean };
+type DaemonHealthState = { connected: boolean; hasConnected: boolean; loading: boolean };
 
 // Svelte 5 $state() runes require `let` for reactivity
 // deno-lint-ignore prefer-const
-let state: DaemonHealthState = $state({ connected: false, loading: true });
+let state: DaemonHealthState = $state({ connected: false, hasConnected: false, loading: true });
 let polling = false;
 let interval: ReturnType<typeof setInterval> | null = null;
 let inFlight: AbortController | null = null;
+let consecutiveFailures = 0;
+let lastSuccessAt = 0;
+
+const HEALTH_TIMEOUT_MS = 4_500;
+const CONNECTED_FAILURE_THRESHOLD = 2;
+const CONNECTED_FAILURE_GRACE_MS = 12_000;
+
+function recordHealthSuccess() {
+  consecutiveFailures = 0;
+  lastSuccessAt = Date.now();
+  state.connected = true;
+  state.hasConnected = true;
+}
+
+function recordHealthFailure() {
+  consecutiveFailures++;
+
+  // When chat/tool actions open long-lived streams, browser/dev-server
+  // connection pools can delay one health probe even though the daemon is
+  // still serving requests. Avoid flashing the full-page daemon gate for a
+  // single transient probe miss; only mark an already-connected daemon down
+  // after repeated failures across a short grace window.
+  if (state.connected && consecutiveFailures < CONNECTED_FAILURE_THRESHOLD) return;
+  if (state.connected && Date.now() - lastSuccessAt < CONNECTED_FAILURE_GRACE_MS) return;
+
+  state.connected = false;
+}
 
 async function check() {
   if (inFlight) return;
   const controller = new AbortController();
   inFlight = controller;
-  const timeout = setTimeout(() => controller.abort(), 4_500);
+  const timeout = setTimeout(() => controller.abort(), HEALTH_TIMEOUT_MS);
   try {
     const res = await fetch("/api/daemon/health", { signal: controller.signal });
-    state.connected = res.ok;
+    if (res.ok) recordHealthSuccess();
+    else recordHealthFailure();
   } catch {
-    state.connected = false;
+    recordHealthFailure();
   } finally {
     clearTimeout(timeout);
     if (inFlight === controller) inFlight = null;

--- a/tools/agent-playground/src/lib/daemon-health.svelte.ts
+++ b/tools/agent-playground/src/lib/daemon-health.svelte.ts
@@ -15,26 +15,46 @@ type DaemonHealthState = { connected: boolean; loading: boolean };
 // deno-lint-ignore prefer-const
 let state: DaemonHealthState = $state({ connected: false, loading: true });
 let polling = false;
+let interval: ReturnType<typeof setInterval> | null = null;
+let inFlight: AbortController | null = null;
 
 async function check() {
+  if (inFlight) return;
+  const controller = new AbortController();
+  inFlight = controller;
+  const timeout = setTimeout(() => controller.abort(), 4_500);
   try {
-    const res = await fetch("/api/daemon/health");
+    const res = await fetch("/api/daemon/health", { signal: controller.signal });
     state.connected = res.ok;
   } catch {
     state.connected = false;
   } finally {
+    clearTimeout(timeout);
+    if (inFlight === controller) inFlight = null;
     state.loading = false;
   }
 }
 
 /**
  * Begin polling daemon health. Safe to call multiple times — only starts once.
+ * Returns a cleanup callback for HMR/component teardown.
  */
-export function startHealthPolling() {
-  if (polling) return;
+export function startHealthPolling(): () => void {
+  if (polling) return stopHealthPolling;
   polling = true;
-  check();
-  setInterval(check, 5_000);
+  void check();
+  interval = setInterval(() => void check(), 5_000);
+  return stopHealthPolling;
+}
+
+export function stopHealthPolling(): void {
+  if (interval !== null) {
+    clearInterval(interval);
+    interval = null;
+  }
+  polling = false;
+  inFlight?.abort();
+  inFlight = null;
 }
 
 /** Trigger an immediate health check (used by retry buttons). */

--- a/tools/agent-playground/src/lib/queries/elicitation-queries.test.ts
+++ b/tools/agent-playground/src/lib/queries/elicitation-queries.test.ts
@@ -1,0 +1,70 @@
+import type { Elicitation, ElicitationSummary } from "@atlas/core/elicitations/model";
+import { QueryClient } from "@tanstack/query-core";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@tanstack/svelte-query", async () => {
+  const core = await import("@tanstack/query-core");
+  return {
+    ...core,
+    createMutation: vi.fn(),
+    queryOptions: <T>(options: T) => options,
+    useQueryClient: vi.fn(),
+  };
+});
+
+const { applyElicitationSummaryEvent, elicitationListKey } = await import(
+  "./elicitation-queries.ts"
+);
+
+function makeElicitation(overrides: Partial<Elicitation> = {}): Elicitation {
+  return {
+    id: overrides.id ?? "elc_1",
+    workspaceId: overrides.workspaceId ?? "ws_1",
+    sessionId: overrides.sessionId ?? "sess_1",
+    kind: overrides.kind ?? "open-question",
+    question: overrides.question ?? "Continue?",
+    createdAt: overrides.createdAt ?? "2026-05-05T00:00:00.000Z",
+    expiresAt: overrides.expiresAt ?? "2026-05-05T01:00:00.000Z",
+    status: overrides.status ?? "pending",
+    ...(overrides.actionId ? { actionId: overrides.actionId } : {}),
+    ...(overrides.options ? { options: overrides.options } : {}),
+    ...(overrides.pendingTool ? { pendingTool: overrides.pendingTool } : {}),
+    ...(overrides.answer ? { answer: overrides.answer } : {}),
+  };
+}
+
+describe("elicitation query cache helpers", () => {
+  it("summary events patch safe fields and preserve sensitive full details", () => {
+    const queryClient = new QueryClient();
+    const full = makeElicitation({
+      question: "Sensitive question?",
+      pendingTool: { name: "send_email", args: { body: "private" } },
+    });
+    queryClient.setQueryData<Elicitation[]>(elicitationListKey(null), [full]);
+    queryClient.setQueryData<Elicitation[]>(elicitationListKey("ws_1"), [full]);
+
+    const summary: ElicitationSummary = {
+      id: "elc_1",
+      workspaceId: "ws_1",
+      sessionId: "sess_1",
+      kind: "open-question",
+      createdAt: "2026-05-05T00:00:00.000Z",
+      expiresAt: "2026-05-05T01:00:00.000Z",
+      status: "answered",
+    };
+
+    applyElicitationSummaryEvent(queryClient, summary);
+
+    const global = queryClient.getQueryData<Elicitation[]>(elicitationListKey(null));
+    const scoped = queryClient.getQueryData<Elicitation[]>(elicitationListKey("ws_1"));
+    expect(global?.[0]).toMatchObject({
+      id: "elc_1",
+      status: "answered",
+      question: "Sensitive question?",
+      pendingTool: { name: "send_email", args: { body: "private" } },
+    });
+    expect(scoped?.[0]?.status).toBe("answered");
+    expect(queryClient.getQueryState(elicitationListKey(null))?.isInvalidated).toBe(true);
+    expect(queryClient.getQueryState(elicitationListKey("ws_1"))?.isInvalidated).toBe(true);
+  });
+});

--- a/tools/agent-playground/src/lib/queries/elicitation-queries.ts
+++ b/tools/agent-playground/src/lib/queries/elicitation-queries.ts
@@ -80,7 +80,11 @@ export const elicitationQueries = {
         return ListResponseSchema.parse(data).elicitations;
       },
       staleTime: 5_000,
-      refetchInterval: 5_000,
+      // Workspace-scoped views subscribe to the SSE feed; keep polling only
+      // for the global Activity view, which intentionally has no all-workspace
+      // SSE endpoint.
+      refetchInterval: workspaceId ? false : 5_000,
+      refetchIntervalInBackground: false,
     }),
 };
 

--- a/tools/agent-playground/src/lib/queries/elicitation-queries.ts
+++ b/tools/agent-playground/src/lib/queries/elicitation-queries.ts
@@ -16,7 +16,12 @@
 // which transitively pulls `@atlas/logger` → `node:path` into client bundles
 // and 500s the playground at `paths.ts`. The model module only depends on zod,
 // so it bundles cleanly for browser code.
-import { ElicitationSchema, type Elicitation } from "@atlas/core/elicitations/model";
+import {
+  ElicitationSchema,
+  ElicitationSummarySchema,
+  type Elicitation,
+  type ElicitationSummary,
+} from "@atlas/core/elicitations/model";
 import {
   createMutation,
   queryOptions,
@@ -28,6 +33,9 @@ import { z } from "zod";
 // ==============================================================================
 // SCHEMAS
 // ==============================================================================
+
+export { ElicitationSummarySchema };
+export type { ElicitationSummary };
 
 const ListResponseSchema = z.object({
   elicitations: z.array(ElicitationSchema),
@@ -80,10 +88,9 @@ export const elicitationQueries = {
         return ListResponseSchema.parse(data).elicitations;
       },
       staleTime: 5_000,
-      // Workspace-scoped views subscribe to the SSE feed; keep polling only
-      // for the global Activity view, which intentionally has no all-workspace
-      // SSE endpoint.
-      refetchInterval: workspaceId ? false : 5_000,
+      // Live updates come from workspace-scoped full SSE streams and the
+      // sanitized global summary stream mounted at the app root.
+      refetchInterval: false,
       refetchIntervalInBackground: false,
     }),
 };
@@ -170,6 +177,33 @@ export function mergeElicitationIntoCache(queryClient: QueryClient, next: Elicit
   };
   queryClient.setQueryData<Elicitation[]>(elicitationListKey(null), merge);
   queryClient.setQueryData<Elicitation[]>(elicitationListKey(next.workspaceId), merge);
+}
+
+/**
+ * Apply a sanitized global SSE event. Since summary events intentionally lack
+ * question/options/answers, they only patch fields that are already safe and
+ * then invalidate the affected list queries so mounted views refetch full
+ * details through the normal authorized list endpoint.
+ */
+export function applyElicitationSummaryEvent(
+  queryClient: QueryClient,
+  next: ElicitationSummary,
+): void {
+  const patch = (prev: Elicitation[] | undefined): Elicitation[] | undefined => {
+    if (!prev) return prev;
+    const idx = prev.findIndex((e) => e.id === next.id);
+    if (idx === -1) return prev;
+    const copy = prev.slice();
+    const current = copy[idx];
+    if (!current) return prev;
+    copy[idx] = { ...current, ...next };
+    return copy;
+  };
+
+  queryClient.setQueryData<Elicitation[]>(elicitationListKey(null), patch);
+  queryClient.setQueryData<Elicitation[]>(elicitationListKey(next.workspaceId), patch);
+  void queryClient.invalidateQueries({ queryKey: elicitationListKey(null) });
+  void queryClient.invalidateQueries({ queryKey: elicitationListKey(next.workspaceId) });
 }
 
 function mergeAndInvalidate(queryClient: QueryClient, next: Elicitation): void {

--- a/tools/agent-playground/src/lib/queries/session-queries.ts
+++ b/tools/agent-playground/src/lib/queries/session-queries.ts
@@ -50,11 +50,14 @@ export const sessionQueries = {
     queryOptions({
       queryKey: ["daemon", "sessions", "view", sessionId] as const,
       queryFn: sessionId
-        ? experimental_streamedQuery<SessionStreamEvent | EphemeralChunk, ReturnType<typeof initialSessionView>>({
-          streamFn: () => sessionEventStream(sessionId),
-          reducer: reduceSessionEvent,
-          initialValue: initialSessionView(),
-        })
+        ? experimental_streamedQuery<
+            SessionStreamEvent | EphemeralChunk,
+            ReturnType<typeof initialSessionView>
+          >({
+            streamFn: ({ signal }) => sessionEventStream(sessionId, { signal }),
+            reducer: reduceSessionEvent,
+            initialValue: initialSessionView(),
+          })
         : skipToken,
       staleTime: 60_000,
     }),

--- a/tools/agent-playground/src/routes/+layout.svelte
+++ b/tools/agent-playground/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { NotificationPortal } from "@atlas/ui";
   import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
+  import { onMount } from "svelte";
   import { browser } from "$app/environment";
   import "@atlas/ui/tokens.css";
   import "@atlas/ui/colors.css";
@@ -16,9 +17,10 @@
   const { children } = $props();
 
   if (browser) {
-    startHealthPolling();
     void loadUpdateStatus();
   }
+
+  onMount(() => startHealthPolling());
 
   const queryClient = new QueryClient({
     defaultOptions: { queries: { enabled: browser, refetchOnReconnect: true } },

--- a/tools/agent-playground/src/routes/+layout.svelte
+++ b/tools/agent-playground/src/routes/+layout.svelte
@@ -10,6 +10,7 @@
   import CascadeStatusBanner from "$lib/components/shared/cascade-status-banner.svelte";
   import Sidebar from "$lib/components/shared/sidebar.svelte";
   import CommandPalette from "$lib/components/shared/command-palette.svelte";
+  import ElicitationGlobalStream from "$lib/components/shared/elicitation-global-stream.svelte";
   import UpdateBanner from "$lib/components/shared/update-banner.svelte";
   import { startHealthPolling } from "$lib/daemon-health.svelte";
   import { loadUpdateStatus } from "$lib/update-status.svelte";
@@ -72,6 +73,7 @@
   <div class="app-root">
     <UpdateBanner />
     <CascadeStatusBanner />
+    <ElicitationGlobalStream {queryClient} />
     <div class="app-shell">
       <Sidebar />
       <main>

--- a/tools/agent-playground/src/routes/activity/(components)/activity-view.svelte
+++ b/tools/agent-playground/src/routes/activity/(components)/activity-view.svelte
@@ -24,6 +24,7 @@
   import { PageLayout } from "@atlas/ui";
   import { createQuery, useQueryClient } from "@tanstack/svelte-query";
   import { browser } from "$app/environment";
+  import { page } from "$app/state";
   import { countPendingElicitations, effectiveElicitationStatus } from "$lib/elicitation-counts.ts";
   import { workspaceQueries } from "$lib/queries";
   import {
@@ -141,6 +142,16 @@
   // Selection — id is component-local state
   // ---------------------------------------------------------------------------
   let selectedId = $state<string | null>(null);
+  const requestedElicitationId = $derived(page.url.searchParams.get("elicitationId"));
+  let appliedRequestedId = "";
+
+  $effect(() => {
+    const id = requestedElicitationId;
+    if (!id || id === appliedRequestedId) return;
+    if (!elicitations.some((e) => e.id === id)) return;
+    selectedId = id;
+    appliedRequestedId = id;
+  });
 
   // Auto-select first row if nothing's selected (or selection was filtered out).
   $effect(() => {
@@ -268,31 +279,10 @@
         {/if}
       {/if}
     </PageLayout.Content>
-    <PageLayout.Sidebar>
-      {#if workspaceId === null}
-        <p class="subtitle">Pause-and-ask events from every workspace.</p>
-      {:else}
-        <p class="subtitle">Pause-and-ask events for this workspace.</p>
-      {/if}
-      <p class="subtitle subtle">
-        Pending entries block FSM jobs until you answer or decline. Expired entries become
-        read-only.
-      </p>
-    </PageLayout.Sidebar>
   </PageLayout.Body>
 </PageLayout.Root>
 
 <style>
-  .subtitle {
-    color: color-mix(in srgb, var(--color-text), transparent 40%);
-    font-size: var(--font-size-2);
-  }
-
-  .subtle {
-    font-size: var(--font-size-1);
-    margin-top: var(--size-3);
-  }
-
   .filters {
     align-items: end;
     border-block-end: 1px solid var(--color-border-1);

--- a/tools/agent-playground/src/routes/activity/(components)/activity-view.svelte
+++ b/tools/agent-playground/src/routes/activity/(components)/activity-view.svelte
@@ -148,9 +148,17 @@
   $effect(() => {
     const id = requestedElicitationId;
     if (!id || id === appliedRequestedId) return;
-    if (!elicitations.some((e) => e.id === id)) return;
+    const target = elicitations.find((e) => e.id === id);
+    if (!target) return;
     selectedId = id;
     appliedRequestedId = id;
+
+    const targetStatus = effectiveStatus(target);
+    if (statusFilter !== "all" && statusFilter !== targetStatus) statusFilter = targetStatus;
+    if (kindFilter !== "all" && kindFilter !== target.kind) kindFilter = target.kind;
+    if (!workspaceId && workspaceFilter !== "all" && workspaceFilter !== target.workspaceId) {
+      workspaceFilter = target.workspaceId;
+    }
   });
 
   // Auto-select first row if nothing's selected (or selection was filtered out).

--- a/tools/agent-playground/src/routes/activity/(components)/activity-view.svelte
+++ b/tools/agent-playground/src/routes/activity/(components)/activity-view.svelte
@@ -4,10 +4,10 @@
 
   Two-column: filtered list on the left, detail panel on the right.
 
-  Live updates via workspace-scoped SSE on `/api/elicitations/stream?workspaceId=...`.
-  Replay-then-subscribe ordering, mirrors `/schedules/+page.svelte`:
-  the EventSource doesn't open until the initial list query has
-  succeeded so SSE pushes can't be clobbered by a late-arriving replay.
+  Workspace pages receive full-envelope live updates via
+  `/api/elicitations/stream?workspaceId=...`. The global page is refreshed by
+  the sanitized app-root stream at `/api/elicitations/stream/global`, avoiding
+  both full-envelope global leakage and per-workspace EventSource fanout.
 
   @component
 -->

--- a/tools/agent-playground/src/routes/api/daemon/[...path]/+server.ts
+++ b/tools/agent-playground/src/routes/api/daemon/[...path]/+server.ts
@@ -6,6 +6,56 @@ import { DAEMON_BASE_URL } from "$lib/daemon-url";
  * Strips the `/api/daemon` prefix and forwards the rest of the path.
  * SSE responses (`text/event-stream`) are passed through without buffering.
  */
+function proxyAbortableBody(
+  body: ReadableStream<Uint8Array>,
+  requestSignal: AbortSignal,
+  abortUpstream: () => void,
+): ReadableStream<Uint8Array> {
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let cancelled = false;
+
+  const cancelUpstream = () => {
+    if (cancelled) return;
+    cancelled = true;
+    abortUpstream();
+    void reader?.cancel().catch(() => {
+      // The upstream may already be gone.
+    });
+  };
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      reader = body.getReader();
+      requestSignal.addEventListener("abort", cancelUpstream, { once: true });
+      if (requestSignal.aborted) cancelUpstream();
+
+      void (async () => {
+        try {
+          while (!cancelled) {
+            const { done, value } = await reader!.read();
+            if (done) break;
+            controller.enqueue(value);
+          }
+          if (!cancelled) controller.close();
+        } catch (err) {
+          if (!cancelled) controller.error(err);
+        } finally {
+          requestSignal.removeEventListener("abort", cancelUpstream);
+          try {
+            reader?.releaseLock();
+          } catch {
+            // Reader may already be released after cancellation.
+          }
+          abortUpstream();
+        }
+      })();
+    },
+    cancel() {
+      cancelUpstream();
+    },
+  });
+}
+
 const handler: RequestHandler = async ({ params, request }) => {
   const path = params.path ?? "";
   const target = new URL(`/${path}`, DAEMON_BASE_URL);
@@ -14,6 +64,10 @@ const handler: RequestHandler = async ({ params, request }) => {
   const headers = new Headers(request.headers);
   headers.delete("host");
   headers.delete("content-length");
+
+  const upstreamController = new AbortController();
+  const abortUpstream = () => upstreamController.abort();
+  request.signal.addEventListener("abort", abortUpstream, { once: true });
 
   // Buffer the request body for methods that carry one. Streaming with
   // `duplex: "half"` races the response: when the daemon short-circuits
@@ -28,8 +82,14 @@ const handler: RequestHandler = async ({ params, request }) => {
 
   let res: Response;
   try {
-    res = await fetch(target, { method: request.method, headers, body, signal: request.signal });
+    res = await fetch(target, {
+      method: request.method,
+      headers,
+      body,
+      signal: upstreamController.signal,
+    });
   } catch (err) {
+    request.signal.removeEventListener("abort", abortUpstream);
     const message = err instanceof Error ? err.message : String(err);
     return new Response(
       JSON.stringify({ error: `daemon proxy fetch failed: ${message}` }),
@@ -37,10 +97,20 @@ const handler: RequestHandler = async ({ params, request }) => {
     );
   }
 
-  // SSE: pass through the readable stream without buffering
+  // SSE: proxy with explicit cancellation. Returning `res.body` directly
+  // leaves the upstream daemon fetch alive when the browser closes the
+  // EventSource/fetch, which leaks daemon subscriptions and dev-server fds.
   if (res.headers.get("content-type")?.includes("text/event-stream")) {
-    return new Response(res.body, { status: res.status, headers: res.headers });
+    if (!res.body) {
+      request.signal.removeEventListener("abort", abortUpstream);
+      return new Response(null, { status: res.status, headers: res.headers });
+    }
+    request.signal.removeEventListener("abort", abortUpstream);
+    const stream = proxyAbortableBody(res.body, request.signal, abortUpstream);
+    return new Response(stream, { status: res.status, headers: res.headers });
   }
+
+  request.signal.removeEventListener("abort", abortUpstream);
 
   // Strip content-encoding — fetch() already decompresses the body,
   // so forwarding the header causes the browser to double-decompress.

--- a/tools/agent-playground/src/routes/api/daemon/[...path]/server.test.ts
+++ b/tools/agent-playground/src/routes/api/daemon/[...path]/server.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GET } from "./+server.ts";
+
+function failAfter(ms: number, message: string): Promise<never> {
+  return new Promise((_, reject) => {
+    setTimeout(() => reject(new Error(message)), ms);
+  });
+}
+
+describe("daemon proxy route", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("aborts the upstream daemon fetch when a downstream SSE client disconnects", async () => {
+    let upstreamSignal: AbortSignal | undefined;
+    let upstreamCancel!: () => void;
+    const upstreamCancelled = new Promise<void>((resolve) => {
+      upstreamCancel = resolve;
+    });
+
+    const upstreamBody = new ReadableStream<Uint8Array>({
+      cancel() {
+        upstreamCancel();
+      },
+    });
+
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      upstreamSignal = init?.signal ?? undefined;
+      return new Response(upstreamBody, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await GET({
+      params: { path: "api/elicitations/stream" },
+      request: new Request(
+        "http://localhost/api/daemon/api/elicitations/stream?workspaceId=leak_probe",
+      ),
+    } as unknown as Parameters<typeof GET>[0]);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("text/event-stream");
+    expect(upstreamSignal?.aborted).toBe(false);
+
+    await response.body?.getReader().cancel();
+
+    expect(upstreamSignal?.aborted).toBe(true);
+    await Promise.race([
+      upstreamCancelled,
+      failAfter(500, "timed out waiting for upstream SSE body cancellation"),
+    ]);
+  });
+});

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/+layout.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/+layout.svelte
@@ -86,6 +86,9 @@
   /** Jobs page renders job index sidebar. */
   const isJobs = $derived(page.route.id === "/platform/[workspaceId]/jobs");
 
+  /** Activity page needs full width for elicitation forms. */
+  const isActivity = $derived(page.route.id === "/platform/[workspaceId]/activity");
+
   /** Skills page renders skill index sidebar. */
   const isSkills = $derived(page.route.id === "/platform/[workspaceId]/skills");
 
@@ -143,7 +146,7 @@
   <Page.Content scrollable={!isChat} padded={false}>
     {@render children?.()}
   </Page.Content>
-  {#if !isSessionDetail && !isSignalDetail && !isOverview && !isEdit && !isChat && !isChatDebug}
+  {#if !isSessionDetail && !isSignalDetail && !isOverview && !isEdit && !isChat && !isChatDebug && !isActivity}
     <Page.Sidebar>
       {#if isAgents}
         <AgentIndexSidebar agents={workspaceAgents} {providerStatus} />

--- a/tools/agent-playground/static-server.ts
+++ b/tools/agent-playground/static-server.ts
@@ -54,6 +54,56 @@ async function indexHtml(): Promise<string> {
   return CACHED_HTML;
 }
 
+function proxyAbortableBody(
+  body: ReadableStream<Uint8Array>,
+  requestSignal: AbortSignal,
+  abortUpstream: () => void,
+): ReadableStream<Uint8Array> {
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let cancelled = false;
+
+  const cancelUpstream = () => {
+    if (cancelled) return;
+    cancelled = true;
+    abortUpstream();
+    void reader?.cancel().catch(() => {
+      // The upstream may already be gone.
+    });
+  };
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      reader = body.getReader();
+      requestSignal.addEventListener("abort", cancelUpstream, { once: true });
+      if (requestSignal.aborted) cancelUpstream();
+
+      void (async () => {
+        try {
+          while (!cancelled) {
+            const { done, value } = await reader!.read();
+            if (done) break;
+            controller.enqueue(value);
+          }
+          if (!cancelled) controller.close();
+        } catch (err) {
+          if (!cancelled) controller.error(err);
+        } finally {
+          requestSignal.removeEventListener("abort", cancelUpstream);
+          try {
+            reader?.releaseLock();
+          } catch {
+            // Reader may already be released after cancellation.
+          }
+          abortUpstream();
+        }
+      })();
+    },
+    cancel() {
+      cancelUpstream();
+    },
+  });
+}
+
 // Daemon proxy for /api/daemon/*. The SvelteKit dev server has this as
 // src/routes/api/daemon/[...path]/+server.ts, but adapter-static strips
 // all server routes — the production binary has no daemon proxy unless
@@ -82,19 +132,39 @@ const daemonProxy = new Hono().all("/api/daemon/*", async (c) => {
     body = new Uint8Array(await c.req.raw.arrayBuffer());
   }
 
+  const upstreamController = new AbortController();
+  const abortUpstream = () => upstreamController.abort();
+  c.req.raw.signal.addEventListener("abort", abortUpstream, { once: true });
+
   let res: Response;
   try {
-    res = await fetch(target, { method: c.req.method, headers, body });
+    res = await fetch(target, {
+      method: c.req.method,
+      headers,
+      body,
+      signal: upstreamController.signal,
+    });
   } catch (err) {
+    c.req.raw.signal.removeEventListener("abort", abortUpstream);
     const message = err instanceof Error ? err.message : String(err);
     return c.json({ error: `daemon proxy fetch failed: ${message}` }, 502);
   }
 
   // SSE: pass the body stream through unbuffered so live event streams
-  // don't get held up at our proxy boundary.
+  // don't get held up at our proxy boundary. Wrap the body so browser
+  // disconnects cancel the daemon fetch instead of leaving subscriptions
+  // and file descriptors open behind the static playground proxy.
   if (res.headers.get("content-type")?.includes("text/event-stream")) {
-    return new Response(res.body, { status: res.status, headers: res.headers });
+    if (!res.body) {
+      c.req.raw.signal.removeEventListener("abort", abortUpstream);
+      return new Response(null, { status: res.status, headers: res.headers });
+    }
+    c.req.raw.signal.removeEventListener("abort", abortUpstream);
+    const stream = proxyAbortableBody(res.body, c.req.raw.signal, abortUpstream);
+    return new Response(stream, { status: res.status, headers: res.headers });
   }
+
+  c.req.raw.signal.removeEventListener("abort", abortUpstream);
 
   // Strip content-encoding/length — fetch() decompressed the body, so
   // forwarding the original encoding header makes the browser try to

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   plugins: [svelte()],
   resolve: {
     alias: {
+      $lib: fileURLToPath(new URL("./tools/agent-playground/src/lib", import.meta.url)),
       // Vitest does not load the SvelteKit Vite plugin, so `$app/*`
       // virtual modules never get registered. Stub the ones component
       // tests reach for.


### PR DESCRIPTION
## Summary
- remove the Activity right sidebars, including the workspace shell sidebar on workspace Activity
- keep chat HITL elicitations inline by syncing chat with the workspace-scoped elicitation SSE feed
- deep-link Open Activity to the matched elicitation, select it on Activity, and adjust filters so non-pending targets remain visible
- fix playground daemon proxy cancellation so closed browser SSE/fetch consumers tear down upstream daemon streams
- clean up daemon-side MCP session transports and signal/SSE NATS subscriptions on terminal/abort paths
- close MCP HTTP sockets promptly after tool calls by terminating server-side MCP sessions, closing daemon-held transports, guarding active requests, and marking internal agent MCP fetches `Connection: close`
- track MCP active request lifetimes through streaming `response.body` close/cancel instead of only `handleRequest()` resolution
- cancel queued/in-flight cascades by signal correlation id when clients disconnect before `data-session-start`, with NATS `flush()` readiness barriers before request publish
- keep the playground content mounted after first daemon connection and show only a non-blocking reconnect banner for transient health misses
- add a single sanitized global elicitation SSE stream for global Activity/sidebar live updates without leaking prompt/options/tool args/answers
- exclude gitignored local Claude worktrees/projects from Deno typecheck

## Validation
- `deno task typecheck`
- `npx knip`
- `git diff --check`
- `deno task -f @atlas/agent-playground check` (0 errors, existing warnings)
- `npx @sveltejs/mcp svelte-autofixer ...`
- targeted chat HITL tests: 65 passed
- proxy route SSE cancellation test: passed
- elicitation global stream backend tests: passed
- elicitation query helper tests: passed
- daemon MCP/signal cleanup targeted tests: passed
- agent orchestrator + atlas daemon MCP socket cleanup tests: passed
- signal cascade cancellation tests: passed
- MCP streaming response lifetime tests: passed
- SSE parser cancellation tests: passed

## Notes
- Follow-up issue for optional route-level abort regression: #233
- Workspace chat/activity still use scoped full-envelope SSE where form data is required.
- Global Activity/sidebar live updates use one sanitized stream only; no global full-envelope subscription and no one-EventSource-per-workspace fanout.
- Existing leaked local dev sockets from before these fixes still require restarting the local daemon/playground dev server; the code prevents new buildup after restart.

