### PR TITLE
Cache non-chat LLM calls + roll nested usage into chat metadata

### DIFF
--- a/apps/atlasd/src/capability-handlers.test.ts
+++ b/apps/atlasd/src/capability-handlers.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Bridges the workspace-chat `enterUsageScope` ALS across the NATS
+ * subscriber boundary by re-entering the registered counter inside
+ * `handleLlm`. Without that bridge, the daemon's LLM capability handler
+ * runs in the NATS callback's own ALS root and any `traceModel`-wrapped
+ * call inside `createLlmGenerateHandler` would not credit the
+ * workspace-chat turn.
+ */
+
+import { getActiveUsageCounter, type UsageCounter } from "@atlas/llm";
+import type { Logger } from "@atlas/logger";
+import { StringCodec } from "nats";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const createLlmGenerateHandlerMock = vi.fn<(opts: unknown) => (json: string) => Promise<string>>();
+const createHttpFetchHandlerMock = vi.fn(() => () => Promise.resolve("{}"));
+
+vi.mock("@atlas/workspace/agent-executor-utils", () => ({
+  createLlmGenerateHandler: (opts: unknown) => createLlmGenerateHandlerMock(opts),
+  createHttpFetchHandler: () => createHttpFetchHandlerMock(),
+}));
+
+const { CapabilityHandlerRegistry } = await import("./capability-handlers.ts");
+
+function noopLogger(): Logger {
+  const noop = () => {};
+  const logger = {
+    trace: noop,
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error: noop,
+    fatal: noop,
+    child: () => logger,
+  } as unknown as Logger;
+  return logger;
+}
+
+const sc = StringCodec();
+
+function makeMsg(subject: string, body: Record<string, unknown>) {
+  return { subject, data: sc.encode(JSON.stringify(body)), reply: "_INBOX.test" };
+}
+
+const fakeNc = { publish: vi.fn() } as unknown as Parameters<// deno-lint-ignore no-explicit-any
+any>[0];
+
+beforeEach(() => {
+  createLlmGenerateHandlerMock.mockReset();
+  createHttpFetchHandlerMock.mockReset();
+});
+
+describe("CapabilityHandlerRegistry handleLlm — usage scope bridge", () => {
+  it("re-enters the registered counter when handling a caps.*.llm.generate", async () => {
+    const counter: UsageCounter = {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    };
+    const reg = new CapabilityHandlerRegistry();
+    reg.register("session-1", {
+      mcpToolCall: vi.fn(),
+      mcpListTools: vi.fn(),
+      logger: noopLogger(),
+      usageCounter: counter,
+    });
+
+    // The mocked LLM handler observes whether `getActiveUsageCounter()`
+    // returns the registered counter at call time — that's exactly what
+    // the workspace's `traceModel`-wrapped model would do via its
+    // middleware. If the bridge works, the same object reference comes
+    // back; if it doesn't, we get `undefined`.
+    let observedCounter: UsageCounter | undefined;
+    createLlmGenerateHandlerMock.mockReturnValue(() => {
+      observedCounter = getActiveUsageCounter();
+      return Promise.resolve(JSON.stringify({ text: "ok" }));
+    });
+
+    const msg = makeMsg("caps.session-1.llm.generate", { prompt: "hi" });
+    // handleLlm is a private class field — cast through to call it.
+    const handler = (
+      reg as unknown as {
+        handleLlm: (err: Error | null, msg: ReturnType<typeof makeMsg>, nc: typeof fakeNc) => void;
+      }
+    ).handleLlm;
+    handler(null, msg, fakeNc);
+
+    // handleLlm returns void and fires the promise chain async — wait
+    // for it to settle. A microtask flush is enough since the mocked
+    // handler resolves immediately.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(observedCounter).toBe(counter);
+  });
+
+  it("skips the scope wrap when no counter is registered", async () => {
+    const reg = new CapabilityHandlerRegistry();
+    reg.register("session-2", {
+      mcpToolCall: vi.fn(),
+      mcpListTools: vi.fn(),
+      logger: noopLogger(),
+      // no usageCounter
+    });
+
+    let observedCounter: UsageCounter | undefined = {} as UsageCounter;
+    createLlmGenerateHandlerMock.mockReturnValue(() => {
+      observedCounter = getActiveUsageCounter();
+      return Promise.resolve(JSON.stringify({ text: "ok" }));
+    });
+
+    const msg = makeMsg("caps.session-2.llm.generate", { prompt: "hi" });
+    const handler = (
+      reg as unknown as {
+        handleLlm: (err: Error | null, msg: ReturnType<typeof makeMsg>, nc: typeof fakeNc) => void;
+      }
+    ).handleLlm;
+    handler(null, msg, fakeNc);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(observedCounter).toBeUndefined();
+  });
+
+  it("responds with 'unknown session' when subject sessionId is not registered", async () => {
+    const reg = new CapabilityHandlerRegistry();
+    const publishedReplies: string[] = [];
+    const nc = {
+      publish: (_subject: string, data: Uint8Array) => {
+        publishedReplies.push(sc.decode(data));
+      },
+    } as unknown as typeof fakeNc;
+
+    const msg = makeMsg("caps.ghost-session.llm.generate", { prompt: "hi" });
+    const handler = (
+      reg as unknown as {
+        handleLlm: (err: Error | null, msg: ReturnType<typeof makeMsg>, nc: typeof fakeNc) => void;
+      }
+    ).handleLlm;
+    handler(null, msg, nc);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(publishedReplies).toHaveLength(1);
+    expect(JSON.parse(publishedReplies[0]!)).toEqual({ error: "unknown session" });
+    // createLlmGenerateHandler must not have been called for an unknown session.
+    expect(createLlmGenerateHandlerMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/atlasd/src/capability-handlers.ts
+++ b/apps/atlasd/src/capability-handlers.ts
@@ -7,6 +7,7 @@
  */
 
 import type { AgentLLMConfig } from "@atlas/agent-sdk";
+import { enterUsageScope, type UsageCounter } from "@atlas/llm";
 import type { Logger } from "@atlas/logger";
 import { logger as rootLogger } from "@atlas/logger";
 import {
@@ -26,6 +27,15 @@ export interface CapabilityContext {
   agentLlmConfig?: AgentLLMConfig;
   logger: Logger;
   abortSignal?: AbortSignal;
+  /**
+   * Optional usage counter from the calling scope (e.g. a workspace-chat
+   * turn). When set, `handleLlm` re-enters this counter via
+   * `enterUsageScope` before invoking the LLM handler, so the
+   * traceModel-wrapped model bumps the same counter the caller is reading.
+   * Bridges the NATS subscriber boundary, which is otherwise its own ALS
+   * root.
+   */
+  usageCounter?: UsageCounter;
 }
 
 export class CapabilityHandlerRegistry {
@@ -96,7 +106,11 @@ export class CapabilityHandlerRegistry {
       logger: ctx.logger,
     });
 
-    handler(sc.decode(msg.data))
+    const run = ctx.usageCounter
+      ? () => enterUsageScope(ctx.usageCounter!, () => handler(sc.decode(msg.data)))
+      : () => handler(sc.decode(msg.data));
+
+    run()
       .then((result) => this.respond(nc, msg, result))
       .catch((e) =>
         this.respond(

--- a/apps/atlasd/src/process-agent-executor.ts
+++ b/apps/atlasd/src/process-agent-executor.ts
@@ -17,6 +17,7 @@
 import { spawn } from "node:child_process";
 import process from "node:process";
 import type { AgentExecutionSuccess, AgentResult, AtlasUIMessageChunk } from "@atlas/agent-sdk";
+import { getActiveUsageCounter } from "@atlas/llm";
 import { logger as rootLogger } from "@atlas/logger";
 import type { CodeAgentExecutorOptions } from "@atlas/workspace/agent-executor-utils";
 import { serializeAgentContext } from "@atlas/workspace/agent-executor-utils";
@@ -56,6 +57,12 @@ export class ProcessAgentExecutor {
       agentLlmConfig: options.agentLlmConfig,
       logger: options.logger,
       abortSignal: options.abortSignal,
+      // Forward the calling scope's usage counter so the daemon's LLM
+      // capability handler can bump the same object across the NATS hop.
+      // ALS lookup happens here (in the workspace-chat tool-execute async
+      // chain), then the reference rides the CapabilityContext until
+      // unregister().
+      usageCounter: getActiveUsageCounter(),
     });
 
     // 2. Subscribe to stream events from the agent on the private subprocess→host

--- a/packages/bundled-agents/src/hubspot/agent.ts
+++ b/packages/bundled-agents/src/hubspot/agent.ts
@@ -1,7 +1,7 @@
 import { env } from "node:process";
 import { createAgent, err, ok, repairToolCall } from "@atlas/agent-sdk";
 import { collectToolUsageFromSteps, streamTextWithEvents } from "@atlas/agent-sdk/vercel-helpers";
-import { registry, traceModel } from "@atlas/llm";
+import { getCachingRequestOpts, getDefaultProviderOpts, registry, traceModel } from "@atlas/llm";
 import { stringifyError } from "@atlas/utils";
 import { Client, DEFAULT_LIMITER_OPTIONS } from "@hubspot/api-client";
 import { stepCountIs } from "ai";
@@ -632,14 +632,17 @@ export const hubspotAgent = createAgent<string, HubSpotOutput>({
       const result = await streamTextWithEvents({
         params: {
           model: traceModel(registry.languageModel("anthropic:claude-sonnet-4-6")),
-          messages: [
-            { role: "system", content: SYSTEM_PROMPT },
-            { role: "user", content: prompt },
-          ],
+          system: {
+            role: "system",
+            content: SYSTEM_PROMPT,
+            providerOptions: getDefaultProviderOpts("anthropic"),
+          },
+          prompt,
           tools,
           abortSignal,
           maxRetries: 3,
           stopWhen: stepCountIs(MAX_STEPS),
+          providerOptions: getCachingRequestOpts({ cacheKey: "hubspot" }),
           experimental_repairToolCall: repairToolCall,
         },
         stream,

--- a/packages/bundled-agents/src/knowledge/agent.ts
+++ b/packages/bundled-agents/src/knowledge/agent.ts
@@ -6,7 +6,7 @@
  */
 import process from "node:process";
 import { createAgent, err, ok } from "@atlas/agent-sdk";
-import { getDefaultProviderOpts, registry, traceModel } from "@atlas/llm";
+import { getCachingRequestOpts, registry, traceModel } from "@atlas/llm";
 import { stringifyError } from "@atlas/utils";
 import { Database } from "@db/sqlite";
 import { generateText } from "ai";
@@ -284,16 +284,17 @@ export const knowledgeHybridAgent = createAgent<string, KnowledgeResult>({
       const systemPrompt = buildHybridPrompt(reranked, bm25Count, vecCount, guidelines);
       const llmStart = performance.now();
 
+      // No Anthropic cache_control here: `buildHybridPrompt` interpolates
+      // per-query search results into the system prompt, so the prefix
+      // changes every call — a cache breakpoint would pay write cost
+      // every turn with zero read hits. OpenAI's `promptCacheKey` is a
+      // routing hint and is harmless when the prefix doesn't actually
+      // cache, so keep it for the small "role" header that's stable.
       const result = await generateText({
         model: traceModel(registry.languageModel("anthropic:claude-sonnet-4-6")),
-        messages: [
-          {
-            role: "system",
-            content: systemPrompt,
-            providerOptions: getDefaultProviderOpts("anthropic"),
-          },
-          { role: "user", content: synthesisQuery },
-        ],
+        system: systemPrompt,
+        prompt: synthesisQuery,
+        providerOptions: getCachingRequestOpts({ cacheKey: "knowledge" }),
         temperature: 0,
         maxRetries: 2,
         abortSignal,

--- a/packages/bundled-agents/src/knowledge/rerank.ts
+++ b/packages/bundled-agents/src/knowledge/rerank.ts
@@ -86,17 +86,11 @@ export async function rerank(
     const { object } = await generateObject({
       model: groq("meta-llama/llama-4-scout-17b-16e-instruct"),
       schema: RerankResponseSchema,
-      messages: [
-        {
-          role: "system",
-          content:
-            "You are a relevance scorer. Given a query and documents, rate each document 0-10. " +
-            "knowledge_base and confluence documents get a +2 bonus when they address the query topic. " +
-            "Respond in JSON with a rankings array.",
-        },
-        {
-          role: "user",
-          content: `<query>${escapeForPrompt(query)}</query>
+      system:
+        "You are a relevance scorer. Given a query and documents, rate each document 0-10. " +
+        "knowledge_base and confluence documents get a +2 bonus when they address the query topic. " +
+        "Respond in JSON with a rankings array.",
+      prompt: `<query>${escapeForPrompt(query)}</query>
 
 <documents>
 ${candidateXml}
@@ -105,8 +99,6 @@ ${candidateXml}
 Score every document's relevance to the query (0 = irrelevant, 10 = perfect match).
 
 Example output: {"rankings": [{"index": 0, "score": 8}, {"index": 1, "score": 3}]}`,
-        },
-      ],
       temperature: 0,
     });
 

--- a/packages/bundled-agents/src/slack/communicator.ts
+++ b/packages/bundled-agents/src/slack/communicator.ts
@@ -17,7 +17,7 @@ import {
   streamTextWithEvents,
 } from "@atlas/agent-sdk/vercel-helpers";
 
-import { getDefaultProviderOpts, registry, traceModel } from "@atlas/llm";
+import { getCachingRequestOpts, getDefaultProviderOpts, registry, traceModel } from "@atlas/llm";
 import { stringifyError } from "@atlas/utils";
 import { generateObject, stepCountIs, wrapLanguageModel } from "ai";
 import { z } from "zod";
@@ -123,6 +123,7 @@ export const slackCommunicatorAgent = createAgent<string, SlackOutput>({
 
     const planResult = await generateObject({
       model: traceModel(registry.languageModel("anthropic:claude-haiku-4-5")),
+      allowSystemInMessages: true,
       messages: [
         {
           role: "system",
@@ -136,6 +137,7 @@ export const slackCommunicatorAgent = createAgent<string, SlackOutput>({
       temperature: 0,
       maxOutputTokens: 2000,
       maxRetries: 3,
+      providerOptions: getCachingRequestOpts({ cacheKey: "slack-plan" }),
       experimental_repairText: repairJson,
     });
 
@@ -161,6 +163,7 @@ export const slackCommunicatorAgent = createAgent<string, SlackOutput>({
           model: traceModel(registry.languageModel("anthropic:claude-haiku-4-5")),
           abortSignal,
           maxRetries: 3,
+          allowSystemInMessages: true,
           messages: [
             {
               role: "system",
@@ -171,7 +174,10 @@ export const slackCommunicatorAgent = createAgent<string, SlackOutput>({
           ],
           tools,
           maxOutputTokens: 2000,
-          providerOptions: { anthropic: { thinking: { type: "enabled", budgetTokens: 12000 } } },
+          providerOptions: {
+            anthropic: { thinking: { type: "enabled", budgetTokens: 12000 } },
+            ...getCachingRequestOpts({ cacheKey: "slack-translate" }),
+          },
           stopWhen: stepCountIs(10),
           experimental_repairToolCall: repairToolCall,
         },
@@ -257,6 +263,7 @@ export const slackCommunicatorAgent = createAgent<string, SlackOutput>({
           }),
           abortSignal,
           maxRetries: 3,
+          allowSystemInMessages: true,
           messages: [
             {
               role: "system",
@@ -269,7 +276,10 @@ export const slackCommunicatorAgent = createAgent<string, SlackOutput>({
           toolChoice: "auto",
           stopWhen: stepCountIs(10),
           maxOutputTokens: 800,
-          providerOptions: { anthropic: { thinking: { type: "enabled", budgetTokens: 12000 } } },
+          providerOptions: {
+            anthropic: { thinking: { type: "enabled", budgetTokens: 12000 } },
+            ...getCachingRequestOpts({ cacheKey: "slack-execute" }),
+          },
           experimental_repairToolCall: repairToolCall,
         },
         stream,

--- a/packages/bundled-agents/src/summary.ts
+++ b/packages/bundled-agents/src/summary.ts
@@ -4,7 +4,7 @@ import {
   extractArtifactRefsFromToolResults,
   streamTextWithEvents,
 } from "@atlas/agent-sdk/vercel-helpers";
-import { getDefaultProviderOpts, registry, traceModel } from "@atlas/llm";
+import { getCachingRequestOpts, getDefaultProviderOpts, registry, traceModel } from "@atlas/llm";
 import { stringifyError } from "@atlas/utils";
 import { stepCountIs } from "ai";
 import { z } from "zod";
@@ -88,6 +88,7 @@ export const summaryAgent = createAgent<string, SummaryOutput>({
           model: traceModel(registry.languageModel("anthropic:claude-haiku-4-5")),
           abortSignal,
           maxRetries: 3,
+          allowSystemInMessages: true,
           messages: [
             {
               role: "system",
@@ -98,7 +99,10 @@ export const summaryAgent = createAgent<string, SummaryOutput>({
           ],
           tools,
           maxOutputTokens: 2000,
-          providerOptions: { anthropic: { thinking: { type: "enabled", budgetTokens: 12000 } } },
+          providerOptions: {
+            anthropic: { thinking: { type: "enabled", budgetTokens: 12000 } },
+            ...getCachingRequestOpts({ cacheKey: "summary" }),
+          },
           stopWhen: stepCountIs(10),
           experimental_repairToolCall: repairToolCall,
         },

--- a/packages/bundled-agents/src/web/index.ts
+++ b/packages/bundled-agents/src/web/index.ts
@@ -2,7 +2,13 @@ import { randomUUID } from "node:crypto";
 import process from "node:process";
 import { createAgent, err, ok } from "@atlas/agent-sdk";
 import { streamTextWithEvents } from "@atlas/agent-sdk/vercel-helpers";
-import { registry, temporalGroundingMessage, traceModel } from "@atlas/llm";
+import {
+  getCachingRequestOpts,
+  getDefaultProviderOpts,
+  registry,
+  temporalGroundingMessage,
+  traceModel,
+} from "@atlas/llm";
 import { stringifyError } from "@atlas/utils";
 import { stepCountIs } from "ai";
 import { z } from "zod";
@@ -80,8 +86,13 @@ export const webAgent = createAgent<string, WebAgentResult>({
       const result = await streamTextWithEvents({
         params: {
           model: traceModel(registry.languageModel("anthropic:claude-sonnet-4-6")),
+          allowSystemInMessages: true,
           messages: [
-            { role: "system", content: getWebAgentPrompt({ hasSearch: hasSearchKey }) },
+            {
+              role: "system",
+              content: getWebAgentPrompt({ hasSearch: hasSearchKey }),
+              providerOptions: getDefaultProviderOpts("anthropic"),
+            },
             temporalGroundingMessage(),
             { role: "user", content: prompt },
           ],
@@ -89,7 +100,10 @@ export const webAgent = createAgent<string, WebAgentResult>({
           stopWhen: stepCountIs(300),
           maxRetries: 3,
           abortSignal,
-          providerOptions: { anthropic: { thinking: { type: "enabled", budgetTokens: 4000 } } },
+          providerOptions: {
+            anthropic: { thinking: { type: "enabled", budgetTokens: 4000 } },
+            ...getCachingRequestOpts({ cacheKey: "web" }),
+          },
         },
         stream,
       });

--- a/packages/bundled-agents/src/web/tools/search.test.ts
+++ b/packages/bundled-agents/src/web/tools/search.test.ts
@@ -25,6 +25,8 @@ vi.mock("@atlas/llm", () => ({
   registry: { languageModel: vi.fn(() => "mock-model") },
   traceModel: vi.fn((m: unknown) => m),
   temporalGroundingMessage: vi.fn(() => ({ role: "system", content: "Today is 2026-03-11" })),
+  getDefaultProviderOpts: vi.fn(() => ({})),
+  getCachingRequestOpts: vi.fn(() => ({})),
 }));
 
 vi.mock("@atlas/agent-sdk", async (importOriginal) => {

--- a/packages/bundled-agents/src/web/tools/search.ts
+++ b/packages/bundled-agents/src/web/tools/search.ts
@@ -1,7 +1,14 @@
 import process from "node:process";
 import type { AgentSessionData, StreamEmitter } from "@atlas/agent-sdk";
 import { createFailTool, repairToolCall } from "@atlas/agent-sdk";
-import { type PlatformModels, registry, temporalGroundingMessage, traceModel } from "@atlas/llm";
+import {
+  getCachingRequestOpts,
+  getDefaultProviderOpts,
+  type PlatformModels,
+  registry,
+  temporalGroundingMessage,
+  traceModel,
+} from "@atlas/llm";
 import type { Logger } from "@atlas/logger";
 import { generateText, tool } from "ai";
 import { Parallel } from "parallel-web";
@@ -58,8 +65,8 @@ RECENCY (recencyDays):
 
 EXAMPLES:
 
-"Who is Parker Conrad?"
-→ analyzeQuery: {"complexity":"simple","searchQueries":["Parker Conrad","Parker Conrad CEO","Parker Conrad Rippling founder"]}
+"Who is Stephen Curry?"
+→ analyzeQuery: {"complexity":"simple","searchQueries":["Stephen Curry","Stephen Curry NBA","Stephen Curry Warriors point guard"]}
 
 "Compare IBM and Google quantum computing 2024"
 → analyzeQuery: {"complexity":"complex","searchQueries":["IBM quantum 2024","Google quantum AI 2024","IBM vs Google quantum","quantum error correction"],"recencyDays":365}
@@ -103,11 +110,17 @@ async function analyzeQuery(
   try {
     const response = await generateText({
       model: traceModel(registry.languageModel(ANALYSIS_MODEL)),
+      allowSystemInMessages: true,
       messages: [
-        { role: "system", content: QUERY_ANALYSIS_PROMPT },
+        {
+          role: "system",
+          content: QUERY_ANALYSIS_PROMPT,
+          providerOptions: getDefaultProviderOpts("anthropic"),
+        },
         temporalGroundingMessage(),
         { role: "user", content: objective },
       ],
+      providerOptions: getCachingRequestOpts({ cacheKey: "web-search-analyze" }),
       tools: {
         analyzeQuery: tool({
           description: "Produce the query analysis for the search",
@@ -270,9 +283,14 @@ export function createSearchTool(ctx: SearchToolContext) {
         })
         .join("\n\n---\n\n");
 
+      // No cache control on this call: the system prompt is ~70 tokens,
+      // well below both Anthropic's and OpenAI's 1024-token minimum for
+      // prompt caching. Attaching `cacheControl` or `promptCacheKey`
+      // would be inert and misleading.
       const synthesis = await generateText({
         model: traceModel(registry.languageModel(SYNTHESIS_MODEL)),
         abortSignal,
+        allowSystemInMessages: true,
         messages: [
           {
             role: "system",

--- a/packages/core/src/agent-conversion/from-llm.ts
+++ b/packages/core/src/agent-conversion/from-llm.ts
@@ -9,6 +9,7 @@ import {
 } from "@atlas/agent-sdk/vercel-helpers";
 import type { LLMAgentConfig } from "@atlas/config";
 import {
+  getCachingRequestOpts,
   getDefaultProviderOpts,
   registry,
   temporalGroundingMessage,
@@ -63,7 +64,10 @@ export function convertLLMToAgent(
     outputSchema: LLMOutputSchema,
     expertise: { examples: [] },
     useWorkspaceSkills: true,
-    handler: async (prompt, { tools, stream, abortSignal, config: ctxConfig, outputSchema }) => {
+    handler: async (
+      prompt,
+      { tools, session, stream, abortSignal, config: ctxConfig, outputSchema },
+    ) => {
       try {
         // Use agent's system prompt directly - no attribution protocol injection
         let systemPrompt = config.config.prompt || "";
@@ -189,6 +193,13 @@ export function convertLLMToAgent(
             : stepCountIs(config.config.max_steps || 10),
           abortSignal,
           experimental_repairToolCall: repairToolCall,
+          // Default request-level caching (OpenAI promptCacheKey).
+          // Compose with workspaceId so an agent named e.g. "summarizer"
+          // in different workspaces gets distinct cache routes — agentId
+          // is workspace-scoped and would otherwise collide. The
+          // workspace.yml `provider_options` spread below can override
+          // by supplying its own `providerOptions` field.
+          providerOptions: getCachingRequestOpts({ cacheKey: `${session.workspaceId}:${agentId}` }),
           ...(config.config.provider_options || {}),
         });
 

--- a/packages/llm/mod.ts
+++ b/packages/llm/mod.ts
@@ -59,16 +59,27 @@ export {
 } from "./src/session-title.ts";
 export { smallLLM } from "./src/small.ts";
 export { createStubPlatformModels } from "./src/test-utils.ts";
-export { enterTraceScope, type TraceEntry, traceModel } from "./src/tracing.ts";
+export {
+  enterTraceScope,
+  enterUsageScope,
+  getActiveUsageCounter,
+  type TraceEntry,
+  traceModel,
+  type UsageCounter,
+} from "./src/tracing.ts";
 export { validateProvider } from "./src/util.ts";
 
 /**
- * Retrieves our default set of provider-specific metadata to apply
- * to generate/stream LLM calls.
- * @see https://ai-sdk.dev/docs/foundations/prompts#provider-options
+ * Per-message provider options for caching. Attach to the system message
+ * (or any content block) you want to act as the cache breakpoint.
+ *
+ * Anthropic: 1h ephemeral cache_control on the attached content block —
+ *   matches every block from the start of the prompt up to and including
+ *   the marked block, so place it on the static prefix (system prompt).
+ *   OpenAI ignores per-message providerOptions for caching.
  *
  * @param provider inference provider
- * @param overrides call-site specific options
+ * @param overrides call-site specific options merged on top of the defaults
  */
 export function getDefaultProviderOpts(
   provider: ValidProvider,
@@ -85,4 +96,21 @@ export function getDefaultProviderOpts(
     return defaults;
   }
   return deepMerge(defaults, overrides);
+}
+
+/**
+ * Top-level (request-scope) provider options for caching. Merge into the
+ * `providerOptions` field of generateText / streamText / generateObject.
+ *
+ * OpenAI: prompt_cache_key routing hint. OpenAI caches prefixes ≥1024
+ *   tokens automatically; the key improves cache-routing reliability so
+ *   requests from the same logical call site land on the same warm
+ *   cache. Use a stable per-call-site string (e.g. `"agent-summary"`,
+ *   `"slack-plan"`) — colliding keys across unrelated call sites
+ *   degrade routing.
+ * Anthropic: no top-level caching knob — cache_control sits per-message
+ *   (see `getDefaultProviderOpts`).
+ */
+export function getCachingRequestOpts(opts: { cacheKey: string }): SharedV2ProviderOptions {
+  return { openai: { promptCacheKey: opts.cacheKey } };
 }

--- a/packages/llm/src/small.ts
+++ b/packages/llm/src/small.ts
@@ -17,10 +17,8 @@ export async function smallLLM(params: {
   try {
     const result = await generateText({
       model: params.platformModels.get("labels"),
-      messages: [
-        { role: "system", content: params.system },
-        { role: "user", content: params.prompt },
-      ],
+      system: params.system,
+      prompt: params.prompt,
       abortSignal: params.abortSignal,
       temperature: 0.4,
       maxOutputTokens: params.maxOutputTokens ?? 250,

--- a/packages/llm/src/tests/tracing.test.ts
+++ b/packages/llm/src/tests/tracing.test.ts
@@ -5,7 +5,14 @@ import type {
   LanguageModelV3StreamPart,
 } from "@ai-sdk/provider";
 import { describe, expect, it } from "vitest";
-import { enterTraceScope, type TraceEntry, traceModel } from "../tracing.ts";
+import {
+  enterTraceScope,
+  enterUsageScope,
+  getActiveUsageCounter,
+  type TraceEntry,
+  traceModel,
+  type UsageCounter,
+} from "../tracing.ts";
 
 const MINIMAL_OPTS: Pick<LanguageModelV3CallOptions, "prompt"> = {
   prompt: [{ role: "user", content: [{ type: "text", text: "hi" }] }],
@@ -430,6 +437,238 @@ describe("tracing", () => {
         role: "user",
         content: [{ type: "text", text: "inner" }],
       });
+    });
+  });
+
+  describe("enterUsageScope", () => {
+    const freshCounter = (): UsageCounter => ({
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+
+    /** Model that emits cache token fields and supports a synthetic doGenerate error. */
+    function createUsageMockModel(opts?: {
+      inputTotal?: number;
+      outputTotal?: number;
+      cacheRead?: number;
+      cacheWrite?: number;
+      doGenerateError?: Error;
+      doStreamError?: Error;
+    }): LanguageModelV3 {
+      const inputTotal = opts?.inputTotal ?? 100;
+      const outputTotal = opts?.outputTotal ?? 50;
+      const cacheRead = opts?.cacheRead ?? 0;
+      const cacheWrite = opts?.cacheWrite ?? 0;
+      return {
+        specificationVersion: "v3",
+        provider: "test-provider",
+        modelId: "test-provider:test-model",
+        supportedUrls: {},
+        // deno-lint-ignore require-await
+        doGenerate: async () => {
+          if (opts?.doGenerateError) throw opts.doGenerateError;
+          return {
+            content: [{ type: "text", text: "ok" }] as LanguageModelV3Content[],
+            finishReason: { unified: "stop" as const, raw: undefined },
+            usage: {
+              inputTokens: { total: inputTotal, noCache: undefined, cacheRead, cacheWrite },
+              outputTokens: { total: outputTotal, text: undefined, reasoning: undefined },
+            },
+            warnings: [],
+          };
+        },
+        // deno-lint-ignore require-await
+        doStream: async () => {
+          if (opts?.doStreamError) throw opts.doStreamError;
+          return {
+            stream: new ReadableStream<LanguageModelV3StreamPart>({
+              start(controller) {
+                controller.enqueue({ type: "stream-start", warnings: [] });
+                controller.enqueue({
+                  type: "finish",
+                  usage: {
+                    inputTokens: { total: inputTotal, noCache: undefined, cacheRead, cacheWrite },
+                    outputTokens: { total: outputTotal, text: undefined, reasoning: undefined },
+                  },
+                  finishReason: { unified: "stop" as const, raw: undefined },
+                });
+                controller.close();
+              },
+            }),
+          };
+        },
+      };
+    }
+
+    it("getActiveUsageCounter returns the counter inside scope and undefined outside", async () => {
+      const counter = freshCounter();
+      expect(getActiveUsageCounter()).toBeUndefined();
+      await enterUsageScope(counter, () => {
+        expect(getActiveUsageCounter()).toBe(counter);
+        return Promise.resolve();
+      });
+      expect(getActiveUsageCounter()).toBeUndefined();
+    });
+
+    it("wrapGenerate mutates the counter for in-scope calls", async () => {
+      const counter = freshCounter();
+      const model = traceModel(createUsageMockModel({ inputTotal: 120, outputTotal: 70 }));
+
+      await enterUsageScope(counter, async () => {
+        await model.doGenerate(MINIMAL_OPTS);
+      });
+
+      expect(counter).toEqual({
+        inputTokens: 120,
+        outputTokens: 70,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      });
+    });
+
+    it("wrapStream mutates the counter on the finish chunk", async () => {
+      const counter = freshCounter();
+      const model = traceModel(createUsageMockModel({ inputTotal: 80, outputTotal: 40 }));
+
+      await enterUsageScope(counter, async () => {
+        const { stream } = await model.doStream(MINIMAL_OPTS);
+        await drainStream(stream);
+      });
+
+      expect(counter).toEqual({
+        inputTokens: 80,
+        outputTokens: 40,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      });
+    });
+
+    it("cache token fields under inputTokens flow into cacheReadTokens/cacheWriteTokens", async () => {
+      const counter = freshCounter();
+      const model = traceModel(
+        createUsageMockModel({
+          inputTotal: 1000,
+          outputTotal: 50,
+          cacheRead: 600,
+          cacheWrite: 200,
+        }),
+      );
+
+      await enterUsageScope(counter, async () => {
+        await model.doGenerate(MINIMAL_OPTS);
+        const { stream } = await model.doStream(MINIMAL_OPTS);
+        await drainStream(stream);
+      });
+
+      // Two calls × 1000 input each, 50 output each, 600 cacheRead, 200 cacheWrite
+      expect(counter).toEqual({
+        inputTokens: 2000,
+        outputTokens: 100,
+        cacheReadTokens: 1200,
+        cacheWriteTokens: 400,
+      });
+    });
+
+    it("nested calls all credit to the same counter", async () => {
+      const counter = freshCounter();
+      const model = traceModel(createUsageMockModel({ inputTotal: 10, outputTotal: 5 }));
+
+      await enterUsageScope(counter, async () => {
+        await model.doGenerate(MINIMAL_OPTS);
+        // Simulate a tool-execute fan-out: nested awaits inside the same scope
+        await Promise.all([
+          model.doGenerate(MINIMAL_OPTS),
+          model.doGenerate(MINIMAL_OPTS),
+          (async () => {
+            const { stream } = await model.doStream(MINIMAL_OPTS);
+            await drainStream(stream);
+          })(),
+        ]);
+      });
+
+      expect(counter.inputTokens).toBe(40);
+      expect(counter.outputTokens).toBe(20);
+    });
+
+    it("captures the counter reference at scope entry — drained outside scope still credits", async () => {
+      // The wrapStream middleware reads `usageStorage.getStore()` at scope
+      // entry (when doStream is called) and closes over it. When the
+      // consumer drains the stream later — possibly in a different async
+      // context — the captured closure must keep mutating the original
+      // counter, not look up ALS at finish-chunk time.
+      const counter = freshCounter();
+      const model = traceModel(createUsageMockModel({ inputTotal: 80, outputTotal: 40 }));
+
+      let stream: ReadableStream<LanguageModelV3StreamPart> | undefined;
+      await enterUsageScope(counter, async () => {
+        const result = await model.doStream(MINIMAL_OPTS);
+        stream = result.stream;
+      });
+
+      // We're now outside the scope.
+      expect(getActiveUsageCounter()).toBeUndefined();
+      expect(counter.inputTokens).toBe(0); // finish chunk not yet processed
+
+      if (!stream) throw new Error("stream not captured");
+      await drainStream(stream);
+
+      // The finish chunk fired outside the ALS scope — but the closure
+      // reference is intact, so the counter is still mutated.
+      expect(counter.inputTokens).toBe(80);
+      expect(counter.outputTokens).toBe(40);
+    });
+
+    it("calls outside any scope do not throw or accumulate", async () => {
+      const model = traceModel(createUsageMockModel());
+      await expect(model.doGenerate(MINIMAL_OPTS)).resolves.toBeDefined();
+      const { stream } = await model.doStream(MINIMAL_OPTS);
+      await expect(drainStream(stream)).resolves.toBeUndefined();
+    });
+
+    it("errored doGenerate does not mutate the counter", async () => {
+      const counter = freshCounter();
+      const model = traceModel(createUsageMockModel({ doGenerateError: new Error("boom") }));
+
+      await enterUsageScope(counter, async () => {
+        await expect(model.doGenerate(MINIMAL_OPTS)).rejects.toThrow("boom");
+      });
+
+      expect(counter).toEqual({
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      });
+    });
+
+    it("errored doStream (rejects before stream) does not mutate the counter", async () => {
+      const counter = freshCounter();
+      const model = traceModel(createUsageMockModel({ doStreamError: new Error("boom") }));
+
+      await enterUsageScope(counter, async () => {
+        await expect(model.doStream(MINIMAL_OPTS)).rejects.toThrow("boom");
+      });
+
+      expect(counter.inputTokens).toBe(0);
+    });
+
+    it("nested enterUsageScope shadows the outer counter (inner calls credit inner only)", async () => {
+      const outer = freshCounter();
+      const inner = freshCounter();
+      const model = traceModel(createUsageMockModel({ inputTotal: 10, outputTotal: 5 }));
+
+      await enterUsageScope(outer, async () => {
+        await model.doGenerate(MINIMAL_OPTS);
+        await enterUsageScope(inner, async () => {
+          await model.doGenerate(MINIMAL_OPTS);
+        });
+        await model.doGenerate(MINIMAL_OPTS);
+      });
+
+      expect(outer.inputTokens).toBe(20);
+      expect(inner.inputTokens).toBe(10);
     });
   });
 });

--- a/packages/llm/src/tracing.ts
+++ b/packages/llm/src/tracing.ts
@@ -7,7 +7,7 @@ import { wrapLanguageModel } from "ai";
 function endSpanWithError(span: Span | null, err: unknown): void {
   if (!span) return;
   if (err instanceof Error) span.recordException(err);
-  span.setStatus({ code: 2 /* SpanStatusCode.ERROR */, message: String(err) });
+  span.setStatus({ code: 2, /* SpanStatusCode.ERROR */ message: String(err) });
   span.end();
 }
 
@@ -37,6 +37,58 @@ interface TraceStore {
 }
 
 const traceStorage = new AsyncLocalStorage<TraceStore>();
+
+/**
+ * Running per-turn LLM usage counter. One object, mutated in place by every
+ * traceModel-wrapped call inside the active `enterUsageScope`. Memory is
+ * O(1) per scope regardless of call count — we never retain per-call detail
+ * here (that's what `TraceEntry` is for).
+ */
+export interface UsageCounter {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+}
+
+const usageStorage = new AsyncLocalStorage<UsageCounter>();
+
+/**
+ * Open a usage-accumulation scope. Every traceModel-wrapped LLM call made
+ * inside `fn` (including across async/await boundaries, including nested
+ * tool executes) increments the counter in place. Call sites read the
+ * counter after `fn` resolves.
+ *
+ * The scope does NOT propagate across process or NATS boundaries — for
+ * out-of-process LLM work (user agents going through the daemon's LLM
+ * capability handler), pass a `usageAccumulator` callback via
+ * `CapabilityContext` and have the handler invoke it explicitly.
+ */
+export function enterUsageScope<T>(counter: UsageCounter, fn: () => Promise<T>): Promise<T> {
+  return usageStorage.run(counter, fn);
+}
+
+/**
+ * Returns the active usage counter, if any. Used by code that bridges
+ * across an ALS boundary (e.g. registering a callback on a NATS capability
+ * handler) and needs to forward usage back to the calling scope.
+ */
+export function getActiveUsageCounter(): UsageCounter | undefined {
+  return usageStorage.getStore();
+}
+
+function addUsage(
+  counter: UsageCounter,
+  usage: {
+    inputTokens: { total?: number; cacheRead?: number; cacheWrite?: number };
+    outputTokens: { total?: number };
+  },
+): void {
+  counter.inputTokens += usage.inputTokens.total ?? 0;
+  counter.outputTokens += usage.outputTokens.total ?? 0;
+  counter.cacheReadTokens += usage.inputTokens.cacheRead ?? 0;
+  counter.cacheWriteTokens += usage.inputTokens.cacheWrite ?? 0;
+}
 
 /** Parse JSON, falling back to the raw string on malformed input. */
 function tryParseJson(raw: string): unknown {
@@ -76,12 +128,15 @@ export function traceModel(model: LanguageModelV3): LanguageModelV3 {
           },
           async (span) => {
             const store = traceStorage.getStore();
+            const counter = usageStorage.getStore();
             const t0 = performance.now();
             const result = await doGenerate();
             const latencyMs = performance.now() - t0;
 
             const inTok = result.usage.inputTokens.total ?? 0;
             const outTok = result.usage.outputTokens.total ?? 0;
+
+            if (counter) addUsage(counter, result.usage);
 
             if (span) {
               span.setAttributes({
@@ -130,6 +185,13 @@ export function traceModel(model: LanguageModelV3): LanguageModelV3 {
           { "llm.model": model.modelId, "llm.provider": model.provider, "llm.operation": "stream" },
           async (span) => {
             const store = traceStorage.getStore();
+            // Capture at scope entry — the TransformStream's transform()
+            // is invoked by the consumer's read loop, which may run in a
+            // different async context (writer.merge, server tee, etc.).
+            // ALS lookup at finish-time could miss the workspace-chat
+            // scope; capture the counter reference here while we're
+            // still in it.
+            const counter = usageStorage.getStore();
             const t0 = performance.now();
 
             let result: Awaited<ReturnType<typeof doStream>>;
@@ -175,6 +237,7 @@ export function traceModel(model: LanguageModelV3): LanguageModelV3 {
                   const latencyMs = performance.now() - t0;
                   const finishInTok = chunk.usage.inputTokens.total ?? 0;
                   const finishOutTok = chunk.usage.outputTokens.total ?? 0;
+                  if (counter) addUsage(counter, chunk.usage);
                   if (span && !spanEnded) {
                     span.setAttributes({
                       "llm.input_tokens": finishInTok,

--- a/packages/system/agents/session-supervisor/session-supervisor.agent.ts
+++ b/packages/system/agents/session-supervisor/session-supervisor.agent.ts
@@ -1,6 +1,6 @@
 import { createAgent, err, ok, repairJson } from "@atlas/agent-sdk";
 import { client, parseResult } from "@atlas/client/v2";
-import { getDefaultProviderOpts } from "@atlas/llm";
+import { getCachingRequestOpts, getDefaultProviderOpts } from "@atlas/llm";
 import { stringifyError } from "@atlas/utils";
 import type { SystemModelMessage, UserModelMessage } from "ai";
 import { generateObject } from "ai";
@@ -142,6 +142,7 @@ export const sessionSupervisorAgent = createAgent<SupervisorInput, SupervisorOut
         messages,
         maxOutputTokens: 16384,
         maxRetries: 3,
+        providerOptions: getCachingRequestOpts({ cacheKey: "session-supervisor" }),
         abortSignal,
       });
 

--- a/packages/system/agents/workspace-chat/workspace-chat.agent.ts
+++ b/packages/system/agents/workspace-chat/workspace-chat.agent.ts
@@ -20,7 +20,13 @@ import { scrubAssistantMessage } from "@atlas/core/artifacts/scrubber";
 import { ChatStorage } from "@atlas/core/chat/storage";
 import { createDelegateTool } from "@atlas/core/delegate";
 import { createErrorCause, getErrorDisplayMessage } from "@atlas/core/errors";
-import { buildTemporalFacts, type PlatformModels, smallLLM } from "@atlas/llm";
+import {
+  buildTemporalFacts,
+  enterUsageScope,
+  type PlatformModels,
+  smallLLM,
+  type UsageCounter,
+} from "@atlas/llm";
 import type { Logger } from "@atlas/logger";
 import { getAtlasDaemonUrl } from "@atlas/oapi-client";
 import type { SkillSummary } from "@atlas/skills";
@@ -528,9 +534,19 @@ export const workspaceChatAgent = createAgent<string, WorkspaceChatResult>({
     }
 
     let finalText: string | undefined;
-    // Per-turn token + cache usage captured from streamText.onFinish so
-    // the assistant message metadata (and downstream UI badges +
-    // /usage aggregations) can read it without re-reading session events.
+    // Per-turn token + cache usage. Mutated in place by traceModel
+    // middleware on every wrapped LLM call inside `enterUsageScope`
+    // below — that includes the parent streamText (one entry per step),
+    // every nested call fired from a tool execute (bundled agents,
+    // from-llm agents, delegate, fsm, supervisor), and user-agent
+    // `ctx.llm` requests bridged via `CapabilityContext.usageCounter`.
+    // Read in `onFinish` and written to the persisted message metadata.
+    const usageCounter: UsageCounter = {
+      inputTokens: 0,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    };
     let turnUsage:
       | {
           inputTokens?: number;
@@ -1118,7 +1134,9 @@ export const workspaceChatAgent = createAgent<string, WorkspaceChatResult>({
           // operator can spot prefix drift by comparing block-by-block
           // across turns instead of squinting at a single 26K-char blob.
           const capturedSystemMessages: string[] = [systemBlocks.block1, systemBlocks.block2];
-          if (systemBlocks.block3) capturedSystemMessages.push(systemBlocks.block3);
+          if (systemBlocks.block3) {
+            capturedSystemMessages.push(systemBlocks.block3);
+          }
           capturedSystemMessages.push(block4Preface);
           ChatStorage.setSystemPromptContext(
             session.streamId,
@@ -1254,119 +1272,151 @@ export const workspaceChatAgent = createAgent<string, WorkspaceChatResult>({
           : [];
 
         try {
-          const result = streamText({
-            model: conversationalModel,
-            experimental_repairToolCall: repairToolCall,
-            system: isAnthropic ? undefined : systemPrompt,
-            messages: isAnthropic ? [...systemModelMessages, ...modelMessages] : modelMessages,
-            allowSystemInMessages: isAnthropic ? true : undefined,
-            tools: allTools,
-            toolChoice: "auto",
-            stopWhen: [stepCountIs(40), connectServiceSucceeded(), connectCommunicatorSucceeded()],
-            maxOutputTokens: 20000,
-            experimental_transform: smoothStream({ chunking: "word" }),
-            maxRetries: 3,
-            abortSignal,
-            // Provider-level cache controls.
-            //
-            // Anthropic — per-block `cacheControl` markers sit on the
-            //   system messages above. Setting a top-level
-            //   `cache_control` here would land on the messages block
-            //   AFTER block 3, violating Anthropic's non-increasing-
-            //   TTL rule (1h cannot come after 5m). Leave it off.
-            //
-            // OpenAI — caching is automatic for prefixes ≥1024 tokens;
-            //   no explicit markers are needed. The optional
-            //   `promptCacheKey` is a routing hint that pins requests
-            //   sharing a long common prefix to the same backend, which
-            //   improves cache hit rate when the serving fleet would
-            //   otherwise scatter them. Keying on `workspaceId` groups
-            //   every chat in the same workspace onto the same cache.
-            //
-            // Other providers (Gemini, Groq) auto-cache without any
-            // markers; their unused providerOptions are no-ops.
-            providerOptions: { openai: { promptCacheKey: workspaceId } },
-            onFinish: ({ text, steps, toolCalls, toolResults, reasoningText, totalUsage }) => {
-              finalText = text;
-              // J3: harvest internal tool calls from streamText's terminal
-              // event. `collectToolUsageFromSteps` flattens per-step calls
-              // (the AI SDK populates them under `steps[*].toolCalls` /
-              // `.toolResults`) and falls back to top-level arrays. Mirrors
-              // the canonical pattern in `from-llm.ts:195-211`.
-              const collected = collectToolUsageFromSteps({ steps, toolCalls, toolResults });
-              assembledToolCalls = collected.assembledToolCalls;
-              assembledToolResults = collected.assembledToolResults;
-              assembledReasoning = reasoningText || undefined;
-              // `totalUsage` aggregates across every step in the
-              // streamText loop. `result.usage` would be the last-step
-              // count and would undercount multi-tool turns. Cache token
-              // fields ride under `inputTokenDetails` in the SDK shape;
-              // flatten so consumers don't need to know the SDK layout.
-              turnUsage = {
-                inputTokens: totalUsage.inputTokens,
-                outputTokens: totalUsage.outputTokens,
-                cacheReadTokens: totalUsage.inputTokenDetails?.cacheReadTokens,
-                cacheWriteTokens: totalUsage.inputTokenDetails?.cacheWriteTokens,
-              };
-              // Emit a `data-usage` chunk so the UI can render the
-              // badge live for the in-flight assistant turn instead of
-              // waiting for a page reload to read the persisted
-              // metadata. The persisted message metadata (set just
-              // before append, below) is the source of truth on
-              // refresh; this chunk is a peer signal for the live
-              // render path.
-              if (stream) {
-                writer.write({ id: crypto.randomUUID(), type: "data-usage", data: turnUsage });
-              }
-            },
-            onError: ({ error }) => {
-              if (!error) return;
-
-              logger.error("Stream error in workspace-chat agent", { error });
-
-              const errorCause = createErrorCause(error);
-              const displayMessage = getErrorDisplayMessage(errorCause);
-
-              if (stream && !errorEmitted) {
-                writer.write({
-                  id: crypto.randomUUID(),
-                  type: "data-error",
-                  data: { error: displayMessage, errorCause },
-                });
-                errorEmitted = true;
-              }
-            },
-          });
-
-          // Start piping the UI message stream
-          let startTimestamp: string | undefined;
-          let endTimestamp: string | undefined;
-
-          writer.merge(
-            result.toUIMessageStream({
-              originalMessages: messages,
-              messageMetadata: (metadata) => {
-                if (!startTimestamp) {
-                  startTimestamp = new Date().toISOString();
-                }
-                if (metadata.part.type === "finish") {
-                  endTimestamp = new Date().toISOString();
-                }
-                return {
-                  startTimestamp,
-                  endTimestamp,
-                  provider: conversationalModel.provider,
-                  modelId: conversationalModel.modelId,
-                  agentId: "workspace-chat",
-                  // Usage is set by `onFinish` (above) once the stream
-                  // settles. On in-flight metadata frames this is
-                  // undefined — UI consumers treat absence as
-                  // "still streaming".
-                  ...(turnUsage ? { usage: turnUsage } : {}),
+          // Open the usage scope around streamText creation AND stream
+          // consumption. `traceModel`'s wrapStream middleware captures
+          // the counter reference at scope entry (during the first
+          // `model.doStream` invocation); the mutation happens later
+          // when the transform sees the `finish` chunk, by which point
+          // the captured closure does the work — ALS context at finish
+          // time doesn't matter. The await on `result.finishReason`
+          // keeps the scope alive until every nested call (tool
+          // executes, sub-agents) has settled. Nested in-process calls
+          // ride this same scope through async/await propagation;
+          // user-agent `ctx.llm` calls cross NATS, so they bridge via
+          // `CapabilityContext.usageCounter` (see
+          // ProcessAgentExecutor).
+          await enterUsageScope(usageCounter, async () => {
+            const result = streamText({
+              model: conversationalModel,
+              experimental_repairToolCall: repairToolCall,
+              system: isAnthropic ? undefined : systemPrompt,
+              messages: isAnthropic ? [...systemModelMessages, ...modelMessages] : modelMessages,
+              allowSystemInMessages: isAnthropic ? true : undefined,
+              tools: allTools,
+              toolChoice: "auto",
+              stopWhen: [
+                stepCountIs(40),
+                connectServiceSucceeded(),
+                connectCommunicatorSucceeded(),
+              ],
+              maxOutputTokens: 20000,
+              experimental_transform: smoothStream({ chunking: "word" }),
+              maxRetries: 3,
+              abortSignal,
+              // Provider-level cache controls.
+              //
+              // Anthropic — per-block `cacheControl` markers sit on the
+              //   system messages above. Setting a top-level
+              //   `cache_control` here would land on the messages block
+              //   AFTER block 3, violating Anthropic's non-increasing-
+              //   TTL rule (1h cannot come after 5m). Leave it off.
+              //
+              // OpenAI — caching is automatic for prefixes ≥1024 tokens;
+              //   no explicit markers are needed. The optional
+              //   `promptCacheKey` is a routing hint that pins requests
+              //   sharing a long common prefix to the same backend, which
+              //   improves cache hit rate when the serving fleet would
+              //   otherwise scatter them. Keying on `workspaceId` groups
+              //   every chat in the same workspace onto the same cache.
+              //
+              // Other providers (Gemini, Groq) auto-cache without any
+              // markers; their unused providerOptions are no-ops.
+              providerOptions: { openai: { promptCacheKey: workspaceId } },
+              onFinish: ({ text, steps, toolCalls, toolResults, reasoningText }) => {
+                finalText = text;
+                // J3: harvest internal tool calls from streamText's terminal
+                // event. `collectToolUsageFromSteps` flattens per-step calls
+                // (the AI SDK populates them under `steps[*].toolCalls` /
+                // `.toolResults`) and falls back to top-level arrays. Mirrors
+                // the canonical pattern in `from-llm.ts:195-211`.
+                const collected = collectToolUsageFromSteps({ steps, toolCalls, toolResults });
+                assembledToolCalls = collected.assembledToolCalls;
+                assembledToolResults = collected.assembledToolResults;
+                assembledReasoning = reasoningText || undefined;
+                // Snapshot the accumulator at turn-end. By the time
+                // onFinish fires the wrapStream middleware has already
+                // processed the parent's `finish` chunk, and every
+                // nested call's `wrapGenerate`/`wrapStream` has
+                // resolved, so the counter holds the full turn total
+                // (parent multi-step + all in-process nested calls +
+                // any cross-NATS user-agent LLM calls).
+                turnUsage = {
+                  inputTokens: usageCounter.inputTokens,
+                  outputTokens: usageCounter.outputTokens,
+                  cacheReadTokens: usageCounter.cacheReadTokens,
+                  cacheWriteTokens: usageCounter.cacheWriteTokens,
                 };
+                // Emit a `data-usage` chunk so the UI can render the
+                // badge live for the in-flight assistant turn instead of
+                // waiting for a page reload to read the persisted
+                // metadata. The persisted message metadata (set just
+                // before append, below) is the source of truth on
+                // refresh; this chunk is a peer signal for the live
+                // render path.
+                if (stream) {
+                  writer.write({ id: crypto.randomUUID(), type: "data-usage", data: turnUsage });
+                }
               },
-            }),
-          );
+              onError: ({ error }) => {
+                if (!error) return;
+
+                logger.error("Stream error in workspace-chat agent", { error });
+
+                const errorCause = createErrorCause(error);
+                const displayMessage = getErrorDisplayMessage(errorCause);
+
+                if (stream && !errorEmitted) {
+                  writer.write({
+                    id: crypto.randomUUID(),
+                    type: "data-error",
+                    data: { error: displayMessage, errorCause },
+                  });
+                  errorEmitted = true;
+                }
+              },
+            });
+
+            // Start piping the UI message stream
+            let startTimestamp: string | undefined;
+            let endTimestamp: string | undefined;
+
+            writer.merge(
+              result.toUIMessageStream({
+                originalMessages: messages,
+                messageMetadata: (metadata) => {
+                  if (!startTimestamp) {
+                    startTimestamp = new Date().toISOString();
+                  }
+                  if (metadata.part.type === "finish") {
+                    endTimestamp = new Date().toISOString();
+                  }
+                  return {
+                    startTimestamp,
+                    endTimestamp,
+                    provider: conversationalModel.provider,
+                    modelId: conversationalModel.modelId,
+                    agentId: "workspace-chat",
+                    // Usage is set by `onFinish` (above) once the stream
+                    // settles. On in-flight metadata frames this is
+                    // undefined — UI consumers treat absence as
+                    // "still streaming".
+                    ...(turnUsage ? { usage: turnUsage } : {}),
+                  };
+                },
+              }),
+            );
+
+            // Keep the usage scope alive until the stream actually
+            // completes. Awaiting any of `result.finishReason`,
+            // `result.usage`, etc. blocks here until the underlying
+            // stream settles — at which point every wrapStream
+            // middleware (parent + nested) has already mutated the
+            // counter and the onFinish snapshot above has fired. The
+            // outer pipeUIMessageStream consumer continues to pull
+            // chunks while we're parked here, so this await doesn't
+            // deadlock the merge.
+            await result.finishReason;
+          });
         } catch (error) {
           const errorCause = createErrorCause(error);
           const displayMessage = getErrorDisplayMessage(errorCause);

--- a/packages/system/agents/workspace-chat/workspace-chat.handler.test.ts
+++ b/packages/system/agents/workspace-chat/workspace-chat.handler.test.ts
@@ -300,7 +300,11 @@ function setupDefaultMocks(existingMessages: AtlasUIMessage[] = []): void {
   // convertToModelMessages: pass through
   mockConvertToModelMessages.mockImplementation((msgs: unknown) => msgs);
 
-  // streamText: returns an object with toUIMessageStream
+  // streamText: returns an object with toUIMessageStream + finishReason.
+  // The real workspace-chat now opens an `enterUsageScope` and awaits
+  // `result.finishReason` to keep that scope alive until the underlying
+  // stream settles — the mock must therefore expose `finishReason` as a
+  // resolved promise so the await actually resolves under test.
   mockStreamText.mockImplementation((opts: { onFinish?: (arg: { text: string }) => void }) => {
     opts.onFinish?.({ text: "Hello from LLM" });
     return {
@@ -311,6 +315,7 @@ function setupDefaultMocks(existingMessages: AtlasUIMessage[] = []): void {
           },
         }),
       ),
+      finishReason: Promise.resolve("stop"),
     };
   });
 
@@ -668,6 +673,7 @@ describe("workspace-chat handler", () => {
             },
           }),
         ),
+        finishReason: Promise.resolve("stop"),
       };
     });
 
@@ -753,6 +759,7 @@ describe("workspace-chat handler", () => {
             },
           }),
         ),
+        finishReason: Promise.resolve("stop"),
       };
     });
 
@@ -1050,6 +1057,7 @@ describe("workspace-chat handler", () => {
               },
             }),
           ),
+          finishReason: Promise.resolve("stop"),
         };
       },
     );

--- a/tools/evals/lib/llm-judge.ts
+++ b/tools/evals/lib/llm-judge.ts
@@ -29,6 +29,7 @@ export async function llmJudge(output: unknown, criteria: string): Promise<Score
     schema: evaluationSchema,
     experimental_repairText: repairJson,
     maxOutputTokens: 2000,
+    allowSystemInMessages: true,
     messages: [
       {
         role: "system",


### PR DESCRIPTION
## Summary

- Wires prompt caching across the bundled agents, the workspace-yml LLM agent runner, and a couple of system agents that were uncached or only partially cached. Anthropic per-message `cacheControl` on stable prefixes, OpenAI top-level `promptCacheKey` for routing. Skips caching where it'd be inert (sub-1024-token prompts) or wasteful (dynamic prompts that change every turn — write-without-read churn).
- Adds an `enterUsageScope` ALS primitive in `@atlas/llm`. The `traceModel` middleware (already wraps every model in the repo) reads the active counter on each `wrapGenerate` / `wrapStream` and bumps it in place. Memory is O(1) per turn — single mutable counter, not a list of entries. Workspace-chat opens the scope around `streamText` and snapshots the counter in `onFinish`, so the persisted `metadata.usage` reflects total turn cost across nested bundled-agent / sub-agent / FSM calls instead of just the parent model.
- Bridges the user-agent `ctx.llm` path: `handleLlm` runs in a NATS subscriber callback (its own ALS root), so `ProcessAgentExecutor` reads the active counter at register-time and threads the reference into `CapabilityContext`; `handleLlm` re-enters the same counter via `enterUsageScope` before running the LLM handler. Same counter object is mutated across the NATS hop.
- Also clears the AI SDK "system in messages" warning at every call site — routes to the `system:` parameter where the system block doesn't need per-message `providerOptions`, sets `allowSystemInMessages: true` where it does.

## Implementation notes

**Caching by call site:**
- Static, ≥1024-token system prompts get cache control: hubspot, web (main loop), summary, slack (plan/translate/execute), session-supervisor, from-llm.ts agents, web search query-analysis
- Dynamic system prompt skips per-message cache control (would write every turn with no read hits): knowledge synthesis
- Sub-1024-token system prompts skip both (inert anyway): web search synthesis, knowledge rerank, llm-judge, the small/labels helper
- `from-llm.ts` cache key composes `${workspaceId}:${agentId}` so an agent named e.g. "summarizer" in different workspaces gets distinct cache routes

**Usage scope:**
- `enterUsageScope(counter, fn)` opens `AsyncLocalStorage<UsageCounter>`. The middleware mutates `inputTokens / outputTokens / cacheReadTokens / cacheWriteTokens` directly. Counter ref is captured at scope entry inside `wrapStream` so the transform mutation still works when the consumer drains the stream in a different async context.
- Workspace-chat's `onFinish` no longer reads `streamText.totalUsage` — the counter already covers parent multi-step + nested calls in one read.

## Test plan

- [x] `deno task typecheck` — 0 errors / 8340 files
- [x] `npx knip` — clean
- [x] `deno task test --run` — all green
- [x] 11 new tests for `enterUsageScope` in `tracing.test.ts` (scope visibility, generate/stream mutation, cache-token field flow, nested accumulation, counter-ref captured at scope entry survives stream-drained-after-scope-exit, no mutation outside scope, errored calls don't mutate, nested scopes shadow)
- [x] 3 new tests for the NATS bridge in `capability-handlers.test.ts` (re-enters registered counter, skips wrap when none, unknown-session fallback)
- [x] `workspace-chat.handler.test.ts` mock now exposes `finishReason: Promise<...>` so the new `await result.finishReason` in production is exercised under test
- [x] Smoke test in dev: send a chat turn that fans out to a bundled agent and confirm the assistant message metadata's `usage` reflects both the parent model and the bundled agent's tokens