### PR TITLE
Chat-UI: right-align user bubble after virtualization regression

### DIFF
--- a/tools/agent-playground/src/lib/components/chat/chat-message-list.svelte
+++ b/tools/agent-playground/src/lib/components/chat/chat-message-list.svelte
@@ -1014,6 +1014,12 @@
   }
 
   .virtual-item {
+    /* Flex column so `.message.user`'s `align-self: flex-end` still
+       right-anchors the bubble. Without this each item is a plain
+       block and the user bubble stretches to the full inset-inline
+       span instead of shrinking to its content. */
+    display: flex;
+    flex-direction: column;
     inset-block-start: 0;
     inset-inline: 0;
     /* The flex `gap` doesn't reach absolute children, so the


### PR DESCRIPTION
## Summary

- `.virtual-item` (introduced by the chat virtualizer) is an absolutely-positioned block with `inset-inline: 0`, which broke `.message.user`'s `align-self: flex-end` because `align-self` only resolves inside a flex parent. User bubbles stretched full width and the actions row (timestamp + ellipsis) splayed across the chat.
- Pure CSS fix: add `display: flex; flex-direction: column;` to `.virtual-item` so the existing `.message.user { align-self: flex-end }` right-anchors at content width again (capped by `max-inline-size: 95%`). Assistant bubbles keep their `width: 100%` + `margin-inline-end: auto` left-anchored layout.
- No template / imperative DOM changes — the recent streamed-bubble blank-out fix (`copyButtons` micro-task gating) is untouched. Virtualizer `measureElement` reads `offsetHeight`, which is identical under flex-column vs block when the container has a single block child.

## Test plan

- [ ] Send a user message, confirm the blue bubble right-anchors and sizes to content (≤95% of column width).
- [ ] Long user message wraps inside the bubble, doesn't exceed 95%.
- [ ] Assistant reply renders left-anchored at full width as before.
- [ ] Timestamp + ellipsis row sits directly under the bubble at the correct edge for the role.
- [ ] System messages still center-aligned.
- [ ] Thinking placeholder unaffected.
- [ ] Stream a long assistant reply with code blocks / tables — copy-button wrappers still inject and don't blank out the bubble.