### PR TITLE
feat(playground): HTTP/2 + TLS for local dev

### DIFF
--- a/apps/atlas-cli/src/commands/daemon/start.tsx
+++ b/apps/atlas-cli/src/commands/daemon/start.tsx
@@ -621,12 +621,39 @@ async function startForeground(argv: StartArgs): Promise<void> {
   // the daemon's route types via @atlas/client don't drag the daemon's
   // module graph (NATS, JetStream, migrations) into their process at load.
   const { AtlasDaemon } = await import("@atlas/atlasd/daemon");
+
+  // TLS for HTTP/2 — gated on both cert and key being present and
+  // readable. Missing files fall back to plain HTTP so the daemon still
+  // boots in environments that haven't run `bash scripts/setup-tls.sh`
+  // (CI, fresh checkouts). Reading here (vs. inside the daemon) keeps
+  // the daemon module pure-data and lets us surface fs errors cleanly.
+  const tlsCertPath = process.env.FRIDAY_TLS_CERT;
+  const tlsKeyPath = process.env.FRIDAY_TLS_KEY;
+  let tlsCert: string | undefined;
+  let tlsKey: string | undefined;
+  if (tlsCertPath && tlsKeyPath) {
+    try {
+      tlsCert = await readFile(tlsCertPath, "utf8");
+      tlsKey = await readFile(tlsKeyPath, "utf8");
+    } catch (err) {
+      errorOutput(
+        `FRIDAY_TLS_CERT/_KEY set but unreadable — falling back to HTTP. ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      tlsCert = undefined;
+      tlsKey = undefined;
+    }
+  }
+  const corsOrigin = tlsCert ? "https://127.0.0.1:1420" : "http://127.0.0.1:1420";
   const daemon = new AtlasDaemon({
     port: argv.port,
     hostname: argv.hostname,
     maxConcurrentWorkspaces: argv.maxWorkspaces,
     idleTimeoutMs: (argv.idleTimeout || 300) * 1000,
-    cors: ["http://127.0.0.1:1420"],
+    cors: [corsOrigin],
+    tlsCert,
+    tlsKey,
   });
 
   // Catch unhandled promise rejections so a single async error
@@ -651,8 +678,9 @@ async function startForeground(argv: StartArgs): Promise<void> {
     Deno.addSignalListener("SIGTERM", shutdown);
   }
 
+  const scheme = tlsCert ? "https" : "http";
   infoOutput(
-    `Starting Atlas daemon on http://${argv.hostname || "127.0.0.1"}:${argv.port || 8080}...`,
+    `Starting Atlas daemon on ${scheme}://${argv.hostname || "127.0.0.1"}:${argv.port || 8080}...`,
   );
   successOutput("Atlas daemon is running. Press Ctrl+C to stop.");
 

--- a/apps/atlasd/routes/agents/register.test.ts
+++ b/apps/atlasd/routes/agents/register.test.ts
@@ -89,7 +89,7 @@ vi.mock("@atlas/logger", () => ({
 const { registerAgentRoute } = await import("./register.ts");
 const { daemonFactory } = await import("../../src/factory.ts");
 
-function makeApp(subPayload: unknown = null) {
+function makeApp(subPayload: unknown = null, natsUrl = "nats://127.0.0.1:14222") {
   const app = daemonFactory.createApp();
   app.use("*", async (c, next) => {
     const sub = subPayload !== null ? makeMockSub(subPayload) : null;
@@ -99,6 +99,7 @@ function makeApp(subPayload: unknown = null) {
           subscribe: mockSubscribe.mockReturnValue(sub),
           flush: vi.fn().mockResolvedValue(undefined),
         }),
+        getNatsUrl: () => natsUrl,
       },
       getAgentRegistry: () => ({ reload: vi.fn() }),
     } as never);
@@ -231,20 +232,16 @@ describe("POST /register", () => {
     expect(body.phase).toBe("validate");
   });
 
-  it("passes FRIDAY_VALIDATE_ID and the active NATS_URL to spawned process", async () => {
-    const app = makeApp({ id: "env-agent", version: "1.0.0", description: "Env test" });
-    const original = process.env.FRIDAY_NATS_URL;
-    process.env.FRIDAY_NATS_URL = "nats://127.0.0.1:4555";
-    try {
-      await app.request("/register", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ entrypoint: "/agents/agent.py" }),
-      });
-    } finally {
-      if (original === undefined) delete process.env.FRIDAY_NATS_URL;
-      else process.env.FRIDAY_NATS_URL = original;
-    }
+  it("passes FRIDAY_VALIDATE_ID and the daemon's NATS URL to spawned process", async () => {
+    const app = makeApp(
+      { id: "env-agent", version: "1.0.0", description: "Env test" },
+      "nats://127.0.0.1:4555",
+    );
+    await app.request("/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ entrypoint: "/agents/agent.py" }),
+    });
 
     const spawnCall = mockSpawn.mock.calls[0];
     const env = spawnCall?.[2]?.env as Record<string, string>;

--- a/apps/atlasd/routes/agents/register.ts
+++ b/apps/atlasd/routes/agents/register.ts
@@ -80,6 +80,7 @@ registerAgentRoute.post("/register", async (c) => {
   const sourceDir = dirname(entrypointPath);
 
   const nc = c.get("app").daemon.getNatsConnection();
+  const natsUrl = c.get("app").daemon.getNatsUrl();
 
   // Subscribe BEFORE spawning to avoid race (agent may publish and exit fast).
   // The flush() is load-bearing: without it, the SUB protocol message can sit
@@ -94,11 +95,7 @@ registerAgentRoute.post("/register", async (c) => {
 
   const [cmd, args] = buildAgentSpawnArgs(entrypointPath);
   const proc = spawn(cmd, args, {
-    env: {
-      ...process.env,
-      FRIDAY_VALIDATE_ID: registerId,
-      NATS_URL: process.env.FRIDAY_NATS_URL ?? "nats://localhost:4222",
-    },
+    env: { ...process.env, FRIDAY_VALIDATE_ID: registerId, NATS_URL: natsUrl },
     stdio: "pipe",
   });
 

--- a/apps/atlasd/routes/link.ts
+++ b/apps/atlasd/routes/link.ts
@@ -31,11 +31,17 @@ linkRoutes.use("/*", devOnlyMiddleware());
  *      workspace-chat agent can't reach Gmail / Slack / etc.
  *   3. http://localhost:3100 — legacy default for in-tree dev runs.
  */
+// Scheme matches the s2s mesh: when FRIDAY_TLS_CERT/_KEY are set in
+// the daemon's env, link is also listening on TLS via the same env
+// pair (apps/link/src/index.ts), so the daemon must reach it over
+// https. Without TLS env, fall back to http on loopback — the
+// pre-s2s-mesh behavior.
+const linkScheme = process.env.FRIDAY_TLS_CERT && process.env.FRIDAY_TLS_KEY ? "https" : "http";
 const LINK_SERVICE_URL =
   process.env.LINK_SERVICE_URL ??
   (process.env.FRIDAY_PORT_LINK
-    ? `http://localhost:${process.env.FRIDAY_PORT_LINK}`
-    : "http://localhost:3100");
+    ? `${linkScheme}://localhost:${process.env.FRIDAY_PORT_LINK}`
+    : `${linkScheme}://localhost:3100`);
 const PROXY_PREFIX = "/api/link";
 
 /**

--- a/apps/atlasd/routes/mcp-registry.ts
+++ b/apps/atlasd/routes/mcp-registry.ts
@@ -58,12 +58,14 @@ async function createLinkProvider(
   // Same resolution order as the link proxy in routes/link.ts —
   // explicit LINK_SERVICE_URL beats FRIDAY_PORT_LINK fallback beats
   // the legacy :3100 default. Keeps desktop port-override installs
-  // talking to the right link binary.
+  // talking to the right link binary. Scheme follows the s2s mesh
+  // (https when FRIDAY_TLS_CERT/_KEY set, http fallback otherwise).
+  const linkScheme = process.env.FRIDAY_TLS_CERT && process.env.FRIDAY_TLS_KEY ? "https" : "http";
   const linkServiceUrl =
     process.env.LINK_SERVICE_URL ??
     (process.env.FRIDAY_PORT_LINK
-      ? `http://localhost:${process.env.FRIDAY_PORT_LINK}`
-      : "http://localhost:3100");
+      ? `${linkScheme}://localhost:${process.env.FRIDAY_PORT_LINK}`
+      : `${linkScheme}://localhost:3100`);
   const url = `${linkServiceUrl}/v1/providers`;
   const headers: Record<string, string> = { "Content-Type": "application/json" };
   const atlasKey = process.env.FRIDAY_KEY;

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -152,6 +152,13 @@ export interface AtlasDaemonOptions {
   idleTimeoutMs?: number;
   sseHeartbeatIntervalMs?: number;
   sseConnectionTimeoutMs?: number;
+  // PEM-encoded cert + key. When both are set, `Deno.serve` listens with
+  // TLS and ALPN-negotiates HTTP/2, lifting the browser's per-origin
+  // 6-socket HTTP/1.1 cap that strands the playground when SSE feeds
+  // saturate the pool. Both must be set or neither — the CLI loads them
+  // from FRIDAY_TLS_CERT / FRIDAY_TLS_KEY paths.
+  tlsCert?: string;
+  tlsKey?: string;
 }
 
 const INTERNAL_SIGNAL_BYPASS_TOKEN_ENV = "FRIDAY_INTERNAL_SIGNAL_BYPASS_TOKEN";
@@ -1851,7 +1858,11 @@ export class AtlasDaemon {
           workspacePath, // Pass workspace path for daemon mode
           platformModels: this.getPlatformModels(),
           agentExecutor: this.processAgentExecutor ?? undefined,
-          daemonUrl: `http://localhost:${this.options.port}`, // Pass daemon URL for MCP tool fetching
+          // Daemon self-loopback URL for MCP tool fetching. Scheme matches
+          // whatever the daemon is bound on — without this, the workspace
+          // runtime sends a cleartext HTTP request to a TLS listener and
+          // gets "invalid HTTP version parsed" back from reqwest/hyper.
+          daemonUrl: `${this.options.tlsCert && this.options.tlsKey ? "https" : "http"}://localhost:${this.options.port}`,
           broadcastNotifier: createFSMBroadcastNotifier({
             workspaceId: workspace.id,
             getInstance: (id) => this.getOrCreateChatSdkInstance(id),
@@ -2612,10 +2623,16 @@ export class AtlasDaemon {
 
     const port = this.options.port ?? 8080;
     const hostname = this.options.hostname || "localhost";
+    const tls =
+      this.options.tlsCert && this.options.tlsKey
+        ? { cert: this.options.tlsCert, key: this.options.tlsKey }
+        : null;
+    const scheme = tls ? "https" : "http";
 
     logger.info("Starting Atlas daemon", {
       hostname,
       port,
+      scheme,
       maxConcurrentWorkspaces: this.options.maxConcurrentWorkspaces,
       idleTimeoutMs: this.options.idleTimeoutMs,
     });
@@ -2625,9 +2642,10 @@ export class AtlasDaemon {
         port,
         hostname,
         signal: this.serverAbortController.signal,
+        ...(tls ?? {}),
         onListen: ({ hostname, port }) => {
           this.#port = port;
-          logger.info("👹 Atlas daemon running", { hostname, port });
+          logger.info("👹 Atlas daemon running", { hostname, port, scheme });
         },
       },
       this.app.fetch,
@@ -2648,10 +2666,16 @@ export class AtlasDaemon {
 
     const port = this.options.port ?? 8080;
     const hostname = this.options.hostname || "localhost";
+    const tls =
+      this.options.tlsCert && this.options.tlsKey
+        ? { cert: this.options.tlsCert, key: this.options.tlsKey }
+        : null;
+    const scheme = tls ? "https" : "http";
 
     logger.info("Starting Atlas daemon", {
       hostname,
       port,
+      scheme,
       maxConcurrentWorkspaces: this.options.maxConcurrentWorkspaces,
       idleTimeoutMs: this.options.idleTimeoutMs,
     });
@@ -2666,9 +2690,10 @@ export class AtlasDaemon {
         port,
         hostname,
         signal: this.serverAbortController.signal,
+        ...(tls ?? {}),
         onListen: ({ hostname, port }) => {
           this.#port = port; // Store the actual port
-          logger.info("Atlas daemon running", { hostname, port });
+          logger.info("Atlas daemon running", { hostname, port, scheme });
           serverReady();
         },
       },

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -614,7 +614,11 @@ export class AtlasDaemon {
     // Start capability handlers (wildcard subscribers for agent back-channel)
     this.capabilityRegistry = new CapabilityHandlerRegistry();
     this.capabilityRegistry.start(nc);
-    this.processAgentExecutor = new ProcessAgentExecutor(nc, this.capabilityRegistry);
+    this.processAgentExecutor = new ProcessAgentExecutor(
+      nc,
+      this.natsManager.url,
+      this.capabilityRegistry,
+    );
 
     // Create WorkspaceManager (initialize later once registrars and watcher are ready).
     // Registry storage is JetStream-KV-backed; the per-workspace records
@@ -1324,6 +1328,14 @@ export class AtlasDaemon {
       throw new Error("NATS not initialized — call initialize() first");
     }
     return this.natsManager.connection;
+  }
+
+  /** Get the resolved NATS broker URL (available after initialize()). */
+  public getNatsUrl(): string {
+    if (!this.natsManager) {
+      throw new Error("NATS not initialized — call initialize() first");
+    }
+    return this.natsManager.url;
   }
 
   /** Get the ProcessAgentExecutor (available after NATS initializes). */

--- a/apps/atlasd/src/nats-manager.test.ts
+++ b/apps/atlasd/src/nats-manager.test.ts
@@ -146,6 +146,23 @@ describe("NatsManager — URL file is the rendezvous for out-of-env consumers", 
     expect(written).toBe(server.url);
   }, 15_000);
 
+  it("publishes resolved URL to process.env.FRIDAY_NATS_URL so child spawns inherit it", async () => {
+    // Regression: process-agent-executor reads process.env.FRIDAY_NATS_URL
+    // when spawning Python agents. pickPort() in spawn.ts chooses
+    // dynamically in the 14222 range, so the hardcoded
+    // `?? "nats://localhost:4222"` fallback fires on every dev run where
+    // the user's .env doesn't pin the URL — every Python agent then hangs
+    // 30s on the wrong port. The manager must propagate its resolved URL
+    // into in-process env so subsequent child spawns see the right host.
+    delete process.env.FRIDAY_NATS_URL;
+    server = await startNatsTestServer();
+    process.env.FRIDAY_NATS_URL = server.url;
+    mgr = new NatsManager();
+    await mgr.start();
+
+    expect(process.env.FRIDAY_NATS_URL).toBe(server.url);
+  }, 15_000);
+
   it("deletes <home>/nats/url on stop()", async () => {
     server = await startNatsTestServer();
     process.env.FRIDAY_NATS_URL = server.url;

--- a/apps/atlasd/src/nats-manager.test.ts
+++ b/apps/atlasd/src/nats-manager.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
 import { startNatsTestServer, type TestNatsServer } from "@atlas/core/test-utils/nats-test-server";
+import { writeBrokerUrlFile } from "jetstream";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { NatsManager } from "./nats-manager.ts";
 
@@ -146,21 +147,31 @@ describe("NatsManager — URL file is the rendezvous for out-of-env consumers", 
     expect(written).toBe(server.url);
   }, 15_000);
 
-  it("publishes resolved URL to process.env.FRIDAY_NATS_URL so child spawns inherit it", async () => {
+  it("publishes resolved URL to FRIDAY_NATS_URL on start and restores it on stop", async () => {
     // Regression: process-agent-executor reads process.env.FRIDAY_NATS_URL
     // when spawning Python agents. pickPort() in spawn.ts chooses
     // dynamically in the 14222 range, so the hardcoded
     // `?? "nats://localhost:4222"` fallback fires on every dev run where
     // the user's .env doesn't pin the URL — every Python agent then hangs
     // 30s on the wrong port. The manager must propagate its resolved URL
-    // into in-process env so subsequent child spawns see the right host.
+    // into in-process env so child spawns see the right host, and revert
+    // on stop() so a between-restarts spawn doesn't inherit a dead URL.
+    //
+    // We exercise the URL-file-reuse path (env unset, live broker
+    // advertised via <home>/nats/url) on purpose: the external-broker
+    // path is a tautology here because the test would have to pre-set
+    // env to the resolved URL, masking a missing production write.
     delete process.env.FRIDAY_NATS_URL;
     server = await startNatsTestServer();
-    process.env.FRIDAY_NATS_URL = server.url;
+    await writeBrokerUrlFile(home as string, server.url);
+
     mgr = new NatsManager();
     await mgr.start();
-
     expect(process.env.FRIDAY_NATS_URL).toBe(server.url);
+
+    await mgr.stop();
+    mgr = undefined;
+    expect(process.env.FRIDAY_NATS_URL).toBeUndefined();
   }, 15_000);
 
   it("deletes <home>/nats/url on stop()", async () => {

--- a/apps/atlasd/src/nats-manager.test.ts
+++ b/apps/atlasd/src/nats-manager.test.ts
@@ -147,31 +147,27 @@ describe("NatsManager — URL file is the rendezvous for out-of-env consumers", 
     expect(written).toBe(server.url);
   }, 15_000);
 
-  it("publishes resolved URL to FRIDAY_NATS_URL on start and restores it on stop", async () => {
-    // Regression: process-agent-executor reads process.env.FRIDAY_NATS_URL
-    // when spawning Python agents. pickPort() in spawn.ts chooses
-    // dynamically in the 14222 range, so the hardcoded
-    // `?? "nats://localhost:4222"` fallback fires on every dev run where
-    // the user's .env doesn't pin the URL — every Python agent then hangs
-    // 30s on the wrong port. The manager must propagate its resolved URL
-    // into in-process env so child spawns see the right host, and revert
-    // on stop() so a between-restarts spawn doesn't inherit a dead URL.
-    //
-    // We exercise the URL-file-reuse path (env unset, live broker
-    // advertised via <home>/nats/url) on purpose: the external-broker
-    // path is a tautology here because the test would have to pre-set
-    // env to the resolved URL, masking a missing production write.
+  it("exposes resolved URL via .url getter so callers can plumb it to child spawns", async () => {
+    // process-agent-executor + the agent-register route used to read
+    // process.env.FRIDAY_NATS_URL and fall back to a hardcoded
+    // localhost:4222 — wrong on every dev run because pickPort()
+    // allocates dynamically in the 14222 range. They now read the URL
+    // directly off the manager (via AtlasDaemon.getNatsUrl()) and pass
+    // it into the child's env explicitly. This test exercises the
+    // URL-file-reuse path on purpose: external-broker would be a
+    // tautology, and the spawn path would require running nats-server.
     delete process.env.FRIDAY_NATS_URL;
     server = await startNatsTestServer();
     await writeBrokerUrlFile(home as string, server.url);
 
     mgr = new NatsManager();
+    expect(() => mgr?.url).toThrow(/not started/);
+
     await mgr.start();
-    expect(process.env.FRIDAY_NATS_URL).toBe(server.url);
+    expect(mgr.url).toBe(server.url);
 
     await mgr.stop();
-    mgr = undefined;
-    expect(process.env.FRIDAY_NATS_URL).toBeUndefined();
+    expect(() => mgr?.url).toThrow(/not started/);
   }, 15_000);
 
   it("deletes <home>/nats/url on stop()", async () => {

--- a/apps/atlasd/src/nats-manager.ts
+++ b/apps/atlasd/src/nats-manager.ts
@@ -122,6 +122,14 @@ export class NatsManager {
     this.ownsUrlFile = true;
     logger.info("Wrote broker URL file", { url, urlFile: brokerUrlFilePath(home) });
 
+    // Propagate the resolved URL to in-process env so child spawns
+    // (process-agent-executor, tool-worker-launcher, etc.) inherit it
+    // instead of falling back to the hardcoded `nats://localhost:4222`.
+    // pickPort() chooses dynamically in the 14222 range, so the
+    // hardcoded fallback is wrong on every dev run where `.env` doesn't
+    // carry FRIDAY_NATS_URL.
+    process.env.FRIDAY_NATS_URL = url;
+
     if (process.env.FRIDAY_NATS_MONITOR === "1") {
       logger.info(`NATS monitoring enabled at http://127.0.0.1:${DEFAULT_NATS_MONITOR_PORT}`);
     }

--- a/apps/atlasd/src/nats-manager.ts
+++ b/apps/atlasd/src/nats-manager.ts
@@ -43,21 +43,13 @@ import type { NatsConnection } from "nats";
 export class NatsManager {
   private spawned: SpawnedNats | null = null;
   private nc: NatsConnection | null = null;
+  private resolvedUrl: string | null = null;
   /**
    * Set after a successful start. The daemon is the canonical writer
    * of `<home>/nats/url` — `stop()` deletes the file regardless of
    * which path put us on the broker (env URL, cached URL, own spawn).
    */
   private ownsUrlFile = false;
-  /**
-   * Whether start() overwrote `process.env.FRIDAY_NATS_URL` so child
-   * spawns inherit the resolved URL. stop() restores the prior value
-   * (or clears it) — without that, a spawn between stop() and the next
-   * start() would inherit a URL pointing at the dead broker and hit
-   * the same 30s connect timeout the env-write was added to prevent.
-   */
-  private priorNatsUrl: string | undefined = undefined;
-  private envSet = false;
 
   async start(): Promise<NatsConnection> {
     // Log resolved JetStream config + provenance unconditionally — applies
@@ -131,16 +123,14 @@ export class NatsManager {
     this.ownsUrlFile = true;
     logger.info("Wrote broker URL file", { url, urlFile: brokerUrlFilePath(home) });
 
-    // Propagate the resolved URL to in-process env so child spawns
-    // inherit it instead of falling back to the hardcoded
-    // `nats://localhost:4222`. pickPort() chooses dynamically in the
-    // 14222 range, so the hardcoded fallback is wrong on every dev
-    // run where `.env` doesn't carry FRIDAY_NATS_URL. Capture the
-    // prior value first so stop() can restore the env to its
-    // pre-start state.
-    this.priorNatsUrl = process.env.FRIDAY_NATS_URL;
-    process.env.FRIDAY_NATS_URL = url;
-    this.envSet = true;
+    // Make the resolved URL available to in-process consumers
+    // (process-agent-executor, the agent-register route) so they pass
+    // it explicitly to child spawns instead of reading from
+    // `process.env.FRIDAY_NATS_URL`. pickPort() chooses dynamically in
+    // the 14222 range, so the historical hardcoded `localhost:4222`
+    // fallback at those call sites was wrong on every dev run where
+    // `.env` didn't carry FRIDAY_NATS_URL.
+    this.resolvedUrl = url;
 
     if (process.env.FRIDAY_NATS_MONITOR === "1") {
       logger.info(`NATS monitoring enabled at http://127.0.0.1:${DEFAULT_NATS_MONITOR_PORT}`);
@@ -153,6 +143,12 @@ export class NatsManager {
   get connection(): NatsConnection {
     if (!this.nc) throw new Error("NatsManager not started — call start() first");
     return this.nc;
+  }
+
+  /** Resolved broker URL, valid after start() completes. */
+  get url(): string {
+    if (!this.resolvedUrl) throw new Error("NatsManager not started — call start() first");
+    return this.resolvedUrl;
   }
 
   /**
@@ -201,15 +197,7 @@ export class NatsManager {
       this.ownsUrlFile = false;
     }
 
-    if (this.envSet) {
-      if (this.priorNatsUrl === undefined) {
-        delete process.env.FRIDAY_NATS_URL;
-      } else {
-        process.env.FRIDAY_NATS_URL = this.priorNatsUrl;
-      }
-      this.priorNatsUrl = undefined;
-      this.envSet = false;
-    }
+    this.resolvedUrl = null;
   }
 
   /**

--- a/apps/atlasd/src/nats-manager.ts
+++ b/apps/atlasd/src/nats-manager.ts
@@ -49,6 +49,15 @@ export class NatsManager {
    * which path put us on the broker (env URL, cached URL, own spawn).
    */
   private ownsUrlFile = false;
+  /**
+   * Whether start() overwrote `process.env.FRIDAY_NATS_URL` so child
+   * spawns inherit the resolved URL. stop() restores the prior value
+   * (or clears it) — without that, a spawn between stop() and the next
+   * start() would inherit a URL pointing at the dead broker and hit
+   * the same 30s connect timeout the env-write was added to prevent.
+   */
+  private priorNatsUrl: string | undefined = undefined;
+  private envSet = false;
 
   async start(): Promise<NatsConnection> {
     // Log resolved JetStream config + provenance unconditionally — applies
@@ -123,12 +132,15 @@ export class NatsManager {
     logger.info("Wrote broker URL file", { url, urlFile: brokerUrlFilePath(home) });
 
     // Propagate the resolved URL to in-process env so child spawns
-    // (process-agent-executor, tool-worker-launcher, etc.) inherit it
-    // instead of falling back to the hardcoded `nats://localhost:4222`.
-    // pickPort() chooses dynamically in the 14222 range, so the
-    // hardcoded fallback is wrong on every dev run where `.env` doesn't
-    // carry FRIDAY_NATS_URL.
+    // inherit it instead of falling back to the hardcoded
+    // `nats://localhost:4222`. pickPort() chooses dynamically in the
+    // 14222 range, so the hardcoded fallback is wrong on every dev
+    // run where `.env` doesn't carry FRIDAY_NATS_URL. Capture the
+    // prior value first so stop() can restore the env to its
+    // pre-start state.
+    this.priorNatsUrl = process.env.FRIDAY_NATS_URL;
     process.env.FRIDAY_NATS_URL = url;
+    this.envSet = true;
 
     if (process.env.FRIDAY_NATS_MONITOR === "1") {
       logger.info(`NATS monitoring enabled at http://127.0.0.1:${DEFAULT_NATS_MONITOR_PORT}`);
@@ -187,6 +199,16 @@ export class NatsManager {
     if (this.ownsUrlFile) {
       await deleteBrokerUrlFile(getFridayHome());
       this.ownsUrlFile = false;
+    }
+
+    if (this.envSet) {
+      if (this.priorNatsUrl === undefined) {
+        delete process.env.FRIDAY_NATS_URL;
+      } else {
+        process.env.FRIDAY_NATS_URL = this.priorNatsUrl;
+      }
+      this.priorNatsUrl = undefined;
+      this.envSet = false;
     }
   }
 

--- a/apps/atlasd/src/process-agent-executor.ts
+++ b/apps/atlasd/src/process-agent-executor.ts
@@ -34,6 +34,7 @@ const READY_TIMEOUT_MS = 30_000;
 export class ProcessAgentExecutor {
   constructor(
     private nc: NatsConnection,
+    private natsUrl: string,
     private capabilityRegistry: CapabilityHandlerRegistry,
   ) {}
 
@@ -109,7 +110,7 @@ export class ProcessAgentExecutor {
         env: {
           ...process.env,
           ...options.env,
-          NATS_URL: process.env.FRIDAY_NATS_URL ?? "nats://localhost:4222",
+          NATS_URL: this.natsUrl,
           FRIDAY_SESSION_ID: sessionId,
         },
         stdio: "pipe",

--- a/apps/atlasd/src/services/communicator-wiring.ts
+++ b/apps/atlasd/src/services/communicator-wiring.ts
@@ -51,17 +51,25 @@ const WhatsappCredentialSecretSchema = z.object({ phone_number_id: z.string().mi
 
 const SlackCredentialSecretSchema = z.object({ app_id: z.string().min(1) });
 
+function s2sScheme(): "http" | "https" {
+  // Match the daemon listener's scheme (set by atlas-cli/start.tsx
+  // from the same env pair). If link / tunnel are on TLS the daemon
+  // must speak TLS to them too, and DENO_CERT in the daemon's env
+  // closes the trust path against the private CA.
+  return process.env.FRIDAY_TLS_CERT && process.env.FRIDAY_TLS_KEY ? "https" : "http";
+}
+
 function getLinkServiceUrl(): string {
-  return process.env.LINK_SERVICE_URL ?? "http://localhost:3100";
+  return process.env.LINK_SERVICE_URL ?? `${s2sScheme()}://localhost:3100`;
 }
 
 /**
- * Local URL for webhook-tunnel's `/status` endpoint. Defaults to
- * `http://localhost:9090` (the standard webhook-tunnel listener); override via
- * `WEBHOOK_TUNNEL_URL` for non-default ports / dev rigs.
+ * Local URL for webhook-tunnel's `/status` endpoint. Defaults to the
+ * standard webhook-tunnel listener; override via `WEBHOOK_TUNNEL_URL`
+ * for non-default ports / dev rigs. Scheme follows the s2s mesh.
  */
 function getWebhookTunnelUrl(): string {
-  return process.env.WEBHOOK_TUNNEL_URL ?? "http://localhost:9090";
+  return process.env.WEBHOOK_TUNNEL_URL ?? `${s2sScheme()}://localhost:9090`;
 }
 
 const TunnelStatusSchema = z.object({ url: z.string().url().nullable().optional() });

--- a/apps/atlasd/src/utils.ts
+++ b/apps/atlasd/src/utils.ts
@@ -21,10 +21,11 @@ export function getAtlasDaemonUrl(): string {
     try {
       new URL(url);
     } catch {
+      const scheme = env.FRIDAY_TLS_CERT && env.FRIDAY_TLS_KEY ? "https" : "http";
       logger.warn(
-        `Invalid FRIDAY_DAEMON_URL: "${url}". Must be a valid URL (e.g., http://127.0.0.1:8080). Using default.`,
+        `Invalid FRIDAY_DAEMON_URL: "${url}". Must be a valid URL (e.g., ${scheme}://127.0.0.1:8080). Using default.`,
       );
-      return "http://127.0.0.1:8080";
+      return `${scheme}://127.0.0.1:8080`;
     }
   }
 

--- a/apps/link/deno.json
+++ b/apps/link/deno.json
@@ -4,7 +4,7 @@
   "exports": "./src/index.ts",
   "tasks": {
     "start": "deno run --env-file --allow-all src/index.ts",
-    "dev": "LINK_DEV_MODE=true deno run --watch --env-file=$HOME/.atlas/link.env --allow-all src/index.ts"
+    "dev": "LINK_DEV_MODE=true deno run --watch --env-file=$HOME/.atlas/.env --allow-all src/index.ts"
   },
   "imports": {
     "@atlas/logger": "../../packages/logger/mod.ts",

--- a/apps/link/src/index.ts
+++ b/apps/link/src/index.ts
@@ -317,8 +317,6 @@ export {
 export type { Credential, CredentialSummary, OAuthCredential } from "./types.ts";
 
 if (import.meta.main) {
-  logger.info("Link service starting", { port: config.port });
-
   Deno.addSignalListener("SIGINT", () => shutdown("SIGINT"));
   Deno.addSignalListener("SIGTERM", () => shutdown("SIGTERM"));
 
@@ -329,5 +327,40 @@ if (import.meta.main) {
   // credentials. LINK_BIND_HOST escape hatch for production / containers
   // that need 0.0.0.0 (Docker networking).
   const hostname = Deno.env.get("LINK_BIND_HOST") ?? "127.0.0.1";
-  server = Deno.serve({ port: config.port, hostname, onListen: () => {}, handler: app.fetch });
+
+  // Match the s2s TLS pattern atlasd + webhook-tunnel use: when the
+  // private-CA cert pair is wired (FRIDAY_TLS_CERT/_KEY via
+  // setup-tls.sh for dev or the launcher's s2s_generator + .env
+  // writeback for installed mode), bind https://. The daemon's calls
+  // into link go through fetch() with DENO_CERT/NODE_EXTRA_CA_CERTS
+  // pointed at the matching CA, so the trust path closes end-to-end.
+  // Without the env, fall back to plain http on loopback — the
+  // pre-TLS-mesh behavior.
+  const certPath = Deno.env.get("FRIDAY_TLS_CERT");
+  const keyPath = Deno.env.get("FRIDAY_TLS_KEY");
+  let tls: { cert: string; key: string } | null = null;
+  if (certPath && keyPath) {
+    try {
+      tls = { cert: Deno.readTextFileSync(certPath), key: Deno.readTextFileSync(keyPath) };
+    } catch (err) {
+      logger.warn("FRIDAY_TLS_CERT/_KEY set but unreadable — falling back to HTTP", {
+        error: err instanceof Error ? err.message : String(err),
+      });
+      tls = null;
+    }
+  }
+  const scheme = tls ? "https" : "http";
+  logger.info("Link service starting", { port: config.port, scheme });
+  server = Deno.serve(
+    tls
+      ? {
+          port: config.port,
+          hostname,
+          cert: tls.cert,
+          key: tls.key,
+          onListen: () => {},
+          handler: app.fetch,
+        }
+      : { port: config.port, hostname, onListen: () => {}, handler: app.fetch },
+  );
 }

--- a/apps/studio-installer/src-tauri/src/commands/download_tls.rs
+++ b/apps/studio-installer/src-tauri/src/commands/download_tls.rs
@@ -1,0 +1,260 @@
+// Downloads the browser-trusted TLS cert pair that the playground origin
+// uses in installed mode (https://local.hellofriday.ai:<port>). The certs
+// are publicly issued by Let's Encrypt for `local.hellofriday.ai`, served
+// from the CDN at download.fridayplatform.io, and rotate when LE re-issues
+// — the manifest carries the current sha256 for each artifact so the
+// installer can verify integrity before writing them to disk.
+//
+// File mapping (manifest filename → on-disk filename under tls-paths.ts
+// resolution order):
+//   fullchain.pem → <friday_home>/tls/browser.crt
+//   key.pem       → <friday_home>/tls/browser.key  (0600 on Unix)
+//
+// The on-disk names match what `tls-paths.ts` (playground) and the
+// launcher's TLS detection look for. The launcher and `playground_url`
+// command also check for browser.crt to decide between
+// https://local.hellofriday.ai:<port> and the legacy http://localhost
+// fallback — so if this command fails, the rest of the install proceeds
+// on http:// and the user is not blocked.
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::friday_home::friday_home_dir;
+
+const DEFAULT_MANIFEST_URL: &str = "https://download.fridayplatform.io/tls/manifest.json";
+
+/// Filename inside the manifest's `files` map → on-disk filename under
+/// `<friday_home>/tls/`. Single source of truth for the mapping so the
+/// command code below stays a flat loop.
+const FILES: &[(&str, &str)] = &[("fullchain.pem", "browser.crt"), ("key.pem", "browser.key")];
+
+#[derive(Debug, Deserialize)]
+struct Manifest {
+    domain: String,
+    #[serde(rename = "notAfter")]
+    not_after: Option<String>,
+    files: HashMap<String, FileEntry>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FileEntry {
+    url: String,
+    sha256: String,
+    size: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TlsInstallReport {
+    pub domain: String,
+    pub cert_path: String,
+    pub key_path: String,
+    pub not_after: Option<String>,
+}
+
+fn manifest_url() -> String {
+    std::env::var("FRIDAY_TLS_MANIFEST_URL").unwrap_or_else(|_| DEFAULT_MANIFEST_URL.to_string())
+}
+
+fn tls_dir() -> Result<PathBuf, String> {
+    Ok(friday_home_dir()?.join("tls"))
+}
+
+/// Atomic write: tmp + fsync + rename. Mirrors env_file.rs:atomic_write —
+/// duplicated here so this module stays self-contained, and because the
+/// cert pair has a stricter durability story (a torn cert.pem would mean
+/// the playground fails to start TLS on next launch).
+fn atomic_write(path: &Path, bytes: &[u8], mode: Option<u32>) -> Result<(), String> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| format!("path has no parent: {}", path.display()))?;
+    fs::create_dir_all(parent)
+        .map_err(|e| format!("create parent dir {}: {e}", parent.display()))?;
+
+    let tmp = path.with_extension({
+        let existing = path.extension().map(|e| e.to_string_lossy().into_owned());
+        match existing {
+            Some(e) if !e.is_empty() => format!("{e}.tmp"),
+            _ => "tmp".to_string(),
+        }
+    });
+    if tmp.exists() {
+        let _ = fs::remove_file(&tmp);
+    }
+
+    {
+        use std::io::Write;
+        let mut f = fs::File::create(&tmp)
+            .map_err(|e| format!("create tmp {}: {e}", tmp.display()))?;
+        f.write_all(bytes)
+            .map_err(|e| format!("write tmp {}: {e}", tmp.display()))?;
+        f.sync_data()
+            .map_err(|e| format!("fsync tmp {}: {e}", tmp.display()))?;
+    }
+
+    // Set restrictive perms BEFORE the rename so the file is never visible
+    // at the final path with a permissive mode. On Windows, fs::Permissions
+    // ignores Unix bits — keys there are protected by the user's AppData
+    // ACL inherited from the parent dir, which is sufficient.
+    #[cfg(unix)]
+    if let Some(m) = mode {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&tmp, fs::Permissions::from_mode(m))
+            .map_err(|e| format!("set perms on tmp {}: {e}", tmp.display()))?;
+    }
+    #[cfg(not(unix))]
+    let _ = mode;
+
+    fs::rename(&tmp, path).map_err(|e| {
+        format!(
+            "rename {} → {}: {e}",
+            tmp.display(),
+            path.display()
+        )
+    })
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut h = Sha256::new();
+    h.update(bytes);
+    hex::encode(h.finalize())
+}
+
+async fn fetch_manifest(client: &reqwest::Client, url: &str) -> Result<Manifest, String> {
+    let res = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("manifest fetch failed: {e}"))?;
+    if !res.status().is_success() {
+        return Err(format!("manifest HTTP error: {}", res.status()));
+    }
+    res.json::<Manifest>()
+        .await
+        .map_err(|e| format!("manifest parse: {e}"))
+}
+
+async fn fetch_bytes(client: &reqwest::Client, url: &str) -> Result<Vec<u8>, String> {
+    let res = client
+        .get(url)
+        .send()
+        .await
+        .map_err(|e| format!("download {url}: {e}"))?;
+    if !res.status().is_success() {
+        return Err(format!("download {url}: HTTP {}", res.status()));
+    }
+    let bytes = res
+        .bytes()
+        .await
+        .map_err(|e| format!("read body {url}: {e}"))?;
+    Ok(bytes.to_vec())
+}
+
+#[tauri::command]
+pub async fn download_tls_certs() -> Result<TlsInstallReport, String> {
+    let client = reqwest::Client::builder()
+        .use_rustls_tls()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| format!("http client build: {e}"))?;
+
+    let url = manifest_url();
+    let manifest = fetch_manifest(&client, &url).await?;
+
+    let dir = tls_dir()?;
+    let mut paths: HashMap<&str, PathBuf> = HashMap::new();
+
+    for (manifest_name, on_disk_name) in FILES {
+        let entry = manifest
+            .files
+            .get(*manifest_name)
+            .ok_or_else(|| format!("manifest missing {manifest_name}"))?;
+
+        let bytes = fetch_bytes(&client, &entry.url).await?;
+
+        if bytes.len() as u64 != entry.size {
+            return Err(format!(
+                "{manifest_name}: size mismatch (got {}, manifest {})",
+                bytes.len(),
+                entry.size
+            ));
+        }
+
+        let got = sha256_hex(&bytes);
+        if !got.eq_ignore_ascii_case(&entry.sha256) {
+            return Err(format!(
+                "{manifest_name}: sha256 mismatch (got {got}, manifest {})",
+                entry.sha256
+            ));
+        }
+
+        let path = dir.join(on_disk_name);
+        // The private key MUST be 0600 — the playground (Deno) reads it
+        // directly and will accept any mode, but other users on the
+        // machine should not be able to read a private key off disk.
+        // fullchain is public, leave at default umask.
+        let mode = if *on_disk_name == "browser.key" { Some(0o600) } else { None };
+        atomic_write(&path, &bytes, mode)?;
+        paths.insert(on_disk_name, path);
+    }
+
+    let cert_path = paths
+        .get("browser.crt")
+        .ok_or("internal: missing browser.crt path")?
+        .display()
+        .to_string();
+    let key_path = paths
+        .get("browser.key")
+        .ok_or("internal: missing browser.key path")?
+        .display()
+        .to_string();
+
+    Ok(TlsInstallReport {
+        domain: manifest.domain,
+        cert_path,
+        key_path,
+        not_after: manifest.not_after,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sha256_hex_matches_known_vector() {
+        // "abc" → e9ec... (well-known SHA-256 vector).
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn atomic_write_round_trips_and_sets_mode() {
+        let tmp = tempfile::tempdir().expect("create tmp");
+        let p = tmp.path().join("nested").join("file.key");
+        atomic_write(&p, b"hello", Some(0o600)).expect("write");
+        assert_eq!(fs::read(&p).expect("read"), b"hello");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let m = fs::metadata(&p).expect("meta").permissions().mode() & 0o777;
+            assert_eq!(m, 0o600);
+        }
+    }
+
+    #[test]
+    fn atomic_write_overwrites_existing() {
+        let tmp = tempfile::tempdir().expect("create tmp");
+        let p = tmp.path().join("file.crt");
+        atomic_write(&p, b"v1", None).expect("v1");
+        atomic_write(&p, b"v2", None).expect("v2");
+        assert_eq!(fs::read(&p).expect("read"), b"v2");
+    }
+}

--- a/apps/studio-installer/src-tauri/src/commands/env_file.rs
+++ b/apps/studio-installer/src-tauri/src/commands/env_file.rs
@@ -270,6 +270,13 @@ pub fn ensure_platform_env_vars() -> Result<String, String> {
 /// (Welcome, launchByOpening, openPlaygroundAndExit) lands on the
 /// same URL — pre-fix, all three hardcoded :5200 and broke any
 /// install with a port override.
+///
+/// Scheme/host selection: if `<friday_home>/tls/browser.crt` exists
+/// (written by download_tls_certs), the playground origin is serving
+/// a publicly-trusted cert for `local.hellofriday.ai` — return the
+/// https URL so the browser lands on a green-lock origin matching the
+/// cert SAN. Without the cert, fall back to plain http://localhost so
+/// installs that skipped or failed the cert download still work.
 #[tauri::command]
 pub fn playground_url() -> Result<String, String> {
     let port = match fs::read_to_string(env_file_path()?) {
@@ -283,7 +290,12 @@ pub fn playground_url() -> Result<String, String> {
             .unwrap_or_else(|| "15200".to_string()),
         Err(_) => "15200".to_string(),
     };
-    Ok(format!("http://localhost:{port}"))
+    let cert = friday_home_dir()?.join("tls").join("browser.crt");
+    if cert.exists() {
+        Ok(format!("https://local.hellofriday.ai:{port}"))
+    } else {
+        Ok(format!("http://localhost:{port}"))
+    }
 }
 
 #[tauri::command]

--- a/apps/studio-installer/src-tauri/src/commands/mod.rs
+++ b/apps/studio-installer/src-tauri/src/commands/mod.rs
@@ -3,6 +3,7 @@ pub mod create_app_bundle;
 pub mod delete_partial;
 pub mod download;
 pub mod download_checkpoint;
+pub mod download_tls;
 pub mod ensure_agent_browser_chrome;
 pub mod ensure_claude_code;
 pub mod env_file;

--- a/apps/studio-installer/src-tauri/src/lib.rs
+++ b/apps/studio-installer/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ use commands::{
     create_app_bundle::create_app_bundle,
     delete_partial::delete_partial,
     download::download_file,
+    download_tls::download_tls_certs,
     ensure_agent_browser_chrome::ensure_agent_browser_chrome,
     ensure_claude_code::ensure_claude_code,
     download_checkpoint::{check_download_complete, mark_download_complete},
@@ -41,6 +42,7 @@ pub fn run() {
         .manage(WaitDeadlineState::default())
         .invoke_handler(tauri::generate_handler![
             download_file,
+            download_tls_certs,
             delete_partial,
             mark_download_complete,
             check_download_complete,

--- a/apps/studio-installer/src/steps/Extract.svelte
+++ b/apps/studio-installer/src/steps/Extract.svelte
@@ -45,6 +45,18 @@ let tools = $state<Tool[]>([
     status: "pending",
   },
   {
+    // Downloads the browser-trusted cert pair for local.hellofriday.ai
+    // from download.fridayplatform.io and sha256-verifies against the
+    // manifest, writing browser.crt/browser.key under
+    // ~/.friday/local/tls/. Once present, playground_url() and the
+    // launcher's playgroundURL() both return https://local.hellofriday.ai;
+    // without it, both fall back to http://localhost. Non-fatal: a
+    // network failure here still lets the install proceed on http://.
+    display: "Browser TLS certificate",
+    command: "download_tls_certs",
+    status: "pending",
+  },
+  {
     // Runs `friday migrate`. Idempotent. Failures are non-fatal — the
     // row flips to ✗ and the launcher boots anyway. What `migrate`
     // does is atlas-cli's concern, not the installer's.

--- a/deno.json
+++ b/deno.json
@@ -53,7 +53,7 @@
     "compile": "./scripts/compile.sh",
     "evals": "deno run --allow-all tools/evals/run.ts",
     "sync:svelte": "deno task -f @atlas/ui sync && deno task -f @atlas/agent-playground sync",
-    "playground": "deno task sync:svelte && cd tools/agent-playground && EXTERNAL_DAEMON_URL=http://localhost:8080 EXTERNAL_TUNNEL_URL=http://localhost:9090 npx vite dev"
+    "playground": "deno task sync:svelte && bash scripts/run-playground-vite.sh"
   },
   "lint": { "rules": { "tags": ["recommended"] }, "exclude": ["opensrc/**"] },
   "imports": {

--- a/deno.lock
+++ b/deno.lock
@@ -153,7 +153,6 @@
     "npm:nanoid@^5.1.6": "5.1.11",
     "npm:nats@2": "2.29.3",
     "npm:nats@^2.29.3": "2.29.3",
-    "npm:node-html-parser@^7.1.0": "7.1.0",
     "npm:oauth4webapi@3.8.6": "3.8.6",
     "npm:oauth4webapi@^3.8.3": "3.8.6",
     "npm:openapi-fetch@0.15": "0.15.2",
@@ -2802,9 +2801,6 @@
         "type-is"
       ]
     },
-    "boolbase@1.0.0": {
-      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
-    },
     "bottleneck@2.19.5": {
       "integrity": "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="
     },
@@ -3063,25 +3059,12 @@
         "which"
       ]
     },
-    "css-select@5.2.2": {
-      "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
-      "dependencies": [
-        "boolbase",
-        "css-what",
-        "domhandler",
-        "domutils",
-        "nth-check"
-      ]
-    },
     "css-tree@3.2.1": {
       "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
       "dependencies": [
         "mdn-data",
         "source-map-js"
       ]
-    },
-    "css-what@6.2.2": {
-      "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA=="
     },
     "cssesc@3.0.0": {
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
@@ -3178,35 +3161,10 @@
         "undici@6.24.1"
       ]
     },
-    "dom-serializer@2.0.0": {
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dependencies": [
-        "domelementtype",
-        "domhandler",
-        "entities@4.5.0"
-      ]
-    },
-    "domelementtype@2.3.0": {
-      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
-    },
-    "domhandler@5.0.3": {
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dependencies": [
-        "domelementtype"
-      ]
-    },
     "dompurify@3.4.2": {
       "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
       "optionalDependencies": [
         "@types/trusted-types"
-      ]
-    },
-    "domutils@3.2.2": {
-      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
-      "dependencies": [
-        "dom-serializer",
-        "domelementtype",
-        "domhandler"
       ]
     },
     "dotenv@17.4.2": {
@@ -3778,10 +3736,6 @@
       "dependencies": [
         "@types/hast"
       ]
-    },
-    "he@1.2.0": {
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "bin": true
     },
     "hono-openapi@1.3.0_@hono+standard-validator@0.2.2__@standard-schema+spec@1.1.0__hono@4.12.18_hono@4.12.18_zod@4.4.3": {
       "integrity": "sha512-xDvCWpWEIv0weEmnl3EjRQzqbHIO8LnfzMuYOCmbuyE5aes6aXxLg4vM3ybnoZD5TiTUkA6PuRQPJs3R7WRBig==",
@@ -4818,19 +4772,6 @@
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": [
         "whatwg-url@5.0.0"
-      ]
-    },
-    "node-html-parser@7.1.0": {
-      "integrity": "sha512-iJo8b2uYGT40Y8BTyy5ufL6IVbN8rbm/1QK2xffXU/1a/v3AAa0d1YAoqBNYqaS4R/HajkWIpIfdE6KcyFh1AQ==",
-      "dependencies": [
-        "css-select",
-        "he"
-      ]
-    },
-    "nth-check@2.1.1": {
-      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-      "dependencies": [
-        "boolbase"
       ]
     },
     "oauth4webapi@3.8.6": {
@@ -6733,7 +6674,6 @@
             "npm:happy-dom@^20.9.0",
             "npm:hono@4.12.18",
             "npm:jszip@^3.10.1",
-            "npm:node-html-parser@^7.1.0",
             "npm:prettier@^3.8.3",
             "npm:shiki@^4.0.2",
             "npm:svelte-check@^4.4.7",

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/f1bonacc1/process-compose v1.110.0
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/go-chi/cors v1.2.2
+	github.com/joho/godotenv v1.5.1
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sys v0.44.0
@@ -35,7 +36,6 @@ require (
 	github.com/go-ole/go-ole v1.3.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
-	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/lucasb-eyer/go-colorful v1.4.0 // indirect

--- a/packages/openapi-client/src/utils.ts
+++ b/packages/openapi-client/src/utils.ts
@@ -47,10 +47,28 @@ export function getAtlasDaemonUrl(): string {
   // least one message is required" because the workspace context comes
   // back empty (Connection refused → silently empty messages array).
   if (process?.env) {
+    // FRIDAY_TLS_CERT signals the daemon is bound with TLS (set by
+    // `bash scripts/setup-tls.sh`). Default the scheme to match so CLI
+    // subcommands reach the right port without each call site having to
+    // remember to override FRIDAYD_URL.
+    const tlsOn = !!(process.env.FRIDAY_TLS_CERT && process.env.FRIDAY_TLS_KEY);
     const explicit = process.env.FRIDAYD_URL || process.env.FRIDAY_DAEMON_URL;
-    if (explicit) return explicit;
+    if (explicit) {
+      // If the explicit URL is http:// but TLS is on, upgrade the scheme.
+      // The daemon's TLS listener rejects cleartext requests, so an out-of-
+      // sync FRIDAYD_URL (e.g. left over from a prior non-TLS run) would
+      // surface as "Response does not match HTTP/1.1 protocol". Don't
+      // downgrade https→http: a user with explicit https config knows
+      // their setup.
+      if (tlsOn && explicit.startsWith("http://")) {
+        return "https://" + explicit.slice("http://".length);
+      }
+      return explicit;
+    }
+    const scheme = tlsOn ? "https" : "http";
     const port = process.env.FRIDAY_PORT_FRIDAY;
-    if (port) return `http://127.0.0.1:${port}`;
+    if (port) return `${scheme}://127.0.0.1:${port}`;
+    return `${scheme}://127.0.0.1:8080`;
   }
 
   return "http://127.0.0.1:8080";

--- a/scripts/dev-watcher.ts
+++ b/scripts/dev-watcher.ts
@@ -17,12 +17,39 @@
  */
 
 import { type ChildProcess, spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import process from "node:process";
 
 const REPO_ROOT = process.cwd();
+
+// Pre-load <FRIDAY_HOME>/.env into this process's env BEFORE Deno's
+// RootCertStore initializes on first TLS use. The daemon spawned below
+// reads FRIDAY_TLS_CERT/_KEY from --env-file flags, so it serves HTTPS
+// when those are set in ~/.atlas/.env (setup-tls.sh seeds them). The
+// dev-watcher itself does its own fetch() against /api/sessions to
+// drive the restart loop, so it also needs:
+//   - the right URL scheme (http vs https) → reads FRIDAY_TLS_CERT
+//   - to trust the private CA → reads DENO_CERT before Deno binds the
+//     RootCertStore. Setting DENO_CERT post-bind has no effect.
+// Mirrors scripts/run-atlasd.sh; same .env, same precedence (shell
+// exports win).
+(() => {
+  const envFile = path.join(process.env.FRIDAY_HOME || path.join(homedir(), ".atlas"), ".env");
+  if (!existsSync(envFile)) return;
+  const text = readFileSync(envFile, "utf8");
+  for (const raw of text.split("\n")) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const eq = line.indexOf("=");
+    if (eq <= 0) continue;
+    const key = line.slice(0, eq).trim();
+    const value = line.slice(eq + 1);
+    if (process.env[key] !== undefined) continue;
+    process.env[key] = value;
+  }
+})();
 
 /**
  * Env files loaded by every daemon spawn. Deno's `--env-file` is LAST-wins
@@ -102,7 +129,18 @@ const INCLUDE_EXTENSIONS: readonly string[] = [
 ];
 
 const DEBOUNCE_MS = 500;
-const SESSIONS_URL = "http://localhost:8080/api/sessions?limit=100";
+// Resolve at call time, not module load: the daemon listener scheme
+// (http vs https) depends on FRIDAY_TLS_CERT/_KEY being set in this
+// process's env, which we top up from ~/.atlas/.env at startup. A
+// module-level const would freeze the URL before the env load runs.
+// FRIDAYD_URL wins as an explicit override; otherwise derive from
+// FRIDAY_TLS_CERT presence. Without TLS env, falls back to http.
+function sessionsURL(): string {
+  const override = process.env.FRIDAYD_URL;
+  if (override) return `${override.replace(/\/+$/, "")}/api/sessions?limit=100`;
+  const scheme = process.env.FRIDAY_TLS_CERT && process.env.FRIDAY_TLS_KEY ? "https" : "http";
+  return `${scheme}://localhost:8080/api/sessions?limit=100`;
+}
 const IDLE_POLL_MS = 2000;
 const MAX_WAIT_MS = 30 * 60 * 1000; // 30 min — FAST sessions can legitimately run 20+ min
 const SHUTDOWN_GRACE_MS = 10_000;
@@ -263,7 +301,7 @@ function spawnDaemon(): ChildProcess {
 async function activeSessionCount(): Promise<number | null> {
   let resp: Response;
   try {
-    resp = await fetch(SESSIONS_URL, { signal: AbortSignal.timeout(2000) });
+    resp = await fetch(sessionsURL(), { signal: AbortSignal.timeout(2000) });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     warn(`sessions fetch failed (${message}) — treating as "unknown"`);

--- a/scripts/dev-watcher.ts
+++ b/scripts/dev-watcher.ts
@@ -45,7 +45,24 @@ const REPO_ROOT = process.cwd();
     const eq = line.indexOf("=");
     if (eq <= 0) continue;
     const key = line.slice(0, eq).trim();
-    const value = line.slice(eq + 1);
+    let value = line.slice(eq + 1);
+    // Strip surrounding quotes the same way Deno's `--env-file`
+    // parser (and @std/dotenv) does. Required because the .env we're
+    // reading was usually written by tools that quote values
+    // containing punctuation (mkcert paths with spaces,
+    // ANTHROPIC_API_KEY with dashes). Without this, e.g.
+    // `ANTHROPIC_API_KEY='sk-ant-...'` ends up in process.env as a
+    // value with literal quotes, which the Anthropic client then
+    // sends in the `x-api-key` header → "invalid x-api-key" 401.
+    // The daemon child inherits the bad value and Deno's own
+    // --env-file is a no-op because the key is "already set".
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    }
     if (process.env[key] !== undefined) continue;
     process.env[key] = value;
   }

--- a/scripts/run-atlasd.sh
+++ b/scripts/run-atlasd.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Wrapper for `atlas-cli` (otel-bootstrap.ts). Exports the small set of
+# env vars that are consumed at *module-load time* (i.e. before user
+# code can dotenv-load anything) and exec's deno. Everything else
+# (FRIDAY_KEY, ANTHROPIC_API_KEY, OAuth tokens, etc.) is loaded by
+# atlas-cli's own dotenv.load() in start.tsx — no double-parse.
+#
+# What needs to land before module load:
+#   - DENO_CERT             — Deno's RootCertStore initializes on first
+#                             TLS use, which fires before user code.
+#                             OTEL traffic hits TLS during bootstrap.
+#   - FRIDAY_TLS_CERT/_KEY  — getAtlasDaemonUrl() in @atlas/oapi-client
+#                             reads these at module-init to decide
+#                             between http:// and https:// when building
+#                             baseUrl in @atlas/client/v2. The baseUrl
+#                             is *frozen* at first import — if these
+#                             aren't set yet, every subsequent client
+#                             call hits the wrong scheme.
+#
+# Installer (friday-launcher Go) doesn't go through this wrapper — it
+# pre-populates process.env via commonServiceEnv() before spawning the
+# compiled atlasd binary. This wrapper is the dev-mode equivalent.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Pick the canonical .env: FRIDAY_HOME wins (installer points at
+# ~/.friday/local; manual overrides ditto), otherwise dev default
+# ~/.atlas/.env which setup-tls.sh always seeds.
+ENV_FILE="${FRIDAY_HOME:-$HOME/.atlas}/.env"
+
+# Extract a single key=value line from .env, returning the value with
+# the key prefix stripped. Path values may contain spaces (mkcert's
+# CAROOT on macOS lives under `Application Support`); taking the head
+# of grep + parameter expansion handles them correctly without quoting
+# games.
+read_env_var() {
+    local key="$1" file="$2"
+    local line
+    line="$(grep "^${key}=" "$file" | head -1 || true)"
+    [[ -n "$line" ]] && printf '%s' "${line#${key}=}"
+}
+
+if [[ -f "$ENV_FILE" ]]; then
+    for key in DENO_CERT FRIDAY_TLS_CERT FRIDAY_TLS_KEY; do
+        # Don't clobber a shell-exported value — explicit > .env.
+        [[ -n "${!key:-}" ]] && continue
+        value="$(read_env_var "$key" "$ENV_FILE")"
+        [[ -n "$value" ]] && export "$key=$value"
+    done
+fi
+
+cd "$REPO_ROOT"
+exec deno run -q --allow-all --unstable-worker-options --unstable-kv --unstable-raw-imports apps/atlas-cli/src/otel-bootstrap.ts "$@"

--- a/scripts/run-playground-vite.sh
+++ b/scripts/run-playground-vite.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Wrapper for `vite dev` that:
+#   1. Invokes vite via real `node` (not `npx`) so `deno task` doesn't
+#      route the bin script through Deno's node-compat — Deno's
+#      `node:http2` polyfill is missing `setupConnectionsTracking`,
+#      which `Http2SecureServer`'s constructor calls when vite serves
+#      HTTPS. Real Node 22+ has it.
+#   2. Sets `NODE_EXTRA_CA_CERTS` to mkcert's root CA *before* Node
+#      starts. Node 25 reads this only at startup; setting it from
+#      inside `vite.config.ts` is too late — the default secure context
+#      is created before our config runs, and the SvelteKit dev proxy's
+#      fetch to https://daemon then fails with `fetch failed` because
+#      the mkcert leaf chains to an untrusted CA.
+#
+# Without TLS / mkcert this still works — `NODE_EXTRA_CA_CERTS` simply
+# isn't set, vite serves HTTP, and the proxy fetches HTTP. No-op cost.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLAYGROUND_DIR="$REPO_ROOT/tools/agent-playground"
+VITE_BIN="$REPO_ROOT/node_modules/vite/bin/vite.js"
+
+if [[ ! -f "$VITE_BIN" ]]; then
+    echo "✗ vite not installed at $VITE_BIN — run \`deno install\`" >&2
+    exit 1
+fi
+
+# Resolve mkcert's root CA so Node trusts the (mkcert-signed) daemon. Only
+# set NODE_EXTRA_CA_CERTS if we actually have a usable CA file — passing
+# a missing path silently triggers a Node warning and breaks every TLS
+# handshake.
+if [[ -z "${NODE_EXTRA_CA_CERTS:-}" ]] && command -v mkcert >/dev/null 2>&1; then
+    ca_path="$(mkcert -CAROOT 2>/dev/null)/rootCA.pem"
+    if [[ -f "$ca_path" ]]; then
+        export NODE_EXTRA_CA_CERTS="$ca_path"
+    fi
+fi
+
+cd "$PLAYGROUND_DIR"
+exec node "$VITE_BIN" dev "$@"

--- a/scripts/run-playground-vite.sh
+++ b/scripts/run-playground-vite.sh
@@ -6,15 +6,15 @@
 #      `node:http2` polyfill is missing `setupConnectionsTracking`,
 #      which `Http2SecureServer`'s constructor calls when vite serves
 #      HTTPS. Real Node 22+ has it.
-#   2. Sets `NODE_EXTRA_CA_CERTS` to mkcert's root CA *before* Node
+#   2. Sets `NODE_EXTRA_CA_CERTS` to the private s2s CA *before* Node
 #      starts. Node 25 reads this only at startup; setting it from
 #      inside `vite.config.ts` is too late — the default secure context
 #      is created before our config runs, and the SvelteKit dev proxy's
 #      fetch to https://daemon then fails with `fetch failed` because
-#      the mkcert leaf chains to an untrusted CA.
+#      the s2s leaf chains to a CA no system trust store knows about.
 #
-# Without TLS / mkcert this still works — `NODE_EXTRA_CA_CERTS` simply
-# isn't set, vite serves HTTP, and the proxy fetches HTTP. No-op cost.
+# Without s2s TLS this still works — `NODE_EXTRA_CA_CERTS` simply isn't
+# set, daemon/tunnel serve HTTP, and the proxy fetches HTTP. No-op cost.
 
 set -euo pipefail
 
@@ -28,14 +28,18 @@ if [[ ! -f "$VITE_BIN" ]]; then
     exit 1
 fi
 
-# Resolve mkcert's root CA so Node trusts the (mkcert-signed) daemon. Only
-# set NODE_EXTRA_CA_CERTS if we actually have a usable CA file — passing
-# a missing path silently triggers a Node warning and breaks every TLS
-# handshake.
-if [[ -z "${NODE_EXTRA_CA_CERTS:-}" ]] && command -v mkcert >/dev/null 2>&1; then
-    ca_path="$(mkcert -CAROOT 2>/dev/null)/rootCA.pem"
-    if [[ -f "$ca_path" ]]; then
-        export NODE_EXTRA_CA_CERTS="$ca_path"
+# Resolve the private s2s CA so Node trusts the (private-CA-signed) daemon
+# + tunnel. Source: FRIDAY_TLS_CA in <friday-home>/.env, written by
+# scripts/setup-tls.sh. Only set NODE_EXTRA_CA_CERTS if we have a real
+# file — pointing at a missing path triggers a Node warning and breaks
+# every TLS handshake.
+if [[ -z "${NODE_EXTRA_CA_CERTS:-}" ]]; then
+    env_file="${FRIDAY_HOME:-$HOME/.atlas}/.env"
+    if [[ -f "$env_file" ]]; then
+        ca_path="$(grep "^FRIDAY_TLS_CA=" "$env_file" | head -1 | sed -E 's/^FRIDAY_TLS_CA=//')"
+        if [[ -n "$ca_path" && -f "$ca_path" ]]; then
+            export NODE_EXTRA_CA_CERTS="$ca_path"
+        fi
     fi
 fi
 

--- a/scripts/run-playground-vite.sh
+++ b/scripts/run-playground-vite.sh
@@ -28,19 +28,34 @@ if [[ ! -f "$VITE_BIN" ]]; then
     exit 1
 fi
 
-# Resolve the private s2s CA so Node trusts the (private-CA-signed) daemon
-# + tunnel. Source: FRIDAY_TLS_CA in <friday-home>/.env, written by
-# scripts/setup-tls.sh. Only set NODE_EXTRA_CA_CERTS if we have a real
-# file — pointing at a missing path triggers a Node warning and breaks
-# every TLS handshake.
-if [[ -z "${NODE_EXTRA_CA_CERTS:-}" ]]; then
-    env_file="${FRIDAY_HOME:-$HOME/.atlas}/.env"
-    if [[ -f "$env_file" ]]; then
-        ca_path="$(grep "^FRIDAY_TLS_CA=" "$env_file" | head -1 | sed -E 's/^FRIDAY_TLS_CA=//')"
-        if [[ -n "$ca_path" && -f "$ca_path" ]]; then
-            export NODE_EXTRA_CA_CERTS="$ca_path"
-        fi
-    fi
+# Pull s2s + browser TLS env keys from <friday-home>/.env BEFORE
+# exec'ing node. Two reasons it has to happen here, not in
+# vite.config.ts:
+#
+#   1. vite.config.ts reads FRIDAY_TLS_CERT/_KEY at module load to
+#      decide the daemon + tunnel URL scheme (http vs https). If the
+#      env vars aren't set at that point, the URL is frozen at
+#      http://, and every SSR proxy fetch hits the wrong scheme.
+#
+#   2. Node's RootCertStore initializes on first TLS use, which fires
+#      before vite.config.ts can run. Setting NODE_EXTRA_CA_CERTS
+#      after that has no effect and the daemon-proxy fetch fails with
+#      "self signed certificate in certificate chain".
+#
+# Pre-existing shell exports win over .env (mirrors run-atlasd.sh).
+# Each cert/key/CA path is sanity-checked for file existence before
+# export — pointing NODE_EXTRA_CA_CERTS at a missing file makes Node
+# warn and abort every handshake, which is worse than not setting it.
+env_file="${FRIDAY_HOME:-$HOME/.atlas}/.env"
+if [[ -f "$env_file" ]]; then
+    for key in FRIDAY_TLS_CERT FRIDAY_TLS_KEY FRIDAY_TLS_CA FRIDAY_BROWSER_TLS_CERT FRIDAY_BROWSER_TLS_KEY DENO_CERT NODE_EXTRA_CA_CERTS; do
+        [[ -n "${!key:-}" ]] && continue
+        line="$(grep "^${key}=" "$env_file" | head -1 || true)"
+        [[ -z "$line" ]] && continue
+        value="${line#${key}=}"
+        [[ -f "$value" ]] || continue
+        export "$key=$value"
+    done
 fi
 
 cd "$PLAYGROUND_DIR"

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -27,6 +27,11 @@
 #   7. Writes daemon envfile (FRIDAY_UV_PATH, UV_*, FRIDAY_AGENT_SDK_VERSION,
 #      FRIDAY_JETSTREAM_STORE_DIR).
 #   8. Pre-warms the uv cache (Python 3.12 + pinned SDK).
+#   9. Sets up local TLS (mkcert) so vite + atlasd can serve HTTP/2,
+#      lifting the per-origin 6-socket cap that deadlocks the playground
+#      once SSE feeds + multiple tabs saturate the pool. Skippable via
+#      SKIP_TLS=1 for environments where mkcert can't run (no admin
+#      access, no NSS tools).
 #
 # Each tool's existing install is **preferred** if it satisfies the
 # minimum version — we never replace a working toolchain. Auto-install
@@ -468,6 +473,25 @@ UV_CACHE_DIR="$PRIMARY_HOME/uv/cache" \
 "$UV_PATH" run --python 3.12 \
     --with "friday-agent-sdk==$PINNED_SDK_VERSION" \
     python -c "import friday_agent_sdk; print(f'  ✓ friday_agent_sdk imported from {friday_agent_sdk.__file__}')"
+
+# ── 9. Local TLS for HTTP/2 ─────────────────────────────────────────────────
+# Without this, the playground's 3 SSE feeds × multiple tabs hit Chrome's
+# 6-socket-per-origin HTTP/1.1 cap and every fetch deadlocks. With TLS the
+# dev server (and atlasd) negotiate h2 over ALPN and the cap is gone.
+# Honors SKIP_TLS=1 for sandboxed CI / environments where `mkcert -install`
+# can't reach the OS trust store.
+if [[ "${SKIP_TLS:-0}" == "1" ]]; then
+    echo "→ Skipping TLS setup (SKIP_TLS=1)"
+    SKIPPED_TOOLS+=("TLS (mkcert) — playground HTTP/1.1 will deadlock under multiple tabs. Re-run \`bash scripts/setup-tls.sh\`.")
+else
+    if bash "$SCRIPT_DIR/setup-tls.sh"; then
+        :
+    else
+        echo "  ⚠ TLS setup failed — playground will run on HTTP/1.1 and may deadlock with multiple tabs." >&2
+        echo "    Re-run after fixing: bash scripts/setup-tls.sh" >&2
+        SKIPPED_TOOLS+=("TLS (mkcert) — re-run \`bash scripts/setup-tls.sh\` after resolving the install error.")
+    fi
+fi
 
 echo ""
 echo "✓ Dev environment ready."

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -27,11 +27,20 @@
 #   7. Writes daemon envfile (FRIDAY_UV_PATH, UV_*, FRIDAY_AGENT_SDK_VERSION,
 #      FRIDAY_JETSTREAM_STORE_DIR).
 #   8. Pre-warms the uv cache (Python 3.12 + pinned SDK).
-#   9. Sets up local TLS (mkcert) so vite + atlasd can serve HTTP/2,
-#      lifting the per-origin 6-socket cap that deadlocks the playground
-#      once SSE feeds + multiple tabs saturate the pool. Skippable via
-#      SKIP_TLS=1 for environments where mkcert can't run (no admin
-#      access, no NSS tools).
+#   9. Sets up local TLS in two layers:
+#       - Browser cert: mkcert-signed for the playground origin only, so
+#         vite can negotiate HTTP/2 and the per-origin 6-socket cap that
+#         deadlocks the playground (3 SSE feeds × multiple tabs) is lifted.
+#         This is the only chain that requires `mkcert -install` and
+#         therefore the only one that touches the system trust store.
+#       - S2S cert: openssl-signed by a private CA for atlasd and the
+#         webhook-tunnel listener. Trust flows only via DENO_CERT /
+#         NODE_EXTRA_CA_CERTS — no system trust store install. Browser
+#         traffic to those services goes through the playground's
+#         /api/{daemon,tunnel}/* proxies so the browser never sees these
+#         certs directly.
+#      Toggles: SKIP_TLS=1 skips everything; SKIP_MKCERT=1 generates the
+#      s2s chain only (use in headless / CI envs that don't open a browser).
 #
 # Each tool's existing install is **preferred** if it satisfies the
 # minimum version — we never replace a working toolchain. Auto-install
@@ -474,22 +483,23 @@ UV_CACHE_DIR="$PRIMARY_HOME/uv/cache" \
     --with "friday-agent-sdk==$PINNED_SDK_VERSION" \
     python -c "import friday_agent_sdk; print(f'  ✓ friday_agent_sdk imported from {friday_agent_sdk.__file__}')"
 
-# ── 9. Local TLS for HTTP/2 ─────────────────────────────────────────────────
-# Without this, the playground's 3 SSE feeds × multiple tabs hit Chrome's
-# 6-socket-per-origin HTTP/1.1 cap and every fetch deadlocks. With TLS the
-# dev server (and atlasd) negotiate h2 over ALPN and the cap is gone.
-# Honors SKIP_TLS=1 for sandboxed CI / environments where `mkcert -install`
-# can't reach the OS trust store.
+# ── 9. Local TLS ────────────────────────────────────────────────────────────
+# Browser cert (mkcert-signed) + s2s cert (private CA, no system trust).
+# Without the browser cert the playground falls back to HTTP/1.1 and 3 SSE
+# feeds × multiple tabs deadlock Chrome's 6-socket-per-origin cap. Without
+# the s2s cert atlasd + tunnel fall back to plain HTTP (no harm beyond the
+# transport being cleartext on localhost). Honors SKIP_TLS=1 (skip both)
+# and SKIP_MKCERT=1 (skip browser only — for headless / CI envs).
 if [[ "${SKIP_TLS:-0}" == "1" ]]; then
     echo "→ Skipping TLS setup (SKIP_TLS=1)"
-    SKIPPED_TOOLS+=("TLS (mkcert) — playground HTTP/1.1 will deadlock under multiple tabs. Re-run \`bash scripts/setup-tls.sh\`.")
+    SKIPPED_TOOLS+=("TLS — playground HTTP/1.1 will deadlock under multiple tabs. Re-run \`bash scripts/setup-tls.sh\`.")
 else
     if bash "$SCRIPT_DIR/setup-tls.sh"; then
         :
     else
         echo "  ⚠ TLS setup failed — playground will run on HTTP/1.1 and may deadlock with multiple tabs." >&2
         echo "    Re-run after fixing: bash scripts/setup-tls.sh" >&2
-        SKIPPED_TOOLS+=("TLS (mkcert) — re-run \`bash scripts/setup-tls.sh\` after resolving the install error.")
+        SKIPPED_TOOLS+=("TLS — re-run \`bash scripts/setup-tls.sh\` after resolving the install error.")
     fi
 fi
 

--- a/scripts/setup-tls.sh
+++ b/scripts/setup-tls.sh
@@ -1,37 +1,56 @@
 #!/usr/bin/env bash
 #
-# Generate a local TLS cert pair for the dev playground + daemon, so both
-# can negotiate HTTP/2 from the browser. HTTP/1.1 caps Chrome at 6 sockets
-# per origin, and the playground holds 3 long-lived SSE streams plus the
-# Vite HMR socket — multiple tabs deadlock waiting for a free socket. With
-# HTTP/2 every fetch multiplexes onto a single connection.
+# Generate the TLS material the playground + daemon + webhook-tunnel need
+# for local dev. Produces two cert chains with different trust requirements:
 #
-# What this does:
-#   1. Ensures `mkcert` is on PATH (brew on macOS, instruction on Linux).
-#   2. Runs `mkcert -install` so the generated cert chains to a CA your OS
-#      and browsers already trust — no "self-signed cert" prompts.
-#   3. Generates a cert pair valid for localhost + 127.0.0.1 + ::1 in
-#      `<friday-home>/tls/`, idempotent: skips regen if the existing cert
-#      is still valid for >30 days.
-#   4. Upserts `FRIDAY_TLS_CERT` / `FRIDAY_TLS_KEY` into `<friday-home>/.env`
-#      so atlasd, the playground binary, and the Vite dev server can find
-#      them at runtime.
+#   1. Browser-facing chain (the playground origin only)
+#      Signed by mkcert's local CA, which `mkcert -install` adds to the
+#      OS + browser trust stores. Required so Chrome/Safari accept
+#      https://localhost:5200 without warnings — the only endpoint a human
+#      browser hits directly.
+#
+#   2. Server-to-server chain (atlasd + webhook-tunnel)
+#      Signed by a private CA generated locally with openssl. NOT installed
+#      in any system trust store. Trust is plumbed per-process via
+#      `DENO_CERT` (atlasd, atlas-cli) and `NODE_EXTRA_CA_CERTS` (vite SSR,
+#      static-server proxy). The browser never sees these certs because
+#      the playground proxies `/api/daemon/*` and `/api/tunnel/*` itself.
+#
+# Why split: the original single-cert design forced `mkcert -install`
+# on every machine just to talk to the daemon and tunnel. Splitting lets
+# headless/CI environments skip the system-trust step entirely
+# (`SKIP_MKCERT=1`) while keeping the dev cycle working.
+#
+# Why HTTP/2 still matters: the playground holds 3 long-lived SSE feeds
+# per tab plus the Vite HMR socket. Two open tabs saturate Chrome's
+# 6-socket-per-origin HTTP/1.1 cap and every fetch (page document
+# included) stalls until a tab closes. h2 multiplexes over one connection
+# so the cap disappears. This is the reason the playground origin needs
+# TLS at all — h2 only negotiates over ALPN, which requires TLS.
+#
+# Outputs in <friday-home>/tls/:
+#   browser.crt / browser.key     — mkcert-signed, system-trusted
+#   s2s.crt / s2s.key             — openssl-signed, NOT system-trusted
+#   s2s-ca.crt / s2s-ca.key       — private CA (key kept locally, mode 600)
+#
+# Env vars written to <friday-home>/.env:
+#   FRIDAY_BROWSER_TLS_CERT/_KEY  — playground origin (vite + static-server)
+#   FRIDAY_TLS_CERT/_KEY          — s2s (atlasd + webhook-tunnel listeners)
+#   FRIDAY_TLS_CA                 — private CA bundle for in-process trust
+#   DENO_CERT, NODE_EXTRA_CA_CERTS — point at FRIDAY_TLS_CA
 #
 # Usage:
-#   bash scripts/setup-tls.sh                    # uses detected FRIDAY_HOME(s)
-#   FRIDAY_HOME=/path bash scripts/setup-tls.sh  # override
+#   bash scripts/setup-tls.sh                # full setup (both chains)
+#   SKIP_MKCERT=1 bash scripts/setup-tls.sh  # s2s chain only, no system root
+#   SKIP_TLS=1    bash scripts/setup-tls.sh  # skip everything (CI fallback)
 #
-# Idempotent. Safe to re-run after `mkcert -install` updates the local CA.
+# Idempotent. Re-runs reuse fresh certs and only regenerate near expiry.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-# Honor SKIP_TLS=1 from any caller (setup-dev-env.sh, manual run, CI). The
-# parent script already gates the call on this, but checking here too means
-# `SKIP_TLS=1 bash scripts/setup-tls.sh` no-ops cleanly instead of installing
-# mkcert and writing certs the user explicitly asked us to skip.
 if [[ "${SKIP_TLS:-0}" == "1" ]]; then
     echo "→ SKIP_TLS=1 set — skipping TLS setup."
     echo "  Playground will run on HTTP/1.1; multi-tab dev may deadlock when"
@@ -39,31 +58,42 @@ if [[ "${SKIP_TLS:-0}" == "1" ]]; then
     exit 0
 fi
 
-# ── 1. Ensure mkcert ─────────────────────────────────────────────────────────
-# mkcert ships a small self-signed CA into the OS trust store and signs
-# leaf certs from it — the only sane way to get trusted certs for
-# localhost without paying for ACME-via-DNS or maintaining your own CA.
-if ! command -v mkcert >/dev/null 2>&1; then
-    if [[ "$OSTYPE" == "darwin"* ]] && command -v brew >/dev/null 2>&1; then
-        echo "→ mkcert not found — installing via Homebrew"
-        brew install mkcert nss
-    else
-        echo "✗ mkcert not found on PATH" >&2
-        echo "  install: https://github.com/FiloSottile/mkcert#installation" >&2
-        echo "  on Debian/Ubuntu: apt install libnss3-tools && go install filippo.io/mkcert@latest" >&2
-        exit 1
-    fi
+SKIP_MKCERT="${SKIP_MKCERT:-0}"
+
+# ── 1. Tooling: openssl is required; mkcert only if not skipped ─────────────
+if ! command -v openssl >/dev/null 2>&1; then
+    echo "✗ openssl not found on PATH" >&2
+    echo "  install: macOS ships openssl by default; on Linux \`apt install openssl\`." >&2
+    exit 1
 fi
-echo "→ mkcert: $(command -v mkcert)"
+echo "→ openssl: $(command -v openssl)"
 
-# ── 2. Install local CA into system + browser trust stores ──────────────────
-# `mkcert -install` is idempotent. First run on a machine prompts for
-# admin (system keychain on macOS, sudo on Linux); subsequent runs
-# detect the CA is already trusted and exit fast.
-echo "→ Ensuring mkcert root CA is trusted (may prompt for admin password)"
-mkcert -install
+if [[ "$SKIP_MKCERT" == "1" ]]; then
+    echo "→ SKIP_MKCERT=1 — skipping browser-trusted cert generation."
+    echo "  The playground origin will run on HTTP and tabs > 1 will deadlock,"
+    echo "  but daemon + tunnel still get their (private-CA) s2s certs."
+else
+    if ! command -v mkcert >/dev/null 2>&1; then
+        if [[ "$OSTYPE" == "darwin"* ]] && command -v brew >/dev/null 2>&1; then
+            echo "→ mkcert not found — installing via Homebrew"
+            brew install mkcert nss
+        else
+            echo "✗ mkcert not found on PATH" >&2
+            echo "  install: https://github.com/FiloSottile/mkcert#installation" >&2
+            echo "  on Debian/Ubuntu: apt install libnss3-tools && go install filippo.io/mkcert@latest" >&2
+            echo "  or re-run with SKIP_MKCERT=1 to set up s2s certs only." >&2
+            exit 1
+        fi
+    fi
+    echo "→ mkcert: $(command -v mkcert)"
+    # Idempotent. First run on a machine prompts for admin (system keychain
+    # on macOS, sudo on Linux); subsequent runs detect the CA is already
+    # trusted and exit fast.
+    echo "→ Ensuring mkcert root CA is trusted (may prompt for admin password)"
+    mkcert -install
+fi
 
-# ── 3. Resolve Friday home(s) — match setup-dev-env.sh's detection ──────────
+# ── 2. Resolve Friday home(s) — match setup-dev-env.sh's detection ──────────
 declare -a FRIDAY_HOMES=()
 detect_home() {
     local candidate="$1"
@@ -96,10 +126,7 @@ if [[ ! " ${FRIDAY_HOMES[*]} " =~ " $HOME/.atlas " ]]; then
     FRIDAY_HOMES+=("$HOME/.atlas")
 fi
 
-# ── 4. Generate or reuse cert per home ──────────────────────────────────────
-# One cert pair covers both the playground (5200) and the daemon (8080) —
-# they share the localhost / 127.0.0.1 / ::1 SAN set, so a single mkcert
-# leaf is enough. Browsers cache trust by SAN+CA, not by port.
+# ── 3. Env helpers ──────────────────────────────────────────────────────────
 upsert_env() {
     local file="$1" key="$2" value="$3"
     if [[ -f "$file" ]] && grep -qE "^${key}=" "$file"; then
@@ -126,76 +153,163 @@ remove_env() {
 
 # Returns 0 iff openssl can verify the cert is still valid past `days_min`
 # days from now. Lets idempotent re-runs skip regen instead of forcing the
-# user to re-trust after every dev setup. mkcert defaults to 825-day leaf
-# certs (Apple's max); we regenerate well before expiry just to be safe.
+# user to re-trust after every dev setup.
 cert_is_fresh() {
     local cert="$1" days_min="${2:-30}"
     [[ -f "$cert" ]] || return 1
-    command -v openssl >/dev/null 2>&1 || return 0
     local secs=$(( days_min * 86400 ))
     openssl x509 -checkend "$secs" -noout -in "$cert" >/dev/null 2>&1
 }
 
+# Generate a private CA + leaf cert pair with openssl. The CA stays local
+# (key file mode 600 in $tls_dir/s2s-ca.key); the leaf is what daemon +
+# tunnel present. Trust is plumbed via env (DENO_CERT, NODE_EXTRA_CA_CERTS)
+# pointing at the CA cert, so no system keystore install is needed.
+generate_s2s_chain() {
+    local tls_dir="$1"
+    local ca_crt="$tls_dir/s2s-ca.crt"
+    local ca_key="$tls_dir/s2s-ca.key"
+    local crt="$tls_dir/s2s.crt"
+    local key="$tls_dir/s2s.key"
+
+    if cert_is_fresh "$crt" && cert_is_fresh "$ca_crt"; then
+        echo "  → s2s.crt valid >30d, reusing"
+        return 0
+    fi
+
+    # CA: 1-year self-signed, ECDSA P-256 (small, modern, every TLS stack
+    # we touch supports it). Bounded lifetime caps the blast radius of a
+    # leaked s2s-ca.key — a stolen key mints trusted certs for at most
+    # 1 year from generation, after which setup-tls.sh rotates on next
+    # run. Regeneration only fires when missing or within 30 days of
+    # expiry — otherwise re-plumbing trust would become a daily chore.
+    if ! cert_is_fresh "$ca_crt"; then
+        echo "  → Generating private CA at $ca_crt"
+        openssl ecparam -name prime256v1 -genkey -noout -out "$ca_key"
+        openssl req -new -x509 -days 365 \
+            -key "$ca_key" \
+            -out "$ca_crt" \
+            -subj "/CN=Friday Local Dev CA/O=Friday Local Dev" \
+            -addext "basicConstraints=critical,CA:TRUE" \
+            -addext "keyUsage=critical,keyCertSign,cRLSign" \
+            >/dev/null 2>&1
+        chmod 600 "$ca_key"
+    fi
+
+    # Leaf: 1-year ECDSA, signed by the private CA, covering localhost +
+    # 127.0.0.1 + ::1 so the same cert works for daemon (:8080) and tunnel
+    # (:9090) listeners.
+    echo "  → Generating s2s leaf at $crt"
+    local leaf_csr="$tls_dir/.s2s.csr"
+    local leaf_ext="$tls_dir/.s2s.ext"
+    openssl ecparam -name prime256v1 -genkey -noout -out "$key"
+    openssl req -new \
+        -key "$key" \
+        -out "$leaf_csr" \
+        -subj "/CN=localhost/O=Friday Local Dev" \
+        >/dev/null 2>&1
+    cat > "$leaf_ext" <<EOF
+basicConstraints=CA:FALSE
+keyUsage=critical,digitalSignature,keyEncipherment
+extendedKeyUsage=serverAuth,clientAuth
+subjectAltName=DNS:localhost,IP:127.0.0.1,IP:::1
+EOF
+    openssl x509 -req \
+        -in "$leaf_csr" \
+        -CA "$ca_crt" -CAkey "$ca_key" -CAcreateserial \
+        -days 365 \
+        -extfile "$leaf_ext" \
+        -out "$crt" \
+        >/dev/null 2>&1
+    rm -f "$leaf_csr" "$leaf_ext" "$tls_dir/s2s-ca.srl"
+    chmod 600 "$key"
+}
+
+# ── 4. Generate or reuse cert per home ──────────────────────────────────────
 for home in "${FRIDAY_HOMES[@]}"; do
     tls_dir="$home/tls"
-    cert_file="$tls_dir/localhost.crt"
-    key_file="$tls_dir/localhost.key"
     env_file="$home/.env"
 
     mkdir -p "$tls_dir"
     chmod 700 "$tls_dir"
 
-    if cert_is_fresh "$cert_file"; then
-        echo "→ $cert_file (valid >30d, reusing)"
-    else
-        echo "→ Generating $cert_file"
-        # mkcert writes to the cwd; cd into tls_dir so paths land deterministically
-        # regardless of where the script was invoked from.
-        ( cd "$tls_dir" && mkcert -cert-file localhost.crt -key-file localhost.key \
-            localhost 127.0.0.1 ::1 ) >/dev/null
+    # Browser cert (playground origin)
+    browser_crt="$tls_dir/browser.crt"
+    browser_key="$tls_dir/browser.key"
+    if [[ "$SKIP_MKCERT" != "1" ]]; then
+        if cert_is_fresh "$browser_crt"; then
+            echo "→ $browser_crt (valid >30d, reusing)"
+        else
+            echo "→ Generating $browser_crt"
+            ( cd "$tls_dir" && mkcert -cert-file browser.crt -key-file browser.key \
+                localhost 127.0.0.1 ::1 ) >/dev/null
+        fi
+        chmod 600 "$browser_key"
     fi
-    chmod 600 "$key_file"
+
+    # S2S cert chain (daemon + tunnel)
+    echo "→ S2S certs in $tls_dir"
+    generate_s2s_chain "$tls_dir"
 
     touch "$env_file"
-    # The .env in FRIDAY_HOME holds FRIDAY_KEY and OAuth tokens elsewhere;
-    # tighten perms before writing values into it. chmod is idempotent.
+    # The .env in FRIDAY_HOME holds OAuth tokens and other secrets — tighten
+    # perms before writing.
     chmod 600 "$env_file"
-    upsert_env "$env_file" "FRIDAY_TLS_CERT" "$cert_file"
-    upsert_env "$env_file" "FRIDAY_TLS_KEY"  "$key_file"
-    # CA trust for runtimes that talk to the (now https) daemon over the
-    # loopback, neither of which reads the system keychain by default:
-    #   - DENO_CERT          → atlasd, atlas-cli, anything `deno run`
-    #     (Deno ignores the keychain unless --use-system-ca is set; the env
-    #      var is the cleanest way to plumb it without touching invocations)
-    #   - NODE_EXTRA_CA_CERTS → vite SSR proxy, any Node tool fetching the
-    #     daemon. Also set by run-playground-vite.sh for the playground;
-    #     putting it in .env covers other Node entrypoints like tests
-    # Intentionally NOT setting SSL_CERT_FILE: that var (honored by Python
-    # httpx/requests/urllib3, curl, Rustls + rustls-native-certs) replaces
-    # the system CA bundle entirely, so user agents would lose verification
-    # for api.openai.com, api.anthropic.com, OAuth callbacks, OTEL exporter,
-    # etc. None of those clients need to reach the local daemon over TLS
-    # today; if a future path does, scope the var to that subprocess.
-    # mkcert puts its CA at `mkcert -CAROOT`/rootCA.pem; resolve once.
-    ca_root="$(mkcert -CAROOT 2>/dev/null)"
-    if [[ -n "$ca_root" && -f "$ca_root/rootCA.pem" ]]; then
-        upsert_env "$env_file" "DENO_CERT"           "$ca_root/rootCA.pem"
-        upsert_env "$env_file" "NODE_EXTRA_CA_CERTS" "$ca_root/rootCA.pem"
+
+    if [[ "$SKIP_MKCERT" != "1" ]]; then
+        upsert_env "$env_file" "FRIDAY_BROWSER_TLS_CERT" "$browser_crt"
+        upsert_env "$env_file" "FRIDAY_BROWSER_TLS_KEY"  "$browser_key"
+    else
+        # If a previous run wrote browser entries, leave them; the playground
+        # will pick them up if the files still exist. But a fresh SKIP_MKCERT
+        # run on a virgin machine shouldn't set entries that point at
+        # nonexistent files (Node/Deno warn loudly on missing cert files).
+        if [[ ! -f "$browser_crt" ]]; then
+            remove_env "$env_file" "FRIDAY_BROWSER_TLS_CERT"
+            remove_env "$env_file" "FRIDAY_BROWSER_TLS_KEY"
+        fi
     fi
+
+    upsert_env "$env_file" "FRIDAY_TLS_CERT"     "$tls_dir/s2s.crt"
+    upsert_env "$env_file" "FRIDAY_TLS_KEY"      "$tls_dir/s2s.key"
+    upsert_env "$env_file" "FRIDAY_TLS_CA"       "$tls_dir/s2s-ca.crt"
+
+    # CA trust for runtimes that talk to the (now https) daemon + tunnel:
+    #   - DENO_CERT          → atlasd, atlas-cli (Deno ignores the keychain
+    #     unless --use-system-ca is set; this env var is the cleanest way)
+    #   - NODE_EXTRA_CA_CERTS → vite SSR proxy, static-server proxy, any
+    #     Node tool fetching daemon/tunnel
+    # Intentionally NOT setting SSL_CERT_FILE: that var (Python httpx/
+    # requests/urllib3, curl, Rustls + rustls-native-certs) *replaces* the
+    # system CA bundle, so user agents would lose verification for
+    # api.openai.com / api.anthropic.com / OAuth callbacks / OTEL exporter.
+    upsert_env "$env_file" "DENO_CERT"           "$tls_dir/s2s-ca.crt"
+    upsert_env "$env_file" "NODE_EXTRA_CA_CERTS" "$tls_dir/s2s-ca.crt"
+
     # Earlier versions of this script wrote SSL_CERT_FILE here; that var
     # *replaces* the system CA bundle for Python/curl/Rust callers, so
     # outbound TLS to OpenAI/Anthropic/OAuth callbacks broke. Remove any
     # legacy entry from upgraded setups.
     remove_env "$env_file" "SSL_CERT_FILE"
-    echo "  → wrote FRIDAY_TLS_*, DENO_CERT, NODE_EXTRA_CA_CERTS to $env_file (chmod 600)"
+
+    echo "  → wrote FRIDAY_{BROWSER_,}TLS_*, FRIDAY_TLS_CA, DENO_CERT, NODE_EXTRA_CA_CERTS to $env_file (chmod 600)"
 done
 
 echo ""
-echo "✓ TLS ready. Restart the daemon and playground to pick up the cert:"
-echo "    deno task playground   →  https://localhost:5200"
-echo "    atlas daemon start     →  https://localhost:8080"
+echo "✓ TLS ready. Restart the daemon and playground to pick up the certs:"
+if [[ "$SKIP_MKCERT" != "1" ]]; then
+    echo "    deno task playground   →  https://localhost:5200  (mkcert, system-trusted)"
+else
+    echo "    deno task playground   →  http://localhost:5200   (SKIP_MKCERT=1)"
+fi
+echo "    atlas daemon start     →  https://localhost:8080  (private-CA, in-process trust)"
+echo "    deno task webhook-tunnel → https://localhost:9090  (private-CA, in-process trust)"
 echo ""
-echo "ℹ A local root CA is now installed in your system trust store (and"
-echo "  Firefox/Chrome stores). Any process running as your user can mint"
-echo "  certs trusted by your browsers using the key in \`mkcert -CAROOT\`."
-echo "  Remove with: mkcert -uninstall"
+if [[ "$SKIP_MKCERT" != "1" ]]; then
+    echo "ℹ mkcert installed a local root CA in your system trust store. Any process"
+    echo "  running as your user can mint certs trusted by your browsers using the"
+    echo "  key in \`mkcert -CAROOT\`. Remove with: mkcert -uninstall"
+fi
+echo "ℹ The private CA at \`<friday-home>/tls/s2s-ca.crt\` is NOT installed in any"
+echo "  system trust store. Trust flows only via DENO_CERT / NODE_EXTRA_CA_CERTS"
+echo "  in <friday-home>/.env, scoped to processes that load that env file."

--- a/scripts/setup-tls.sh
+++ b/scripts/setup-tls.sh
@@ -93,37 +93,30 @@ else
     mkcert -install
 fi
 
-# ── 2. Resolve Friday home(s) — match setup-dev-env.sh's detection ──────────
+# ── 2. Resolve dev Friday home ──────────────────────────────────────────────
+#
+# This is a DEV-ONLY script. ~/.friday/local is the installed-Studio home
+# and the launcher owns the cert chain there (s2s_generator.go writes the
+# private CA + leaf, tls_renewer.go fetches the LE browser cert from
+# download.fridayplatform.io). Writing into ~/.friday/local from here
+# would clobber the launcher's certs and the LE browser chain — and would
+# silently switch the installed playground origin from the LE cert (for
+# local.hellofriday.ai:15200) to a mkcert cert for localhost, breaking the
+# tray's https URL.
+#
+# Resolution order:
+#   1. `FRIDAY_HOME` env var, if set — explicit caller intent wins (e.g.
+#      a dev pinning a custom home dir). The user accepts whatever they
+#      pointed it at, including ~/.friday/local if they really mean it.
+#   2. Default to ~/.atlas (the dev convention pinned in deno.json's
+#      `atlas` / `atlas:dev` tasks). Created if absent.
 declare -a FRIDAY_HOMES=()
-detect_home() {
-    local candidate="$1"
-    [[ -d "$candidate" ]] || return 1
-    for marker in agents chats sessions activity.db skills.db storage.db; do
-        if [[ -e "$candidate/$marker" ]]; then return 0; fi
-    done
-    return 1
-}
-
 if [[ -n "${FRIDAY_HOME:-}" ]]; then
     FRIDAY_HOMES=("$FRIDAY_HOME")
+    mkdir -p "$FRIDAY_HOME"
 else
-    detect_home "$HOME/.atlas" && FRIDAY_HOMES+=("$HOME/.atlas")
-    detect_home "$HOME/.friday/local" && FRIDAY_HOMES+=("$HOME/.friday/local")
-    if [[ ${#FRIDAY_HOMES[@]} -eq 0 ]]; then
-        FRIDAY_HOMES=("$HOME/.friday/local")
-        mkdir -p "${FRIDAY_HOMES[0]}"
-    fi
-fi
-
-# Always seed ~/.atlas/.env so the `atlas` / `atlas:dev` deno tasks (which
-# load `--env-file=$HOME/.atlas/.env` at process start so DENO_CERT lands
-# before Deno's RootCertStore initializes) find a usable file regardless
-# of which home is the user's primary. Deno's task shell doesn't support
-# ${VAR:-default} expansion, so the path is hardcoded; making sure the
-# file exists is the simpler half of the contract.
-if [[ ! " ${FRIDAY_HOMES[*]} " =~ " $HOME/.atlas " ]]; then
     mkdir -p "$HOME/.atlas"
-    FRIDAY_HOMES+=("$HOME/.atlas")
+    FRIDAY_HOMES=("$HOME/.atlas")
 fi
 
 # ── 3. Env helpers ──────────────────────────────────────────────────────────

--- a/scripts/setup-tls.sh
+++ b/scripts/setup-tls.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+#
+# Generate a local TLS cert pair for the dev playground + daemon, so both
+# can negotiate HTTP/2 from the browser. HTTP/1.1 caps Chrome at 6 sockets
+# per origin, and the playground holds 3 long-lived SSE streams plus the
+# Vite HMR socket — multiple tabs deadlock waiting for a free socket. With
+# HTTP/2 every fetch multiplexes onto a single connection.
+#
+# What this does:
+#   1. Ensures `mkcert` is on PATH (brew on macOS, instruction on Linux).
+#   2. Runs `mkcert -install` so the generated cert chains to a CA your OS
+#      and browsers already trust — no "self-signed cert" prompts.
+#   3. Generates a cert pair valid for localhost + 127.0.0.1 + ::1 in
+#      `<friday-home>/tls/`, idempotent: skips regen if the existing cert
+#      is still valid for >30 days.
+#   4. Upserts `FRIDAY_TLS_CERT` / `FRIDAY_TLS_KEY` into `<friday-home>/.env`
+#      so atlasd, the playground binary, and the Vite dev server can find
+#      them at runtime.
+#
+# Usage:
+#   bash scripts/setup-tls.sh                    # uses detected FRIDAY_HOME(s)
+#   FRIDAY_HOME=/path bash scripts/setup-tls.sh  # override
+#
+# Idempotent. Safe to re-run after `mkcert -install` updates the local CA.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Honor SKIP_TLS=1 from any caller (setup-dev-env.sh, manual run, CI). The
+# parent script already gates the call on this, but checking here too means
+# `SKIP_TLS=1 bash scripts/setup-tls.sh` no-ops cleanly instead of installing
+# mkcert and writing certs the user explicitly asked us to skip.
+if [[ "${SKIP_TLS:-0}" == "1" ]]; then
+    echo "→ SKIP_TLS=1 set — skipping TLS setup."
+    echo "  Playground will run on HTTP/1.1; multi-tab dev may deadlock when"
+    echo "  the 3 SSE feeds × tabs saturate Chrome's 6-socket-per-origin cap."
+    exit 0
+fi
+
+# ── 1. Ensure mkcert ─────────────────────────────────────────────────────────
+# mkcert ships a small self-signed CA into the OS trust store and signs
+# leaf certs from it — the only sane way to get trusted certs for
+# localhost without paying for ACME-via-DNS or maintaining your own CA.
+if ! command -v mkcert >/dev/null 2>&1; then
+    if [[ "$OSTYPE" == "darwin"* ]] && command -v brew >/dev/null 2>&1; then
+        echo "→ mkcert not found — installing via Homebrew"
+        brew install mkcert nss
+    else
+        echo "✗ mkcert not found on PATH" >&2
+        echo "  install: https://github.com/FiloSottile/mkcert#installation" >&2
+        echo "  on Debian/Ubuntu: apt install libnss3-tools && go install filippo.io/mkcert@latest" >&2
+        exit 1
+    fi
+fi
+echo "→ mkcert: $(command -v mkcert)"
+
+# ── 2. Install local CA into system + browser trust stores ──────────────────
+# `mkcert -install` is idempotent. First run on a machine prompts for
+# admin (system keychain on macOS, sudo on Linux); subsequent runs
+# detect the CA is already trusted and exit fast.
+echo "→ Ensuring mkcert root CA is trusted (may prompt for admin password)"
+mkcert -install
+
+# ── 3. Resolve Friday home(s) — match setup-dev-env.sh's detection ──────────
+declare -a FRIDAY_HOMES=()
+detect_home() {
+    local candidate="$1"
+    [[ -d "$candidate" ]] || return 1
+    for marker in agents chats sessions activity.db skills.db storage.db; do
+        if [[ -e "$candidate/$marker" ]]; then return 0; fi
+    done
+    return 1
+}
+
+if [[ -n "${FRIDAY_HOME:-}" ]]; then
+    FRIDAY_HOMES=("$FRIDAY_HOME")
+else
+    detect_home "$HOME/.atlas" && FRIDAY_HOMES+=("$HOME/.atlas")
+    detect_home "$HOME/.friday/local" && FRIDAY_HOMES+=("$HOME/.friday/local")
+    if [[ ${#FRIDAY_HOMES[@]} -eq 0 ]]; then
+        FRIDAY_HOMES=("$HOME/.friday/local")
+        mkdir -p "${FRIDAY_HOMES[0]}"
+    fi
+fi
+
+# Always seed ~/.atlas/.env so the `atlas` / `atlas:dev` deno tasks (which
+# load `--env-file=$HOME/.atlas/.env` at process start so DENO_CERT lands
+# before Deno's RootCertStore initializes) find a usable file regardless
+# of which home is the user's primary. Deno's task shell doesn't support
+# ${VAR:-default} expansion, so the path is hardcoded; making sure the
+# file exists is the simpler half of the contract.
+if [[ ! " ${FRIDAY_HOMES[*]} " =~ " $HOME/.atlas " ]]; then
+    mkdir -p "$HOME/.atlas"
+    FRIDAY_HOMES+=("$HOME/.atlas")
+fi
+
+# ── 4. Generate or reuse cert per home ──────────────────────────────────────
+# One cert pair covers both the playground (5200) and the daemon (8080) —
+# they share the localhost / 127.0.0.1 / ::1 SAN set, so a single mkcert
+# leaf is enough. Browsers cache trust by SAN+CA, not by port.
+upsert_env() {
+    local file="$1" key="$2" value="$3"
+    if [[ -f "$file" ]] && grep -qE "^${key}=" "$file"; then
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' -E "s|^${key}=.*$|${key}=${value}|" "$file"
+        else
+            sed -i -E "s|^${key}=.*$|${key}=${value}|" "$file"
+        fi
+    else
+        printf '%s=%s\n' "$key" "$value" >> "$file"
+    fi
+}
+
+remove_env() {
+    local file="$1" key="$2"
+    [[ -f "$file" ]] || return 0
+    grep -qE "^${key}=" "$file" || return 0
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        sed -i '' -E "/^${key}=/d" "$file"
+    else
+        sed -i -E "/^${key}=/d" "$file"
+    fi
+}
+
+# Returns 0 iff openssl can verify the cert is still valid past `days_min`
+# days from now. Lets idempotent re-runs skip regen instead of forcing the
+# user to re-trust after every dev setup. mkcert defaults to 825-day leaf
+# certs (Apple's max); we regenerate well before expiry just to be safe.
+cert_is_fresh() {
+    local cert="$1" days_min="${2:-30}"
+    [[ -f "$cert" ]] || return 1
+    command -v openssl >/dev/null 2>&1 || return 0
+    local secs=$(( days_min * 86400 ))
+    openssl x509 -checkend "$secs" -noout -in "$cert" >/dev/null 2>&1
+}
+
+for home in "${FRIDAY_HOMES[@]}"; do
+    tls_dir="$home/tls"
+    cert_file="$tls_dir/localhost.crt"
+    key_file="$tls_dir/localhost.key"
+    env_file="$home/.env"
+
+    mkdir -p "$tls_dir"
+    chmod 700 "$tls_dir"
+
+    if cert_is_fresh "$cert_file"; then
+        echo "→ $cert_file (valid >30d, reusing)"
+    else
+        echo "→ Generating $cert_file"
+        # mkcert writes to the cwd; cd into tls_dir so paths land deterministically
+        # regardless of where the script was invoked from.
+        ( cd "$tls_dir" && mkcert -cert-file localhost.crt -key-file localhost.key \
+            localhost 127.0.0.1 ::1 ) >/dev/null
+    fi
+    chmod 600 "$key_file"
+
+    touch "$env_file"
+    # The .env in FRIDAY_HOME holds FRIDAY_KEY and OAuth tokens elsewhere;
+    # tighten perms before writing values into it. chmod is idempotent.
+    chmod 600 "$env_file"
+    upsert_env "$env_file" "FRIDAY_TLS_CERT" "$cert_file"
+    upsert_env "$env_file" "FRIDAY_TLS_KEY"  "$key_file"
+    # CA trust for runtimes that talk to the (now https) daemon over the
+    # loopback, neither of which reads the system keychain by default:
+    #   - DENO_CERT          → atlasd, atlas-cli, anything `deno run`
+    #     (Deno ignores the keychain unless --use-system-ca is set; the env
+    #      var is the cleanest way to plumb it without touching invocations)
+    #   - NODE_EXTRA_CA_CERTS → vite SSR proxy, any Node tool fetching the
+    #     daemon. Also set by run-playground-vite.sh for the playground;
+    #     putting it in .env covers other Node entrypoints like tests
+    # Intentionally NOT setting SSL_CERT_FILE: that var (honored by Python
+    # httpx/requests/urllib3, curl, Rustls + rustls-native-certs) replaces
+    # the system CA bundle entirely, so user agents would lose verification
+    # for api.openai.com, api.anthropic.com, OAuth callbacks, OTEL exporter,
+    # etc. None of those clients need to reach the local daemon over TLS
+    # today; if a future path does, scope the var to that subprocess.
+    # mkcert puts its CA at `mkcert -CAROOT`/rootCA.pem; resolve once.
+    ca_root="$(mkcert -CAROOT 2>/dev/null)"
+    if [[ -n "$ca_root" && -f "$ca_root/rootCA.pem" ]]; then
+        upsert_env "$env_file" "DENO_CERT"           "$ca_root/rootCA.pem"
+        upsert_env "$env_file" "NODE_EXTRA_CA_CERTS" "$ca_root/rootCA.pem"
+    fi
+    # Earlier versions of this script wrote SSL_CERT_FILE here; that var
+    # *replaces* the system CA bundle for Python/curl/Rust callers, so
+    # outbound TLS to OpenAI/Anthropic/OAuth callbacks broke. Remove any
+    # legacy entry from upgraded setups.
+    remove_env "$env_file" "SSL_CERT_FILE"
+    echo "  → wrote FRIDAY_TLS_*, DENO_CERT, NODE_EXTRA_CA_CERTS to $env_file (chmod 600)"
+done
+
+echo ""
+echo "✓ TLS ready. Restart the daemon and playground to pick up the cert:"
+echo "    deno task playground   →  https://localhost:5200"
+echo "    atlas daemon start     →  https://localhost:8080"
+echo ""
+echo "ℹ A local root CA is now installed in your system trust store (and"
+echo "  Firefox/Chrome stores). Any process running as your user can mint"
+echo "  certs trusted by your browsers using the key in \`mkcert -CAROOT\`."
+echo "  Remove with: mkcert -uninstall"

--- a/tools/agent-playground/package.json
+++ b/tools/agent-playground/package.json
@@ -45,7 +45,6 @@
     "diff": "^9.0.0",
     "hono": "4.12.18",
     "jszip": "^3.10.1",
-    "node-html-parser": "^7.1.0",
     "shiki": "^4.0.2",
     "svelte": "^5.55.5",
     "dompurify": "^3.4.2",

--- a/tools/agent-playground/src/hooks.server.ts
+++ b/tools/agent-playground/src/hooks.server.ts
@@ -1,37 +1,3 @@
-import { building } from "$app/environment";
 import type { Handle } from "@sveltejs/kit";
-import process from "node:process";
-import { parse } from "node-html-parser";
 
-const config: Record<string, string> = {};
-if (process.env.EXTERNAL_DAEMON_URL) config.externalDaemonUrl = process.env.EXTERNAL_DAEMON_URL;
-if (process.env.EXTERNAL_TUNNEL_URL) config.externalTunnelUrl = process.env.EXTERNAL_TUNNEL_URL;
-
-// `!building`: prerendered HTML is what static-server.ts re-injects
-// against in production; injecting at build time would bake the wrong
-// (build-host) env into the artifact.
-const shouldInject = !building && Object.keys(config).length > 0;
-const configJson = JSON.stringify(config).replace(/</g, "\\u003c");
-const configScript = `<script>window.__FRIDAY_CONFIG__=${configJson};</script>`;
-
-function injectConfig(html: string): string {
-	const root = parse(html);
-	const head = root.querySelector("head");
-	if (!head) return html;
-	head.appendChild(parse(configScript));
-	return root.toString();
-}
-
-export const handle: Handle = ({ event, resolve }) => {
-	// The export-preview route is fetched by the export orchestrator and
-	// packaged verbatim into a downloadable zip. Injecting the playground's
-	// dev daemon URL there would leak it into every shared export — and the
-	// HTML has nothing client-side that would consume it anyway.
-	const isExportPreview = event.url.pathname.endsWith("/export/preview");
-	return resolve(event, {
-		transformPageChunk: ({ html, done }) => {
-			if (!shouldInject || !done || isExportPreview) return html;
-			return injectConfig(html);
-		},
-	});
-};
+export const handle: Handle = ({ event, resolve }) => resolve(event);

--- a/tools/agent-playground/src/lib/components/workspace/jobs-card-row.svelte
+++ b/tools/agent-playground/src/lib/components/workspace/jobs-card-row.svelte
@@ -12,7 +12,7 @@
   import { DropdownMenu } from "@atlas/ui";
   import { goto } from "$app/navigation";
   import RunJobDialog from "$lib/components/workspace/run-job-dialog.svelte";
-  import { externalDaemonUrl } from "$lib/daemon-url";
+  import { daemonUrl } from "$lib/daemon-url";
   import { JsonSchemaObjectShape, JsonSchemaPropertyShape } from "$lib/schema-utils";
 
   type Job = {
@@ -69,7 +69,7 @@
           "curl -X POST",
           `-H 'Content-Type: application/json'`,
           `-d '${escaped}'`,
-          `${externalDaemonUrl()}/api/workspaces/${workspaceId}/signals/${trigger.signal}`,
+          `${daemonUrl()}/api/workspaces/${workspaceId}/signals/${trigger.signal}`,
         ].join(" \\\n  ");
         navigator.clipboard.writeText(curl);
       }

--- a/tools/agent-playground/src/lib/components/workspace/signal-row.svelte
+++ b/tools/agent-playground/src/lib/components/workspace/signal-row.svelte
@@ -15,7 +15,7 @@
   import { Dialog, DropdownMenu, Icons } from "@atlas/ui";
   import InlineBadge from "$lib/components/shared/inline-badge.svelte";
   import { goto } from "$app/navigation";
-  import { externalDaemonUrl, externalTunnelUrl } from "$lib/daemon-url";
+  import { daemonUrl, tunnelUrl } from "$lib/daemon-url";
 
   type Signal = {
     id: string;
@@ -147,7 +147,7 @@
     if (tunnelFetched) return;
     tunnelFetched = true;
     try {
-      const res = await fetch(`${externalTunnelUrl()}/status`);
+      const res = await fetch(`${tunnelUrl()}/status`);
       if (res.ok) {
         const data = await res.json();
         cachedTunnelUrl = data.url ?? null;
@@ -164,7 +164,7 @@
   });
 
   function copySignalUrl() {
-    const url = `${externalDaemonUrl()}/api/workspaces/${workspaceId}/signals/${signal.id}`;
+    const url = `${daemonUrl()}/api/workspaces/${workspaceId}/signals/${signal.id}`;
     copyToClipboard(url);
   }
 

--- a/tools/agent-playground/src/lib/daemon-url.ts
+++ b/tools/agent-playground/src/lib/daemon-url.ts
@@ -1,69 +1,40 @@
-import { z } from "zod";
-
-/** Base URL of the local Atlas daemon. Used by the SvelteKit dev proxy
- * (`/api/daemon/*` route). The compiled binary uses static-server.ts
- * which reads `FRIDAYD_URL` from env for the same purpose; this dev
- * path always targets the default 8080 since it only runs under
- * `deno task playground`.
+/** Base URL of the local Atlas daemon, used by the SvelteKit SSR proxy
+ * (`/api/daemon/*` route). The scheme is injected at build time by vite
+ * via the `__FRIDAY_DAEMON_BASE_URL__` define key (see vite.config.ts).
+ * We can't read it from `process.env` because vite's
+ * `define: { "process.env": "{}" }` wipes that for everything that goes
+ * through the route SSR transform — an http→https daemon mismatch trips
+ * an HTTPParserError as soon as the daemon starts the TLS handshake on a
+ * cleartext request.
  *
- * The scheme is injected at build time by vite via the
- * `__FRIDAY_DAEMON_BASE_URL__` define key (see vite.config.ts). We can't
- * read it from `process.env` because vite's `define: { "process.env": "{}" }`
- * wipes that for everything that goes through the route SSR transform —
- * an http→https daemon mismatch trips an HTTPParserError as soon as the
- * daemon starts the TLS handshake on a cleartext request. */
+ * The compiled binary uses `static-server.ts` which reads `FRIDAYD_URL`
+ * from env directly. */
 declare const __FRIDAY_DAEMON_BASE_URL__: string | undefined;
+declare const __FRIDAY_TUNNEL_BASE_URL__: string | undefined;
 export const DAEMON_BASE_URL =
 	typeof __FRIDAY_DAEMON_BASE_URL__ !== "undefined"
 		? __FRIDAY_DAEMON_BASE_URL__
 		: "http://localhost:8080";
+export const TUNNEL_BASE_URL =
+	typeof __FRIDAY_TUNNEL_BASE_URL__ !== "undefined"
+		? __FRIDAY_TUNNEL_BASE_URL__
+		: "http://localhost:9090";
 
-interface RuntimeConfig {
-	externalDaemonUrl?: string;
-	externalTunnelUrl?: string;
-}
-
-declare global {
-	// biome-ignore lint/style/noVar: ambient declarations require var
-	var __FRIDAY_CONFIG__: RuntimeConfig | undefined;
-}
-
-const urlSchema = z.string().url();
-
-function normalize(value: string): string {
-	const parsed = urlSchema.safeParse(value);
-	if (!parsed.success) {
-		throw new Error(`invalid URL configured: ${value}`);
-	}
-	return parsed.data.replace(/\/$/, "");
-}
-
-/** Resolve a browser-facing URL from `window.__FRIDAY_CONFIG__`,
- * injected at request time. Production: `static-server.ts` reads
- * EXTERNAL_*_URL from process env and embeds them in served HTML. Dev:
- * the `fridayRuntimeConfig` Vite plugin (vite.config.ts) does the same.
- * Nothing about the URLs is baked into the JS bundle.
+/** Browser-facing daemon URL — same-origin proxy path served by
+ * `/api/daemon/[...path]/+server.ts` (dev) or `static-server.ts` (prod).
+ * Using same-origin means the browser only ever needs to trust the
+ * playground origin's cert; the daemon ships a private-CA cert that no
+ * system trust store knows about, and the proxy injects the right
+ * NODE_EXTRA_CA_CERTS-aware fetch behind the scenes.
  *
- * Resolution is lazy (called per access) so the missing-config throw
- * fires in the browser, not during SvelteKit's build-time prerender.
- */
-function resolve(configKey: keyof RuntimeConfig, envVarName: string, humanName: string): string {
-	const value = globalThis.__FRIDAY_CONFIG__?.[configKey];
-	if (!value) {
-		throw new Error(
-			`${humanName} is not configured. Set ${envVarName} on the playground process ` +
-				`(launcher .env in production; deno.json playground task in dev).`,
-		);
-	}
-	return normalize(value);
+ * Browser-only — every caller is a click handler / mount effect / popup
+ * URL builder. */
+export function daemonUrl(): string {
+	return `${globalThis.location.origin}/api/daemon`;
 }
 
-/** Browser-facing daemon URL. */
-export function externalDaemonUrl(): string {
-	return resolve("externalDaemonUrl", "EXTERNAL_DAEMON_URL", "External daemon URL");
-}
-
-/** Browser-facing webhook-tunnel URL. */
-export function externalTunnelUrl(): string {
-	return resolve("externalTunnelUrl", "EXTERNAL_TUNNEL_URL", "External tunnel URL");
+/** Browser-facing webhook-tunnel URL — same-origin proxy path served by
+ * `/api/tunnel/[...path]/+server.ts` (dev) or `static-server.ts` (prod). */
+export function tunnelUrl(): string {
+	return `${globalThis.location.origin}/api/tunnel`;
 }

--- a/tools/agent-playground/src/lib/daemon-url.ts
+++ b/tools/agent-playground/src/lib/daemon-url.ts
@@ -4,8 +4,19 @@ import { z } from "zod";
  * (`/api/daemon/*` route). The compiled binary uses static-server.ts
  * which reads `FRIDAYD_URL` from env for the same purpose; this dev
  * path always targets the default 8080 since it only runs under
- * `deno task playground`. */
-export const DAEMON_BASE_URL = "http://localhost:8080";
+ * `deno task playground`.
+ *
+ * The scheme is injected at build time by vite via the
+ * `__FRIDAY_DAEMON_BASE_URL__` define key (see vite.config.ts). We can't
+ * read it from `process.env` because vite's `define: { "process.env": "{}" }`
+ * wipes that for everything that goes through the route SSR transform —
+ * an http→https daemon mismatch trips an HTTPParserError as soon as the
+ * daemon starts the TLS handshake on a cleartext request. */
+declare const __FRIDAY_DAEMON_BASE_URL__: string | undefined;
+export const DAEMON_BASE_URL =
+	typeof __FRIDAY_DAEMON_BASE_URL__ !== "undefined"
+		? __FRIDAY_DAEMON_BASE_URL__
+		: "http://localhost:8080";
 
 interface RuntimeConfig {
 	externalDaemonUrl?: string;

--- a/tools/agent-playground/src/lib/oauth-popup.ts
+++ b/tools/agent-playground/src/lib/oauth-popup.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { externalDaemonUrl } from "./daemon-url.ts";
+import { daemonUrl } from "./daemon-url.ts";
 
 /** Schema for OAuth callback message from popup window. */
 export const OAuthCallbackMessageSchema = z.object({
@@ -16,7 +16,7 @@ export type OAuthCallbackMessage = z.infer<typeof OAuthCallbackMessageSchema>;
  */
 export function getOAuthUrl(provider: string): string {
   const callbackUrl = new URL("/oauth/callback", globalThis.location.origin);
-  const url = new URL(`/api/link/v1/oauth/authorize/${provider}`, externalDaemonUrl());
+  const url = new URL(`${daemonUrl()}/api/link/v1/oauth/authorize/${provider}`);
   url.searchParams.set("redirect_uri", callbackUrl.href);
   return url.href;
 }
@@ -27,7 +27,7 @@ export function getOAuthUrl(provider: string): string {
  */
 export function getAppInstallUrl(provider: string): string {
   const callbackUrl = new URL("/oauth/callback", globalThis.location.origin);
-  const url = new URL(`/api/link/v1/app-install/${provider}/authorize`, externalDaemonUrl());
+  const url = new URL(`${daemonUrl()}/api/link/v1/app-install/${provider}/authorize`);
   url.searchParams.set("redirect_uri", callbackUrl.href);
   return url.href;
 }

--- a/tools/agent-playground/src/lib/server/proxy.test.ts
+++ b/tools/agent-playground/src/lib/server/proxy.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildProxyHandler, HOP_BY_HOP_HEADERS } from "./proxy.ts";
+
+/** Build a SvelteKit `RequestEvent`-shaped argument for the handler.
+ * The catch-all `[...path]/+server.ts` route would populate
+ * `params.path` from the URL; we set it directly. */
+function event(opts: {
+  path: string;
+  method?: string;
+  url?: string;
+  headers?: HeadersInit;
+  body?: BodyInit | null;
+  signal?: AbortSignal;
+}): Parameters<ReturnType<typeof buildProxyHandler>>[0] {
+  const request = new Request(opts.url ?? `https://playground.local/api/x/${opts.path}`, {
+    method: opts.method ?? "GET",
+    headers: opts.headers,
+    body: opts.body ?? null,
+    signal: opts.signal,
+  });
+  // RequestEvent has many fields we don't exercise; cast through unknown.
+  return { params: { path: opts.path }, request } as unknown as Parameters<
+    ReturnType<typeof buildProxyHandler>
+  >[0];
+}
+
+describe("buildProxyHandler", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("forwards path + query to the upstream URL", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    const handler = buildProxyHandler({ upstream: "https://daemon.local:8080", label: "daemon" });
+    await handler(
+      event({ path: "api/workspaces/x", url: "https://playground.local/api/daemon/api/workspaces/x?foo=1" }),
+    );
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const target = fetchMock.mock.calls[0]?.[0] as URL;
+    expect(target.toString()).toBe("https://daemon.local:8080/api/workspaces/x?foo=1");
+  });
+
+  it("strips hop-by-hop headers from the response", async () => {
+    const upstreamHeaders = new Headers({
+      "content-type": "application/json",
+      "transfer-encoding": "chunked",
+      connection: "keep-alive",
+      "x-custom": "preserve-me",
+    });
+    fetchMock.mockResolvedValueOnce(new Response("{}", { status: 200, headers: upstreamHeaders }));
+    const handler = buildProxyHandler({ upstream: "https://daemon.local:8080", label: "daemon" });
+    const res = await handler(event({ path: "anything" }));
+    for (const h of HOP_BY_HOP_HEADERS) {
+      expect(res.headers.get(h)).toBeNull();
+    }
+    expect(res.headers.get("x-custom")).toBe("preserve-me");
+    expect(res.headers.get("content-type")).toBe("application/json");
+  });
+
+  it("buffers request body for POST so upstream short-circuits don't race", async () => {
+    fetchMock.mockResolvedValueOnce(new Response("", { status: 401 }));
+    const handler = buildProxyHandler({ upstream: "https://daemon.local:8080", label: "daemon" });
+    const res = await handler(
+      event({ path: "p", method: "POST", body: JSON.stringify({ a: 1 }) }),
+    );
+    expect(res.status).toBe(401);
+    const callBody = fetchMock.mock.calls[0]?.[1]?.body;
+    // Buffered as Uint8Array — never a ReadableStream that could race.
+    expect(callBody).toBeInstanceOf(Uint8Array);
+  });
+
+  it("returns 502 with label-tagged JSON when upstream fetch fails", async () => {
+    fetchMock.mockRejectedValueOnce(new TypeError("connection refused"));
+    const handler = buildProxyHandler({ upstream: "https://tunnel.local:9090", label: "tunnel" });
+    const res = await handler(event({ path: "status" }));
+    expect(res.status).toBe(502);
+    const json = (await res.json()) as { error: string };
+    expect(json.error).toMatch(/^tunnel proxy fetch failed:/);
+    expect(json.error).toContain("connection refused");
+  });
+
+  it("passes SSE responses through with the same status + cleaned headers", async () => {
+    const sseBody = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("data: hello\n\n"));
+        controller.close();
+      },
+    });
+    fetchMock.mockResolvedValueOnce(
+      new Response(sseBody, {
+        status: 200,
+        headers: { "content-type": "text/event-stream", connection: "keep-alive" },
+      }),
+    );
+    const handler = buildProxyHandler({ upstream: "https://daemon.local:8080", label: "daemon" });
+    const res = await handler(event({ path: "stream" }));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+    expect(res.headers.get("connection")).toBeNull();
+    expect(await res.text()).toBe("data: hello\n\n");
+  });
+
+  it("aborts the upstream fetch when the client aborts", async () => {
+    let abortedSignal: AbortSignal | undefined;
+    fetchMock.mockImplementation((_url, init) => {
+      abortedSignal = init.signal;
+      return new Promise<Response>((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () => {
+          reject(new DOMException("aborted", "AbortError"));
+        });
+      });
+    });
+    const ctrl = new AbortController();
+    const handler = buildProxyHandler({ upstream: "https://daemon.local:8080", label: "daemon" });
+    const responsePromise = handler(event({ path: "slow", signal: ctrl.signal }));
+    // Tick once so fetch is in-flight before we abort.
+    await Promise.resolve();
+    ctrl.abort();
+    const res = await responsePromise;
+    expect(res.status).toBe(502);
+    expect(abortedSignal?.aborted).toBe(true);
+  });
+});

--- a/tools/agent-playground/src/lib/server/proxy.ts
+++ b/tools/agent-playground/src/lib/server/proxy.ts
@@ -1,0 +1,147 @@
+import type { RequestHandler } from "@sveltejs/kit";
+
+/** Hop-by-hop / connection-specific headers that don't survive the
+ * proxy or HTTP/2 boundary:
+ *  - content-encoding: fetch() already decompressed; forwarding makes
+ *    the browser double-decompress.
+ *  - content-length: chunked re-encoding may invalidate it.
+ *  - RFC 7230 connection-specific headers: when the playground serves
+ *    TLS the dev server negotiates h2 with the browser; h2 forbids
+ *    `transfer-encoding`, `connection`, etc. The upstream daemon /
+ *    tunnel is h1.1, so its responses carry these — drop them.
+ */
+export const HOP_BY_HOP_HEADERS = [
+  "content-encoding",
+  "content-length",
+  "transfer-encoding",
+  "connection",
+  "keep-alive",
+  "upgrade",
+  "proxy-connection",
+  "te",
+  "trailer",
+] as const;
+
+/** Wrap an upstream body stream so the consumer's `AbortSignal` cancels
+ * the upstream fetch instead of leaving subscriptions and file
+ * descriptors open. Used for SSE responses where the body is long-lived
+ * and we can't rely on response completion to trigger cleanup. */
+export function proxyAbortableBody(
+  body: ReadableStream<Uint8Array>,
+  requestSignal: AbortSignal,
+  abortUpstream: () => void,
+): ReadableStream<Uint8Array> {
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let cancelled = false;
+
+  const cancelUpstream = () => {
+    if (cancelled) return;
+    cancelled = true;
+    abortUpstream();
+    void reader?.cancel().catch(() => {
+      // The upstream may already be gone.
+    });
+  };
+
+  return new ReadableStream<Uint8Array>({
+    start(controller) {
+      reader = body.getReader();
+      requestSignal.addEventListener("abort", cancelUpstream, { once: true });
+      if (requestSignal.aborted) cancelUpstream();
+
+      void (async () => {
+        try {
+          while (!cancelled) {
+            const { done, value } = await reader!.read();
+            if (done) break;
+            controller.enqueue(value);
+          }
+          if (!cancelled) controller.close();
+        } catch (err) {
+          if (!cancelled) controller.error(err);
+        } finally {
+          requestSignal.removeEventListener("abort", cancelUpstream);
+          try {
+            reader?.releaseLock();
+          } catch {
+            // Reader may already be released after cancellation.
+          }
+          abortUpstream();
+        }
+      })();
+    },
+    cancel() {
+      cancelUpstream();
+    },
+  });
+}
+
+export interface BuildProxyOptions {
+  /** Absolute URL of the upstream service (daemon or tunnel). */
+  upstream: string;
+  /** Short label used in 502 error bodies — "daemon" or "tunnel". */
+  label: string;
+}
+
+/** Build a SvelteKit `RequestHandler` that reverse-proxies the path
+ * parameter (`params.path`, set by the catch-all `[...path]/+server.ts`
+ * route) to the upstream service. Used by both `/api/daemon/*` and
+ * `/api/tunnel/*` so they stay behaviorally identical. */
+export function buildProxyHandler({ upstream, label }: BuildProxyOptions): RequestHandler {
+  return async ({ params, request }) => {
+    const path = params.path ?? "";
+    const target = new URL(`/${path}`, upstream);
+    target.search = new URL(request.url).search;
+
+    const headers = new Headers(request.headers);
+    headers.delete("host");
+    headers.delete("content-length");
+
+    const upstreamController = new AbortController();
+    const abortUpstream = () => upstreamController.abort();
+    request.signal.addEventListener("abort", abortUpstream, { once: true });
+
+    // Buffer the request body for methods that carry one. Streaming with
+    // `duplex: "half"` races the response: when the upstream short-
+    // circuits (e.g. 401 before consuming the body) the in-flight body
+    // sender can error with `TypeError: fetch failed`, swallowing the
+    // upstream's real status code.
+    let body: BodyInit | null = null;
+    if (request.method !== "GET" && request.method !== "HEAD") {
+      body = new Uint8Array(await request.arrayBuffer());
+    }
+
+    let res: Response;
+    try {
+      res = await fetch(target, {
+        method: request.method,
+        headers,
+        body,
+        signal: upstreamController.signal,
+      });
+    } catch (err) {
+      request.signal.removeEventListener("abort", abortUpstream);
+      const message = err instanceof Error ? err.message : String(err);
+      return new Response(
+        JSON.stringify({ error: `${label} proxy fetch failed: ${message}` }),
+        { status: 502, headers: { "content-type": "application/json" } },
+      );
+    }
+
+    const responseHeaders = new Headers(res.headers);
+    for (const h of HOP_BY_HOP_HEADERS) responseHeaders.delete(h);
+
+    if (res.headers.get("content-type")?.includes("text/event-stream")) {
+      if (!res.body) {
+        request.signal.removeEventListener("abort", abortUpstream);
+        return new Response(null, { status: res.status, headers: responseHeaders });
+      }
+      request.signal.removeEventListener("abort", abortUpstream);
+      const stream = proxyAbortableBody(res.body, request.signal, abortUpstream);
+      return new Response(stream, { status: res.status, headers: responseHeaders });
+    }
+
+    request.signal.removeEventListener("abort", abortUpstream);
+    return new Response(res.body, { status: res.status, headers: responseHeaders });
+  };
+}

--- a/tools/agent-playground/src/lib/server/routes/discover.ts
+++ b/tools/agent-playground/src/lib/server/routes/discover.ts
@@ -4,11 +4,20 @@ import { Hono } from "hono";
 import JSZip from "jszip";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
+// Daemon URL is injected at vite-config time (FRIDAYD_URL or fallback,
+// scheme upgraded to https:// when TLS is detected). We can't read
+// `process.env.FRIDAYD_URL` here directly: SSR routes go through vite's
+// transform which has `define: { "process.env": "{}" }`, collapsing the
+// read to undefined. See ../../daemon-url.ts and vite.config.ts.
+import { DAEMON_BASE_URL as DAEMON_URL } from "../../daemon-url.ts";
 
+// REPO/PATH/REF/GITHUB_TOKEN are read for completeness but are subject to
+// the same `process.env` wipe at SSR transform time — the env-override
+// path was already non-functional pre-TLS. Fixing those is out of scope
+// here; the fallbacks are what runs.
 const REPO = process.env.DISCOVER_REPO ?? "friday-platform/friday-studio-examples";
 const PATH = process.env.DISCOVER_PATH ?? "";
 const REF = process.env.DISCOVER_REF ?? "main";
-const DAEMON_URL = process.env.FRIDAYD_URL ?? "http://localhost:8080";
 
 const GH_TOKEN = process.env.GITHUB_TOKEN ?? "";
 

--- a/tools/agent-playground/src/lib/server/routes/execute.ts
+++ b/tools/agent-playground/src/lib/server/routes/execute.ts
@@ -1,5 +1,4 @@
 import { join } from "node:path";
-import process from "node:process";
 import { bundledAgents } from "@atlas/bundled-agents";
 import { UserAdapter } from "@atlas/core/agent-loader";
 import { enterTraceScope, type TraceEntry } from "@atlas/llm";
@@ -11,12 +10,12 @@ import { parseSSEEvents } from "@atlas/utils/sse";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
-// Match the resolution used by static-server.ts and routes/discover.ts —
-// the launcher exports FRIDAYD_URL in .env at the configured FRIDAY_PORT_FRIDAY
-// (which is 18080 in FAST/LINK_DEV mode, not 8080). Without this read, the
-// playground binary running on a non-default port silently posts user-agent
-// runs to :8080 and reports "Connection refused".
-const DAEMON_BASE_URL = process.env.FRIDAYD_URL ?? "http://localhost:8080";
+// Daemon URL is injected at vite-config time (FRIDAYD_URL or fallback,
+// scheme upgraded to https:// when TLS is detected). We can't read
+// `process.env` here directly: SSR routes go through vite's transform
+// which has `define: { "process.env": "{}" }`, collapsing the read to
+// undefined. See ../../daemon-url.ts and tools/agent-playground/vite.config.ts.
+import { DAEMON_BASE_URL } from "../../daemon-url.ts";
 import { PlaygroundContextAdapter } from "../lib/context.ts";
 import { createSSEStream } from "../lib/sse.ts";
 

--- a/tools/agent-playground/src/routes/api/daemon/[...path]/+server.ts
+++ b/tools/agent-playground/src/routes/api/daemon/[...path]/+server.ts
@@ -97,27 +97,45 @@ const handler: RequestHandler = async ({ params, request }) => {
     );
   }
 
+  // Strip headers that don't survive the proxy / HTTP/2 boundary:
+  //  - content-encoding: fetch() already decompressed; forwarding makes
+  //    the browser try to decompress again.
+  //  - content-length: chunked re-encoding by the dev server breaks the
+  //    invariant; let the framework recompute (or omit and stream).
+  //  - HTTP/1.1 connection-specific headers: HTTP/2 forbids them
+  //    (Node throws ERR_HTTP2_INVALID_CONNECTION_HEADERS at writeHead).
+  //    The daemon serves h1.1 to us; the browser talks h2 to vite, so
+  //    the SvelteKit response writer hits Http2ServerResponse and rejects
+  //    `transfer-encoding: chunked`. Same applies to SSE responses.
+  const responseHeaders = new Headers(res.headers);
+  for (const h of [
+    "content-encoding",
+    "content-length",
+    "transfer-encoding",
+    "connection",
+    "keep-alive",
+    "upgrade",
+    "proxy-connection",
+    "te",
+    "trailer",
+  ]) {
+    responseHeaders.delete(h);
+  }
+
   // SSE: proxy with explicit cancellation. Returning `res.body` directly
   // leaves the upstream daemon fetch alive when the browser closes the
   // EventSource/fetch, which leaks daemon subscriptions and dev-server fds.
   if (res.headers.get("content-type")?.includes("text/event-stream")) {
     if (!res.body) {
       request.signal.removeEventListener("abort", abortUpstream);
-      return new Response(null, { status: res.status, headers: res.headers });
+      return new Response(null, { status: res.status, headers: responseHeaders });
     }
     request.signal.removeEventListener("abort", abortUpstream);
     const stream = proxyAbortableBody(res.body, request.signal, abortUpstream);
-    return new Response(stream, { status: res.status, headers: res.headers });
+    return new Response(stream, { status: res.status, headers: responseHeaders });
   }
 
   request.signal.removeEventListener("abort", abortUpstream);
-
-  // Strip content-encoding — fetch() already decompresses the body,
-  // so forwarding the header causes the browser to double-decompress.
-  const responseHeaders = new Headers(res.headers);
-  responseHeaders.delete("content-encoding");
-  responseHeaders.delete("content-length");
-
   return new Response(res.body, { status: res.status, headers: responseHeaders });
 };
 

--- a/tools/agent-playground/src/routes/api/tunnel/[...path]/+server.ts
+++ b/tools/agent-playground/src/routes/api/tunnel/[...path]/+server.ts
@@ -1,7 +1,7 @@
-import { DAEMON_BASE_URL } from "$lib/daemon-url";
+import { TUNNEL_BASE_URL } from "$lib/daemon-url";
 import { buildProxyHandler } from "$lib/server/proxy";
 
-const handler = buildProxyHandler({ upstream: DAEMON_BASE_URL, label: "daemon" });
+const handler = buildProxyHandler({ upstream: TUNNEL_BASE_URL, label: "tunnel" });
 
 export const GET = handler;
 export const POST = handler;

--- a/tools/agent-playground/src/routes/inspector/+page.svelte
+++ b/tools/agent-playground/src/routes/inspector/+page.svelte
@@ -31,7 +31,7 @@
   import PipelineDiagram from "$lib/components/workspace/pipeline-diagram.svelte";
   import SignalInputForm from "$lib/components/workspace/signal-input-form.svelte";
   import WorkspaceJobSelector from "$lib/components/workspace/workspace-job-selector.svelte";
-  import { externalDaemonUrl } from "$lib/daemon-url";
+  import { daemonUrl } from "$lib/daemon-url";
   import { createInspectorState, type ResolvedStepAgent } from "$lib/inspector-state.svelte";
   import {
     AGENT_TYPE_LABELS,
@@ -340,7 +340,7 @@
       "curl -X POST",
       `-H 'Content-Type: application/json'`,
       `-d '${escaped}'`,
-      `${externalDaemonUrl()}/api/workspaces/${workspaceId}/signals/${primarySignal.name}`,
+      `${daemonUrl()}/api/workspaces/${workspaceId}/signals/${primarySignal.name}`,
     ].join(" \\\n  ");
     navigator.clipboard.writeText(curl);
   }

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/jobs/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/jobs/+page.svelte
@@ -28,7 +28,7 @@
   import RunJobDialog from "$lib/components/workspace/run-job-dialog.svelte";
   import WorkspaceBreadcrumb from "$lib/components/workspace/workspace-breadcrumb.svelte";
   import { humanizeCronSchedule } from "$lib/cron-humanize";
-  import { externalDaemonUrl } from "$lib/daemon-url";
+  import { daemonUrl } from "$lib/daemon-url";
   import { integrationQueries, workspaceQueries, type IntegrationStatus } from "$lib/queries";
   import { JsonSchemaObjectShape, JsonSchemaPropertyShape } from "$lib/schema-utils";
 
@@ -241,7 +241,7 @@
           "curl -X POST",
           `-H 'Content-Type: application/json'`,
           `-d '${escaped}'`,
-          `${externalDaemonUrl()}/api/workspaces/${workspaceId}/signals/${trigger.signal}`,
+          `${daemonUrl()}/api/workspaces/${workspaceId}/signals/${trigger.signal}`,
         ].join(" \\\n  ");
         navigator.clipboard.writeText(curl);
       }

--- a/tools/agent-playground/src/routes/settings/+page.svelte
+++ b/tools/agent-playground/src/routes/settings/+page.svelte
@@ -23,7 +23,7 @@
   import { Button, PageLayout, toast } from "@atlas/ui";
   import ModelChain from "$lib/components/settings/model-chain.svelte";
   import ModelPicker from "$lib/components/settings/model-picker.svelte";
-  import { externalTunnelUrl } from "$lib/daemon-url";
+  import { tunnelUrl as tunnelProxyUrl } from "$lib/daemon-url";
   import { useQueryClient } from "@tanstack/svelte-query";
   import { workspaceQueries } from "$lib/queries";
   import {
@@ -172,7 +172,7 @@
     tunnelLoading = true;
     tunnelError = null;
     try {
-      const res = await fetch(`${externalTunnelUrl()}/status`);
+      const res = await fetch(`${tunnelProxyUrl()}/status`);
       if (!res.ok) {
         tunnelError = `Tunnel unreachable (HTTP ${res.status})`;
         return;

--- a/tools/agent-playground/static-server.ts
+++ b/tools/agent-playground/static-server.ts
@@ -7,59 +7,34 @@
  * via `deno compile --include build`, so the executable is fully
  * self-contained.
  */
-import { existsSync } from "node:fs";
-import { homedir } from "node:os";
 import process from "node:process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Hono } from "hono";
 import { serveStatic } from "hono/deno";
-import { parse as parseHtml } from "node-html-parser";
 import { api } from "./src/lib/server/router.ts";
+import { resolveBrowserTlsPaths } from "./tls-paths.ts";
 
 const PORT = Number(process.env.PLAYGROUND_PORT ?? "5200");
 const HOST = process.env.PLAYGROUND_HOST ?? "127.0.0.1";
 
-// HTTP/2 + TLS resolution. Same source-of-truth as the Vite dev config:
-// env vars first, then ~/.friday/local/tls, then ~/.atlas/tls. When a
-// pair is found, `Deno.serve` negotiates h2 over ALPN and the per-origin
-// 6-socket HTTP/1.1 cap (which the playground hits with 3 SSE feeds ×
-// multiple tabs) goes away. No cert → HTTP fallback, behaviour unchanged.
-function resolveTls(): { cert: string; key: string } | null {
-  const candidates: Array<[string, string]> = [];
-  const envCert = process.env.FRIDAY_TLS_CERT;
-  const envKey = process.env.FRIDAY_TLS_KEY;
-  if (envCert && envKey) candidates.push([envCert, envKey]);
-  const home = homedir();
-  candidates.push([
-    join(home, ".friday", "local", "tls", "localhost.crt"),
-    join(home, ".friday", "local", "tls", "localhost.key"),
-  ]);
-  candidates.push([
-    join(home, ".atlas", "tls", "localhost.crt"),
-    join(home, ".atlas", "tls", "localhost.key"),
-  ]);
-  for (const [c, k] of candidates) {
-    if (existsSync(c) && existsSync(k)) {
-      return { cert: Deno.readTextFileSync(c), key: Deno.readTextFileSync(k) };
-    }
-  }
-  return null;
-}
-
-const TLS = resolveTls();
+// Browser-facing TLS for this origin. The cert here must be browser-trusted
+// (mkcert-signed); the s2s `FRIDAY_TLS_CERT/_KEY` pair used by daemon +
+// tunnel is private-CA-signed and intentionally not browser-trusted —
+// browser traffic to those services goes through this origin's
+// /api/{daemon,tunnel}/* proxies instead. When a pair is found, `Deno.serve`
+// negotiates h2 over ALPN and the per-origin 6-socket HTTP/1.1 cap goes
+// away. No cert → HTTP fallback, behaviour unchanged.
+const tlsPaths = resolveBrowserTlsPaths();
+const TLS = tlsPaths
+  ? { cert: Deno.readTextFileSync(tlsPaths.certPath), key: Deno.readTextFileSync(tlsPaths.keyPath) }
+  : null;
 const SCHEME = TLS ? "https" : "http";
-const DAEMON_URL = process.env.FRIDAYD_URL ?? `${SCHEME}://localhost:8080`;
-
-// Browser-facing URLs. The launcher owns the port layout, so we can't
-// bake these into the bundle — read them at runtime and inject into the
-// served HTML. Daemon URL falls back to FRIDAYD_URL since the daemon
-// proxy and the browser-facing daemon are the same endpoint in Studio.
-// When TLS is on, browser fetches to a plain http:// daemon would be
-// blocked as mixed content — default the public URL to the same scheme
-// we're serving on, while still letting an explicit env value win.
-const EXTERNAL_DAEMON_URL = process.env.EXTERNAL_DAEMON_URL ?? DAEMON_URL;
-const EXTERNAL_TUNNEL_URL = process.env.EXTERNAL_TUNNEL_URL ?? null;
+// Daemon and tunnel scheme depend on their own s2s cert env, not on this
+// origin's browser cert. They're separate listeners with separate certs.
+const S2S_SCHEME = process.env.FRIDAY_TLS_CERT && process.env.FRIDAY_TLS_KEY ? "https" : "http";
+const DAEMON_URL = process.env.FRIDAYD_URL ?? `${S2S_SCHEME}://localhost:8080`;
+const TUNNEL_URL = process.env.EXTERNAL_TUNNEL_URL ?? `${S2S_SCHEME}://localhost:9090`;
 
 // Resolve `./build` relative to this source file, so the path is correct
 // both when running via `deno run` from any cwd and when running as a
@@ -67,27 +42,6 @@ const EXTERNAL_TUNNEL_URL = process.env.EXTERNAL_TUNNEL_URL ?? null;
 const HERE = dirname(fileURLToPath(import.meta.url));
 const BUILD_ROOT = join(HERE, "build");
 const INDEX_HTML = join(BUILD_ROOT, "index.html");
-
-const RUNTIME_CONFIG: Record<string, string> = {
-  externalDaemonUrl: EXTERNAL_DAEMON_URL,
-};
-if (EXTERNAL_TUNNEL_URL) RUNTIME_CONFIG.externalTunnelUrl = EXTERNAL_TUNNEL_URL;
-const CONFIG_JSON = JSON.stringify(RUNTIME_CONFIG).replace(/</g, "\\u003c");
-const CONFIG_SCRIPT_HTML = `<script>window.__FRIDAY_CONFIG__=${CONFIG_JSON};</script>`;
-
-let CACHED_HTML: string | null = null;
-async function indexHtml(): Promise<string> {
-  if (CACHED_HTML !== null) return CACHED_HTML;
-  const raw = await Deno.readTextFile(INDEX_HTML);
-  const root = parseHtml(raw);
-  const head = root.querySelector("head");
-  if (!head) {
-    throw new Error(`build/index.html is missing a <head> element — refusing to serve`);
-  }
-  head.appendChild(parseHtml(CONFIG_SCRIPT_HTML));
-  CACHED_HTML = root.toString();
-  return CACHED_HTML;
-}
 
 function proxyAbortableBody(
   body: ReadableStream<Uint8Array>,
@@ -139,98 +93,107 @@ function proxyAbortableBody(
   });
 }
 
-// Daemon proxy for /api/daemon/*. The SvelteKit dev server has this as
-// src/routes/api/daemon/[...path]/+server.ts, but adapter-static strips
-// all server routes — the production binary has no daemon proxy unless
-// we explicitly mount one here. Without it, /api/daemon/api/workspaces/X
-// falls through to the SPA fallback returning index.html, surfacing as
-// "Unexpected token '<', '<!doctype' is not valid JSON" on every page
-// that loads workspace config.
-const daemonProxy = new Hono().all("/api/daemon/*", async (c) => {
-  const url = new URL(c.req.url);
-  // Strip the /api/daemon prefix; preserve query string.
-  const path = url.pathname.replace(/^\/api\/daemon/, "");
-  const target = new URL(path + url.search, DAEMON_URL);
+// Reverse proxy for browser → local service. The SvelteKit dev server has
+// per-route versions of this under src/routes/api/{daemon,tunnel}/[...path]/,
+// but adapter-static strips all server routes — the production binary has
+// no proxy unless we explicitly mount it. Without it,
+// /api/daemon/api/workspaces/X falls through to the SPA fallback returning
+// index.html, surfacing as "Unexpected token '<', '<!doctype' is not valid
+// JSON" on every page that loads workspace config.
+function buildProxy(prefix: string, upstream: string, label: string) {
+  return async (c: { req: { url: string; method: string; raw: Request } }) => {
+    const url = new URL(c.req.url);
+    const path = url.pathname.replace(new RegExp(`^${prefix}`), "");
+    const target = new URL(path + url.search, upstream);
 
-  const headers = new Headers(c.req.raw.headers);
-  headers.delete("host");
-  headers.delete("content-length");
+    const headers = new Headers(c.req.raw.headers);
+    headers.delete("host");
+    headers.delete("content-length");
 
-  // Buffer the request body for methods that carry one. Streaming with
-  // `duplex: "half"` races the response: when the daemon short-circuits
-  // (e.g. 401 from requireUser before consuming the body) the in-flight
-  // body sender can error with `TypeError: fetch failed`, swallowing the
-  // upstream's real status code. Buffering eliminates the race so the
-  // browser sees the actual 401 and the user gets a useful message.
-  let body: BodyInit | null = null;
-  if (c.req.method !== "GET" && c.req.method !== "HEAD") {
-    body = new Uint8Array(await c.req.raw.arrayBuffer());
-  }
-
-  const upstreamController = new AbortController();
-  const abortUpstream = () => upstreamController.abort();
-  c.req.raw.signal.addEventListener("abort", abortUpstream, { once: true });
-
-  let res: Response;
-  try {
-    res = await fetch(target, {
-      method: c.req.method,
-      headers,
-      body,
-      signal: upstreamController.signal,
-    });
-  } catch (err) {
-    c.req.raw.signal.removeEventListener("abort", abortUpstream);
-    const message = err instanceof Error ? err.message : String(err);
-    return c.json({ error: `daemon proxy fetch failed: ${message}` }, 502);
-  }
-
-  // Strip headers that don't survive the proxy / HTTP/2 boundary:
-  //  - content-encoding: fetch() already decompressed; forwarding makes
-  //    the browser double-decompress.
-  //  - content-length: chunked re-encoding may invalidate it.
-  //  - HTTP/1.1 connection-specific headers: when this binary serves TLS
-  //    (https://) the Deno HTTP server negotiates h2 with the browser;
-  //    h2 forbids `transfer-encoding`, `connection`, etc. The daemon
-  //    upstream is h1.1, so its responses carry these — drop them.
-  const responseHeaders = new Headers(res.headers);
-  for (const h of [
-    "content-encoding",
-    "content-length",
-    "transfer-encoding",
-    "connection",
-    "keep-alive",
-    "upgrade",
-    "proxy-connection",
-    "te",
-    "trailer",
-  ]) {
-    responseHeaders.delete(h);
-  }
-
-  // SSE: pass the body stream through unbuffered so live event streams
-  // don't get held up at our proxy boundary. Wrap the body so browser
-  // disconnects cancel the daemon fetch instead of leaving subscriptions
-  // and file descriptors open behind the static playground proxy.
-  if (res.headers.get("content-type")?.includes("text/event-stream")) {
-    if (!res.body) {
-      c.req.raw.signal.removeEventListener("abort", abortUpstream);
-      return new Response(null, { status: res.status, headers: responseHeaders });
+    // Buffer the request body for methods that carry one. Streaming with
+    // `duplex: "half"` races the response: when the upstream short-circuits
+    // (e.g. 401 before consuming the body) the in-flight body sender can
+    // error with `TypeError: fetch failed`, swallowing the real status code.
+    let body: BodyInit | null = null;
+    if (c.req.method !== "GET" && c.req.method !== "HEAD") {
+      body = new Uint8Array(await c.req.raw.arrayBuffer());
     }
+
+    const upstreamController = new AbortController();
+    const abortUpstream = () => upstreamController.abort();
+    c.req.raw.signal.addEventListener("abort", abortUpstream, { once: true });
+
+    let res: Response;
+    try {
+      res = await fetch(target, {
+        method: c.req.method,
+        headers,
+        body,
+        signal: upstreamController.signal,
+      });
+    } catch (err) {
+      c.req.raw.signal.removeEventListener("abort", abortUpstream);
+      const message = err instanceof Error ? err.message : String(err);
+      return new Response(JSON.stringify({ error: `${label} proxy fetch failed: ${message}` }), {
+        status: 502,
+        headers: { "content-type": "application/json" },
+      });
+    }
+
+    // Strip headers that don't survive the proxy / HTTP/2 boundary:
+    //  - content-encoding: fetch() already decompressed; forwarding makes
+    //    the browser double-decompress.
+    //  - content-length: chunked re-encoding may invalidate it.
+    //  - HTTP/1.1 connection-specific headers: when this binary serves TLS
+    //    (https://) the Deno HTTP server negotiates h2 with the browser;
+    //    h2 forbids `transfer-encoding`, `connection`, etc. The upstream
+    //    is h1.1, so its responses carry these — drop them.
+    const responseHeaders = new Headers(res.headers);
+    for (const h of [
+      "content-encoding",
+      "content-length",
+      "transfer-encoding",
+      "connection",
+      "keep-alive",
+      "upgrade",
+      "proxy-connection",
+      "te",
+      "trailer",
+    ]) {
+      responseHeaders.delete(h);
+    }
+
+    // SSE: pass the body stream through unbuffered so live event streams
+    // don't get held up at our proxy boundary. Wrap the body so browser
+    // disconnects cancel the upstream fetch instead of leaving
+    // subscriptions and file descriptors open behind the proxy.
+    if (res.headers.get("content-type")?.includes("text/event-stream")) {
+      if (!res.body) {
+        c.req.raw.signal.removeEventListener("abort", abortUpstream);
+        return new Response(null, { status: res.status, headers: responseHeaders });
+      }
+      c.req.raw.signal.removeEventListener("abort", abortUpstream);
+      const stream = proxyAbortableBody(res.body, c.req.raw.signal, abortUpstream);
+      return new Response(stream, { status: res.status, headers: responseHeaders });
+    }
+
     c.req.raw.signal.removeEventListener("abort", abortUpstream);
-    const stream = proxyAbortableBody(res.body, c.req.raw.signal, abortUpstream);
-    return new Response(stream, { status: res.status, headers: responseHeaders });
-  }
+    return new Response(res.body, { status: res.status, headers: responseHeaders });
+  };
+}
 
-  c.req.raw.signal.removeEventListener("abort", abortUpstream);
-  return new Response(res.body, { status: res.status, headers: responseHeaders });
-});
+const proxies = new Hono()
+  .all("/api/daemon/*", buildProxy("/api/daemon", DAEMON_URL, "daemon"))
+  .all("/api/tunnel/*", buildProxy("/api/tunnel", TUNNEL_URL, "tunnel"));
 
-// Serve the index with the runtime-config script tag injected. This
-// covers both `/` and the SPA fallback below; a static-file serve of
-// build/index.html would skip the injection.
+let CACHED_HTML: string | null = null;
+async function indexHtml(): Promise<string> {
+  if (CACHED_HTML === null) CACHED_HTML = await Deno.readTextFile(INDEX_HTML);
+  return CACHED_HTML;
+}
+
 const app = new Hono()
-  .route("/", daemonProxy)
+  .route("/", proxies)
   .route("/", api)
   .get("/", async (c) => c.html(await indexHtml()))
   .use(
@@ -241,15 +204,11 @@ const app = new Hono()
     }),
   )
   // SPA fallback: any GET that doesn't resolve to a file or `/api/*` route
-  // gets the SvelteKit shell (with config injected) so client-side
-  // routing can take over.
+  // gets the SvelteKit shell so client-side routing can take over.
   .get("/*", async (c) => c.html(await indexHtml()));
 
 // Log only origins (protocol+host+port) — these are config URLs the user
-// expects in plain text, but never log paths or query strings, since a
-// bad/exotic env value could carry credentials or markup we don't want
-// surfaced in shipped logs (the URLs are also injected into served HTML
-// via window.__FRIDAY_CONFIG__, where escaping is handled separately).
+// expects in plain text, but never log paths or query strings.
 function origin(u: string): string {
   try {
     return new URL(u).origin;
@@ -259,8 +218,7 @@ function origin(u: string): string {
 }
 console.log(`[playground] listening on ${SCHEME}://${HOST}:${PORT}`);
 console.log(`[playground] daemon proxy → ${origin(DAEMON_URL)}`);
-console.log(`[playground] external daemon → ${origin(EXTERNAL_DAEMON_URL)}`);
-if (EXTERNAL_TUNNEL_URL) console.log(`[playground] external tunnel → ${origin(EXTERNAL_TUNNEL_URL)}`);
+console.log(`[playground] tunnel proxy → ${origin(TUNNEL_URL)}`);
 Deno.serve(
   TLS ? { port: PORT, hostname: HOST, cert: TLS.cert, key: TLS.key } : { port: PORT, hostname: HOST },
   app.fetch,

--- a/tools/agent-playground/static-server.ts
+++ b/tools/agent-playground/static-server.ts
@@ -7,6 +7,8 @@
  * via `deno compile --include build`, so the executable is fully
  * self-contained.
  */
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
 import process from "node:process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -17,12 +19,45 @@ import { api } from "./src/lib/server/router.ts";
 
 const PORT = Number(process.env.PLAYGROUND_PORT ?? "5200");
 const HOST = process.env.PLAYGROUND_HOST ?? "127.0.0.1";
-const DAEMON_URL = process.env.FRIDAYD_URL ?? "http://localhost:8080";
+
+// HTTP/2 + TLS resolution. Same source-of-truth as the Vite dev config:
+// env vars first, then ~/.friday/local/tls, then ~/.atlas/tls. When a
+// pair is found, `Deno.serve` negotiates h2 over ALPN and the per-origin
+// 6-socket HTTP/1.1 cap (which the playground hits with 3 SSE feeds ×
+// multiple tabs) goes away. No cert → HTTP fallback, behaviour unchanged.
+function resolveTls(): { cert: string; key: string } | null {
+  const candidates: Array<[string, string]> = [];
+  const envCert = process.env.FRIDAY_TLS_CERT;
+  const envKey = process.env.FRIDAY_TLS_KEY;
+  if (envCert && envKey) candidates.push([envCert, envKey]);
+  const home = homedir();
+  candidates.push([
+    join(home, ".friday", "local", "tls", "localhost.crt"),
+    join(home, ".friday", "local", "tls", "localhost.key"),
+  ]);
+  candidates.push([
+    join(home, ".atlas", "tls", "localhost.crt"),
+    join(home, ".atlas", "tls", "localhost.key"),
+  ]);
+  for (const [c, k] of candidates) {
+    if (existsSync(c) && existsSync(k)) {
+      return { cert: Deno.readTextFileSync(c), key: Deno.readTextFileSync(k) };
+    }
+  }
+  return null;
+}
+
+const TLS = resolveTls();
+const SCHEME = TLS ? "https" : "http";
+const DAEMON_URL = process.env.FRIDAYD_URL ?? `${SCHEME}://localhost:8080`;
 
 // Browser-facing URLs. The launcher owns the port layout, so we can't
 // bake these into the bundle — read them at runtime and inject into the
 // served HTML. Daemon URL falls back to FRIDAYD_URL since the daemon
 // proxy and the browser-facing daemon are the same endpoint in Studio.
+// When TLS is on, browser fetches to a plain http:// daemon would be
+// blocked as mixed content — default the public URL to the same scheme
+// we're serving on, while still letting an explicit env value win.
 const EXTERNAL_DAEMON_URL = process.env.EXTERNAL_DAEMON_URL ?? DAEMON_URL;
 const EXTERNAL_TUNNEL_URL = process.env.EXTERNAL_TUNNEL_URL ?? null;
 
@@ -150,6 +185,29 @@ const daemonProxy = new Hono().all("/api/daemon/*", async (c) => {
     return c.json({ error: `daemon proxy fetch failed: ${message}` }, 502);
   }
 
+  // Strip headers that don't survive the proxy / HTTP/2 boundary:
+  //  - content-encoding: fetch() already decompressed; forwarding makes
+  //    the browser double-decompress.
+  //  - content-length: chunked re-encoding may invalidate it.
+  //  - HTTP/1.1 connection-specific headers: when this binary serves TLS
+  //    (https://) the Deno HTTP server negotiates h2 with the browser;
+  //    h2 forbids `transfer-encoding`, `connection`, etc. The daemon
+  //    upstream is h1.1, so its responses carry these — drop them.
+  const responseHeaders = new Headers(res.headers);
+  for (const h of [
+    "content-encoding",
+    "content-length",
+    "transfer-encoding",
+    "connection",
+    "keep-alive",
+    "upgrade",
+    "proxy-connection",
+    "te",
+    "trailer",
+  ]) {
+    responseHeaders.delete(h);
+  }
+
   // SSE: pass the body stream through unbuffered so live event streams
   // don't get held up at our proxy boundary. Wrap the body so browser
   // disconnects cancel the daemon fetch instead of leaving subscriptions
@@ -157,21 +215,14 @@ const daemonProxy = new Hono().all("/api/daemon/*", async (c) => {
   if (res.headers.get("content-type")?.includes("text/event-stream")) {
     if (!res.body) {
       c.req.raw.signal.removeEventListener("abort", abortUpstream);
-      return new Response(null, { status: res.status, headers: res.headers });
+      return new Response(null, { status: res.status, headers: responseHeaders });
     }
     c.req.raw.signal.removeEventListener("abort", abortUpstream);
     const stream = proxyAbortableBody(res.body, c.req.raw.signal, abortUpstream);
-    return new Response(stream, { status: res.status, headers: res.headers });
+    return new Response(stream, { status: res.status, headers: responseHeaders });
   }
 
   c.req.raw.signal.removeEventListener("abort", abortUpstream);
-
-  // Strip content-encoding/length — fetch() decompressed the body, so
-  // forwarding the original encoding header makes the browser try to
-  // decompress again. Drop content-length too; chunked is fine.
-  const responseHeaders = new Headers(res.headers);
-  responseHeaders.delete("content-encoding");
-  responseHeaders.delete("content-length");
   return new Response(res.body, { status: res.status, headers: responseHeaders });
 });
 
@@ -206,8 +257,11 @@ function origin(u: string): string {
     return "<invalid url>";
   }
 }
-console.log(`[playground] listening on http://${HOST}:${PORT}`);
+console.log(`[playground] listening on ${SCHEME}://${HOST}:${PORT}`);
 console.log(`[playground] daemon proxy → ${origin(DAEMON_URL)}`);
 console.log(`[playground] external daemon → ${origin(EXTERNAL_DAEMON_URL)}`);
 if (EXTERNAL_TUNNEL_URL) console.log(`[playground] external tunnel → ${origin(EXTERNAL_TUNNEL_URL)}`);
-Deno.serve({ port: PORT, hostname: HOST }, app.fetch);
+Deno.serve(
+  TLS ? { port: PORT, hostname: HOST, cert: TLS.cert, key: TLS.key } : { port: PORT, hostname: HOST },
+  app.fetch,
+);

--- a/tools/agent-playground/tls-paths.ts
+++ b/tools/agent-playground/tls-paths.ts
@@ -1,0 +1,46 @@
+// Shared path resolution for the playground origin's browser-trusted
+// TLS cert pair. Single source of truth — vite.config.ts (Node, Buffer
+// reads) and static-server.ts (Deno, string reads) both import this
+// and then read bytes with their own runtime API.
+//
+// The s2s cert pair (FRIDAY_TLS_CERT/_KEY) is for daemon + tunnel
+// listeners, not the playground origin, and is intentionally NOT
+// resolved here — those processes consume those env vars directly.
+
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+
+export interface TlsPaths {
+  certPath: string;
+  keyPath: string;
+}
+
+/** Resolve `{certPath, keyPath}` for the playground origin's browser-
+ * trusted cert (mkcert-signed by scripts/setup-tls.sh). Returns `null`
+ * when no cert pair exists, in which case callers fall back to plain
+ * HTTP and the dev cycle is unchanged.
+ *
+ * Resolution order:
+ *   1. `FRIDAY_BROWSER_TLS_CERT` + `FRIDAY_BROWSER_TLS_KEY` (explicit)
+ *   2. `~/.friday/local/tls/browser.{crt,key}`
+ *   3. `~/.atlas/tls/browser.{crt,key}`
+ */
+export function resolveBrowserTlsPaths(): TlsPaths | null {
+  const candidates: TlsPaths[] = [];
+  const envCert = process.env.FRIDAY_BROWSER_TLS_CERT;
+  const envKey = process.env.FRIDAY_BROWSER_TLS_KEY;
+  if (envCert && envKey) candidates.push({ certPath: envCert, keyPath: envKey });
+  const home = homedir();
+  for (const root of [join(home, ".friday", "local"), join(home, ".atlas")]) {
+    candidates.push({
+      certPath: join(root, "tls", "browser.crt"),
+      keyPath: join(root, "tls", "browser.key"),
+    });
+  }
+  for (const c of candidates) {
+    if (existsSync(c.certPath) && existsSync(c.keyPath)) return c;
+  }
+  return null;
+}

--- a/tools/agent-playground/tls-paths.ts
+++ b/tools/agent-playground/tls-paths.ts
@@ -7,10 +7,11 @@
 // listeners, not the playground origin, and is intentionally NOT
 // resolved here — those processes consume those env vars directly.
 
-import { existsSync } from "node:fs";
+import { readFileSync, existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
+import { X509Certificate } from "node:crypto";
 
 export interface TlsPaths {
   certPath: string;
@@ -18,9 +19,16 @@ export interface TlsPaths {
 }
 
 /** Resolve `{certPath, keyPath}` for the playground origin's browser-
- * trusted cert (mkcert-signed by scripts/setup-tls.sh). Returns `null`
- * when no cert pair exists, in which case callers fall back to plain
- * HTTP and the dev cycle is unchanged.
+ * trusted cert. Returns `null` when no usable pair exists — caller
+ * falls back to plain HTTP and the dev cycle is unchanged.
+ *
+ * "Usable" means: both files exist AND the cert is currently within
+ * its `notBefore..notAfter` window. An expired cert would make every
+ * page load show a browser security warning; the user gets a better
+ * experience falling back to http:// while the launcher's TTL-based
+ * renewer (friday-launcher/tls_renewer.go) fetches a fresh one and
+ * triggers a restart. Same applies to a `notBefore` in the future —
+ * usually a clock-skew symptom on the user's machine.
  *
  * Resolution order:
  *   1. `FRIDAY_BROWSER_TLS_CERT` + `FRIDAY_BROWSER_TLS_KEY` (explicit)
@@ -40,7 +48,38 @@ export function resolveBrowserTlsPaths(): TlsPaths | null {
     });
   }
   for (const c of candidates) {
-    if (existsSync(c.certPath) && existsSync(c.keyPath)) return c;
+    if (!existsSync(c.certPath) || !existsSync(c.keyPath)) continue;
+    if (!isCertCurrentlyValid(c.certPath)) continue;
+    return c;
   }
   return null;
+}
+
+/** Parse the first cert in a PEM file and check that `now` is within
+ * `notBefore..notAfter`. Returns `false` on any parse / IO error so a
+ * malformed cert is treated the same as an expired one: don't serve,
+ * fall back to http and let the renewer fix it.
+ *
+ * Uses `X509Certificate` from `node:crypto`, which is available in
+ * both Node ≥ 15.6 and Deno ≥ 1.30 — both runtimes that consume this
+ * module.
+ */
+function isCertCurrentlyValid(path: string): boolean {
+  let bytes: Uint8Array;
+  try {
+    bytes = readFileSync(path);
+  } catch {
+    return false;
+  }
+  let cert: X509Certificate;
+  try {
+    cert = new X509Certificate(bytes);
+  } catch {
+    return false;
+  }
+  const now = Date.now();
+  const notBefore = Date.parse(cert.validFrom);
+  const notAfter = Date.parse(cert.validTo);
+  if (Number.isNaN(notBefore) || Number.isNaN(notAfter)) return false;
+  return now >= notBefore && now <= notAfter;
 }

--- a/tools/agent-playground/vite.config.ts
+++ b/tools/agent-playground/vite.config.ts
@@ -72,14 +72,20 @@ function effectiveDaemonUrl(): string {
 }
 const DAEMON_URL = effectiveDaemonUrl();
 
-// `EXTERNAL_DAEMON_URL` / `EXTERNAL_TUNNEL_URL` flow into the runtime
-// config the SvelteKit hook injects on the served HTML. When TLS is on
-// the page is https://, so any direct browser fetch to a plain http://
-// daemon would be blocked as mixed content (Chrome makes a localhost
-// exception, Firefox/Safari don't). Default to the resolved scheme; let
-// an explicit env value still win for split-host setups.
+// `EXTERNAL_DAEMON_URL` flows into the runtime config the SvelteKit hook
+// injects on the served HTML. When TLS is on the page is https://, so any
+// direct browser fetch to a plain http:// daemon would be blocked as mixed
+// content (Chrome makes a localhost exception, Firefox/Safari don't).
+// Default to the resolved daemon scheme; explicit env wins for split-host.
 process.env.EXTERNAL_DAEMON_URL ??= DAEMON_URL;
-process.env.EXTERNAL_TUNNEL_URL ??= `${scheme}://localhost:9090`;
+// `EXTERNAL_TUNNEL_URL` stays http:// regardless of TLS. The webhook-tunnel
+// (tools/webhook-tunnel/main.go) is a plain http.Server; auto-upgrading the
+// browser-facing URL to https:// when this side gains TLS would break
+// settings/signal-row's ${externalTunnelUrl()}/status fetch with a TLS
+// handshake against a non-TLS listener. Mixed-content from an https page
+// to http://localhost is allowed in Chrome; Firefox/Safari users will hit
+// the block until the tunnel itself learns TLS.
+process.env.EXTERNAL_TUNNEL_URL ??= "http://localhost:9090";
 
 console.log(`[vite] dev server scheme: ${scheme}://  daemon: ${DAEMON_URL}`);
 

--- a/tools/agent-playground/vite.config.ts
+++ b/tools/agent-playground/vite.config.ts
@@ -1,88 +1,63 @@
-import type { Buffer } from "node:buffer";
-import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { readFileSync } from "node:fs";
 import process from "node:process";
 import { sveltekit } from "@sveltejs/kit/vite";
 import { defineConfig } from "vite";
+import { resolveBrowserTlsPaths } from "./tls-paths.ts";
 
-// HTTP/2 + TLS resolution. Vite 7's `server.https` switches the underlying
-// dev server from `node:http` (HTTP/1.1) to `node:http2.createSecureServer`
-// with `allowHTTP1: true` fallback — so once we hand it cert+key bytes,
-// the browser negotiates h2 over ALPN and the 6-socket-per-origin HTTP/1.1
-// limit (which deadlocks once the playground's 3 SSE feeds × multiple tabs
-// run out of sockets) goes away.
+// HTTP/2 + TLS for the playground origin. Vite 7's `server.https` switches
+// the dev server from `node:http` (HTTP/1.1) to `node:http2.createSecureServer`
+// with `allowHTTP1: true` fallback — once we hand it cert+key bytes, the
+// browser negotiates h2 over ALPN and the 6-socket-per-origin HTTP/1.1
+// limit (which deadlocks once the playground's 3 SSE feeds × multiple
+// tabs run out of sockets) goes away.
 //
-// Resolution order: env vars → ~/.friday/local/tls → ~/.atlas/tls. The
-// first pair where both files exist wins; otherwise we run plain HTTP and
-// the dev cycle is unchanged. Run `bash scripts/setup-tls.sh` to populate.
-function resolveTls(): { cert: Buffer; key: Buffer } | null {
-  const candidates: Array<[string, string]> = [];
-  const envCert = process.env.FRIDAY_TLS_CERT;
-  const envKey = process.env.FRIDAY_TLS_KEY;
-  if (envCert && envKey) candidates.push([envCert, envKey]);
-  const home = homedir();
-  candidates.push([
-    join(home, ".friday", "local", "tls", "localhost.crt"),
-    join(home, ".friday", "local", "tls", "localhost.key"),
-  ]);
-  candidates.push([
-    join(home, ".atlas", "tls", "localhost.crt"),
-    join(home, ".atlas", "tls", "localhost.key"),
-  ]);
-  for (const [c, k] of candidates) {
-    if (existsSync(c) && existsSync(k)) {
-      return { cert: readFileSync(c), key: readFileSync(k) };
-    }
-  }
-  return null;
-}
-
-const tls = resolveTls();
+// This origin's cert must be browser-trusted: `FRIDAY_BROWSER_TLS_CERT/_KEY`
+// (mkcert-signed, system trust store installed by `scripts/setup-tls.sh`).
+// The s2s `FRIDAY_TLS_CERT/_KEY` pair is for daemon + tunnel listeners and
+// is intentionally NOT browser-trusted — browser traffic to those services
+// flows through this origin's `/api/{daemon,tunnel}/*` proxies instead.
+const tlsPaths = resolveBrowserTlsPaths();
+const tls = tlsPaths
+  ? { cert: readFileSync(tlsPaths.certPath), key: readFileSync(tlsPaths.keyPath) }
+  : null;
 const scheme = tls ? "https" : "http";
 
-// Trust for the mkcert root CA has to be plumbed in via `NODE_EXTRA_CA_CERTS`
-// *before* Node starts — Node 25 reads it once when the default secure
+// S2S TLS: daemon and tunnel run on https when FRIDAY_TLS_CERT/_KEY is set
+// in their environments. NODE_EXTRA_CA_CERTS must point at the private CA
+// before Node starts — Node 25 reads it once when the default secure
 // context is created, which happens before our config evaluates. The
-// `scripts/run-playground-vite.sh` wrapper sets it from `mkcert -CAROOT`
-// before exec'ing node. Without it, the SvelteKit dev proxy's fetch to
-// https://daemon errors with `fetch failed`.
-if (tls && !process.env.NODE_EXTRA_CA_CERTS) {
+// `scripts/run-playground-vite.sh` wrapper sets it before exec'ing node.
+// Without it, the SvelteKit dev proxy's fetch to https://daemon errors
+// with `fetch failed`.
+const s2sTls = Boolean(process.env.FRIDAY_TLS_CERT && process.env.FRIDAY_TLS_KEY);
+if (s2sTls && !process.env.NODE_EXTRA_CA_CERTS) {
   console.warn(
-    "[vite] TLS cert found but NODE_EXTRA_CA_CERTS unset — SSR proxy fetches to https daemon will fail. Launch via `deno task playground` (uses scripts/run-playground-vite.sh wrapper).",
+    "[vite] S2S TLS env set but NODE_EXTRA_CA_CERTS unset — SSR proxy fetches to https daemon will fail. Launch via `deno task playground` (uses scripts/run-playground-vite.sh wrapper).",
   );
 }
 
 // Effective daemon URL for SSR-side proxy + Hono route fetches. Honors
 // FRIDAYD_URL (launcher / wizard / FAST_DEVELOPMENT mode set this — port
-// 18080 is the FAST default), falling back to localhost:8080. When TLS
-// is on but the configured URL is http://, upgrade the scheme: the
-// daemon's listener is TLS-only, so cleartext requests would fail with
-// HTTPParserError. We deliberately do NOT downgrade https→http: a user
-// with explicit https config knows their setup.
+// 18080 is the FAST default), falling back to localhost:8080. When the
+// daemon is listening on TLS but the configured URL is http://, upgrade
+// the scheme: the daemon's listener is TLS-only, so cleartext requests
+// would fail with HTTPParserError. We deliberately do NOT downgrade
+// https→http: a user with explicit https config knows their setup.
 function effectiveDaemonUrl(): string {
+  const s2sScheme = s2sTls ? "https" : "http";
   const explicit = process.env.FRIDAYD_URL;
   if (explicit) {
-    if (tls && explicit.startsWith("http://")) {
+    if (s2sTls && explicit.startsWith("http://")) {
       return "https://" + explicit.slice("http://".length);
     }
     return explicit;
   }
-  return `${scheme}://localhost:8080`;
+  return `${s2sScheme}://localhost:8080`;
 }
 const DAEMON_URL = effectiveDaemonUrl();
+const TUNNEL_URL = `${s2sTls ? "https" : "http"}://localhost:9090`;
 
-// `EXTERNAL_DAEMON_URL` / `EXTERNAL_TUNNEL_URL` flow into the runtime
-// config the SvelteKit hook injects on the served HTML. When TLS is on
-// the page is https://, so any direct browser fetch to a plain http://
-// origin would be blocked as mixed content (Chrome makes a localhost
-// exception, Firefox/Safari don't). Default both to the resolved scheme;
-// webhook-tunnel reads FRIDAY_TLS_CERT/_KEY itself and binds TLS so the
-// browser→tunnel hop matches. Explicit env wins for split-host setups.
-process.env.EXTERNAL_DAEMON_URL ??= DAEMON_URL;
-process.env.EXTERNAL_TUNNEL_URL ??= `${scheme}://localhost:9090`;
-
-console.log(`[vite] dev server scheme: ${scheme}://  daemon: ${DAEMON_URL}`);
+console.log(`[vite] dev server scheme: ${scheme}://  daemon: ${DAEMON_URL}  tunnel: ${TUNNEL_URL}`);
 
 export default defineConfig({
   plugins: [sveltekit()],
@@ -96,6 +71,7 @@ export default defineConfig({
   define: {
     "process.env": "{}",
     __FRIDAY_DAEMON_BASE_URL__: JSON.stringify(DAEMON_URL),
+    __FRIDAY_TUNNEL_BASE_URL__: JSON.stringify(TUNNEL_URL),
   },
   resolve: {
     alias: {

--- a/tools/agent-playground/vite.config.ts
+++ b/tools/agent-playground/vite.config.ts
@@ -1,9 +1,101 @@
+import type { Buffer } from "node:buffer";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
 import { sveltekit } from "@sveltejs/kit/vite";
 import { defineConfig } from "vite";
 
+// HTTP/2 + TLS resolution. Vite 7's `server.https` switches the underlying
+// dev server from `node:http` (HTTP/1.1) to `node:http2.createSecureServer`
+// with `allowHTTP1: true` fallback — so once we hand it cert+key bytes,
+// the browser negotiates h2 over ALPN and the 6-socket-per-origin HTTP/1.1
+// limit (which deadlocks once the playground's 3 SSE feeds × multiple tabs
+// run out of sockets) goes away.
+//
+// Resolution order: env vars → ~/.friday/local/tls → ~/.atlas/tls. The
+// first pair where both files exist wins; otherwise we run plain HTTP and
+// the dev cycle is unchanged. Run `bash scripts/setup-tls.sh` to populate.
+function resolveTls(): { cert: Buffer; key: Buffer } | null {
+  const candidates: Array<[string, string]> = [];
+  const envCert = process.env.FRIDAY_TLS_CERT;
+  const envKey = process.env.FRIDAY_TLS_KEY;
+  if (envCert && envKey) candidates.push([envCert, envKey]);
+  const home = homedir();
+  candidates.push([
+    join(home, ".friday", "local", "tls", "localhost.crt"),
+    join(home, ".friday", "local", "tls", "localhost.key"),
+  ]);
+  candidates.push([
+    join(home, ".atlas", "tls", "localhost.crt"),
+    join(home, ".atlas", "tls", "localhost.key"),
+  ]);
+  for (const [c, k] of candidates) {
+    if (existsSync(c) && existsSync(k)) {
+      return { cert: readFileSync(c), key: readFileSync(k) };
+    }
+  }
+  return null;
+}
+
+const tls = resolveTls();
+const scheme = tls ? "https" : "http";
+
+// Trust for the mkcert root CA has to be plumbed in via `NODE_EXTRA_CA_CERTS`
+// *before* Node starts — Node 25 reads it once when the default secure
+// context is created, which happens before our config evaluates. The
+// `scripts/run-playground-vite.sh` wrapper sets it from `mkcert -CAROOT`
+// before exec'ing node. Without it, the SvelteKit dev proxy's fetch to
+// https://daemon errors with `fetch failed`.
+if (tls && !process.env.NODE_EXTRA_CA_CERTS) {
+  console.warn(
+    "[vite] TLS cert found but NODE_EXTRA_CA_CERTS unset — SSR proxy fetches to https daemon will fail. Launch via `deno task playground` (uses scripts/run-playground-vite.sh wrapper).",
+  );
+}
+
+// Effective daemon URL for SSR-side proxy + Hono route fetches. Honors
+// FRIDAYD_URL (launcher / wizard / FAST_DEVELOPMENT mode set this — port
+// 18080 is the FAST default), falling back to localhost:8080. When TLS
+// is on but the configured URL is http://, upgrade the scheme: the
+// daemon's listener is TLS-only, so cleartext requests would fail with
+// HTTPParserError. We deliberately do NOT downgrade https→http: a user
+// with explicit https config knows their setup.
+function effectiveDaemonUrl(): string {
+  const explicit = process.env.FRIDAYD_URL;
+  if (explicit) {
+    if (tls && explicit.startsWith("http://")) {
+      return "https://" + explicit.slice("http://".length);
+    }
+    return explicit;
+  }
+  return `${scheme}://localhost:8080`;
+}
+const DAEMON_URL = effectiveDaemonUrl();
+
+// `EXTERNAL_DAEMON_URL` / `EXTERNAL_TUNNEL_URL` flow into the runtime
+// config the SvelteKit hook injects on the served HTML. When TLS is on
+// the page is https://, so any direct browser fetch to a plain http://
+// daemon would be blocked as mixed content (Chrome makes a localhost
+// exception, Firefox/Safari don't). Default to the resolved scheme; let
+// an explicit env value still win for split-host setups.
+process.env.EXTERNAL_DAEMON_URL ??= DAEMON_URL;
+process.env.EXTERNAL_TUNNEL_URL ??= `${scheme}://localhost:9090`;
+
+console.log(`[vite] dev server scheme: ${scheme}://  daemon: ${DAEMON_URL}`);
+
 export default defineConfig({
   plugins: [sveltekit()],
-  define: { "process.env": "{}" },
+  // `process.env` → `{}` keeps stray `process.env.X` references in third-party
+  // client-bundled code from crashing the browser. The downside is it also
+  // wipes them in route SSR modules (hooks.server.ts is exempt because
+  // SvelteKit loads it directly without going through vite's transform).
+  // Anything route-side that needs a build-time value must come through an
+  // explicit `define` key — see `__FRIDAY_DAEMON_BASE_URL__` below, which
+  // the dev daemon proxy reads to decide between http:// and https://.
+  define: {
+    "process.env": "{}",
+    __FRIDAY_DAEMON_BASE_URL__: JSON.stringify(DAEMON_URL),
+  },
   resolve: {
     alias: {
       // @db/sqlite uses Deno FFI — stub it out for Vite SSR (runs under Node).
@@ -37,6 +129,7 @@ export default defineConfig({
     port: 5200,
     hmr: { overlay: false },
     fs: { allow: ["../.."] },
+    https: tls ?? undefined,
     headers: {
       "Cross-Origin-Opener-Policy": "same-origin",
       "Cross-Origin-Embedder-Policy": "credentialless",

--- a/tools/agent-playground/vite.config.ts
+++ b/tools/agent-playground/vite.config.ts
@@ -72,20 +72,15 @@ function effectiveDaemonUrl(): string {
 }
 const DAEMON_URL = effectiveDaemonUrl();
 
-// `EXTERNAL_DAEMON_URL` flows into the runtime config the SvelteKit hook
-// injects on the served HTML. When TLS is on the page is https://, so any
-// direct browser fetch to a plain http:// daemon would be blocked as mixed
-// content (Chrome makes a localhost exception, Firefox/Safari don't).
-// Default to the resolved daemon scheme; explicit env wins for split-host.
+// `EXTERNAL_DAEMON_URL` / `EXTERNAL_TUNNEL_URL` flow into the runtime
+// config the SvelteKit hook injects on the served HTML. When TLS is on
+// the page is https://, so any direct browser fetch to a plain http://
+// origin would be blocked as mixed content (Chrome makes a localhost
+// exception, Firefox/Safari don't). Default both to the resolved scheme;
+// webhook-tunnel reads FRIDAY_TLS_CERT/_KEY itself and binds TLS so the
+// browser→tunnel hop matches. Explicit env wins for split-host setups.
 process.env.EXTERNAL_DAEMON_URL ??= DAEMON_URL;
-// `EXTERNAL_TUNNEL_URL` stays http:// regardless of TLS. The webhook-tunnel
-// (tools/webhook-tunnel/main.go) is a plain http.Server; auto-upgrading the
-// browser-facing URL to https:// when this side gains TLS would break
-// settings/signal-row's ${externalTunnelUrl()}/status fetch with a TLS
-// handshake against a non-TLS listener. Mixed-content from an https page
-// to http://localhost is allowed in Chrome; Firefox/Safari users will hit
-// the block until the tunnel itself learns TLS.
-process.env.EXTERNAL_TUNNEL_URL ??= "http://localhost:9090";
+process.env.EXTERNAL_TUNNEL_URL ??= `${scheme}://localhost:9090`;
 
 console.log(`[vite] dev server scheme: ${scheme}://  daemon: ${DAEMON_URL}`);
 

--- a/tools/friday-launcher/cert_env.go
+++ b/tools/friday-launcher/cert_env.go
@@ -68,10 +68,13 @@ func certEnvKeys() [][2]string {
 // 7 cert paths to .env" on first run and stay silent on warm boots.
 func ensureCertEnvFile() (int, error) {
 	path := envFilePath()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return 0, fmt.Errorf("mkdir env dir: %w", err)
 	}
 
+	// #nosec G304 -- envFilePath() resolves to ~/.friday/local/.env via
+	// friendlyHome(); reading the operator's own launcher home is the
+	// intended affordance, not a vulnerability.
 	existing, _ := os.ReadFile(path)
 	present := map[string]struct{}{}
 	for line := range strings.SplitSeq(string(existing), "\n") {

--- a/tools/friday-launcher/cert_env.go
+++ b/tools/friday-launcher/cert_env.go
@@ -1,0 +1,124 @@
+// Cert-path .env writeback.
+//
+// The launcher is the cert authority — it generates the s2s CA + leaf
+// (s2s_generator.go) and downloads / refreshes the browser-trusted LE
+// cert (tls_renewer.go). The PATH each consumer reads them from is
+// communicated through ~/.friday/local/.env, not through env vars
+// injected at child-process spawn time.
+//
+// Why .env and not runtime injection: the launcher is supposed to be a
+// convenient method to run Studio, not the only one. Anyone who runs
+// `friday daemon start` directly — for debugging, for a custom shell,
+// for CI — needs to see the same cert wiring without having to also
+// run friday-launcher. .env is the existing channel the daemon, link,
+// and the playground all read on startup; piggybacking on it keeps
+// "with launcher" and "without launcher" execution paths in lockstep.
+//
+// Idempotency: ensureCertEnvFile writes each key only when it's
+// missing from .env. A user who sets FRIDAY_TLS_CERT manually to a
+// custom location keeps that value forever. The launcher's resolver
+// (s2sCertPath / tlsCertPath / s2sCAPath) honors the same env vars,
+// so generated certs land at the user-pinned location on the next
+// rotation. .env stays the single source of truth.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// envFilePath is the .env the launcher and every supervised service
+// read from. Same path the Tauri installer's env_file.rs writes to.
+func envFilePath() string {
+	return filepath.Join(friendlyHome(), ".env")
+}
+
+// certEnvKeys is the set of cert-related env vars the launcher
+// ensures are present in .env. Built lazily because each value depends
+// on resolver calls (s2sCertPath etc.) which read FRIDAY_LAUNCHER_HOME
+// and the env-var overrides — both of which can change between
+// launcher boots.
+func certEnvKeys() [][2]string {
+	caPath := s2sCAPath()
+	return [][2]string{
+		{"FRIDAY_TLS_CERT", s2sCertPath()},
+		{"FRIDAY_TLS_KEY", s2sKeyPath()},
+		{"FRIDAY_TLS_CA", caPath},
+		{"FRIDAY_BROWSER_TLS_CERT", tlsCertPath()},
+		{"FRIDAY_BROWSER_TLS_KEY", tlsKeyPath()},
+		// DENO_CERT + NODE_EXTRA_CA_CERTS point at the private CA so the
+		// daemon (Deno's RootCertStore) and any Node-based proxy
+		// (vite SSR, static-server's daemon proxy) trust the s2s leaf.
+		// These were dev-only in scripts/setup-tls.sh; pinning them
+		// here makes the installed flow self-sufficient.
+		{"DENO_CERT", caPath},
+		{"NODE_EXTRA_CA_CERTS", caPath},
+	}
+}
+
+// ensureCertEnvFile reads .env, appends any missing cert-env keys with
+// the launcher's resolved paths, and atomic-writes the file back. The
+// .env file is created if absent. Existing values for any of the keys
+// are preserved verbatim — operator overrides win.
+//
+// Returns the number of keys appended so the boot log can say "wrote
+// 7 cert paths to .env" on first run and stay silent on warm boots.
+func ensureCertEnvFile() (int, error) {
+	path := envFilePath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return 0, fmt.Errorf("mkdir env dir: %w", err)
+	}
+
+	existing, _ := os.ReadFile(path)
+	present := map[string]struct{}{}
+	for line := range strings.SplitSeq(string(existing), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		if eq := strings.IndexByte(line, '='); eq > 0 {
+			key := strings.TrimSpace(line[:eq])
+			present[key] = struct{}{}
+		}
+	}
+
+	var toAppend []string
+	for _, kv := range certEnvKeys() {
+		key, value := kv[0], kv[1]
+		if _, ok := present[key]; ok {
+			continue
+		}
+		toAppend = append(toAppend, key+"="+value)
+	}
+	if len(toAppend) == 0 {
+		return 0, nil
+	}
+
+	out := string(existing)
+	// Ensure separator between existing content and our appended lines
+	// (and between our lines and any future trailing content). One
+	// blank-line block keeps the file diff-readable when an operator
+	// cracks .env open.
+	if len(out) > 0 && !strings.HasSuffix(out, "\n") {
+		out += "\n"
+	}
+	if len(out) > 0 {
+		out += "\n# launcher-managed cert paths (managed by friday-launcher; safe to edit)\n"
+	}
+	out += strings.Join(toAppend, "\n") + "\n"
+
+	if err := atomicWrite(path, []byte(out), 0o644); err != nil {
+		return 0, err
+	}
+	// No mirror into os.Setenv: the launcher's own boot path already
+	// resolved cert paths from the existing env / defaults BEFORE
+	// reaching this writeback (ensureS2sCerts ran first), and the
+	// supervised services read .env directly via commonServiceEnv's
+	// loadDotEnv call — which sees the file we just wrote. Touching
+	// the launcher's process env here would leak across tests and
+	// gain nothing in production.
+	return len(toAppend), nil
+}

--- a/tools/friday-launcher/cert_env_test.go
+++ b/tools/friday-launcher/cert_env_test.go
@@ -1,0 +1,110 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureCertEnvFile_FirstRunWritesAllKeys(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+
+	added, err := ensureCertEnvFile()
+	if err != nil {
+		t.Fatalf("ensureCertEnvFile: %v", err)
+	}
+	if added != 7 {
+		t.Errorf("added = %d, want 7 (5 cert + DENO_CERT + NODE_EXTRA_CA_CERTS)", added)
+	}
+
+	body, err := os.ReadFile(filepath.Join(tmp, ".env"))
+	if err != nil {
+		t.Fatalf("read .env: %v", err)
+	}
+	want := []string{
+		"FRIDAY_TLS_CERT=",
+		"FRIDAY_TLS_KEY=",
+		"FRIDAY_TLS_CA=",
+		"FRIDAY_BROWSER_TLS_CERT=",
+		"FRIDAY_BROWSER_TLS_KEY=",
+		"DENO_CERT=",
+		"NODE_EXTRA_CA_CERTS=",
+	}
+	for _, prefix := range want {
+		if !strings.Contains(string(body), prefix) {
+			t.Errorf(".env missing %q\nfull body:\n%s", prefix, body)
+		}
+	}
+}
+
+func TestEnsureCertEnvFile_PreservesUserOverrides(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+
+	existing := "FRIDAY_TLS_CERT=/my/custom/cert.pem\nFRIDAY_PORT_PLAYGROUND=15200\n"
+	if err := os.WriteFile(filepath.Join(tmp, ".env"), []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	added, err := ensureCertEnvFile()
+	if err != nil {
+		t.Fatalf("ensureCertEnvFile: %v", err)
+	}
+	// FRIDAY_TLS_CERT is already present so should NOT be re-added;
+	// 6 keys remain to write.
+	if added != 6 {
+		t.Errorf("added = %d, want 6 (user already set FRIDAY_TLS_CERT)", added)
+	}
+
+	body, _ := os.ReadFile(filepath.Join(tmp, ".env"))
+	// Original line untouched.
+	if !strings.Contains(string(body), "FRIDAY_TLS_CERT=/my/custom/cert.pem") {
+		t.Errorf("user-set FRIDAY_TLS_CERT overwritten\nbody:\n%s", body)
+	}
+	// And not duplicated.
+	if strings.Count(string(body), "FRIDAY_TLS_CERT=") != 1 {
+		t.Errorf("FRIDAY_TLS_CERT appears more than once\nbody:\n%s", body)
+	}
+}
+
+func TestEnsureCertEnvFile_IdempotentOnReRun(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+
+	if _, err := ensureCertEnvFile(); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	body1, _ := os.ReadFile(filepath.Join(tmp, ".env"))
+
+	added, err := ensureCertEnvFile()
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if added != 0 {
+		t.Errorf("second run added = %d, want 0", added)
+	}
+	body2, _ := os.ReadFile(filepath.Join(tmp, ".env"))
+	if string(body1) != string(body2) {
+		t.Errorf(".env modified on idempotent re-run\n--- before ---\n%s\n--- after ---\n%s", body1, body2)
+	}
+}
+
+func TestEnsureCertEnvFile_PicksUpEnvOverridesInResolver(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+	t.Setenv("FRIDAY_TLS_CERT", "/elsewhere/s2s.crt")
+
+	// FRIDAY_TLS_CERT is set in env (not yet in .env). The resolver
+	// returns the env value; ensureCertEnvFile writes that value to
+	// .env so future invocations (without the env var set) still see
+	// the same path.
+	if _, err := ensureCertEnvFile(); err != nil {
+		t.Fatalf("ensureCertEnvFile: %v", err)
+	}
+	body, _ := os.ReadFile(filepath.Join(tmp, ".env"))
+	if !strings.Contains(string(body), "FRIDAY_TLS_CERT=/elsewhere/s2s.crt") {
+		t.Errorf(".env did not capture env-override path\nbody:\n%s", body)
+	}
+}

--- a/tools/friday-launcher/main.go
+++ b/tools/friday-launcher/main.go
@@ -383,6 +383,16 @@ func onReady() {
 		"url", natsServerURL(),
 	)
 
+	// Boot-time browser-cert refresh. Bounded at bootRefreshTimeout
+	// (5s) so a stuck CDN can't delay launcher startup. Run BEFORE
+	// supervisedProcesses() so the playground spec's first read of
+	// browser.{crt,key} (via tls-paths.ts at process startup) sees
+	// the freshly-rotated pair. If it fails or runs out of budget,
+	// the playground starts on whatever's on disk — expired or
+	// missing certs cause tls-paths.ts to return null and the
+	// playground falls back to plain http on its loopback port.
+	maybeBootRefreshTLS()
+
 	// Build project + supervisor.
 	specs := supervisedProcesses(binDir)
 	project := newProjectFromSpecs(specs)
@@ -406,6 +416,15 @@ func onReady() {
 	pollCtx, pollCancel := context.WithCancel(context.Background())
 	healthPollCancel = pollCancel
 	go runHealthPoll(pollCtx, sup, healthCache)
+
+	// Daily browser-cert renewer. Wakes once per tlsRenewInterval
+	// (default 24h, override via FRIDAY_TLS_RENEW_INTERVAL); when the
+	// on-disk cert is past 2/3 of its issued lifetime, expired, or
+	// missing, fetches the manifest, sha256-verifies the new pair,
+	// atomic-installs them, and triggers a single-process restart of
+	// the playground so it picks up the new files. Shares pollCtx so
+	// performShutdown cancels both goroutines in one step.
+	startTLSRenewer(pollCtx, sup)
 
 	// Tray controller (goroutine B + click handlers). healthCache
 	// drives the bucket logic per Decision #4 — the existing

--- a/tools/friday-launcher/main.go
+++ b/tools/friday-launcher/main.go
@@ -383,6 +383,32 @@ func onReady() {
 		"url", natsServerURL(),
 	)
 
+	// First-run s2s cert generation. Synchronous, idempotent. On a
+	// fresh install (or after manual removal of <friendly_home>/tls/)
+	// the launcher mints a private CA + leaf for service-to-service
+	// TLS, valid for 5 years. Subsequent boots find the files valid
+	// and return immediately. Must run BEFORE supervisedProcesses() so
+	// the cert-path .env writeback below points at real files when the
+	// supervised processes wake up to load .env. Generation failure is
+	// logged but non-fatal — services fall back to plain HTTP on
+	// loopback if the s2s pair isn't present.
+	if err := ensureS2sCerts(); err != nil {
+		log.Warn("s2s: ensureS2sCerts failed (services will fall back to plain HTTP)", "error", err)
+	}
+
+	// Persist resolved cert paths to ~/.friday/local/.env (add-if-missing).
+	// commonServiceEnv() loads .env and passes the result to every spawned
+	// service — going through .env (instead of injecting at spawn time)
+	// keeps the launcher convenient-but-optional. Anyone running `friday
+	// daemon start` manually reads the same .env and gets the same cert
+	// wiring, no launcher dependency at runtime. Operator overrides
+	// already in .env are preserved verbatim.
+	if added, err := ensureCertEnvFile(); err != nil {
+		log.Warn("cert env: writeback to .env failed", "error", err)
+	} else if added > 0 {
+		log.Info("cert env: wrote launcher-managed paths to .env", "keys_added", added)
+	}
+
 	// Boot-time browser-cert refresh. Bounded at bootRefreshTimeout
 	// (5s) so a stuck CDN can't delay launcher startup. Run BEFORE
 	// supervisedProcesses() so the playground spec's first read of

--- a/tools/friday-launcher/project.go
+++ b/tools/friday-launcher/project.go
@@ -614,7 +614,23 @@ func supervisedProcesses(binDir string) []processSpec {
 			// reach static-server.ts, which injects them into the
 			// served HTML for the browser's window.__FRIDAY_CONFIG__.
 			name: "playground", binary: filepath.Join(binDir, "playground"),
-			env:        commonServiceEnv(),
+			// Pin the cert-pair path explicitly so tls-paths.ts and
+			// the launcher's hasValidBrowserCert() agree on where to
+			// look. Without this, tls-paths.ts resolves via Node's
+			// homedir() while the launcher uses friendlyHome() — they
+			// agree for default installs (both → ~/.friday/local) but
+			// diverge whenever FRIDAY_LAUNCHER_HOME redirects the
+			// launcher's view (test sandboxes, multi-instance setups).
+			// FRIDAY_BROWSER_TLS_CERT/_KEY are the documented priority-1
+			// resolution slot in tls-paths.ts; always set them so the
+			// playground doesn't fall through to homedir() candidates
+			// that may not match the launcher's reality. tls-paths.ts
+			// still checks existence + validity, so a missing or expired
+			// cert at these paths falls through to http fallback.
+			env: append(commonServiceEnv(),
+				"FRIDAY_BROWSER_TLS_CERT="+tlsCertPath(),
+				"FRIDAY_BROWSER_TLS_KEY="+tlsKeyPath(),
+			),
 			healthPort: "5200", healthPath: "/",
 		},
 	}

--- a/tools/friday-launcher/project.go
+++ b/tools/friday-launcher/project.go
@@ -154,6 +154,13 @@ func commonServiceEnv() []string {
 			env = append(env, "FRIDAY_NATS_URL="+url)
 		}
 	}
+	// Cert paths (FRIDAY_TLS_*, FRIDAY_BROWSER_TLS_*, DENO_CERT,
+	// NODE_EXTRA_CA_CERTS) are NOT injected here. The launcher writes
+	// them to ~/.friday/local/.env once (via ensureCertEnvFile) and the
+	// loadDotEnv() above already carried them into this baseline. Going
+	// through .env keeps the launcher convenient-but-optional: anyone
+	// running `friday daemon start` directly, without the launcher,
+	// reads the same .env and gets the same cert wiring.
 	return env
 }
 
@@ -614,23 +621,11 @@ func supervisedProcesses(binDir string) []processSpec {
 			// reach static-server.ts, which injects them into the
 			// served HTML for the browser's window.__FRIDAY_CONFIG__.
 			name: "playground", binary: filepath.Join(binDir, "playground"),
-			// Pin the cert-pair path explicitly so tls-paths.ts and
-			// the launcher's hasValidBrowserCert() agree on where to
-			// look. Without this, tls-paths.ts resolves via Node's
-			// homedir() while the launcher uses friendlyHome() — they
-			// agree for default installs (both → ~/.friday/local) but
-			// diverge whenever FRIDAY_LAUNCHER_HOME redirects the
-			// launcher's view (test sandboxes, multi-instance setups).
-			// FRIDAY_BROWSER_TLS_CERT/_KEY are the documented priority-1
-			// resolution slot in tls-paths.ts; always set them so the
-			// playground doesn't fall through to homedir() candidates
-			// that may not match the launcher's reality. tls-paths.ts
-			// still checks existence + validity, so a missing or expired
-			// cert at these paths falls through to http fallback.
-			env: append(commonServiceEnv(),
-				"FRIDAY_BROWSER_TLS_CERT="+tlsCertPath(),
-				"FRIDAY_BROWSER_TLS_KEY="+tlsKeyPath(),
-			),
+			// commonServiceEnv() now carries FRIDAY_BROWSER_TLS_CERT/_KEY
+			// (and the s2s + DENO_CERT / NODE_EXTRA_CA_CERTS pins) for
+			// every service — no playground-specific env wiring needed
+			// here.
+			env:        commonServiceEnv(),
 			healthPort: "5200", healthPath: "/",
 		},
 	}

--- a/tools/friday-launcher/project.go
+++ b/tools/friday-launcher/project.go
@@ -691,27 +691,10 @@ func playgroundURL() string {
 	if port == "" {
 		port = "5200"
 	}
-	if hasBrowserTLS() {
+	if hasValidBrowserCert() {
 		return "https://local.hellofriday.ai:" + port
 	}
 	return "http://localhost:" + port
-}
-
-// hasBrowserTLS reports whether the installer-fetched browser-trusted
-// cert pair is on disk. Mirrors the resolution order tls-paths.ts uses
-// on the playground side so the launcher's URL and the playground's
-// listener stay in lock-step: if the playground can serve TLS, the URL
-// the launcher opens must be https.
-func hasBrowserTLS() bool {
-	cert := filepath.Join(friendlyHome(), "tls", "browser.crt")
-	key := filepath.Join(friendlyHome(), "tls", "browser.key")
-	if _, err := os.Stat(cert); err != nil {
-		return false
-	}
-	if _, err := os.Stat(key); err != nil {
-		return false
-	}
-	return true
 }
 
 // newProjectFromSpecs builds the typed types.Project from a list of

--- a/tools/friday-launcher/project.go
+++ b/tools/friday-launcher/project.go
@@ -670,18 +670,48 @@ func portOverride(name string) string {
 	return osGetenv(envName)
 }
 
-// playgroundURL returns the loopback URL the tray opens in the user's
-// browser when the platform reaches "all healthy". Honors the
+// playgroundURL returns the URL the tray opens in the user's browser
+// when the platform reaches "all healthy". Honors the
 // FRIDAY_PORT_playground override so installs that move playground off
 // 5200 (e.g. to avoid collision with another local Friday instance) get
 // the right URL — without this the tray click silently lands on the
 // wrong port and the user sees a "can't connect" page.
+//
+// Scheme/host: when the browser-trusted cert pair downloaded by the
+// installer (apps/studio-installer/src-tauri/src/commands/download_tls.rs)
+// is present at <friendlyHome()>/tls/browser.crt, the playground binary
+// is listening on TLS for `local.hellofriday.ai` — a public DNS name
+// that resolves to 127.0.0.1, with a Let's Encrypt cert in the SAN. We
+// open the https URL so the browser lands on a green-lock origin that
+// matches the cert. Without the cert, fall back to http://localhost so
+// dev/source installs and any install that failed the cert download
+// still work.
 func playgroundURL() string {
 	port := portOverride("playground")
 	if port == "" {
 		port = "5200"
 	}
+	if hasBrowserTLS() {
+		return "https://local.hellofriday.ai:" + port
+	}
 	return "http://localhost:" + port
+}
+
+// hasBrowserTLS reports whether the installer-fetched browser-trusted
+// cert pair is on disk. Mirrors the resolution order tls-paths.ts uses
+// on the playground side so the launcher's URL and the playground's
+// listener stay in lock-step: if the playground can serve TLS, the URL
+// the launcher opens must be https.
+func hasBrowserTLS() bool {
+	cert := filepath.Join(friendlyHome(), "tls", "browser.crt")
+	key := filepath.Join(friendlyHome(), "tls", "browser.key")
+	if _, err := os.Stat(cert); err != nil {
+		return false
+	}
+	if _, err := os.Stat(key); err != nil {
+		return false
+	}
+	return true
 }
 
 // newProjectFromSpecs builds the typed types.Project from a list of

--- a/tools/friday-launcher/project_env_test.go
+++ b/tools/friday-launcher/project_env_test.go
@@ -365,6 +365,40 @@ func TestPlaygroundURL_UsesHttpsWhenCertPresent(t *testing.T) {
 	}
 }
 
+// TestPlaygroundSpec_PinsBrowserTLSEnv guards the contract that the
+// launcher's view of the cert dir (friendlyHome()/tls) flows through
+// to the playground subprocess as FRIDAY_BROWSER_TLS_CERT/_KEY.
+//
+// Regression: an earlier draft relied on tls-paths.ts resolving the
+// cert dir via homedir() independently. That agreed with the launcher
+// for default installs but diverged whenever FRIDAY_LAUNCHER_HOME
+// redirected the launcher's view — playground bound on http while the
+// launcher's tray URL said https.
+func TestPlaygroundSpec_PinsBrowserTLSEnv(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+
+	specs := supervisedProcesses("/tmp/bin")
+	var playground *processSpec
+	for i := range specs {
+		if specs[i].name == "playground" {
+			playground = &specs[i]
+			break
+		}
+	}
+	if playground == nil {
+		t.Fatal("playground spec missing")
+	}
+	wantCert := "FRIDAY_BROWSER_TLS_CERT=" + filepath.Join(tmp, "tls", "browser.crt")
+	wantKey := "FRIDAY_BROWSER_TLS_KEY=" + filepath.Join(tmp, "tls", "browser.key")
+	if !slices.Contains(playground.env, wantCert) {
+		t.Errorf("playground env missing %q\nfull env: %v", wantCert, playground.env)
+	}
+	if !slices.Contains(playground.env, wantKey) {
+		t.Errorf("playground env missing %q\nfull env: %v", wantKey, playground.env)
+	}
+}
+
 func TestPlaygroundURL_FallsBackToHttpWhenCertExpired(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)

--- a/tools/friday-launcher/project_env_test.go
+++ b/tools/friday-launcher/project_env_test.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 )
 
 // Verify the .env values the installer writes flow through to all
@@ -342,7 +343,12 @@ func TestPlaygroundURL_UsesHttpsWhenCertPresent(t *testing.T) {
 	if err := os.MkdirAll(tlsDir, 0o755); err != nil {
 		t.Fatalf("mkdir tls: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(tlsDir, "browser.crt"), []byte("cert"), 0o644); err != nil {
+	// Real PEM matters now that playgroundURL/hasValidBrowserCert parses
+	// the file and checks notBefore/notAfter — a stub body would round-
+	// trip as "invalid cert" and the URL would stay on http.
+	half := 12 * time.Hour
+	certPEM, _ := makeTestCert(t, 24*time.Hour, &half)
+	if err := os.WriteFile(filepath.Join(tlsDir, "browser.crt"), certPEM, 0o644); err != nil {
 		t.Fatalf("write cert: %v", err)
 	}
 	if err := os.WriteFile(filepath.Join(tlsDir, "browser.key"), []byte("key"), 0o600); err != nil {
@@ -356,6 +362,29 @@ func TestPlaygroundURL_UsesHttpsWhenCertPresent(t *testing.T) {
 	t.Setenv("FRIDAY_PORT_PLAYGROUND", "15200")
 	if got := playgroundURL(); got != "https://local.hellofriday.ai:15200" {
 		t.Errorf("playgroundURL with cert+port override = %q, want https://local.hellofriday.ai:15200", got)
+	}
+}
+
+func TestPlaygroundURL_FallsBackToHttpWhenCertExpired(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+
+	tlsDir := filepath.Join(tmp, "tls")
+	if err := os.MkdirAll(tlsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// notBefore = now - 25h, lifetime = 24h → notAfter = now - 1h → expired.
+	pastAge := 25 * time.Hour
+	expiredPEM, _ := makeTestCert(t, 24*time.Hour, &pastAge)
+	if err := os.WriteFile(filepath.Join(tlsDir, "browser.crt"), expiredPEM, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tlsDir, "browser.key"), []byte("k"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("FRIDAY_PORT_PLAYGROUND", "15200")
+	if got := playgroundURL(); got != "http://localhost:15200" {
+		t.Errorf("playgroundURL with expired cert = %q, want http://localhost:15200", got)
 	}
 }
 

--- a/tools/friday-launcher/project_env_test.go
+++ b/tools/friday-launcher/project_env_test.go
@@ -311,13 +311,51 @@ func TestSupervisedProcesses_PortOverridesPropagate(t *testing.T) {
 // the tray click after a port override silently lands on
 // http://localhost:5200 (default) and the user sees connection
 // refused.
+//
+// Uses a tempdir as FRIDAY_LAUNCHER_HOME so the test doesn't depend
+// on whether the real ~/.friday/local/tls/browser.crt happens to be
+// on the developer's machine — keeps the assertion deterministic.
 func TestPlaygroundURL_HonorsPortOverride(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+
 	if got := playgroundURL(); got != "http://localhost:5200" {
 		t.Errorf("default playgroundURL = %q, want http://localhost:5200", got)
 	}
 	t.Setenv("FRIDAY_PORT_PLAYGROUND", "15200")
 	if got := playgroundURL(); got != "http://localhost:15200" {
 		t.Errorf("overridden playgroundURL = %q, want http://localhost:15200", got)
+	}
+}
+
+// TestPlaygroundURL_UsesHttpsWhenCertPresent asserts that once the
+// installer has dropped the browser-trusted cert pair into
+// <friendlyHome()>/tls/, the launcher opens the https origin matching
+// the cert SAN — not http://localhost, which would land on the same
+// port but show a cert-name-mismatch warning (browser → 127.0.0.1 vs
+// cert CN local.hellofriday.ai).
+func TestPlaygroundURL_UsesHttpsWhenCertPresent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+
+	tlsDir := filepath.Join(tmp, "tls")
+	if err := os.MkdirAll(tlsDir, 0o755); err != nil {
+		t.Fatalf("mkdir tls: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tlsDir, "browser.crt"), []byte("cert"), 0o644); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tlsDir, "browser.key"), []byte("key"), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	if got := playgroundURL(); got != "https://local.hellofriday.ai:5200" {
+		t.Errorf("playgroundURL with cert = %q, want https://local.hellofriday.ai:5200", got)
+	}
+
+	t.Setenv("FRIDAY_PORT_PLAYGROUND", "15200")
+	if got := playgroundURL(); got != "https://local.hellofriday.ai:15200" {
+		t.Errorf("playgroundURL with cert+port override = %q, want https://local.hellofriday.ai:15200", got)
 	}
 }
 

--- a/tools/friday-launcher/project_env_test.go
+++ b/tools/friday-launcher/project_env_test.go
@@ -365,18 +365,25 @@ func TestPlaygroundURL_UsesHttpsWhenCertPresent(t *testing.T) {
 	}
 }
 
-// TestPlaygroundSpec_PinsBrowserTLSEnv guards the contract that the
-// launcher's view of the cert dir (friendlyHome()/tls) flows through
-// to the playground subprocess as FRIDAY_BROWSER_TLS_CERT/_KEY.
+// TestPlaygroundSpec_PicksUpCertPathsViaDotEnv guards the contract
+// that cert paths flow from .env (where ensureCertEnvFile writes them)
+// through loadDotEnv → commonServiceEnv → every service spec. The
+// launcher must not inject cert paths at spawn time — anyone running
+// a service manually (via `friday daemon start`, etc.) needs to read
+// the same .env and get the same wiring without the launcher.
 //
-// Regression: an earlier draft relied on tls-paths.ts resolving the
-// cert dir via homedir() independently. That agreed with the launcher
-// for default installs but diverged whenever FRIDAY_LAUNCHER_HOME
-// redirected the launcher's view — playground bound on http while the
-// launcher's tray URL said https.
-func TestPlaygroundSpec_PinsBrowserTLSEnv(t *testing.T) {
+// Regression target: a previous draft injected FRIDAY_BROWSER_TLS_CERT
+// directly on the playground spec, which made the launcher a hard
+// dependency for TLS to work.
+func TestPlaygroundSpec_PicksUpCertPathsViaDotEnv(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+
+	// Simulate the boot-time writeback: ensureCertEnvFile runs and
+	// drops cert paths into .env.
+	if _, err := ensureCertEnvFile(); err != nil {
+		t.Fatalf("ensureCertEnvFile: %v", err)
+	}
 
 	specs := supervisedProcesses("/tmp/bin")
 	var playground *processSpec
@@ -389,13 +396,18 @@ func TestPlaygroundSpec_PinsBrowserTLSEnv(t *testing.T) {
 	if playground == nil {
 		t.Fatal("playground spec missing")
 	}
-	wantCert := "FRIDAY_BROWSER_TLS_CERT=" + filepath.Join(tmp, "tls", "browser.crt")
-	wantKey := "FRIDAY_BROWSER_TLS_KEY=" + filepath.Join(tmp, "tls", "browser.key")
-	if !slices.Contains(playground.env, wantCert) {
-		t.Errorf("playground env missing %q\nfull env: %v", wantCert, playground.env)
-	}
-	if !slices.Contains(playground.env, wantKey) {
-		t.Errorf("playground env missing %q\nfull env: %v", wantKey, playground.env)
+	// The launcher resolver may pick the env-var override; rely on it
+	// for the expected path so this test stays correct even when a
+	// shell export pins FRIDAY_BROWSER_TLS_CERT elsewhere.
+	wantCert := "FRIDAY_BROWSER_TLS_CERT=" + tlsCertPath()
+	wantKey := "FRIDAY_BROWSER_TLS_KEY=" + tlsKeyPath()
+	wantS2sCert := "FRIDAY_TLS_CERT=" + s2sCertPath()
+	wantS2sKey := "FRIDAY_TLS_KEY=" + s2sKeyPath()
+	wantS2sCA := "FRIDAY_TLS_CA=" + s2sCAPath()
+	for _, want := range []string{wantCert, wantKey, wantS2sCert, wantS2sKey, wantS2sCA} {
+		if !slices.Contains(playground.env, want) {
+			t.Errorf("playground env missing %q\nfull env: %v", want, playground.env)
+		}
 	}
 }
 

--- a/tools/friday-launcher/s2s_generator.go
+++ b/tools/friday-launcher/s2s_generator.go
@@ -1,0 +1,252 @@
+// Service-to-service TLS material.
+//
+// The PR #243 split between browser-trusted TLS (Let's Encrypt for
+// local.hellofriday.ai, refreshed from CDN by tls_renewer.go) and
+// service-to-service TLS (private CA + leaf, used by atlasd + webhook-
+// tunnel listeners and trusted by their callers via DENO_CERT /
+// NODE_EXTRA_CA_CERTS) leaves the s2s side without a producer in the
+// installed flow — scripts/setup-tls.sh handles it for dev, but
+// production installs had no s2s certs at all and services fell back to
+// plain HTTP on loopback.
+//
+// This file is the launcher-side producer. On boot, before any service
+// is spawned, the launcher ensures the s2s pair exists and is valid; if
+// not, it generates a fresh private CA + leaf signed by the CA with a
+// 5-year validity window (rotation past 5 years is the operator's
+// problem — re-running the launcher with the files removed regenerates).
+//
+// Path resolution mirrors the browser-cert side: each path honors an
+// override env var first (FRIDAY_TLS_CERT / _KEY / _CA), then defaults
+// to <friendlyHome()>/tls/. Operators using FRIDAY_LAUNCHER_HOME or
+// pinning certs from somewhere else get full control; the default works
+// without configuration.
+
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// s2sValidity is the lifetime stamped on both the CA and the leaf cert
+// at generation time. Five years matches the user's stated requirement;
+// long enough that a fresh install doesn't hit rotation for the life of
+// most deployments, short enough that the cert eventually rotates if a
+// machine stays on the same install indefinitely. When the leaf expires,
+// the launcher's ensureS2sCerts re-generates the whole pair (cheap —
+// generation is sub-second).
+const s2sValidity = 5 * 365 * 24 * time.Hour
+
+// s2sCertPath / s2sKeyPath / s2sCAPath resolve the on-disk paths for
+// the service-to-service cert chain. Each honors the corresponding
+// FRIDAY_TLS_* override env var first; without an override they default
+// to <friendlyHome()>/tls/ with the same filenames scripts/setup-tls.sh
+// produces in dev mode, so any code that already trusts that location
+// (atlas-cli, atlasd, webhook-tunnel, vite SSR via DENO_CERT /
+// NODE_EXTRA_CA_CERTS) keeps working unchanged.
+func s2sCertPath() string {
+	if v := os.Getenv("FRIDAY_TLS_CERT"); v != "" {
+		return v
+	}
+	return filepath.Join(friendlyHome(), "tls", "s2s.crt")
+}
+
+func s2sKeyPath() string {
+	if v := os.Getenv("FRIDAY_TLS_KEY"); v != "" {
+		return v
+	}
+	return filepath.Join(friendlyHome(), "tls", "s2s.key")
+}
+
+func s2sCAPath() string {
+	if v := os.Getenv("FRIDAY_TLS_CA"); v != "" {
+		return v
+	}
+	return filepath.Join(friendlyHome(), "tls", "s2s-ca.crt")
+}
+
+// s2sCAKeyPath is the private CA key. Not exposed to child processes
+// (they only need the CA cert, FRIDAY_TLS_CA) — the key stays on the
+// launcher's filesystem so leaf re-issuance has the signing material.
+// Default path lives next to the public CA cert; no override env var
+// because nothing else should read it.
+func s2sCAKeyPath() string {
+	return filepath.Join(filepath.Dir(s2sCAPath()), "s2s-ca.key")
+}
+
+// ensureS2sCerts is the boot-time call. Synchronous, idempotent. If the
+// existing pair is valid and unexpired the function returns immediately;
+// if anything's missing or the leaf is past notAfter, it regenerates
+// CA + leaf in lockstep (a new CA produces a leaf signed by it, which
+// any process that's currently trusting the OLD CA will reject — so we
+// always regenerate both together rather than re-signing with a stale
+// CA). Returns an error only on filesystem / crypto failure; missing
+// files are not an error, they're the "generate" trigger.
+func ensureS2sCerts() error {
+	if s2sCertsValid(time.Now()) {
+		return nil
+	}
+	caCert, caKey, err := generateS2sCA()
+	if err != nil {
+		return fmt.Errorf("generate s2s CA: %w", err)
+	}
+	leafCert, leafKey, err := generateS2sLeaf(caCert, caKey)
+	if err != nil {
+		return fmt.Errorf("generate s2s leaf: %w", err)
+	}
+
+	caCertPEM := encodePEM("CERTIFICATE", caCert.Raw)
+	caKeyDER, err := x509.MarshalECPrivateKey(caKey)
+	if err != nil {
+		return fmt.Errorf("marshal CA key: %w", err)
+	}
+	caKeyPEM := encodePEM("EC PRIVATE KEY", caKeyDER)
+
+	leafCertPEM := encodePEM("CERTIFICATE", leafCert.Raw)
+	leafKeyDER, err := x509.MarshalECPrivateKey(leafKey)
+	if err != nil {
+		return fmt.Errorf("marshal leaf key: %w", err)
+	}
+	leafKeyPEM := encodePEM("EC PRIVATE KEY", leafKeyDER)
+
+	// Write in atomic-rename order: CA cert first (consumers may probe
+	// for it to set up trust), then CA key (private), then leaf cert,
+	// then leaf key. Each atomicWrite already does tmp+fsync+rename so a
+	// crash mid-sequence leaves either old files or new files at each
+	// path — never half-written. Trust mode bits: CA cert and leaf cert
+	// are public (0644), both keys are 0600.
+	for _, w := range []struct {
+		path string
+		data []byte
+		mode os.FileMode
+	}{
+		{s2sCAPath(), caCertPEM, 0o644},
+		{s2sCAKeyPath(), caKeyPEM, 0o600},
+		{s2sCertPath(), leafCertPEM, 0o644},
+		{s2sKeyPath(), leafKeyPEM, 0o600},
+	} {
+		if err := atomicWrite(w.path, w.data, w.mode); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// s2sCertsValid reports whether the full chain on disk is usable RIGHT
+// NOW: all four files present, leaf parses, leaf is within its
+// notBefore..notAfter window. We only check the leaf's validity, not
+// the CA's — by construction the CA's validity covers the leaf's, and
+// re-checking is overhead the boot path doesn't need.
+func s2sCertsValid(now time.Time) bool {
+	for _, p := range []string{s2sCAPath(), s2sCAKeyPath(), s2sCertPath(), s2sKeyPath()} {
+		if _, err := os.Stat(p); err != nil {
+			return false
+		}
+	}
+	leaf, err := parseCert(s2sCertPath())
+	if err != nil {
+		return false
+	}
+	if isExpired(leaf, now) || notYetValid(leaf, now) {
+		return false
+	}
+	return true
+}
+
+// generateS2sCA produces the private CA used to sign the s2s leaf.
+// Subject CN is informational only ("Friday Studio Internal CA") —
+// nothing trusts this by name, only by the CA cert hash plumbed into
+// DENO_CERT / NODE_EXTRA_CA_CERTS.
+func generateS2sCA() (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, nil, err
+	}
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   "Friday Studio Internal CA",
+			Organization: []string{"Friday Studio"},
+		},
+		NotBefore:             now.Add(-1 * time.Hour),
+		NotAfter:              now.Add(s2sValidity),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cert, key, nil
+}
+
+// generateS2sLeaf signs the actual server certificate atlasd +
+// webhook-tunnel present to clients. SAN covers localhost + loopback
+// IPv4/IPv6 — the only addresses these services bind to in the
+// installed flow. If anyone moves the listeners to a different
+// hostname they'll need to add to this SAN list.
+func generateS2sLeaf(ca *x509.Certificate, caKey *ecdsa.PrivateKey) (*x509.Certificate, *ecdsa.PrivateKey, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return nil, nil, err
+	}
+	serial, err := randomSerial()
+	if err != nil {
+		return nil, nil, err
+	}
+	now := time.Now()
+	tmpl := &x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   "localhost",
+			Organization: []string{"Friday Studio"},
+		},
+		DNSNames:    []string{"localhost"},
+		IPAddresses: []net.IP{net.IPv4(127, 0, 0, 1), net.IPv6loopback},
+		NotBefore:   now.Add(-1 * time.Hour),
+		NotAfter:    now.Add(s2sValidity),
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{
+			x509.ExtKeyUsageServerAuth,
+			x509.ExtKeyUsageClientAuth,
+		},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca, &key.PublicKey, caKey)
+	if err != nil {
+		return nil, nil, err
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		return nil, nil, err
+	}
+	return cert, key, nil
+}
+
+func randomSerial() (*big.Int, error) {
+	limit := new(big.Int).Lsh(big.NewInt(1), 128)
+	return rand.Int(rand.Reader, limit)
+}
+
+func encodePEM(blockType string, der []byte) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: blockType, Bytes: der})
+}

--- a/tools/friday-launcher/s2s_generator_test.go
+++ b/tools/friday-launcher/s2s_generator_test.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"net"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestEnsureS2sCerts_FirstRunGeneratesPair(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+
+	if err := ensureS2sCerts(); err != nil {
+		t.Fatalf("ensureS2sCerts: %v", err)
+	}
+
+	for _, name := range []string{"s2s-ca.crt", "s2s-ca.key", "s2s.crt", "s2s.key"} {
+		p := filepath.Join(tmp, "tls", name)
+		st, err := os.Stat(p)
+		if err != nil {
+			t.Errorf("%s: %v", name, err)
+			continue
+		}
+		var wantMode os.FileMode
+		if name == "s2s-ca.key" || name == "s2s.key" {
+			wantMode = 0o600
+		} else {
+			wantMode = 0o644
+		}
+		if perm := st.Mode().Perm(); perm != wantMode {
+			t.Errorf("%s mode = %o, want %o", name, perm, wantMode)
+		}
+	}
+}
+
+func TestEnsureS2sCerts_LeafSignedByCA(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+
+	if err := ensureS2sCerts(); err != nil {
+		t.Fatalf("ensureS2sCerts: %v", err)
+	}
+
+	ca, err := parseCert(filepath.Join(tmp, "tls", "s2s-ca.crt"))
+	if err != nil {
+		t.Fatalf("parse CA: %v", err)
+	}
+	leaf, err := parseCert(filepath.Join(tmp, "tls", "s2s.crt"))
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+
+	pool := x509.NewCertPool()
+	pool.AddCert(ca)
+	opts := x509.VerifyOptions{
+		Roots:       pool,
+		CurrentTime: time.Now(),
+		// Server auth is the use we actually exercise (atlasd /
+		// webhook-tunnel as servers). Client auth is included in the
+		// leaf cert's EKU but not asserted here — server-auth is the
+		// load-bearing one for the s2s mesh.
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	if _, err := leaf.Verify(opts); err != nil {
+		t.Errorf("leaf does not verify against CA: %v", err)
+	}
+}
+
+func TestEnsureS2sCerts_FiveYearValidity(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+
+	if err := ensureS2sCerts(); err != nil {
+		t.Fatalf("ensureS2sCerts: %v", err)
+	}
+
+	leaf, err := parseCert(filepath.Join(tmp, "tls", "s2s.crt"))
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	lifetime := leaf.NotAfter.Sub(leaf.NotBefore)
+	// Allow slop: the impl uses now-1h..now+5y, so the *issued*
+	// lifetime is slightly over 5y. Lower bound: 5y - 1d (give the
+	// test some flex against leap-year / clock skew). Upper: 5y + 1d.
+	fiveYears := 5 * 365 * 24 * time.Hour
+	day := 24 * time.Hour
+	if lifetime < fiveYears-day || lifetime > fiveYears+day+time.Hour {
+		t.Errorf("lifetime = %v, want ≈ %v", lifetime, fiveYears)
+	}
+}
+
+func TestEnsureS2sCerts_LeafSAN(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+
+	if err := ensureS2sCerts(); err != nil {
+		t.Fatalf("ensureS2sCerts: %v", err)
+	}
+
+	leaf, err := parseCert(filepath.Join(tmp, "tls", "s2s.crt"))
+	if err != nil {
+		t.Fatalf("parse leaf: %v", err)
+	}
+	if !slices.Contains(leaf.DNSNames, "localhost") {
+		t.Errorf("DNSNames missing localhost: %v", leaf.DNSNames)
+	}
+	hasV4, hasV6 := false, false
+	for _, ip := range leaf.IPAddresses {
+		if ip.Equal(net.IPv4(127, 0, 0, 1)) {
+			hasV4 = true
+		}
+		if ip.Equal(net.IPv6loopback) {
+			hasV6 = true
+		}
+	}
+	if !hasV4 || !hasV6 {
+		t.Errorf("IPAddresses missing loopback: %v", leaf.IPAddresses)
+	}
+}
+
+func TestEnsureS2sCerts_Idempotent(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+
+	if err := ensureS2sCerts(); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	certBefore, _ := os.ReadFile(filepath.Join(tmp, "tls", "s2s.crt"))
+	caBefore, _ := os.ReadFile(filepath.Join(tmp, "tls", "s2s-ca.crt"))
+
+	// Second run: cert is fresh, must not regenerate.
+	if err := ensureS2sCerts(); err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	certAfter, _ := os.ReadFile(filepath.Join(tmp, "tls", "s2s.crt"))
+	caAfter, _ := os.ReadFile(filepath.Join(tmp, "tls", "s2s-ca.crt"))
+
+	if string(certBefore) != string(certAfter) {
+		t.Errorf("leaf cert regenerated on idempotent re-run")
+	}
+	if string(caBefore) != string(caAfter) {
+		t.Errorf("CA cert regenerated on idempotent re-run")
+	}
+}
+
+func TestEnsureS2sCerts_RegeneratesWhenLeafMissing(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+
+	if err := ensureS2sCerts(); err != nil {
+		t.Fatalf("first run: %v", err)
+	}
+	// Remove just the leaf cert; re-run should regenerate everything
+	// (CA + leaf in lockstep — see comment in ensureS2sCerts).
+	if err := os.Remove(filepath.Join(tmp, "tls", "s2s.crt")); err != nil {
+		t.Fatal(err)
+	}
+	caBefore, _ := os.ReadFile(filepath.Join(tmp, "tls", "s2s-ca.crt"))
+
+	if err := ensureS2sCerts(); err != nil {
+		t.Fatalf("re-run: %v", err)
+	}
+	caAfter, _ := os.ReadFile(filepath.Join(tmp, "tls", "s2s-ca.crt"))
+	if string(caBefore) == string(caAfter) {
+		t.Errorf("CA unchanged after leaf removal; expected lockstep regeneration")
+	}
+}
+
+func TestS2sPaths_HonorEnvOverrides(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+	t.Setenv("FRIDAY_TLS_CERT", "/custom/s2s.crt")
+	t.Setenv("FRIDAY_TLS_KEY", "/custom/s2s.key")
+	t.Setenv("FRIDAY_TLS_CA", "/custom/s2s-ca.crt")
+
+	if got := s2sCertPath(); got != "/custom/s2s.crt" {
+		t.Errorf("s2sCertPath = %q, want /custom/s2s.crt", got)
+	}
+	if got := s2sKeyPath(); got != "/custom/s2s.key" {
+		t.Errorf("s2sKeyPath = %q, want /custom/s2s.key", got)
+	}
+	if got := s2sCAPath(); got != "/custom/s2s-ca.crt" {
+		t.Errorf("s2sCAPath = %q, want /custom/s2s-ca.crt", got)
+	}
+}
+
+func TestBrowserTlsPaths_HonorEnvOverrides(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+	t.Setenv("FRIDAY_BROWSER_TLS_CERT", "/custom/browser.crt")
+	t.Setenv("FRIDAY_BROWSER_TLS_KEY", "/custom/browser.key")
+
+	if got := tlsCertPath(); got != "/custom/browser.crt" {
+		t.Errorf("tlsCertPath = %q, want /custom/browser.crt", got)
+	}
+	if got := tlsKeyPath(); got != "/custom/browser.key" {
+		t.Errorf("tlsKeyPath = %q, want /custom/browser.key", got)
+	}
+}
+
+// Sanity: PEM blocks must round-trip through the encodePEM helper into
+// real ASN.1 we can re-parse.
+func TestEncodePEM_RoundTrips(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+
+	if err := ensureS2sCerts(); err != nil {
+		t.Fatalf("ensureS2sCerts: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(tmp, "tls", "s2s-ca.key"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil || block.Type != "EC PRIVATE KEY" {
+		t.Fatalf("expected EC PRIVATE KEY block, got %v", block)
+	}
+	if _, err := x509.ParseECPrivateKey(block.Bytes); err != nil {
+		t.Errorf("ParseECPrivateKey: %v", err)
+	}
+}

--- a/tools/friday-launcher/supervisor.go
+++ b/tools/friday-launcher/supervisor.go
@@ -103,6 +103,27 @@ func (s *Supervisor) Shutdown() error {
 	return s.runner.ShutDownProject()
 }
 
+// RestartProcess restarts a single supervised process by name.
+// Serialized with RestartAll via restartMu so a renewer-driven
+// restart can't race a user-initiated full restart.
+//
+// Sets inRestart for the duration so the tray's RestartGraceActive
+// stays true through the restart window — without that the bucket
+// briefly paints red when the one restarting service drops below
+// "healthy" before its readiness probe re-passes.
+func (s *Supervisor) RestartProcess(name string) error {
+	s.restartMu.Lock()
+	defer s.restartMu.Unlock()
+
+	s.inRestart.Store(true)
+	defer func() {
+		s.lastRestartEndNano.Store(time.Now().UnixNano())
+		s.inRestart.Store(false)
+	}()
+
+	return s.runner.RestartProcess(name)
+}
+
 // RestartAll restarts every supervised process by calling
 // runner.RestartProcess(name) in startOrder (dependency order so
 // foundational services come back first).

--- a/tools/friday-launcher/tls_renewer.go
+++ b/tools/friday-launcher/tls_renewer.go
@@ -1,0 +1,464 @@
+// TLS browser-cert renewer.
+//
+// The cert pair at <friendlyHome()>/tls/browser.{crt,key} is issued by
+// Let's Encrypt for `local.hellofriday.ai` (public DNS → 127.0.0.1)
+// and rotates every ~90 days. The Tauri installer fetches them once at
+// install time via apps/studio-installer/src-tauri/src/commands/download_tls.rs;
+// this file is the long-running launcher's renewal counterpart.
+//
+// Trigger model: TTL-based, not filesystem-based. The cert self-describes
+// its lifetime via notBefore / notAfter — once we're past 2/3 of that
+// window, we hit download.fridayplatform.io's manifest, sha256-verify the
+// new pair, atomically install it, and restart the playground so it
+// re-reads the files.
+//
+// Why TTL polling instead of fsnotify: the cert source is our own CDN
+// manifest, not an external rotator like certbot. fsnotify would solve a
+// problem we don't have (someone-else-writes-our-files) while adding
+// per-OS filesystem-notification quirks. TTL polling is bounded,
+// predictable, and the cert itself tells us when to act.
+//
+// Failure handling: if a refresh fails (offline, manifest down, sha
+// mismatch) we log and retry on the next tick (daily). The on-disk cert
+// keeps serving until it actually expires; once it expires, tls-paths.ts
+// (playground) returns null so the playground falls back to plain http
+// on :15200 — the launcher's playgroundURL() likewise downgrades to
+// http://localhost. The browser will fail to validate an expired cert
+// regardless of what we do, so falling back to http is the only path
+// that keeps Studio usable while the network heals.
+
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// Manifest URL is overridable for local testing; matches the Rust
+// installer's FRIDAY_TLS_MANIFEST_URL convention.
+const defaultTLSManifestURL = "https://download.fridayplatform.io/tls/manifest.json"
+
+// tlsRenewInterval is the cadence between renewer ticks. Daily is
+// frequent enough to catch the 2/3-lifetime trigger within a day of it
+// firing (so we always rotate before the cert expires) and infrequent
+// enough that a CDN/manifest outage doesn't burn cycles. Override via
+// FRIDAY_TLS_RENEW_INTERVAL for tests; parsed as a Go duration string.
+const tlsRenewInterval = 24 * time.Hour
+
+// bootRefreshTimeout caps the launcher-startup synchronous refresh
+// attempt so a slow / dead CDN doesn't delay the rest of the boot. If
+// we run out of budget, fall through to async refresh — the playground
+// will come up on whatever certs are on disk (possibly http if they're
+// expired) and the background ticker will retry.
+const bootRefreshTimeout = 5 * time.Second
+
+// tlsManifest mirrors the JSON published at download.fridayplatform.io/tls/manifest.json.
+// Only the fields we consume are decoded.
+type tlsManifest struct {
+	Domain    string                     `json:"domain"`
+	NotAfter  string                     `json:"notAfter"`
+	NotBefore string                     `json:"notBefore"`
+	Files     map[string]tlsManifestFile `json:"files"`
+}
+
+type tlsManifestFile struct {
+	URL    string `json:"url"`
+	SHA256 string `json:"sha256"`
+	Size   int64  `json:"size"`
+}
+
+// manifest file name → on-disk file name under <friendlyHome()>/tls/.
+// Single source of truth for the mapping. fullchain.pem is what TLS
+// servers should present (leaf + intermediate); cert.pem is leaf-only
+// and we deliberately don't use it.
+var tlsFiles = []struct {
+	manifestName string
+	onDiskName   string
+	mode         os.FileMode
+}{
+	{"fullchain.pem", "browser.crt", 0o644},
+	{"key.pem", "browser.key", 0o600},
+}
+
+// tlsCertDir resolves to <friendlyHome()>/tls/. Single helper so the
+// renewer, the validity check (project.go), and any future caller stay
+// in lock-step on where browser certs live.
+func tlsCertDir() string {
+	return filepath.Join(friendlyHome(), "tls")
+}
+
+func tlsCertPath() string {
+	return filepath.Join(tlsCertDir(), "browser.crt")
+}
+
+func tlsKeyPath() string {
+	return filepath.Join(tlsCertDir(), "browser.key")
+}
+
+func tlsManifestURL() string {
+	if v := os.Getenv("FRIDAY_TLS_MANIFEST_URL"); v != "" {
+		return v
+	}
+	return defaultTLSManifestURL
+}
+
+func tlsRenewIntervalValue() time.Duration {
+	if v := os.Getenv("FRIDAY_TLS_RENEW_INTERVAL"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			return d
+		}
+	}
+	return tlsRenewInterval
+}
+
+// parseCert reads a PEM file from disk and returns the first
+// certificate block. Returns nil + error if the file is missing,
+// unreadable, malformed, or contains no CERTIFICATE block.
+func parseCert(path string) (*x509.Certificate, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	for {
+		block, rest := pem.Decode(data)
+		if block == nil {
+			break
+		}
+		if block.Type == "CERTIFICATE" {
+			return x509.ParseCertificate(block.Bytes)
+		}
+		data = rest
+	}
+	return nil, fmt.Errorf("no CERTIFICATE block in %s", path)
+}
+
+// isExpired reports whether the cert is past its notAfter. Treated as a
+// non-revoke-able trigger to drop TLS (the browser would reject the
+// cert anyway, so serving it is worse than falling back to http).
+func isExpired(cert *x509.Certificate, now time.Time) bool {
+	return now.After(cert.NotAfter)
+}
+
+// notYetValid reports whether the cert's notBefore is in the future,
+// which on a correct-clock machine means the cert is malformed. Clock
+// skew on the user's machine is a likely cause — we treat this the
+// same as "expired" (don't serve, refresh).
+func notYetValid(cert *x509.Certificate, now time.Time) bool {
+	return now.Before(cert.NotBefore)
+}
+
+// pastTwoThirds reports whether the cert has consumed more than 2/3 of
+// its issued lifetime. Threshold borrowed from
+// opentelemetry-collector/config/configtls — same idea, same math.
+// For a 90-day LE cert that's day 60; we always have ~30 days of
+// runway to retry on intermittent failures.
+func pastTwoThirds(cert *x509.Certificate, now time.Time) bool {
+	lifetime := cert.NotAfter.Sub(cert.NotBefore)
+	if lifetime <= 0 {
+		// Defensive: a malformed cert with notBefore >= notAfter has
+		// no meaningful "2/3". Treat as needing immediate refresh so
+		// the bad cert gets replaced.
+		return true
+	}
+	age := now.Sub(cert.NotBefore)
+	return age*3 > lifetime*2
+}
+
+// hasValidBrowserCert reports whether the on-disk cert pair exists and
+// the cert is currently within its notBefore..notAfter window. Used by
+// playgroundURL to decide between https://local.hellofriday.ai and
+// http://localhost — the launcher's URL must match what the playground
+// will actually serve, and tls-paths.ts applies the same expiry check
+// on its side.
+func hasValidBrowserCert() bool {
+	if _, err := os.Stat(tlsKeyPath()); err != nil {
+		return false
+	}
+	cert, err := parseCert(tlsCertPath())
+	if err != nil {
+		return false
+	}
+	now := time.Now()
+	if isExpired(cert, now) || notYetValid(cert, now) {
+		return false
+	}
+	return true
+}
+
+// needsRefresh reports whether the on-disk cert is missing, expired,
+// not-yet-valid, or past 2/3 of its issued lifetime. The renewer uses
+// this as the single gate for "should I hit the manifest".
+//
+// Returning true on missing means a fresh launcher (no install-time
+// cert fetch, e.g. a source build of friday-launcher) gets a renewer-
+// driven first-time fetch. Returning true on expired means a stale
+// install picks up service on next launcher boot.
+func needsRefresh(now time.Time) bool {
+	cert, err := parseCert(tlsCertPath())
+	if err != nil {
+		// Missing or malformed → need a fetch. If the directory
+		// hasn't been created yet either, the manifest fetch will
+		// still write it.
+		return true
+	}
+	if isExpired(cert, now) || notYetValid(cert, now) {
+		return true
+	}
+	return pastTwoThirds(cert, now)
+}
+
+// atomicWrite mirrors apps/studio-installer/src-tauri/src/commands/download_tls.rs's
+// atomic_write: write tmp, fsync, chmod, rename. Guarantees an external
+// observer (the playground reading the cert files at startup) sees
+// either the prior content or the full new content — never a torn key
+// that would surface as a TLS handshake failure with no obvious cause.
+func atomicWrite(path string, data []byte, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+	}
+	tmp := path + ".tmp"
+	_ = os.Remove(tmp) // stale tmp from a prior crash is fine to drop
+
+	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("create tmp %s: %w", tmp, err)
+	}
+	if _, err := f.Write(data); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("write tmp %s: %w", tmp, err)
+	}
+	if err := f.Sync(); err != nil {
+		_ = f.Close()
+		_ = os.Remove(tmp)
+		return fmt.Errorf("fsync tmp %s: %w", tmp, err)
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("close tmp %s: %w", tmp, err)
+	}
+	// chmod again post-write because some umasks strip the bits we
+	// passed to OpenFile (notably 0o600 for the key under a 0o022
+	// umask should still be 0o600, but be explicit).
+	if err := os.Chmod(tmp, mode); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("chmod tmp %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename %s → %s: %w", tmp, path, err)
+	}
+	return nil
+}
+
+// fetchTLSManifest pulls the JSON manifest and parses it. Times out at
+// 10s — slower than that and the launcher's renewer is wasting its
+// daily budget on a stuck connection.
+func fetchTLSManifest(ctx context.Context, url string) (*tlsManifest, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("manifest %s: HTTP %d", url, resp.StatusCode)
+	}
+	var m tlsManifest
+	if err := json.NewDecoder(resp.Body).Decode(&m); err != nil {
+		return nil, fmt.Errorf("manifest %s: parse: %w", url, err)
+	}
+	return &m, nil
+}
+
+// fetchAndVerify downloads a file, verifies its size + sha256 against
+// the manifest entry, and returns the bytes. Bounded body size: we cap
+// reads at 2x the manifest-declared size so a malicious / corrupt
+// response can't OOM the launcher.
+func fetchAndVerify(ctx context.Context, entry tlsManifestFile, label string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, entry.URL, nil)
+	if err != nil {
+		return nil, err
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("fetch %s: %w", label, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%s: HTTP %d", label, resp.StatusCode)
+	}
+	maxRead := entry.Size * 2
+	if maxRead < 1024 {
+		maxRead = 1024
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxRead))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", label, err)
+	}
+	if int64(len(body)) != entry.Size {
+		return nil, fmt.Errorf("%s: size mismatch (got %d, manifest %d)", label, len(body), entry.Size)
+	}
+	sum := sha256.Sum256(body)
+	got := hex.EncodeToString(sum[:])
+	if !strings.EqualFold(got, entry.SHA256) {
+		return nil, fmt.Errorf("%s: sha256 mismatch (got %s, manifest %s)", label, got, entry.SHA256)
+	}
+	return body, nil
+}
+
+// refreshFromManifest pulls the manifest and, if any file's sha256
+// differs from what's on disk, downloads and atomic-writes the new
+// pair. Returns (changed, error): changed is true only when files were
+// actually replaced — the caller uses it to decide whether to restart
+// the playground (no-op restarts are pointless and would interrupt
+// active sessions for nothing).
+func refreshFromManifest(ctx context.Context) (bool, error) {
+	m, err := fetchTLSManifest(ctx, tlsManifestURL())
+	if err != nil {
+		return false, err
+	}
+
+	type pending struct {
+		path string
+		data []byte
+		mode os.FileMode
+	}
+	var writes []pending
+
+	for _, f := range tlsFiles {
+		entry, ok := m.Files[f.manifestName]
+		if !ok {
+			return false, fmt.Errorf("manifest missing %s", f.manifestName)
+		}
+		onDisk := filepath.Join(tlsCertDir(), f.onDiskName)
+		existing, _ := os.ReadFile(onDisk)
+		if len(existing) > 0 {
+			sum := sha256.Sum256(existing)
+			if strings.EqualFold(hex.EncodeToString(sum[:]), entry.SHA256) {
+				// Already matches — skip download.
+				continue
+			}
+		}
+		data, err := fetchAndVerify(ctx, entry, f.manifestName)
+		if err != nil {
+			return false, err
+		}
+		writes = append(writes, pending{path: onDisk, data: data, mode: f.mode})
+	}
+
+	if len(writes) == 0 {
+		return false, nil
+	}
+
+	// Write all-or-nothing: stage to .tmp, then rename. We rename in
+	// the order tlsFiles is declared (cert first, then key) — if a
+	// crash happens between the two renames, the cert-without-key
+	// state is briefly visible but tls-paths.ts requires both for a
+	// valid pair and the playground will fall back to http rather
+	// than half-load TLS.
+	for _, w := range writes {
+		if err := atomicWrite(w.path, w.data, w.mode); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+// startTLSRenewer launches the renewer goroutine.
+//
+// Lifecycle:
+//   - Ticker fires every tlsRenewIntervalValue() (default 24h).
+//   - On each tick: parse on-disk cert, call needsRefresh. If yes,
+//     refreshFromManifest. On change, supervisor.RestartProcess("playground").
+//   - The boot-time refresh attempt is NOT done here — see
+//     maybeBootRefreshTLS, which main() calls synchronously before
+//     starting the supervisor so a refresh that completes within
+//     bootRefreshTimeout means the playground starts with TLS from go.
+//
+// Cancelled via ctx; production wires this to the launcher's main
+// shutdown context so renewer goroutines don't outlive the launcher.
+func startTLSRenewer(ctx context.Context, sup *Supervisor) {
+	go func() {
+		interval := tlsRenewIntervalValue()
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-t.C:
+				runRenewerTick(ctx, sup)
+			}
+		}
+	}()
+}
+
+// runRenewerTick is the body of the daily loop, factored out so tests
+// can call it directly without spinning up a ticker.
+func runRenewerTick(ctx context.Context, sup *Supervisor) {
+	if !needsRefresh(time.Now()) {
+		return
+	}
+	changed, err := refreshFromManifest(ctx)
+	if err != nil {
+		log.Warn("tls: manifest refresh failed", "err", err)
+		return
+	}
+	if !changed {
+		// Cert was past 2/3 but the manifest still has the same
+		// sha — the CDN hasn't rotated yet. Try again tomorrow.
+		log.Info("tls: refresh checked, no new cert available")
+		return
+	}
+	log.Info("tls: new cert installed, restarting playground")
+	if sup == nil {
+		return
+	}
+	if err := sup.RestartProcess("playground"); err != nil {
+		log.Error("tls: restart playground after rotation", "err", err)
+	}
+}
+
+// maybeBootRefreshTLS is the launcher-boot synchronous refresh attempt.
+// Called BEFORE sup.runAndWatch starts the supervised processes so a
+// fast manifest fetch means the playground reads the new cert files at
+// the first chance.
+//
+// Bounded: returns within bootRefreshTimeout regardless of network
+// conditions, so a stuck CDN cannot delay the launcher. On timeout or
+// any failure, returns silently — the playground starts with whatever
+// is on disk (possibly nothing, possibly expired) and the async
+// renewer takes over.
+func maybeBootRefreshTLS() {
+	now := time.Now()
+	if !needsRefresh(now) {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), bootRefreshTimeout)
+	defer cancel()
+	changed, err := refreshFromManifest(ctx)
+	if err != nil {
+		log.Warn("tls: boot refresh failed (will retry async)", "err", err)
+		return
+	}
+	if changed {
+		log.Info("tls: boot refresh installed new cert")
+	}
+}

--- a/tools/friday-launcher/tls_renewer.go
+++ b/tools/friday-launcher/tls_renewer.go
@@ -98,11 +98,24 @@ func tlsCertDir() string {
 	return filepath.Join(friendlyHome(), "tls")
 }
 
+// tlsCertPath / tlsKeyPath resolve the browser-trusted cert pair the
+// playground origin presents to Chrome. Each honors the corresponding
+// FRIDAY_BROWSER_TLS_* env var first (symmetric with s2sCertPath); the
+// default location is <friendlyHome()>/tls/browser.{crt,key} — the
+// priority-2 resolution slot in tls-paths.ts. Honoring the env vars
+// here keeps the renewer's write path and the playground's read path
+// in lock-step even when the operator pins certs elsewhere.
 func tlsCertPath() string {
+	if v := os.Getenv("FRIDAY_BROWSER_TLS_CERT"); v != "" {
+		return v
+	}
 	return filepath.Join(tlsCertDir(), "browser.crt")
 }
 
 func tlsKeyPath() string {
+	if v := os.Getenv("FRIDAY_BROWSER_TLS_KEY"); v != "" {
+		return v
+	}
 	return filepath.Join(tlsCertDir(), "browser.key")
 }
 

--- a/tools/friday-launcher/tls_renewer.go
+++ b/tools/friday-launcher/tls_renewer.go
@@ -139,6 +139,9 @@ func tlsRenewIntervalValue() time.Duration {
 // certificate block. Returns nil + error if the file is missing,
 // unreadable, malformed, or contains no CERTIFICATE block.
 func parseCert(path string) (*x509.Certificate, error) {
+	// #nosec G304 -- path is resolved by launcher cert resolvers
+	// (tlsCertPath / s2sCertPath / s2sCAPath) from FRIDAY_LAUNCHER_HOME;
+	// the launcher reads certs it generated or downloaded itself.
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
@@ -237,12 +240,15 @@ func needsRefresh(now time.Time) bool {
 // either the prior content or the full new content — never a torn key
 // that would surface as a TLS handshake failure with no obvious cause.
 func atomicWrite(path string, data []byte, mode os.FileMode) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o750); err != nil {
 		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
 	}
 	tmp := path + ".tmp"
 	_ = os.Remove(tmp) // stale tmp from a prior crash is fine to drop
 
+	// #nosec G304 -- tmp is `<launcher-resolved cert path>.tmp` inside
+	// FRIDAY_LAUNCHER_HOME; opening files the launcher owns is the
+	// intended affordance.
 	f, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
 	if err != nil {
 		return fmt.Errorf("create tmp %s: %w", tmp, err)
@@ -288,7 +294,7 @@ func fetchTLSManifest(ctx context.Context, url string) (*tlsManifest, error) {
 	if err != nil {
 		return nil, fmt.Errorf("fetch %s: %w", url, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("manifest %s: HTTP %d", url, resp.StatusCode)
 	}
@@ -313,7 +319,7 @@ func fetchAndVerify(ctx context.Context, entry tlsManifestFile, label string) ([
 	if err != nil {
 		return nil, fmt.Errorf("fetch %s: %w", label, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("%s: HTTP %d", label, resp.StatusCode)
 	}
@@ -361,6 +367,9 @@ func refreshFromManifest(ctx context.Context) (bool, error) {
 			return false, fmt.Errorf("manifest missing %s", f.manifestName)
 		}
 		onDisk := filepath.Join(tlsCertDir(), f.onDiskName)
+		// #nosec G304 -- onDisk is built from tlsCertDir() (under
+		// FRIDAY_LAUNCHER_HOME) and a manifest-driven filename; reading
+		// the launcher's own cert directory is the intended affordance.
 		existing, _ := os.ReadFile(onDisk)
 		if len(existing) > 0 {
 			sum := sha256.Sum256(existing)

--- a/tools/friday-launcher/tls_renewer_test.go
+++ b/tools/friday-launcher/tls_renewer_test.go
@@ -283,6 +283,59 @@ func TestRefreshFromManifest_RejectsShaMismatch(t *testing.T) {
 	}
 }
 
+// TestRefreshFromManifest_NetworkError covers the "manifest fetch
+// fails" branch — connection refused, DNS error, etc. The renewer must
+// (1) return an error so the caller can log + retry tomorrow, and (2)
+// leave the on-disk cert untouched. Pre-existing tests cover sha-
+// mismatch and happy-path; this one closes the gap for offline /
+// CDN-down conditions, which is exactly the case the user-required
+// http-fallback path relies on (cert can't be refreshed → playground
+// continues serving whatever's on disk, http if expired).
+func TestRefreshFromManifest_NetworkError(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+	tlsDir := filepath.Join(tmp, "tls")
+	if err := os.MkdirAll(tlsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed a cert on disk so we can assert it survives the failure.
+	half := 12 * time.Hour
+	existingPEM, _ := makeTestCert(t, 24*time.Hour, &half)
+	certPath := filepath.Join(tlsDir, "browser.crt")
+	keyPath := filepath.Join(tlsDir, "browser.key")
+	if err := os.WriteFile(certPath, existingPEM, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, []byte("k"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	certStatBefore, _ := os.Stat(certPath)
+
+	// 127.0.0.1:1 reliably refuses connections on every Unix box —
+	// no listener can bind to that port without CAP_NET_BIND_SERVICE,
+	// so the connection-refused round-trip is deterministic.
+	t.Setenv("FRIDAY_TLS_MANIFEST_URL", "http://127.0.0.1:1/manifest.json")
+
+	changed, err := refreshFromManifest(context.Background())
+	if err == nil {
+		t.Fatalf("refreshFromManifest with unreachable manifest = nil error, want error")
+	}
+	if changed {
+		t.Errorf("changed = true on net error, want false")
+	}
+
+	certStatAfter, _ := os.Stat(certPath)
+	if certStatBefore.ModTime() != certStatAfter.ModTime() {
+		t.Errorf("on-disk cert mtime changed (%v → %v) despite fetch failure",
+			certStatBefore.ModTime(), certStatAfter.ModTime())
+	}
+	got, _ := os.ReadFile(certPath)
+	if string(got) != string(existingPEM) {
+		t.Errorf("on-disk cert content changed despite fetch failure")
+	}
+}
+
 func TestAtomicWrite_SetsMode(t *testing.T) {
 	tmp := t.TempDir()
 	p := filepath.Join(tmp, "nested", "key.pem")

--- a/tools/friday-launcher/tls_renewer_test.go
+++ b/tools/friday-launcher/tls_renewer_test.go
@@ -1,0 +1,330 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// makeTestCert produces a self-signed cert with the given lifetime and
+// returns (pemBytes, sha256hex). Lifetime is split equally around now:
+// notBefore = now - half, notAfter = now + half, so a cert with
+// lifetime=24h has 12h consumed and 12h remaining (≈ 50% of its life).
+//
+// `ageOverride` lets a test request a specific age. If set, notBefore =
+// now - ageOverride and notAfter = now + (lifetime - ageOverride).
+func makeTestCert(t *testing.T, lifetime time.Duration, ageOverride *time.Duration) ([]byte, string) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("genkey: %v", err)
+	}
+	now := time.Now()
+	var notBefore, notAfter time.Time
+	if ageOverride != nil {
+		notBefore = now.Add(-*ageOverride)
+		notAfter = notBefore.Add(lifetime)
+	} else {
+		half := lifetime / 2
+		notBefore = now.Add(-half)
+		notAfter = now.Add(half)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test.example"},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("CreateCertificate: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	sum := sha256.Sum256(pemBytes)
+	return pemBytes, hex.EncodeToString(sum[:])
+}
+
+func TestPastTwoThirds(t *testing.T) {
+	tests := []struct {
+		name     string
+		lifetime time.Duration
+		age      time.Duration
+		want     bool
+	}{
+		{"fresh (10%)", 30 * 24 * time.Hour, 3 * 24 * time.Hour, false},
+		{"midlife (50%)", 30 * 24 * time.Hour, 15 * 24 * time.Hour, false},
+		{"just under 2/3 (66%)", 30 * 24 * time.Hour, 19 * 24 * time.Hour, false},
+		{"just over 2/3 (70%)", 30 * 24 * time.Hour, 21 * 24 * time.Hour, true},
+		{"almost expired (95%)", 30 * 24 * time.Hour, 28*24*time.Hour + 12*time.Hour, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pemBytes, _ := makeTestCert(t, tt.lifetime, &tt.age)
+			cert, err := parsePEMCert(pemBytes)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got := pastTwoThirds(cert, time.Now()); got != tt.want {
+				t.Errorf("pastTwoThirds = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsExpired(t *testing.T) {
+	pastAge := 91 * 24 * time.Hour
+	pemBytes, _ := makeTestCert(t, 90*24*time.Hour, &pastAge)
+	cert, err := parsePEMCert(pemBytes)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !isExpired(cert, time.Now()) {
+		t.Errorf("isExpired = false, want true for cert past notAfter")
+	}
+}
+
+func TestNotYetValid(t *testing.T) {
+	// age = -24h → notBefore is 24h in the future
+	futureAge := -24 * time.Hour
+	pemBytes, _ := makeTestCert(t, 90*24*time.Hour, &futureAge)
+	cert, err := parsePEMCert(pemBytes)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !notYetValid(cert, time.Now()) {
+		t.Errorf("notYetValid = false, want true for cert with future notBefore")
+	}
+}
+
+func TestHasValidBrowserCert(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+	tlsDir := filepath.Join(tmp, "tls")
+	if err := os.MkdirAll(tlsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Missing key → invalid.
+	if hasValidBrowserCert() {
+		t.Errorf("hasValidBrowserCert with no files = true, want false")
+	}
+
+	// Fresh cert + key present → valid.
+	half := 12 * time.Hour
+	pem24h, _ := makeTestCert(t, 24*time.Hour, &half)
+	if err := os.WriteFile(filepath.Join(tlsDir, "browser.crt"), pem24h, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tlsDir, "browser.key"), []byte("key"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !hasValidBrowserCert() {
+		t.Errorf("hasValidBrowserCert with fresh cert = false, want true")
+	}
+
+	// Expired cert → invalid.
+	pastAge := 25 * time.Hour
+	pemExpired, _ := makeTestCert(t, 24*time.Hour, &pastAge)
+	if err := os.WriteFile(filepath.Join(tlsDir, "browser.crt"), pemExpired, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if hasValidBrowserCert() {
+		t.Errorf("hasValidBrowserCert with expired cert = true, want false")
+	}
+}
+
+func TestNeedsRefresh(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+	tlsDir := filepath.Join(tmp, "tls")
+	if err := os.MkdirAll(tlsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Missing cert → refresh.
+	if !needsRefresh(time.Now()) {
+		t.Errorf("needsRefresh with no cert = false, want true")
+	}
+
+	// Fresh cert (10% of life used) → no refresh.
+	freshAge := 3 * 24 * time.Hour
+	pemFresh, _ := makeTestCert(t, 30*24*time.Hour, &freshAge)
+	if err := os.WriteFile(filepath.Join(tlsDir, "browser.crt"), pemFresh, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if needsRefresh(time.Now()) {
+		t.Errorf("needsRefresh with fresh cert = true, want false")
+	}
+
+	// Past 2/3 → refresh.
+	oldAge := 25 * 24 * time.Hour
+	pemOld, _ := makeTestCert(t, 30*24*time.Hour, &oldAge)
+	if err := os.WriteFile(filepath.Join(tlsDir, "browser.crt"), pemOld, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !needsRefresh(time.Now()) {
+		t.Errorf("needsRefresh past 2/3 = false, want true")
+	}
+}
+
+func TestRefreshFromManifest_HappyPath(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+
+	// Build the cert pair that the fake CDN will serve.
+	half := 12 * time.Hour
+	certPEM, certSha := makeTestCert(t, 90*24*time.Hour, &half)
+	keyPEM := []byte("-----BEGIN PRIVATE KEY-----\nfake\n-----END PRIVATE KEY-----\n")
+	keySha := sha256SumHex(keyPEM)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest.json":
+			m := tlsManifest{
+				Domain: "local.hellofriday.ai",
+				Files: map[string]tlsManifestFile{
+					"fullchain.pem": {URL: srvURL(r) + "/fullchain.pem", SHA256: certSha, Size: int64(len(certPEM))},
+					"key.pem":       {URL: srvURL(r) + "/key.pem", SHA256: keySha, Size: int64(len(keyPEM))},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(m)
+		case "/fullchain.pem":
+			_, _ = w.Write(certPEM)
+		case "/key.pem":
+			_, _ = w.Write(keyPEM)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("FRIDAY_TLS_MANIFEST_URL", srv.URL+"/manifest.json")
+
+	changed, err := refreshFromManifest(context.Background())
+	if err != nil {
+		t.Fatalf("refreshFromManifest: %v", err)
+	}
+	if !changed {
+		t.Errorf("changed = false, want true (no prior files on disk)")
+	}
+
+	gotCert, err := os.ReadFile(filepath.Join(tmp, "tls", "browser.crt"))
+	if err != nil {
+		t.Fatalf("read cert: %v", err)
+	}
+	if string(gotCert) != string(certPEM) {
+		t.Errorf("on-disk cert does not match manifest payload")
+	}
+	gotKey, err := os.ReadFile(filepath.Join(tmp, "tls", "browser.key"))
+	if err != nil {
+		t.Fatalf("read key: %v", err)
+	}
+	if string(gotKey) != string(keyPEM) {
+		t.Errorf("on-disk key does not match manifest payload")
+	}
+
+	// Re-run: same sha on disk → no change (no download triggered).
+	changed2, err := refreshFromManifest(context.Background())
+	if err != nil {
+		t.Fatalf("refreshFromManifest (idempotent): %v", err)
+	}
+	if changed2 {
+		t.Errorf("second run changed = true, want false (idempotent)")
+	}
+}
+
+func TestRefreshFromManifest_RejectsShaMismatch(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+
+	half := 12 * time.Hour
+	certPEM, _ := makeTestCert(t, 90*24*time.Hour, &half)
+	keyPEM := []byte("k")
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/manifest.json":
+			// Wrong sha on purpose.
+			m := tlsManifest{
+				Files: map[string]tlsManifestFile{
+					"fullchain.pem": {URL: srvURL(r) + "/fullchain.pem", SHA256: "deadbeef", Size: int64(len(certPEM))},
+					"key.pem":       {URL: srvURL(r) + "/key.pem", SHA256: sha256SumHex(keyPEM), Size: int64(len(keyPEM))},
+				},
+			}
+			_ = json.NewEncoder(w).Encode(m)
+		case "/fullchain.pem":
+			_, _ = w.Write(certPEM)
+		case "/key.pem":
+			_, _ = w.Write(keyPEM)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("FRIDAY_TLS_MANIFEST_URL", srv.URL+"/manifest.json")
+
+	_, err := refreshFromManifest(context.Background())
+	if err == nil {
+		t.Fatalf("refreshFromManifest with bad sha = nil error, want error")
+	}
+	if _, statErr := os.Stat(filepath.Join(tmp, "tls", "browser.crt")); statErr == nil {
+		t.Errorf("browser.crt written despite sha mismatch")
+	}
+}
+
+func TestAtomicWrite_SetsMode(t *testing.T) {
+	tmp := t.TempDir()
+	p := filepath.Join(tmp, "nested", "key.pem")
+	if err := atomicWrite(p, []byte("k"), 0o600); err != nil {
+		t.Fatalf("atomicWrite: %v", err)
+	}
+	st, err := os.Stat(p)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := st.Mode().Perm(); perm != 0o600 {
+		t.Errorf("mode = %o, want 0600", perm)
+	}
+}
+
+// ── helpers used only by these tests ─────────────────────────────────
+
+// parsePEMCert is the same shape as parseCert but takes bytes directly,
+// avoiding a tempfile round-trip in tests that already have the PEM in
+// memory.
+func parsePEMCert(data []byte) (*x509.Certificate, error) {
+	block, _ := pem.Decode(data)
+	if block == nil {
+		return nil, errCertParse
+	}
+	return x509.ParseCertificate(block.Bytes)
+}
+
+var errCertParse = &certParseError{}
+
+type certParseError struct{}
+
+func (*certParseError) Error() string { return "no CERTIFICATE block" }
+
+func sha256SumHex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// srvURL reconstructs the scheme+host of the test server from a
+// received request. httptest.Server.URL would also work but isn't
+// in scope inside the handler.
+func srvURL(r *http.Request) string {
+	return "http://" + r.Host
+}

--- a/tools/webhook-tunnel/config.go
+++ b/tools/webhook-tunnel/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/friday-platform/friday-studio/tools/webhook-tunnel/passphrase"
 )
@@ -18,11 +19,16 @@ type Config struct {
 	Port          int
 	TunnelToken   string
 	NoTunnel      bool
-	// TLS cert/key paths (FRIDAY_TLS_CERT / FRIDAY_TLS_KEY). When both
-	// are set the server speaks HTTPS; cloudflared's local origin URL
-	// follows the same scheme. Empty in plain-HTTP mode.
+	// TLS cert/key paths (FRIDAY_TLS_CERT / FRIDAY_TLS_KEY) for our own
+	// listener. When both are set the server speaks HTTPS; cloudflared's
+	// local origin URL follows the same scheme. Empty in plain-HTTP mode.
 	TLSCert string
 	TLSKey  string
+	// FRIDAY_TLS_CA — private CA file used to verify atlasd's s2s cert
+	// on outbound forwarder calls. The system trust store has no entry
+	// for it, so without this the forwarder x509-errors on every POST
+	// once atlasd is on s2s TLS. Empty when atlasd is on plain HTTP.
+	AtlasdCA string
 }
 
 func loadConfig() (*Config, error) {
@@ -38,6 +44,16 @@ func loadConfig() (*Config, error) {
 	if atlasdURL == "" {
 		atlasdURL = "http://localhost:8080"
 	}
+	atlasdCA := os.Getenv("FRIDAY_TLS_CA")
+	// Auto-upgrade scheme when the local s2s CA is configured: atlasd
+	// will be on HTTPS and a stale http:// FRIDAYD_URL (e.g. left over
+	// from a prior non-TLS run) would otherwise hit a TLS listener
+	// with cleartext bytes and fail. Mirrors getAtlasDaemonUrl()'s
+	// upgrade in packages/openapi-client/src/utils.ts. We don't
+	// downgrade https→http for the same reason as the TS path.
+	if atlasdCA != "" && strings.HasPrefix(atlasdURL, "http://") {
+		atlasdURL = "https://" + strings.TrimPrefix(atlasdURL, "http://")
+	}
 	secret := os.Getenv("WEBHOOK_SECRET")
 	if secret == "" {
 		secret = passphrase.Generate()
@@ -50,5 +66,6 @@ func loadConfig() (*Config, error) {
 		NoTunnel:      os.Getenv("NO_TUNNEL") == "true",
 		TLSCert:       os.Getenv("FRIDAY_TLS_CERT"),
 		TLSKey:        os.Getenv("FRIDAY_TLS_KEY"),
+		AtlasdCA:      atlasdCA,
 	}, nil
 }

--- a/tools/webhook-tunnel/config.go
+++ b/tools/webhook-tunnel/config.go
@@ -18,6 +18,11 @@ type Config struct {
 	Port          int
 	TunnelToken   string
 	NoTunnel      bool
+	// TLS cert/key paths (FRIDAY_TLS_CERT / FRIDAY_TLS_KEY). When both
+	// are set the server speaks HTTPS; cloudflared's local origin URL
+	// follows the same scheme. Empty in plain-HTTP mode.
+	TLSCert string
+	TLSKey  string
 }
 
 func loadConfig() (*Config, error) {
@@ -43,5 +48,7 @@ func loadConfig() (*Config, error) {
 		Port:          port,
 		TunnelToken:   os.Getenv("TUNNEL_TOKEN"),
 		NoTunnel:      os.Getenv("NO_TUNNEL") == "true",
+		TLSCert:       os.Getenv("FRIDAY_TLS_CERT"),
+		TLSKey:        os.Getenv("FRIDAY_TLS_KEY"),
 	}, nil
 }

--- a/tools/webhook-tunnel/forwarder/forwarder.go
+++ b/tools/webhook-tunnel/forwarder/forwarder.go
@@ -59,6 +59,10 @@ func buildTransport(caCertPath string) (http.RoundTripper, error) {
 	if caCertPath == "" {
 		return http.DefaultTransport, nil
 	}
+	// #nosec G304 -- caCertPath comes from FRIDAY_TLS_CA, set by
+	// scripts/setup-tls.sh under the user's own FRIDAY_HOME. The
+	// operator chooses what CA to trust; reading an arbitrary path is
+	// the intended affordance, not a vulnerability.
 	pem, err := os.ReadFile(caCertPath)
 	if err != nil {
 		return nil, fmt.Errorf("read FRIDAY_TLS_CA %q: %w", caCertPath, err)

--- a/tools/webhook-tunnel/forwarder/forwarder.go
+++ b/tools/webhook-tunnel/forwarder/forwarder.go
@@ -11,12 +11,16 @@ package forwarder
 
 import (
 	"bytes"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 
@@ -26,16 +30,53 @@ import (
 // Forwarder bundles the atlasd URL + an HTTP client.
 type Forwarder struct {
 	atlasdURL string
+	transport http.RoundTripper
 	client    *http.Client
 }
 
 // New returns a Forwarder pointing at the given atlasd base URL
-// (e.g. "http://localhost:8080").
-func New(atlasdURL string) *Forwarder {
+// (e.g. "http://localhost:8080"). When caCertPath is non-empty, the
+// file at that path is loaded as a PEM-encoded root CA and added to
+// the transport's RootCAs — required when atlasd serves the private-CA
+// s2s cert (see scripts/setup-tls.sh), since the system trust store
+// has no knowledge of that CA.
+func New(atlasdURL, caCertPath string) (*Forwarder, error) {
+	transport, err := buildTransport(caCertPath)
+	if err != nil {
+		return nil, err
+	}
 	return &Forwarder{
 		atlasdURL: strings.TrimRight(atlasdURL, "/"),
-		client:    &http.Client{Timeout: 30 * time.Second},
+		transport: transport,
+		client:    &http.Client{Timeout: 30 * time.Second, Transport: transport},
+	}, nil
+}
+
+// buildTransport clones http.DefaultTransport (preserves keepalive /
+// idle-pool / proxy-env defaults) and, when given a CA path, swaps in
+// a TLSClientConfig that trusts that CA in addition to the system roots.
+func buildTransport(caCertPath string) (http.RoundTripper, error) {
+	if caCertPath == "" {
+		return http.DefaultTransport, nil
 	}
+	pem, err := os.ReadFile(caCertPath)
+	if err != nil {
+		return nil, fmt.Errorf("read FRIDAY_TLS_CA %q: %w", caCertPath, err)
+	}
+	roots, err := x509.SystemCertPool()
+	if err != nil || roots == nil {
+		roots = x509.NewCertPool()
+	}
+	if !roots.AppendCertsFromPEM(pem) {
+		return nil, errors.New("FRIDAY_TLS_CA contains no valid PEM certificates")
+	}
+	base, ok := http.DefaultTransport.(*http.Transport)
+	if !ok {
+		return nil, errors.New("http.DefaultTransport is not *http.Transport — refusing to silently drop pool defaults")
+	}
+	t := base.Clone()
+	t.TLSClientConfig = &tls.Config{RootCAs: roots, MinVersion: tls.VersionTLS12}
+	return t, nil
 }
 
 // SignalResponse is the parsed atlasd signal response. We only care
@@ -98,6 +139,7 @@ func (f *Forwarder) ProxyHandler() http.Handler {
 		})
 	}
 	rp := &httputil.ReverseProxy{
+		Transport: f.transport,
 		Director: func(r *http.Request) {
 			provider := chi.URLParam(r, "provider")
 			// Chi exposes the wildcard tail as URL param "*".

--- a/tools/webhook-tunnel/forwarder/forwarder_test.go
+++ b/tools/webhook-tunnel/forwarder/forwarder_test.go
@@ -171,12 +171,12 @@ func TestForwardTrustsPrivateCA(t *testing.T) {
 	// Mint a self-signed CA + leaf for 127.0.0.1.
 	caKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	caTpl := &x509.Certificate{
-		SerialNumber: big.NewInt(1),
-		Subject:      pkix.Name{CommonName: "Test CA"},
-		NotBefore:    time.Now().Add(-time.Hour),
-		NotAfter:     time.Now().Add(time.Hour),
-		IsCA:         true,
-		KeyUsage:     x509.KeyUsageCertSign,
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "Test CA"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
 		BasicConstraintsValid: true,
 	}
 	caDER, _ := x509.CreateCertificate(rand.Reader, caTpl, caTpl, &caKey.PublicKey, caKey)

--- a/tools/webhook-tunnel/forwarder/forwarder_test.go
+++ b/tools/webhook-tunnel/forwarder/forwarder_test.go
@@ -1,12 +1,24 @@
 package forwarder
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
+	"encoding/pem"
 	"io"
+	"math/big"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -29,7 +41,10 @@ func TestForwardHappyPath(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	f := New(srv.URL)
+	f, err := New(srv.URL, "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	sid, err := f.Forward("ws-1", "sig-1", map[string]any{"foo": "bar"})
 	if err != nil {
 		t.Fatalf("forward: %v", err)
@@ -45,8 +60,11 @@ func TestForwardNon2xx(t *testing.T) {
 		_, _ = w.Write([]byte(`workspace not found`))
 	}))
 	defer srv.Close()
-	f := New(srv.URL)
-	_, err := f.Forward("ws", "sig", nil)
+	f, err := New(srv.URL, "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	_, err = f.Forward("ws", "sig", nil)
 	if err == nil {
 		t.Fatalf("expected error on 5xx response")
 	}
@@ -68,7 +86,10 @@ func TestProxyPathRewrite(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	f := New(srv.URL)
+	f, err := New(srv.URL, "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	r := chi.NewRouter()
 	r.Handle("/platform/{provider}", f.ProxyHandler())
 	r.Handle("/platform/{provider}/*", f.ProxyHandler())
@@ -113,7 +134,10 @@ func TestProxyStripsHopByHop(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	f := New(srv.URL)
+	f, err := New(srv.URL, "")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
 	r := chi.NewRouter()
 	r.Handle("/platform/{provider}", f.ProxyHandler())
 	clientSrv := httptest.NewServer(r)
@@ -137,5 +161,93 @@ func TestProxyStripsHopByHop(t *testing.T) {
 	}
 	if got.Get("X-Custom") != "preserved" {
 		t.Errorf("X-Custom should be preserved, got %q", got.Get("X-Custom"))
+	}
+}
+
+// TestForwardTrustsPrivateCA verifies that when New() is given a CA
+// file, the forwarder can reach an HTTPS atlasd whose cert chains to
+// that CA — the path that breaks without FRIDAY_TLS_CA plumbing.
+func TestForwardTrustsPrivateCA(t *testing.T) {
+	// Mint a self-signed CA + leaf for 127.0.0.1.
+	caKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	caTpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "Test CA"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IsCA:         true,
+		KeyUsage:     x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+	caDER, _ := x509.CreateCertificate(rand.Reader, caTpl, caTpl, &caKey.PublicKey, caKey)
+	caCert, _ := x509.ParseCertificate(caDER)
+
+	leafKey, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	leafTpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
+	}
+	leafDER, _ := x509.CreateCertificate(rand.Reader, leafTpl, caCert, &leafKey.PublicKey, caKey)
+
+	// Persist the CA in PEM so New() can read it via path.
+	tmp := t.TempDir()
+	caPath := filepath.Join(tmp, "ca.crt")
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})
+	if err := os.WriteFile(caPath, caPEM, 0o600); err != nil {
+		t.Fatalf("write ca: %v", err)
+	}
+
+	// Stand up an httptest TLS server presenting the leaf, then validate
+	// that a forwarder configured WITHOUT the CA fails and one WITH the
+	// CA succeeds — exactly the divergence the s2s rollout introduced.
+	tlsCert := tls.Certificate{Certificate: [][]byte{leafDER}, PrivateKey: leafKey}
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"sessionId":"ok"}`))
+	}))
+	srv.TLS = &tls.Config{Certificates: []tls.Certificate{tlsCert}}
+	srv.StartTLS()
+	defer srv.Close()
+
+	// Without CA: must error with an x509 / unknown-authority message.
+	noCA, err := New(srv.URL, "")
+	if err != nil {
+		t.Fatalf("New no-ca: %v", err)
+	}
+	if _, err := noCA.Forward("ws", "sig", nil); err == nil {
+		t.Fatalf("expected TLS verification error without CA")
+	}
+
+	// With CA: must succeed.
+	withCA, err := New(srv.URL, caPath)
+	if err != nil {
+		t.Fatalf("New with-ca: %v", err)
+	}
+	sid, err := withCA.Forward("ws", "sig", nil)
+	if err != nil {
+		t.Fatalf("forward with CA: %v", err)
+	}
+	if sid != "ok" {
+		t.Errorf("sessionId: want ok, got %q", sid)
+	}
+}
+
+// TestNewRejectsInvalidCA covers the loud-failure case: caller passes
+// a path that isn't a valid PEM. We'd rather fail at startup than
+// silently degrade to "no extra trust" and then mysteriously fail at
+// every forward call.
+func TestNewRejectsInvalidCA(t *testing.T) {
+	tmp := t.TempDir()
+	bogus := filepath.Join(tmp, "bogus.crt")
+	_ = os.WriteFile(bogus, []byte("not a certificate"), 0o600)
+	if _, err := New("http://localhost:8080", bogus); err == nil {
+		t.Fatalf("expected error for invalid PEM, got nil")
+	}
+	if _, err := New("http://localhost:8080", filepath.Join(tmp, "missing.crt")); err == nil {
+		t.Fatalf("expected error for missing CA file, got nil")
 	}
 }

--- a/tools/webhook-tunnel/main.go
+++ b/tools/webhook-tunnel/main.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -37,6 +38,7 @@ import (
 	"github.com/friday-platform/friday-studio/tools/webhook-tunnel/tunnel"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/cors"
+	"github.com/joho/godotenv"
 )
 
 // maxBodySize caps request bodies for /hook and /platform routes.
@@ -56,6 +58,17 @@ var (
 )
 
 func main() {
+	// Load FRIDAY_HOME/.env so FRIDAY_TLS_CERT/_KEY (and any other
+	// caller-supplied env) land before loadConfig() reads them. Mirrors
+	// atlas-cli daemon-start; existing process env wins (Load doesn't
+	// overwrite). Tolerant — missing .env is fine on a fresh install.
+	envPath := filepath.Join(fridayHome(), ".env")
+	if _, err := os.Stat(envPath); err == nil {
+		if err := godotenv.Load(envPath); err != nil {
+			log.Warn(".env load failed; continuing with shell env", "path", envPath, "error", err)
+		}
+	}
+
 	conf, err := loadConfig()
 	if err != nil {
 		log.Fatal("config error", "error", err)
@@ -83,24 +96,38 @@ func main() {
 		ReadHeaderTimeout: 10 * time.Second,
 	}
 
+	tlsOn := cfg.TLSCert != "" && cfg.TLSKey != ""
+	scheme := "http"
+	if tlsOn {
+		scheme = "https"
+	}
 	log.Info("webhook listener starting",
 		"port", cfg.Port,
+		"scheme", scheme,
 		"atlasd_url", cfg.AtlasdURL,
 		"secret_configured", cfg.WebhookSecret != "")
 
 	serverErr := make(chan error, 1)
 	go func() {
-		err := srv.ListenAndServe()
+		var err error
+		if tlsOn {
+			// Both files supplied — speak HTTPS. cloudflared's local
+			// origin URL (tunnel/manager.go) follows the same scheme so
+			// the public path stays end-to-end TLS.
+			err = srv.ListenAndServeTLS(cfg.TLSCert, cfg.TLSKey)
+		} else {
+			err = srv.ListenAndServe()
+		}
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
 			serverErr <- err
 		}
 	}()
 
 	if !cfg.NoTunnel {
-		startTunnel()
+		startTunnel(tlsOn)
 	} else {
 		log.Info("tunnel disabled",
-			"local_url", fmt.Sprintf("http://localhost:%d/hook/{provider}/{workspaceId}/{signalId}", cfg.Port))
+			"local_url", fmt.Sprintf("%s://localhost:%d/hook/{provider}/{workspaceId}/{signalId}", scheme, cfg.Port))
 	}
 
 	stop := make(chan os.Signal, 1)
@@ -116,7 +143,7 @@ func main() {
 	}
 }
 
-func startTunnel() {
+func startTunnel(tlsOn bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 	bin, err := cloudflared.Resolve(ctx)
@@ -129,6 +156,7 @@ func startTunnel() {
 		Port:           cfg.Port,
 		TunnelToken:    cfg.TunnelToken,
 		CloudflaredBin: bin,
+		TLS:            tlsOn,
 		Logger:         log.Child("subcomponent", "tunnel"),
 	})
 	if err := tunMgr.Start(ctx); err != nil {
@@ -379,4 +407,23 @@ func writeJSON(w http.ResponseWriter, status int, body any) {
 
 func writeJSONError(w http.ResponseWriter, status int, message string) {
 	writeJSON(w, status, map[string]string{"error": message})
+}
+
+// fridayHome resolves the per-user data dir, mirroring atlasd's
+// getFridayHome() resolution order: $FRIDAY_HOME wins, otherwise
+// ~/.atlas (legacy / dev) if it exists, falling back to
+// ~/.friday/local (new desktop / installer default).
+func fridayHome() string {
+	if v := os.Getenv("FRIDAY_HOME"); v != "" {
+		return v
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	atlas := filepath.Join(home, ".atlas")
+	if st, err := os.Stat(atlas); err == nil && st.IsDir() {
+		return atlas
+	}
+	return filepath.Join(home, ".friday", "local")
 }

--- a/tools/webhook-tunnel/main.go
+++ b/tools/webhook-tunnel/main.go
@@ -77,7 +77,11 @@ func main() {
 	if err := provider.Init(); err != nil {
 		log.Fatal("provider init", "error", err)
 	}
-	fwd = forwarder.New(cfg.AtlasdURL)
+	f, err := forwarder.New(cfg.AtlasdURL, cfg.AtlasdCA)
+	if err != nil {
+		log.Fatal("forwarder init", "error", err)
+	}
+	fwd = f
 
 	r := newRouter()
 

--- a/tools/webhook-tunnel/main_test.go
+++ b/tools/webhook-tunnel/main_test.go
@@ -29,7 +29,11 @@ func setupTestServer(t *testing.T, atlasdURL string) string {
 	if err := provider.Init(); err != nil {
 		t.Fatalf("provider init: %v", err)
 	}
-	fwd = forwarder.New(atlasdURL)
+	f, err := forwarder.New(atlasdURL, "")
+	if err != nil {
+		t.Fatalf("forwarder init: %v", err)
+	}
+	fwd = f
 	tunMgr = nil
 
 	srv := httptest.NewServer(newRouter())

--- a/tools/webhook-tunnel/tunnel/manager.go
+++ b/tools/webhook-tunnel/tunnel/manager.go
@@ -30,6 +30,7 @@ type Options struct {
 	Port           int
 	TunnelToken    string // empty = quick tunnel
 	CloudflaredBin string // resolved binary path (caller does discovery)
+	TLS            bool   // origin speaks https — cloudflared connects via https://localhost:<port>
 	Logger         *logger.Logger
 }
 
@@ -201,7 +202,11 @@ func (m *Manager) connect(parentCtx context.Context) error {
 }
 
 func (m *Manager) buildArgs() []string {
-	url := fmt.Sprintf("http://localhost:%d", m.opts.Port)
+	scheme := "http"
+	if m.opts.TLS {
+		scheme = "https"
+	}
+	url := fmt.Sprintf("%s://localhost:%d", scheme, m.opts.Port)
 	if m.opts.TunnelToken != "" {
 		// Named tunnel via token. cloudflared accepts the token via
 		// `tunnel run --token <t>` (the npm wrapper uses the same


### PR DESCRIPTION
## Summary

- Two open playground tabs hit Chrome's 6-socket-per-origin HTTP/1.1 cap (3 long-lived SSE feeds × N tabs + Vite HMR socket), wedging every fetch including the page document. HTTP/2 multiplexes everything onto one connection — fix is local TLS via mkcert so the runtimes can negotiate h2.
- New `scripts/setup-tls.sh` installs mkcert, generates `localhost.{crt,key}` per FRIDAY_HOME, writes the env vars below to `.env` (chmod 600). Idempotent, opt-in via `bash scripts/setup-tls.sh`, skippable in `setup-dev-env.sh` with `SKIP_TLS=1`.
- `scripts/run-playground-vite.sh` exports `NODE_EXTRA_CA_CERTS` *before* `exec node` (Node 25 reads it once, at TLS context init). Bypasses `npx` so `deno task` shell doesn't route the bin script through the partial `node:http2` polyfill.
- `vite.config.ts` and `static-server.ts` resolve the cert pair, enable TLS on `server.https` / `Deno.serve`, strip HTTP/1.1 hop-by-hop headers (`transfer-encoding` et al — h2 forbids them) when proxying, and inject the daemon URL into route SSR via `define` (route-side `process.env` is wiped).
- `AtlasDaemonOptions` accepts `tlsCert`/`tlsKey`; `atlas-cli` reads paths from env. `getAtlasDaemonUrl()` upgrades an explicit `FRIDAYD_URL=http://…` to `https://` when TLS env is set, so a stale URL stops misrouting.
- `deno task atlas`/`atlas:dev` add `--env-file=$HOME/.atlas/.env` so `DENO_CERT` lands before Deno's RootCertStore initializes.

Without certs everything stays on plain HTTP — backwards-compatible.

## Env vars

| Var | Type | Read by | Set by |
|---|---|---|---|
| `FRIDAY_TLS_CERT` | path | `vite.config.ts`, `static-server.ts`, `atlas-cli daemon start`, `getAtlasDaemonUrl()` (scheme switch) | `setup-tls.sh` writes to `.env` |
| `FRIDAY_TLS_KEY`  | path | same | same |
| `DENO_CERT`       | path to mkcert root CA | Deno runtime at startup — `atlasd`, `atlas-cli`, anything `deno run` | `setup-tls.sh` writes to `.env`; loaded into Deno via `--env-file` on the `atlas` task |
| `NODE_EXTRA_CA_CERTS` | path to mkcert root CA | Node runtime at startup — vite SSR proxy, any Node tool fetching the daemon | `run-playground-vite.sh` exports from `mkcert -CAROOT` before `exec node`. Also written to `.env` for tests / other Node entrypoints |
| `FRIDAYD_URL` | URL | `vite.config.ts`, `static-server.ts`, `getAtlasDaemonUrl()` | optional override; launcher / wizard / `FAST_DEVELOPMENT` mode sets it. Scheme is auto-upgraded to `https://` when `FRIDAY_TLS_*` are set |
| `EXTERNAL_DAEMON_URL` | URL | `hooks.server.ts` → `window.__FRIDAY_CONFIG__` → browser code (oauth-popup, signal-row, etc.) | defaults to resolved daemon URL; explicit env wins |
| `EXTERNAL_TUNNEL_URL` | URL | same | same |
| `SKIP_TLS` | flag | `setup-dev-env.sh`, `setup-tls.sh` | user-set for sandboxed CI / no-admin envs |
| `FRIDAY_HOME` | path | `setup-tls.sh`, `atlas-cli` (via `getFridayHome()`) | user/launcher; default `~/.friday/local`, repo dev typically `~/.atlas` |

## .env sourcing — per-app

The PR settles on **`~/.atlas/.env` as the canonical dev `.env`**, but the two app sides reach trust material through different paths because they have different startup constraints:

**Daemon (`atlas`, `atlas:dev`):** sources `.env` twice.
1. `deno task atlas` boots Deno with `--env-file=$HOME/.atlas/.env` — vars are in `process.env` *before* Deno's RootCertStore initializes (critical for `DENO_CERT`; OTEL fires its first TLS context before `atlas-cli`'s own dotenv load could).
2. `apps/atlas-cli/src/commands/daemon/start.tsx` later calls `@std/dotenv load({ envPath: getFridayHome()+"/.env" })` so `~/.friday/local/.env` (or wherever `FRIDAY_HOME` points) is overlaid for runtime-only vars.

**Playground (vite dev, `static-server.ts`):** does **not** load `.env` directly. Trust comes from:
1. `run-playground-vite.sh` exports `NODE_EXTRA_CA_CERTS` from `mkcert -CAROOT` before `exec node` — has to happen before Node starts, can't wait for a dotenv load.
2. `vite.config.ts` and `static-server.ts` probe the filesystem at `~/.atlas/tls/localhost.{crt,key}` and `~/.friday/local/tls/localhost.{crt,key}` for the cert pair — env-var override (`FRIDAY_TLS_CERT/_KEY`) wins if set in the shell.
3. `process.env.FRIDAYD_URL` is read directly (vite's process; route-SSR reads come through a `define`-injected constant since vite's `process.env: "{}"` wipe blocks runtime env reads in transformed modules).

So daemon-side and playground-side end up with the *same* trust material (mkcert CA + per-host cert) but via different mechanisms — convergence happens at setup time (`setup-tls.sh` populates both `.env` writes and the on-disk cert files), not at runtime.

## Should everything source the same `.env`?

Trade-off: yes for ergonomics, no for startup-ordering correctness.

The dev `.env` (`~/.atlas/.env`) is already the source of truth for env-driven vars on the daemon side — `setup-tls.sh` always seeds it (regardless of which `FRIDAY_HOME` was detected) so the hardcoded `--env-file=$HOME/.atlas/.env` on the `atlas` task always resolves. The playground side could in principle load it too, but:

- `NODE_EXTRA_CA_CERTS` has to land before Node initializes its TLS root store. Node reads it once, lazily on first secure-context creation, but in practice that fires before user code can call `dotenv.load()` — so we set it from a shell wrapper before `exec node` instead of trying to plumb through `.env`.
- Vite traditionally reads `.env` from cwd (`tools/agent-playground/.env`), not from `$HOME`. Wiring the wrapper to also load a non-cwd `.env` is doable (`set -a; . "$HOME/.atlas/.env"; set +a`) but adds another layer that's already covered by filesystem probing for the cert files themselves.
- The compiled playground binary is launched by the Studio installer/launcher, which manages its own env and intentionally doesn't share the dev `.env`.

Net: `~/.atlas/.env` is canonical for the daemon; the playground reaches the same trust material through filesystem probing + a shell-wrapper export. Either side can be moved to read the same `.env` later — the cost is the startup-ordering plumbing, not the file format.

## Test plan

- [ ] `bash scripts/setup-tls.sh` (first run prompts for sudo to install mkcert root CA; subsequent runs no-op)
- [ ] `deno task dev:playground:stable` boots; daemon and vite both serve `https://`
- [ ] Browser loads `https://localhost:5200/platform/<workspace>/chat`, sends a message, agent responds end-to-end
- [ ] Pre-existing `http://localhost` setups (no `setup-tls.sh` run) still boot on plain HTTP
- [ ] OAuth providers with `http://localhost:8080/api/link/v1/callback/<provider>` registered will need `https://…` variants added in their dashboards before reconnecting under TLS