### PR TITLE
docs(setup): hint at Deno installer's interactive shell prompt

### DIFF
--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -234,6 +234,8 @@ case "$(check_min_version deno "$DENO_MIN"; echo $?)" in
            deno upgrade
        fi ;;
     2) echo "→ deno not found — installing user-scoped from deno.land"
+       echo "  ℹ The Deno installer will ask which shells to configure (e.g. [ ] bash)."
+       echo "    Use ↑/↓ to navigate, Space to toggle, Enter to confirm."
        curl -fsSL https://deno.land/install.sh | sh
        export PATH="$HOME/.deno/bin:$PATH"
        if ! command -v deno >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Print a one-line hint in `setup-dev-env.sh` right before `curl ... | sh` runs the Deno installer, explaining how to interact with the `[ ] bash` checkbox prompt (↑/↓ to navigate, Space to toggle, Enter to confirm).
- Only fires when Deno is actually missing — silent for users who already have it installed.

Closes #231

## Test plan
- [ ] Run `bash scripts/setup-dev-env.sh` on a machine without Deno → hint appears before the installer's TUI.
- [ ] Run on a machine with Deno already at >= MIN → hint does not appear.