### PR TITLE
fix(core): make step output optional on session events

### DIFF
--- a/apps/atlas-cli/src/utils/daemon-client.ts
+++ b/apps/atlas-cli/src/utils/daemon-client.ts
@@ -97,7 +97,7 @@ class DaemonClient {
       task: string;
       status: string;
       durationMs?: number;
-      output: unknown;
+      output?: unknown;
       error?: string;
     }>;
     results?: Record<string, unknown>;

--- a/packages/client/src/types/session.ts
+++ b/packages/client/src/types/session.ts
@@ -41,7 +41,7 @@ export interface SessionDetailedInfo {
     durationMs?: number;
     toolCalls: Array<{ toolName: string; args?: unknown; result?: unknown; durationMs?: number }>;
     reasoning?: string;
-    output: unknown;
+    output?: unknown;
     error?: string;
   }>;
   results?: Record<string, unknown>;

--- a/packages/core/src/session/session-events.ts
+++ b/packages/core/src/session/session-events.ts
@@ -166,7 +166,7 @@ export const StepCompleteEventSchema = z.object({
   durationMs: z.number(),
   toolCalls: z.array(ToolCallSummarySchema),
   reasoning: z.string().optional(),
-  output: z.unknown(),
+  output: z.unknown().optional(),
   artifactRefs: z.array(z.unknown()).optional(),
   error: z.string().optional(),
   /**
@@ -304,7 +304,7 @@ export const AgentBlockSchema = z.object({
   durationMs: z.number().optional(),
   toolCalls: z.array(ToolCallSummarySchema),
   reasoning: z.string().optional(),
-  output: z.unknown(),
+  output: z.unknown().optional(),
   artifactRefs: z.array(z.unknown()).optional(),
   error: z.string().optional(),
   ephemeral: z.array(z.custom<AtlasUIMessageChunk>(() => true)).optional(),


### PR DESCRIPTION
## Summary
- `StepCompleteEvent.output` and `AgentBlock.output` are now `z.unknown().optional()` instead of required `z.unknown()` — steps that fail or skip don't always produce an output.

## Test plan
- [ ] Existing session-events tests still pass
- [ ] No downstream consumer breaks on missing `output`