### PR TITLE
fix(playground): clean Svelte warning noise

### DIFF
--- a/packages/ui/src/lib/collapsible/root.svelte
+++ b/packages/ui/src/lib/collapsible/root.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
   import { type CreateCollapsibleProps } from "@melt-ui/svelte";
-  import type { Snippet } from "svelte";
+  import { untrack, type Snippet } from "svelte";
   import { createContext } from "./context";
 
   type Props = CreateCollapsibleProps & { children: Snippet };
 
   let { defaultOpen = false, open, onOpenChange, children }: Props = $props();
 
-  const { root } = createContext({ forceVisible: true, defaultOpen, onOpenChange, open });
+  const { root } = createContext(
+    untrack(() => ({ forceVisible: true, defaultOpen, onOpenChange, open })),
+  );
 </script>
 
 <div {...$root} use:root>

--- a/packages/ui/src/lib/dialog/root.svelte
+++ b/packages/ui/src/lib/dialog/root.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { CreateDialogProps } from "@melt-ui/svelte";
-  import type { Snippet } from "svelte";
+  import { untrack, type Snippet } from "svelte";
   import type { Writable } from "svelte/store";
   import { createContext } from "./context";
 
@@ -8,7 +8,7 @@
 
   let { children, ...rest }: Props = $props();
 
-  const { open } = createContext(rest);
+  const { open } = createContext(untrack(() => rest));
 </script>
 
 {@render children(open)}

--- a/packages/ui/src/lib/dropdown-menu/root.svelte
+++ b/packages/ui/src/lib/dropdown-menu/root.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { CreateDropdownMenuProps } from "@melt-ui/svelte";
-  import { type Snippet } from "svelte";
+  import { untrack, type Snippet } from "svelte";
   import type { Writable } from "svelte/store";
   import { createContext } from "./context";
 
@@ -12,12 +12,14 @@
     ...args
   }: Props & CreateDropdownMenuProps = $props();
 
-  const { open } = createContext({
-    ...args,
-    positioning,
-    forceVisible: true,
-    closeOnOutsideClick: true,
-  });
+  const { open } = createContext(
+    untrack(() => ({
+      ...args,
+      positioning,
+      forceVisible: true,
+      closeOnOutsideClick: true,
+    })),
+  );
 </script>
 
 {@render children(open)}

--- a/packages/ui/src/lib/tooltip.svelte
+++ b/packages/ui/src/lib/tooltip.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { createTooltip } from "@melt-ui/svelte";
-  import type { Snippet } from "svelte";
+  import { untrack, type Snippet } from "svelte";
   import { fade } from "svelte/transition";
 
   type Props = {
@@ -27,10 +27,10 @@
     states: { open },
   } = createTooltip({
     positioning: { placement: "top" },
-    openDelay,
+    openDelay: untrack(() => openDelay),
     closeDelay: 0,
     forceVisible: true,
-    closeOnPointerDown,
+    closeOnPointerDown: untrack(() => closeOnPointerDown),
   });
 </script>
 

--- a/packages/ui/src/lib/tree/root.svelte
+++ b/packages/ui/src/lib/tree/root.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { type CreateTreeViewProps } from "@melt-ui/svelte";
-  import type { Snippet } from "svelte";
+  import { untrack, type Snippet } from "svelte";
   import type { HTMLAttributes } from "svelte/elements";
   import { createContext } from "./context";
 
@@ -15,7 +15,9 @@
     ...rest
   }: Props & HTMLAttributes<HTMLDivElement> = $props();
 
-  const { tree } = createContext({ forceVisible, defaultExpanded, expanded, onExpandedChange });
+  const { tree } = createContext(
+    untrack(() => ({ forceVisible, defaultExpanded, expanded, onExpandedChange })),
+  );
 </script>
 
 <div {...rest} {...$tree} use:tree>

--- a/tools/agent-playground/src/lib/components/chat/artifact-card.svelte
+++ b/tools/agent-playground/src/lib/components/chat/artifact-card.svelte
@@ -504,14 +504,4 @@
     text-align: start;
     unicode-bidi: plaintext;
   }
-
-  .meta-path a {
-    color: inherit;
-    text-decoration: none;
-  }
-
-  .meta-path a:hover {
-    color: var(--color-accent);
-    text-decoration: underline;
-  }
 </style>

