### PR TITLE
fix(chat): prevent send from aborting stream

### DIFF
--- a/docs/reviews/2026-05-08-fix-chat-stream-abort-on-send.md
+++ b/docs/reviews/2026-05-08-fix-chat-stream-abort-on-send.md
@@ -1,0 +1,36 @@
+# Review: fix/chat-stream-abort-on-send
+
+**Date:** 2026-05-08
+**Branch:** fix/chat-stream-abort-on-send
+**Verdict:** Clean
+
+## Summary
+
+This change fixes the chat page aborting its own live response stream after a user sends a message. The implementation is surgical: it prevents `ChatImpl` from sharing the `$state` rehydration array and keeps the resume effect from tracking the rehydrated-message snapshot after the one-shot resume decision.
+
+NATS/JetStream behavior is unchanged. The reviewed stream state for `CHAT_blended_watermelon_chat_4c1gMv9G7W` remained scoped to `chats.blended_watermelon.chat_4c1gMv9G7W.messages.>` with one subject per message ID; the observed NYC itinerary came from a fresh HITL job intake, not merged chat streams.
+
+## Critical
+
+None.
+
+## Important
+
+None.
+
+## Tests
+
+No test files in diff.
+
+Validation performed:
+
+- Browser regression: new chat send streamed the assistant reply live without requiring reload.
+- `npx @sveltejs/mcp svelte-autofixer tools/agent-playground/src/lib/components/chat/user-chat.svelte` reported no issues.
+- `deno task -f @atlas/agent-playground check` completed with 0 errors; existing warnings only.
+- NATS inspection confirmed the target chat stream did not contain messages from another chat ID.
+
+Worth doing: No additional test in this commit — the change is a two-line state isolation fix in a Svelte/AI-SDK integration path that is better covered by an end-to-end chat-send regression than a unit test around framework internals.
+
+## Needs Decision
+
+1. Consider adding a browser/E2E regression for “send message in rehydrated chat streams response without reload.” This would catch this class of Svelte state aliasing bug, but it needs a stable daemon/test chat harness rather than a brittle component mock.

--- a/tools/agent-playground/src/lib/components/chat/user-chat.svelte
+++ b/tools/agent-playground/src/lib/components/chat/user-chat.svelte
@@ -378,7 +378,14 @@
   // before we know whether we're resuming or starting fresh.
   const chat = $derived(
     rehydrationDone && chatId.length > 0
-      ? new ChatImpl<AtlasUIMessage>({ id: chatId, messages: initialMessages, transport })
+      ? new ChatImpl<AtlasUIMessage>({
+          id: chatId,
+          // ChatImpl mutates its `messages` state during send/stream. Do not
+          // hand it our `$state` rehydration array directly, or a user send
+          // will mutate `initialMessages` and retrigger resume-effect cleanup.
+          messages: [...initialMessages],
+          transport,
+        })
       : null,
   );
 
@@ -401,14 +408,17 @@
   // below can't queue a same-tick re-run whose cleanup would `instance.stop()`
   // the just-fired resumeStream. The chatId-change effect sets the flag true
   // BEFORE chat is created, so reading it untracked still observes the right
-  // value when this effect runs on the chat null→ChatImpl transition.
+  // value when this effect runs on the chat null→ChatImpl transition. The
+  // trailing-user check is also one-shot; tracking `initialMessages` here would
+  // make ChatImpl message pushes re-run this cleanup and abort fresh sends.
   $effect(() => {
     if (!chat) return;
     if (!untrack(() => shouldResumeStream)) return;
     shouldResumeStream = false;
     const instance = chat;
-    const hadUnansweredUser =
-      initialMessages.length > 0 && initialMessages.at(-1)?.role === "user";
+    const hadUnansweredUser = untrack(
+      () => initialMessages.length > 0 && initialMessages.at(-1)?.role === "user",
+    );
     instance.resumeStream().catch(() => {
       if (hadUnansweredUser) wasInterrupted = true;
     });


### PR DESCRIPTION
## Summary
- clone rehydrated messages before creating the AI SDK chat instance
- untrack the one-shot resume trailing-user check so sends do not retrigger cleanup
- add review notes covering correctness and NATS stream isolation

## Verification
- browser-tested fresh chat send; assistant streamed live without reload
- npx @sveltejs/mcp svelte-autofixer tools/agent-playground/src/lib/components/chat/user-chat.svelte
- deno task -f @atlas/agent-playground check (0 errors, existing warnings only)
- inspected NATS stream subjects for CHAT_blended_watermelon_chat_4c1gMv9G7W; no cross-chat subject merge