### PR TITLE
Replace stale FRIDAY_LOCAL_ONLY refs with FRIDAY_ENV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,9 +113,12 @@ FRIDAY_LOG_LEVEL=info
 # Show the internal "kernel" workspace in the picker. Off by default.
 # FRIDAY_EXPOSE_KERNEL=0
 
-# Disable any outbound calls (skill registry, telemetry). Useful for
-# air-gapped or fully-local development.
-# FRIDAY_LOCAL_ONLY=0
+# Runtime mode: `dev` auto-mints a local /api/* session and skips remote
+# credential fetching (local-first UX). Any other value — including unset —
+# requires a valid `friday_session` cookie or Bearer token and returns 401
+# otherwise. Friday Studio and `atlas daemon start` set this to `dev`
+# automatically; only set it explicitly for hand-rolled .env files.
+# FRIDAY_ENV=dev
 
 # Allow installing skills from remote registries (off by default in
 # closed environments).

--- a/docker/run-platform.sh
+++ b/docker/run-platform.sh
@@ -17,30 +17,12 @@ export FRIDAY_SQLITE3_PATH=/usr/bin/sqlite3
 # No OTEL collector in this container — disable to avoid dangling metrics
 unset OTEL_DENO
 
-# ── Auto-generate FRIDAY_KEY if not provided ──────────────────────────────────
-# FRIDAY_KEY provides user identity for authenticated endpoints (skill publish,
-# workspace creation). In single-user Docker mode, auto-generate a local JWT
-# so everything works out of the box without extra configuration.
-# ── Local-only mode ──────────────────────────────────────────────────────────
-# In Docker, credentials come from .env (not the Atlas API). Set local-only
-# mode to skip remote credential fetching, and auto-generate FRIDAY_KEY for
-# user identity if not provided.
-export FRIDAY_LOCAL_ONLY="${FRIDAY_LOCAL_ONLY:-true}"
-
-if [ -z "${FRIDAY_KEY:-}" ]; then
-    FRIDAY_KEY=$(node -e "
-        const h = Buffer.from(JSON.stringify({alg:'HS256',typ:'JWT'})).toString('base64url');
-        const p = Buffer.from(JSON.stringify({
-            iss: 'friday-platform',
-            email: 'platform-local@hellofriday.ai',
-            sub: 'local-user',
-            user_metadata: { tempest_user_id: 'local-user' }
-        })).toString('base64url');
-        console.log(h + '.' + p + '.local');
-    ")
-    export FRIDAY_KEY
-    echo "[platform] Auto-generated FRIDAY_KEY for local user identity"
-fi
+# ── Dev mode ─────────────────────────────────────────────────────────────────
+# In Docker, credentials come from .env (not the Atlas API). FRIDAY_ENV=dev
+# tells the daemon to auto-mint a local session for /api/* and skip remote
+# credential fetching, mirroring the Studio installer + `atlas daemon start`
+# behavior.
+export FRIDAY_ENV="${FRIDAY_ENV:-dev}"
 
 # ── Graceful shutdown ─────────────────────────────────────────────────────────
 shutdown() {


### PR DESCRIPTION
## Summary

- `FRIDAY_LOCAL_ONLY` was renamed to `FRIDAY_ENV` in #265, but two files still referenced the old name.
- `docker/run-platform.sh`: swap to `FRIDAY_ENV=dev` so the containerized daemon clears the new fail-closed session middleware. Also drop the placeholder-JWT `FRIDAY_KEY` auto-generation — the daemon no longer decodes `FRIDAY_KEY` for user identity (that path was deleted), and an unset `FRIDAY_KEY` already disables the upstream gateway path in the CLI, so the fake JWT served no purpose.
- `.env.example`: replace the commented-out `FRIDAY_LOCAL_ONLY=0` with a `FRIDAY_ENV=dev` example plus a description of the new fail-closed semantics for operators with hand-rolled `.env` files.

## Test plan

- [ ] `docker compose up` (or equivalent platform image run) — confirm atlasd, link, and playground come up and `/api/*` responds without 401s.
- [ ] Verify a fresh `.env` copied from `.env.example` keeps the local-first UX working when the user uncomments `FRIDAY_ENV=dev`.
- [ ] Grep confirms no remaining `FRIDAY_LOCAL_ONLY` references.