--- a/tools/agent-playground/src/lib/components/chat/connect-service.svelte
+++ b/tools/agent-playground/src/lib/components/chat/connect-service.svelte
@@ -59,7 +59,7 @@
   let connected = $state(false);
   let apiKeyExpanded = $state(false);
 
-  const connect = useCredentialConnect(provider);
+  const connect = useCredentialConnect(() => provider);
 
   // ─── Fetch provider details ──────────────────────────────────────────────────
 
@@ -350,60 +350,5 @@
     block-size: 20px;
     justify-content: center;
     line-height: 20px;
-  }
-
-  /* ─── API key form ─────────────────────────────────────────────────────── */
-
-  .apikey-form {
-    display: flex;
-    flex-direction: column;
-    gap: var(--size-3);
-  }
-
-  .field {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-  }
-
-  .field label {
-    color: color-mix(in srgb, var(--color-text), transparent 30%);
-    font-size: var(--font-size-1);
-    font-weight: var(--font-weight-5);
-  }
-
-  .field input {
-    background: var(--color-surface-3);
-    border: 1px solid var(--color-border-1);
-    border-radius: var(--radius-2);
-    color: var(--color-text);
-    font-family: var(--font-family-monospace);
-    font-size: var(--font-size-2);
-    padding: var(--size-1-5) var(--size-2);
-  }
-
-  .field input:focus {
-    border-color: var(--color-accent);
-    outline: none;
-  }
-
-  .field input::placeholder {
-    color: color-mix(in srgb, var(--color-text), transparent 55%);
-  }
-
-  .form-error {
-    background: color-mix(in srgb, var(--color-error), transparent 90%);
-    border: 1px solid color-mix(in srgb, var(--color-error), transparent 50%);
-    border-radius: var(--radius-2);
-    color: var(--color-error);
-    font-size: var(--font-size-1);
-    padding: var(--size-1) var(--size-2);
-  }
-
-  .form-actions {
-    align-items: center;
-    display: flex;
-    gap: var(--size-2);
-    justify-content: flex-end;
   }
 </style>

--- a/tools/agent-playground/src/lib/components/chat/tool-call-card.svelte
+++ b/tools/agent-playground/src/lib/components/chat/tool-call-card.svelte
@@ -426,11 +426,6 @@
     overflow: hidden;
   }
 
-  .tool-card.with-children {
-    background-color: transparent;
-    border-radius: 0;
-  }
-
   .tool-card-inner {
     display: flex;
     overflow: hidden;

--- a/tools/agent-playground/src/lib/components/shared/communicator-apikey-form.svelte
+++ b/tools/agent-playground/src/lib/components/shared/communicator-apikey-form.svelte
@@ -34,7 +34,7 @@
   let { workspaceId, kind, onConnected, onCancel }: Props = $props();
 
   const detailsQuery = createQuery(() => linkProviderQueries.providerDetails(kind));
-  const connect = useCredentialConnect(kind);
+  const connect = useCredentialConnect(() => kind);
   const connectMut = useConnectCommunicator();
 
   let wireError = $state<string | null>(null);

--- a/tools/agent-playground/src/lib/components/shared/sidebar.svelte
+++ b/tools/agent-playground/src/lib/components/shared/sidebar.svelte
@@ -488,26 +488,6 @@
     }
   }
 
-  .as-button {
-    align-items: center;
-    border-radius: var(--radius-2);
-    color: color-mix(in srgb, var(--color-text), transparent 20%);
-    cursor: pointer;
-    display: flex;
-    inline-size: 100%;
-    outline: none;
-    padding-inline: var(--size-2-5) var(--size-2);
-    position: relative;
-
-    :global(svg) {
-      opacity: 0.4;
-
-      @media (prefers-color-scheme: light) {
-        opacity: 0.6;
-      }
-    }
-  }
-
   /* --- Sub-nav --- */
 
   .sub-nav {
@@ -613,13 +593,5 @@
       margin-block-end: var(--size-1);
     }
 
-    code {
-      background-color: var(--color-surface-1);
-      border-radius: var(--radius-1);
-      color: var(--color-text);
-      display: block;
-      font-size: var(--font-size-1);
-      padding: var(--size-1) var(--size-2);
-    }
   }
 </style>

