### PR TITLE
Chat-UI: open markdown links in a new tab (fixes #263)

### DIFF
--- a/packages/ui/src/lib/markdown/markdown.test.ts
+++ b/packages/ui/src/lib/markdown/markdown.test.ts
@@ -571,6 +571,7 @@ describe("markdownToHTMLSafe", () => {
   it("does not set target=_blank on in-page anchors", () => {
     const result = markdownToHTMLSafe("[toc](#section)");
     expect(result).toContain('href="#section"');
+    expect(result).toContain(">toc</a>");
     expect(result).not.toContain('target="_blank"');
   });
 

--- a/packages/ui/src/lib/markdown/markdown.test.ts
+++ b/packages/ui/src/lib/markdown/markdown.test.ts
@@ -232,7 +232,9 @@ describe("markdownToHTML", () => {
   it("in-page anchor links skip target=_blank", () => {
     const html = markdownToHTML("[see](#foo) and [out](https://example.com)");
     expect(html).toContain('<a href="#foo">see</a>');
-    expect(html).toContain('<a href="https://example.com" target="_blank">out</a>');
+    expect(html).toContain(
+      '<a href="https://example.com" target="_blank" rel="noopener noreferrer">out</a>',
+    );
   });
 
   it("H5 to bold paragraph", () => {
@@ -262,10 +264,11 @@ describe("markdownToHTML", () => {
     expect(markdownToHTML("")).toEqual("");
   });
 
-  it("links open in new tab", () => {
+  it("links open in new tab with reverse-tabnabbing protection", () => {
     const result = markdownToHTML("[link text](https://example.com)");
     expect(result).toContain('href="https://example.com"');
     expect(result).toContain('target="_blank"');
+    expect(result).toContain('rel="noopener noreferrer"');
     expect(result).toContain("link text");
   });
 
@@ -552,6 +555,23 @@ describe("markdownToHTMLSafe", () => {
     expect(result).toContain("<strong>bold</strong>");
     expect(result).toContain('href="https://example.com"');
     expect(result).toContain(">link</a>");
+  });
+
+  it("keeps target=_blank and rel through sanitisation so chat links open in a new tab (#263)", () => {
+    // DOMPurify 2.x strips `target` by default; without the ADD_ATTR
+    // allowlist the marked renderer's `target="_blank"` was silently
+    // dropped here, and chat links navigated the host tab. Re-asserting
+    // both attrs survive guards against future config drift.
+    const result = markdownToHTMLSafe("[click](https://example.com)");
+    expect(result).toContain('href="https://example.com"');
+    expect(result).toContain('target="_blank"');
+    expect(result).toContain('rel="noopener noreferrer"');
+  });
+
+  it("does not set target=_blank on in-page anchors", () => {
+    const result = markdownToHTMLSafe("[toc](#section)");
+    expect(result).toContain('href="#section"');
+    expect(result).not.toContain('target="_blank"');
   });
 
   it("preserves text content of stripped script tags as harmless text", () => {

--- a/packages/ui/src/lib/markdown/markdown.ts
+++ b/packages/ui/src/lib/markdown/markdown.ts
@@ -37,9 +37,11 @@ function slugifyHeading(text: string): string {
 const renderer = {
   // Open links in a new tab — except in-page anchors (`#foo`), which must
   // stay same-tab so clicking a TOC entry actually scrolls the page.
+  // `rel="noopener noreferrer"` prevents the opened tab from accessing
+  // `window.opener` (reverse-tabnabbing) and from leaking the referrer.
   link({ href, text }: { href: string; text: string }): string {
-    const target = href.startsWith("#") ? "" : ' target="_blank"';
-    return `<a href="${href}"${target}>${text}</a>`;
+    if (href.startsWith("#")) return `<a href="${href}">${text}</a>`;
+    return `<a href="${href}" target="_blank" rel="noopener noreferrer">${text}</a>`;
   },
   heading({ text, depth }: { text: string; depth: number }): string {
     // H5/H6 → bold paragraph (matches prior behavior).
@@ -521,5 +523,9 @@ export function markdownToHTML(markdown: string): string {
  * `javascript:` hrefs.
  */
 export function markdownToHTMLSafe(markdown: string): string {
-  return DOMPurify.sanitize(markdownToHTML(markdown));
+  // DOMPurify strips `target` from anchors by default; allowlist it so the
+  // `target="_blank"` produced by the marked renderer above survives. The
+  // marked renderer also emits `rel="noopener noreferrer"`, which DOMPurify
+  // keeps as-is — so the pair lands intact on the rendered chat link.
+  return DOMPurify.sanitize(markdownToHTML(markdown), { ADD_ATTR: ["target"] });
 }

--- a/tools/agent-playground/src/lib/components/chat/connect-service.svelte
+++ b/tools/agent-playground/src/lib/components/chat/connect-service.svelte
@@ -9,9 +9,8 @@
   @component
 -->
 <script lang="ts">
-  import { Button, MarkdownRendered, markdownToHTML } from "@atlas/ui";
+  import { Button, MarkdownRendered, markdownToHTMLSafe } from "@atlas/ui";
   import { browser } from "$app/environment";
-  import DOMPurify from "dompurify";
   import { useCredentialConnect } from "$lib/use-credential-connect.svelte.ts";
   import CredentialSecretForm from "$lib/components/credential-secret-form.svelte";
   import { z } from "zod";
@@ -149,7 +148,7 @@
     {#if details.setupInstructions}
       <div class="instructions">
         <MarkdownRendered>
-          {@html browser ? DOMPurify.sanitize(markdownToHTML(details.setupInstructions)) : markdownToHTML(details.setupInstructions)}
+          {@html markdownToHTMLSafe(details.setupInstructions)}
         </MarkdownRendered>
       </div>
     {/if}

--- a/tools/agent-playground/src/lib/components/execution/execution-stream.svelte
+++ b/tools/agent-playground/src/lib/components/execution/execution-stream.svelte
@@ -3,9 +3,7 @@
    * Streams SSE events from the execute endpoint and renders them in real-time.
    * Parses `event:` / `data:` lines from a ReadableStream response.
    */
-  import { browser } from "$app/environment";
-  import { MarkdownRendered, markdownToHTML } from "@atlas/ui";
-  import DOMPurify from "dompurify";
+  import { MarkdownRendered, markdownToHTMLSafe } from "@atlas/ui";
   import JsonTree from "$lib/components/shared/json-tree.svelte";
   import type { LogEntry, TraceEntry } from "$lib/server/lib/sse.ts";
   import type { SSEEvent } from "$lib/sse-types.ts";
@@ -295,7 +293,7 @@
           {:else if typeof item.event.data === "string"}
             <div class="result-body">
               <MarkdownRendered>
-                {@html browser ? DOMPurify.sanitize(markdownToHTML(item.event.data)) : markdownToHTML(item.event.data)}
+                {@html markdownToHTMLSafe(item.event.data)}
               </MarkdownRendered>
             </div>
           {:else}

--- a/tools/agent-playground/src/lib/components/mcp/mcp-server-detail.svelte
+++ b/tools/agent-playground/src/lib/components/mcp/mcp-server-detail.svelte
@@ -25,11 +25,9 @@
     Dialog,
     IconSmall,
     MarkdownRendered,
-    markdownToHTML,
+    markdownToHTMLSafe,
     SimpleTable,
   } from "@atlas/ui";
-  import { browser } from "$app/environment";
-  import DOMPurify from "dompurify";
   import { writable } from "svelte/store";
   import McpConnectionTest from "./mcp-connection-test.svelte";
   import McpCredentialsPanel from "./mcp-credentials-panel.svelte";
@@ -316,9 +314,7 @@
             <h3 class="section-title">Readme</h3>
             <div class="readme-content">
               <MarkdownRendered>
-                {@html browser
-                  ? DOMPurify.sanitize(markdownToHTML(readme))
-                  : markdownToHTML(readme)}
+                {@html markdownToHTMLSafe(readme)}
               </MarkdownRendered>
             </div>
           </div>

--- a/tools/agent-playground/src/lib/components/shared/output-tabs.svelte
+++ b/tools/agent-playground/src/lib/components/shared/output-tabs.svelte
@@ -13,9 +13,7 @@
 -->
 
 <script lang="ts">
-  import { browser } from "$app/environment";
-  import { MarkdownRendered, markdownToHTML } from "@atlas/ui";
-  import DOMPurify from "dompurify";
+  import { MarkdownRendered, markdownToHTMLSafe } from "@atlas/ui";
   import ExecutionStream from "$lib/components/execution/execution-stream.svelte";
   import JsonTree from "$lib/components/shared/json-tree.svelte";
   import TracePanel from "$lib/components/shared/trace-panel.svelte";
@@ -93,7 +91,7 @@
         <div class="result-pane">
           {#if typeof result === "string"}
             <MarkdownRendered>
-              {@html browser ? DOMPurify.sanitize(markdownToHTML(result)) : markdownToHTML(result)}
+              {@html markdownToHTMLSafe(result)}
             </MarkdownRendered>
           {:else}
             <JsonTree data={result} defaultExpanded={2} />

--- a/tools/agent-playground/src/routes/artifacts/[id]/markdown/+page.svelte
+++ b/tools/agent-playground/src/routes/artifacts/[id]/markdown/+page.svelte
@@ -12,9 +12,7 @@
 -->
 
 <script lang="ts">
-  import { MarkdownRendered, markdownToHTML } from "@atlas/ui";
-  import { browser } from "$app/environment";
-  import DOMPurify from "dompurify";
+  import { MarkdownRendered, markdownToHTMLSafe } from "@atlas/ui";
   import type { PageData } from "./$types";
   import TableActionsBar from "$lib/components/chat/table-actions-bar.svelte";
   import {
@@ -28,14 +26,8 @@
   const segments = $derived<MarkdownSegment[]>(splitMarkdownByTables(data.text));
   const tableCount = $derived(segments.filter((s) => s.kind === "table").length);
 
-  // SSR renders raw HTML from `markdownToHTML`; the browser re-runs after
-  // hydration and re-sanitises through DOMPurify so any prose-side XSS
-  // shape (rare from a known-markdown artifact, but cheap to defend) is
-  // stripped before the final DOM lands. Mirrors the pattern used in
-  // execution-stream.svelte.
   function renderProse(md: string): string {
-    const html = markdownToHTML(md);
-    return browser ? DOMPurify.sanitize(html) : html;
+    return markdownToHTMLSafe(md);
   }
 </script>
 

--- a/tools/agent-playground/src/routes/discover/[[slug]]/+page.svelte
+++ b/tools/agent-playground/src/routes/discover/[[slug]]/+page.svelte
@@ -18,7 +18,7 @@
     Icons,
     ListDetail,
     MarkdownRendered,
-    markdownToHTML,
+    markdownToHTMLSafe,
     toast,
   } from "@atlas/ui";
   import { createQuery, useQueryClient } from "@tanstack/svelte-query";
@@ -27,7 +27,6 @@
   import { getClient } from "$lib/client";
   import { discoverQueries, type DiscoverDetail } from "$lib/queries/discover-queries";
   import { workspaceQueries } from "$lib/queries";
-  import DOMPurify from "dompurify";
 
   const queryClient = useQueryClient();
 
@@ -110,9 +109,7 @@
 
   const renderedReadme = $derived.by(() => {
     if (!detail || !detail.readme) return "";
-    const raw = markdownToHTML(detail.readme);
-    const rebased = rebaseRelativeLinks(raw, detail.source);
-    return DOMPurify.sanitize(rebased);
+    return rebaseRelativeLinks(markdownToHTMLSafe(detail.readme), detail.source);
   });
 </script>
 

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/jobs/[jobName]/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/jobs/[jobName]/+page.svelte
@@ -15,7 +15,7 @@
 -->
 
 <script lang="ts">
-  import { markdownToHTML, toast } from "@atlas/ui";
+  import { markdownToHTMLSafe, toast } from "@atlas/ui";
   import { createQuery, queryOptions, skipToken } from "@tanstack/svelte-query";
   import { page } from "$app/state";
   import WorkspaceBreadcrumb from "$lib/components/workspace/workspace-breadcrumb.svelte";
@@ -558,7 +558,7 @@
       </button>
     </header>
     <!-- Description is authored markdown — render it, don't dump the raw string. -->
-    <div class="drawer-desc markdown-body">{@html markdownToHTML(sel.description)}</div>
+    <div class="drawer-desc markdown-body">{@html markdownToHTMLSafe(sel.description)}</div>
     <dl class="drawer-meta">
       <dt>Version</dt><dd>v{sel.latestVersion}</dd>
       <dt>Namespace</dt><dd>{sel.namespace}</dd>

--- a/tools/agent-playground/src/routes/skills/[namespace]/[name]/+page.svelte
+++ b/tools/agent-playground/src/routes/skills/[namespace]/[name]/+page.svelte
@@ -6,17 +6,15 @@
 -->
 
 <script lang="ts">
-  import { browser } from "$app/environment";
   import {
     Button,
     Dialog,
     DropdownMenu,
     Icons,
     MarkdownRendered,
-    markdownToHTML,
+    markdownToHTMLSafe,
     toast,
   } from "@atlas/ui";
-  import DOMPurify from "dompurify";
   import { createQuery } from "@tanstack/svelte-query";
   import { beforeNavigate, goto } from "$app/navigation";
   import { page } from "$app/state";
@@ -509,7 +507,7 @@
     {:else}
       <div class="preview-content">
         <MarkdownRendered>
-          {@html browser ? DOMPurify.sanitize(rebaseRelativeLinks(markdownToHTML(skill.instructions ?? ""))) : markdownToHTML(skill.instructions ?? "")}
+          {@html rebaseRelativeLinks(markdownToHTMLSafe(skill.instructions ?? ""))}
         </MarkdownRendered>
       </div>
     {/if}

--- a/tools/agent-playground/src/routes/skills/[namespace]/[name]/[...path]/+page.svelte
+++ b/tools/agent-playground/src/routes/skills/[namespace]/[name]/[...path]/+page.svelte
@@ -14,7 +14,7 @@
     MarkdownRendered,
     highlightCode,
     languageFromPath,
-    markdownToHTML,
+    markdownToHTMLSafe,
     toast,
   } from "@atlas/ui";
   import DOMPurify from "dompurify";
@@ -169,7 +169,7 @@
       {:else if isMarkdown}
         <div class="preview-content">
           <MarkdownRendered>
-            {@html browser ? DOMPurify.sanitize(markdownToHTML(fileContent)) : markdownToHTML(fileContent)}
+            {@html markdownToHTMLSafe(fileContent)}
           </MarkdownRendered>
         </div>
       {:else if highlightedCode}


### PR DESCRIPTION
## Summary
- DOMPurify 2.x silently stripped `target` from every chat link, so clicking a link in an assistant bubble navigated the host tab and booted users out of chat (#263).
- Allowlist `target` via `ADD_ATTR: ["target"]` in `markdownToHTMLSafe` and add `rel="noopener noreferrer"` in the marked renderer for reverse-tabnabbing protection.
- In-page anchors (`#section`) still stay same-tab so TOC/heading links keep working.

## Test plan
- [x] `deno task test packages/ui/src/lib/markdown/markdown.test.ts` — 85 passing, including two new regressions that lock target/rel through the full sanitise pipeline.
- [x] Drove the fix in Chrome against the running Friday daemon: asked Friday for a markdown link, confirmed rendered DOM has `target="_blank" rel="noopener noreferrer"`, and clicking it spawned a new tab while the chat tab stayed put.