### PR TITLE
fix(playground): handle undefined tool input on chat debug page

### DIFF
--- a/tools/agent-playground/src/routes/platform/[workspaceId]/chat/[[chatId]]/debug/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/chat/[[chatId]]/debug/+page.svelte
@@ -22,18 +22,22 @@
   }
 
   function shortJson(value: unknown, max = 600): string {
-    let s: string;
+    // JSON.stringify(undefined) returns undefined (not a string), which
+    // crashes the render of error-state tool parts that never received an
+    // `input` field. Coerce to "undefined" so callers always get a string.
+    let s: string | undefined;
     try {
       s = JSON.stringify(value, null, 2);
     } catch {
       s = String(value);
     }
+    if (s === undefined) return String(value);
     return s.length > max ? `${s.slice(0, max)}\n… (${s.length - max} more chars)` : s;
   }
 
   function fullJson(value: unknown): string {
     try {
-      return JSON.stringify(value, null, 2);
+      return JSON.stringify(value, null, 2) ?? String(value);
     } catch {
       return String(value);
     }


### PR DESCRIPTION
## Summary

The chat debug page (\`/platform/{ws}/chat/{chatId}/debug\`) showed a permanent **\"Connecting to daemon...\"** state on chats containing \`tool-*\` parts in \`output-error\` state with no \`input\` field. The daemon was fine the whole time — the symptom was a misleading side-effect of a render error.

\`shortJson()\` / \`fullJson()\` called \`JSON.stringify(undefined)\`, which returns \`undefined\` (not a string), so \`s.length > max\` threw \`TypeError\`. In Svelte 5, throwing inside a child's reactive update aborts the parent render, so \`daemon-gate.svelte\` never committed its \"show children\" branch and stayed pinned on its initial loading UI.

Fix: fall back to \`String(value)\` when \`JSON.stringify\` returns \`undefined\`.

## Test plan

- [x] Repro on a chat with at least one \`tool-run_code\` part in \`output-error\` state and no \`input\` field — page now renders the full debug view instead of \"Connecting to daemon...\"
- [x] Browser console no longer logs \`TypeError: Cannot read properties of undefined (reading 'length') at shortJson\`
- [x] Daemon health check (\`GET /api/daemon/health\`) was already 200 throughout — confirming this was never a connectivity bug