--- a/tools/agent-playground/src/lib/components/shared/update-banner.svelte
+++ b/tools/agent-playground/src/lib/components/shared/update-banner.svelte
@@ -18,7 +18,7 @@
 </script>
 
 {#if visible}
-  <header class="update-banner" role="banner" aria-live="polite">
+  <header class="update-banner" aria-live="polite">
     <span class="message">
       A new version of Friday Studio ({updateStatus.latest}) is available.
     </span>

--- a/tools/agent-playground/src/lib/components/workspace/job-index-sidebar.svelte
+++ b/tools/agent-playground/src/lib/components/workspace/job-index-sidebar.svelte
@@ -1,11 +1,9 @@
 <!--
-  Compact job index for the right sidebar on the jobs page.
-  Each row shows the job title and a trigger type badge, linking to
-  the corresponding job card via hash navigation.
+  Right sidebar wrapper for the jobs page. Shows integrations and recent
+  sessions when the workspace has jobs.
 
   @component
-  @param {JobEntry[]} jobs - Job entries with id, title, and trigger signal refs
-  @param {SignalDetail[]} signalDetails - Signal details from deriveSignalDetails
+  @param {JobEntry[]} jobs - Job entries used to decide whether to render sidebar content
 -->
 
 <script module lang="ts">
@@ -18,14 +16,12 @@
 </script>
 
 <script lang="ts">
-  import type { SignalDetail } from "@atlas/config/signal-details";
   import RecentSessions from "$lib/components/session/recent-sessions.svelte";
   import IntegrationsSidebar from "$lib/components/workspace/integrations-sidebar.svelte";
 
-  type Props = { jobs: JobEntry[]; signalDetails: SignalDetail[]; workspaceId: string };
+  type Props = { jobs: JobEntry[]; workspaceId: string };
 
-  let { jobs, signalDetails, workspaceId }: Props = $props();
-
+  let { jobs, workspaceId }: Props = $props();
 </script>
 
 {#if jobs.length > 0}
@@ -41,63 +37,6 @@
     display: flex;
     flex-direction: column;
     gap: var(--size-8);
-  }
-
-  .jobs-section {
-    display: flex;
-    flex-direction: column;
-    gap: var(--size-2);
-  }
-
-  .section-header {
-    align-items: baseline;
-    display: flex;
-    gap: var(--size-2);
-  }
-
-  .section-title {
-    font-size: var(--font-size-3);
-    font-weight: var(--font-weight-5);
-    margin: 0;
-  }
-
-  .section-badge {
-    color: color-mix(in srgb, var(--color-text), transparent 60%);
-    font-size: var(--font-size-0);
-    font-variant-numeric: tabular-nums;
-    margin-inline-start: auto;
-  }
-
-  .entries {
-    display: flex;
-    flex-direction: column;
-  }
-
-  .entry {
-    align-items: center;
-    color: inherit;
-    display: flex;
-    gap: var(--size-2);
-    padding-block: var(--size-1-5);
-    text-decoration: none;
-  }
-
-  .entry:not(:last-child) {
-    border-block-end: 1px solid color-mix(in srgb, var(--color-border-1), transparent 50%);
-  }
-
-  .entry:hover {
-    background-color: color-mix(in srgb, var(--color-surface-2), transparent 50%);
-  }
-
-  .job-name {
-    color: var(--color-text);
-    font-size: var(--font-size-1);
-    font-weight: var(--font-weight-5);
-    min-inline-size: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
   }
 
 </style>

--- a/tools/agent-playground/src/lib/components/workspace/workspace-loader.svelte
+++ b/tools/agent-playground/src/lib/components/workspace/workspace-loader.svelte
@@ -204,11 +204,6 @@
     font-weight: var(--font-weight-5);
   }
 
-  .drop-hint {
-    color: color-mix(in srgb, var(--color-text), transparent 25%);
-    font-size: var(--font-size-2);
-  }
-
   .drop-error {
     background-color: color-mix(in srgb, var(--color-error), transparent 90%);
     border-radius: var(--radius-2);

--- a/tools/agent-playground/src/lib/use-credential-connect.svelte.ts
+++ b/tools/agent-playground/src/lib/use-credential-connect.svelte.ts
@@ -34,13 +34,19 @@ interface CredentialConnectState {
   error: string | null;
 }
 
+type ProviderIdInput = string | (() => string);
+
+function readProviderId(providerId: ProviderIdInput): string {
+  return typeof providerId === "function" ? providerId() : providerId;
+}
+
 /**
  * Returns reactive state and action functions for connecting a credential
  * for the given provider.
  *
- * @param providerId - The provider identifier (e.g. "openai", "slack")
+ * @param providerId - The provider identifier (e.g. "openai", "slack"), or a getter for reactive props.
  */
-export function useCredentialConnect(providerId: string) {
+export function useCredentialConnect(providerId: ProviderIdInput) {
   // Per-instance reactive state
   // deno-lint-ignore prefer-const
   let state: CredentialConnectState = $state({
@@ -60,19 +66,21 @@ export function useCredentialConnect(providerId: string) {
 
   function startOAuth() {
     reset();
-    const popup = startOAuthFlow(providerId);
+    const currentProviderId = readProviderId(providerId);
+    const popup = startOAuthFlow(currentProviderId);
     if (!popup || popup.closed) {
       state.popupBlocked = true;
-      state.blockedUrl = getOAuthUrl(providerId);
+      state.blockedUrl = getOAuthUrl(currentProviderId);
     }
   }
 
   function startAppInstall() {
     reset();
-    const popup = startAppInstallFlow(providerId);
+    const currentProviderId = readProviderId(providerId);
+    const popup = startAppInstallFlow(currentProviderId);
     if (!popup || popup.closed) {
       state.popupBlocked = true;
-      state.blockedUrl = getAppInstallUrl(providerId);
+      state.blockedUrl = getAppInstallUrl(currentProviderId);
     }
   }
 
@@ -80,7 +88,7 @@ export function useCredentialConnect(providerId: string) {
     cleanup = listenForOAuthCallback((message) => {
       reset();
       onSuccess(message);
-    }, providerId);
+    }, readProviderId(providerId));
 
     return () => {
       cleanup?.();
@@ -106,7 +114,7 @@ export function useCredentialConnect(providerId: string) {
         {
           method: "PUT",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ provider: providerId, label, secret }),
+          body: JSON.stringify({ provider: readProviderId(providerId), label, secret }),
         },
       );
 

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/+layout.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/+layout.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { deriveAgentJobUsage } from "@atlas/config/agent-job-usage";
   import { humanizeStepName } from "@atlas/config/pipeline-utils";
-  import { deriveSignalDetails } from "@atlas/config/signal-details";
   import { deriveTopology } from "@atlas/config/topology";
   import { deriveWorkspaceAgents } from "@atlas/config/workspace-agents";
   import { Page } from "@atlas/ui";
@@ -129,8 +128,6 @@
     goto(`/platform/${workspaceId}/skills?addSkill=true`);
   }
 
-  const signalDetails = $derived(config ? deriveSignalDetails(config) : []);
-
   /** Escape key returns to idle sidebar. */
   function handleKeydown(e: KeyboardEvent) {
     if (e.key === "Escape" && workspaceId && (selectedNode || selectedWorkspaceAgent)) {
@@ -151,7 +148,7 @@
       {#if isAgents}
         <AgentIndexSidebar agents={workspaceAgents} {providerStatus} />
       {:else if isJobs}
-        <JobIndexSidebar jobs={jobEntries} {signalDetails} workspaceId={workspaceId ?? ""} />
+        <JobIndexSidebar jobs={jobEntries} workspaceId={workspaceId ?? ""} />
       {:else if isSkills}
         <SkillIndexSidebar onadd={openSkillPicker} skillCount={workspaceSkillCount} />
       {:else}


### PR DESCRIPTION
## Summary
- remove redundant ARIA role and stale scoped CSS selectors reported by the playground Vite/Svelte logs
- drop unused job sidebar signal-details plumbing
- mark initialization-only Melt UI builder options with `untrack` and pass credential provider ids through getters to avoid Svelte 5 local-state capture warnings

## Validation
- `deno task -f @atlas/ui check`
- `deno task -f @atlas/agent-playground check` (0 errors; unrelated pre-existing warnings remain)
- `npx vitest run --exclude '.claude/**' tools/agent-playground/src/lib/use-credential-connect.test.ts`
- `git diff --check`