### PR TITLE
Migrations: static manifest so deno-compile binaries actually run them

### DIFF
--- a/apps/atlasd/src/migrations/index.test.ts
+++ b/apps/atlasd/src/migrations/index.test.ts
@@ -49,6 +49,23 @@ function extractMigrationId(source: string): string | null {
   return match?.[1] ?? null;
 }
 
+/**
+ * Slice the body of the `MIGRATIONS` array literal in `index.ts` and
+ * strip `//` line comments. Lets the manifest check look for `m_<id>`
+ * inside the array specifically — a bare `m_<id>` reference in a doc
+ * comment elsewhere in the file (or a temporarily-commented-out entry
+ * inside the array) would otherwise satisfy a whole-file scan and let
+ * a missing array entry through. Local to this test file; the unit
+ * tests below cover it directly so we don't have to re-read the real
+ * `index.ts` to verify the predicate.
+ */
+function extractMigrationsArrayBody(indexSource: string): string | null {
+  const re = /const MIGRATIONS:\s*readonly Migration\[\]\s*=\s*\[([\s\S]*?)\];/;
+  const slice = indexSource.match(re)?.[1];
+  if (slice === undefined) return null;
+  return slice.replace(/\/\/.*$/gm, "");
+}
+
 describe("migration manifest convention", () => {
   it("each m_*.ts filename matches the YYYYMMDD_HHMMSS_slug shape", async () => {
     const files = await listMigrationFiles();
@@ -95,14 +112,25 @@ describe("migration manifest convention", () => {
    * it pulls in `@db/sqlite` transitively, which breaks under vitest
    * the same way the other tests in this file avoid.
    *
-   * We require the local-symbol `m_<id>` to appear at least twice:
-   * once in the `import { migration as m_<id> }` line and once in
-   * the `MIGRATIONS` array. Catches both "imported but not added to
-   * the array" and "added to the array without an import."
+   * Two separate assertions per migration file:
+   *  - `from "./<file>"` appears anywhere in `index.ts` (import line).
+   *  - `m_<id>` appears inside the sliced `MIGRATIONS = [ ... ]` body
+   *    (array entry). The slice is essential — a bare `m_<id>` in a
+   *    doc comment elsewhere in the file would otherwise satisfy a
+   *    whole-file scan and let a missing array entry through.
+   *
+   * Plus a size check that the array has exactly the same number of
+   * entries as `m_*.ts` files on disk, so deleting a file but
+   * forgetting to delete its array entry (or vice versa) trips here.
    */
   it("every m_*.ts file appears in the static manifest in index.ts", async () => {
     const files = await listMigrationFiles();
     const indexSource = await readFileContent("index.ts");
+    const arrayBody = extractMigrationsArrayBody(indexSource);
+    expect(
+      arrayBody,
+      "could not locate `const MIGRATIONS: readonly Migration[] = [...]` in index.ts",
+    ).not.toBeNull();
     for (const file of files) {
       const id = file.match(FILENAME_RE)?.[1];
       expect(id, `${file}: failed to derive id from filename`).toBeTruthy();
@@ -110,11 +138,67 @@ describe("migration manifest convention", () => {
         indexSource,
         `${file}: missing \`import ... from "./${file}";\` in index.ts`,
       ).toContain(`from "./${file}"`);
-      const symbolHits = indexSource.match(new RegExp(`\\bm_${id}\\b`, "g")) ?? [];
       expect(
-        symbolHits.length,
-        `${file}: expected \`m_${id}\` in both the import and the MIGRATIONS array of index.ts, found ${symbolHits.length} occurrence(s)`,
-      ).toBeGreaterThanOrEqual(2);
+        arrayBody,
+        `${file}: missing \`m_${id}\` entry inside the MIGRATIONS array literal of index.ts`,
+      ).toMatch(new RegExp(`\\bm_${id}\\b`));
     }
+  });
+
+  it("MIGRATIONS array has exactly one entry per m_*.ts file on disk", async () => {
+    const files = await listMigrationFiles();
+    const indexSource = await readFileContent("index.ts");
+    const arrayBody = extractMigrationsArrayBody(indexSource);
+    if (arrayBody === null) {
+      throw new Error("could not locate the MIGRATIONS array literal in index.ts");
+    }
+    const entries = arrayBody
+      .split("\n")
+      .map((line) => line.trim().replace(/,$/, ""))
+      .filter((line) => /^m_\d{8}_\d{6}_[a-z][a-z0-9_]*$/.test(line));
+    expect(
+      entries.length,
+      `MIGRATIONS has ${entries.length} entries; ${files.length} m_*.ts files on disk — fix index.ts`,
+    ).toBe(files.length);
+  });
+
+  /**
+   * Lock in the predicate independently of the real `index.ts` so a
+   * future refactor of the assertion shape doesn't quietly weaken the
+   * guard. The manual negative test the author ran (delete an entry,
+   * see the test fail) is encoded here.
+   */
+  describe("extractMigrationsArrayBody", () => {
+    const sample = [
+      'import { migration as m_20260101_000000_a } from "./m_20260101_000000_a.ts";',
+      'import { migration as m_20260101_000001_b } from "./m_20260101_000001_b.ts";',
+      "",
+      "const MIGRATIONS: readonly Migration[] = [",
+      "  m_20260101_000000_a,",
+      "  m_20260101_000001_b,",
+      "];",
+    ].join("\n");
+
+    it("returns just the slice between [ and ]", () => {
+      const body = extractMigrationsArrayBody(sample);
+      expect(body).not.toBeNull();
+      expect(body).toContain("m_20260101_000000_a");
+      expect(body).toContain("m_20260101_000001_b");
+      expect(body).not.toContain("import");
+    });
+
+    it("fails to find an entry that's only in a comment outside the array", () => {
+      const withCommentOnly = sample.replace(
+        "  m_20260101_000001_b,\n",
+        "  // m_20260101_000001_b removed temporarily\n",
+      );
+      const body = extractMigrationsArrayBody(withCommentOnly);
+      expect(body).not.toBeNull();
+      expect(body).not.toMatch(/\bm_20260101_000001_b\b/);
+    });
+
+    it("returns null when the array literal isn't present", () => {
+      expect(extractMigrationsArrayBody("// no manifest here")).toBeNull();
+    });
   });
 });

--- a/apps/atlasd/src/migrations/index.test.ts
+++ b/apps/atlasd/src/migrations/index.test.ts
@@ -86,4 +86,35 @@ describe("migration manifest convention", () => {
     expect(ids.length, "every file should declare an id").toBe(files.length);
     expect(new Set(ids).size, "duplicate migration ids detected").toBe(ids.length);
   });
+
+  /**
+   * The static manifest in `index.ts` is what ships in the compiled
+   * binary; `readdir`-based discovery returns nothing under
+   * `deno compile`. So a forgotten manifest entry would silently skip
+   * a migration on every install. Scan `index.ts` as text — importing
+   * it pulls in `@db/sqlite` transitively, which breaks under vitest
+   * the same way the other tests in this file avoid.
+   *
+   * We require the local-symbol `m_<id>` to appear at least twice:
+   * once in the `import { migration as m_<id> }` line and once in
+   * the `MIGRATIONS` array. Catches both "imported but not added to
+   * the array" and "added to the array without an import."
+   */
+  it("every m_*.ts file appears in the static manifest in index.ts", async () => {
+    const files = await listMigrationFiles();
+    const indexSource = await readFileContent("index.ts");
+    for (const file of files) {
+      const id = file.match(FILENAME_RE)?.[1];
+      expect(id, `${file}: failed to derive id from filename`).toBeTruthy();
+      expect(
+        indexSource,
+        `${file}: missing \`import ... from "./${file}";\` in index.ts`,
+      ).toContain(`from "./${file}"`);
+      const symbolHits = indexSource.match(new RegExp(`\\bm_${id}\\b`, "g")) ?? [];
+      expect(
+        symbolHits.length,
+        `${file}: expected \`m_${id}\` in both the import and the MIGRATIONS array of index.ts, found ${symbolHits.length} occurrence(s)`,
+      ).toBeGreaterThanOrEqual(2);
+    }
+  });
 });

--- a/apps/atlasd/src/migrations/index.ts
+++ b/apps/atlasd/src/migrations/index.ts
@@ -1,11 +1,11 @@
 /**
- * Auto-discovered migration manifest.
+ * Static migration manifest.
  *
  * Every `m_<id>.ts` file in this directory is a migration. The id is
  * the filename without the `m_` prefix and `.ts` suffix; the file
  * exports a `migration: Migration` whose `id` field matches the
- * filename. Run order is the lexicographic sort of the filenames —
- * which means **timestamp ordering** if the convention is followed.
+ * filename. Run order is the lexicographic sort of the ids — which
+ * means **timestamp ordering** if the convention is followed.
  *
  * **ID convention** (locked-in 2026-05-03 — the legacy SHA-prefix +
  * manual-slug ids were renamed in this PR; first-merge users have
@@ -18,51 +18,81 @@
  * - The id stored in `_FRIDAY_MIGRATIONS` KV is the same string
  *   without the `m_` prefix or `.ts` suffix.
  *
- * Why timestamp-prefixed: lexicographic sort = chronological sort
- * (no manual array maintenance), parallel-branch authors get
- * distinct ids without renumbering, and the id self-documents when
- * the migration was authored.
- *
  * **Once a migration ships, NEVER rename or delete the file.** Doing
  * so orphans audit-trail records on every existing install + breaks
- * idempotency. The unit test in `index.test.ts` enforces the
- * filename↔id convention; CI fails if you violate it.
+ * idempotency. `index.test.ts` enforces the filename↔id convention
+ * AND that every `m_*.ts` on disk appears in the manifest below; CI
+ * fails if either is violated.
+ *
+ * **Why static imports, not `readdir`:** the daemon ships as a
+ * `deno compile` binary. At runtime, `import.meta.url` resolves into
+ * Deno's compile-internal virtual FS, and `readdir` on it returns
+ * nothing — so a discover-by-filesystem loader silently runs zero
+ * migrations against shipped installs. Static imports put every
+ * migration into the compile graph and survive bundling.
  */
-
-import { readdir } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
 import type { Migration } from "jetstream";
 
-/**
- * Discover and return all migrations in this directory, sorted by id
- * (which equals the filename prefix, which is the timestamp). Async
- * because dynamic imports are async; daemon awaits this once at
- * startup and the CLI awaits it before invoking `runMigrations`.
- */
-export async function getAllMigrations(): Promise<Migration[]> {
-  const dir = new URL(".", import.meta.url);
-  const dirPath = fileURLToPath(dir);
-  const entries = await readdir(dirPath, { withFileTypes: true });
-  const files: string[] = [];
-  for (const entry of entries) {
-    if (!entry.isFile()) continue;
-    if (!entry.name.startsWith("m_") || !entry.name.endsWith(".ts")) continue;
-    if (entry.name.endsWith(".test.ts")) continue;
-    files.push(entry.name);
-  }
-  files.sort();
+import { migration as m_20260501_120000_chat_to_jetstream } from "./m_20260501_120000_chat_to_jetstream.ts";
+import { migration as m_20260501_120100_memory_to_jetstream } from "./m_20260501_120100_memory_to_jetstream.ts";
+import { migration as m_20260502_140000_sessions_stream_upgrade } from "./m_20260502_140000_sessions_stream_upgrade.ts";
+import { migration as m_20260502_140100_delete_activity_db } from "./m_20260502_140100_delete_activity_db.ts";
+import { migration as m_20260502_140200_mcp_registry_to_jetstream } from "./m_20260502_140200_mcp_registry_to_jetstream.ts";
+import { migration as m_20260502_140300_cron_timers_to_jetstream } from "./m_20260502_140300_cron_timers_to_jetstream.ts";
+import { migration as m_20260502_140400_workspace_registry_to_jetstream } from "./m_20260502_140400_workspace_registry_to_jetstream.ts";
+import { migration as m_20260502_140500_scratchpad_to_jetstream } from "./m_20260502_140500_scratchpad_to_jetstream.ts";
+import { migration as m_20260502_140600_artifacts_to_jetstream } from "./m_20260502_140600_artifacts_to_jetstream.ts";
+import { migration as m_20260502_140700_drop_legacy_storage_db } from "./m_20260502_140700_drop_legacy_storage_db.ts";
+import { migration as m_20260503_100000_repair_artifact_object_store } from "./m_20260503_100000_repair_artifact_object_store.ts";
+import { migration as m_20260503_110000_workspace_state_to_jetstream } from "./m_20260503_110000_workspace_state_to_jetstream.ts";
+import { migration as m_20260503_110100_skills_to_jetstream } from "./m_20260503_110100_skills_to_jetstream.ts";
+import { migration as m_20260503_110200_document_store_to_jetstream } from "./m_20260503_110200_document_store_to_jetstream.ts";
+import { migration as m_20260503_110250_remove_legacy_sessions_stream } from "./m_20260503_110250_remove_legacy_sessions_stream.ts";
+import { migration as m_20260503_110300_sessions_v2_to_jetstream } from "./m_20260503_110300_sessions_v2_to_jetstream.ts";
+import { migration as m_20260504_025000_provision_users_bucket } from "./m_20260504_025000_provision_users_bucket.ts";
+import { migration as m_20260504_025500_rekey_default_user_chats } from "./m_20260504_025500_rekey_default_user_chats.ts";
+import { migration as m_20260505_120000_elicitations_bootstrap } from "./m_20260505_120000_elicitations_bootstrap.ts";
+import { migration as m_20260507_120000_drop_scratchpad_kv } from "./m_20260507_120000_drop_scratchpad_kv.ts";
+import { migration as m_20260511_110800_provision_workspace_members } from "./m_20260511_110800_provision_workspace_members.ts";
+import { migration as m_20260511_120000_cleanup_userid_as_name } from "./m_20260511_120000_cleanup_userid_as_name.ts";
 
-  const migrations: Migration[] = [];
-  for (const file of files) {
-    const mod = (await import(new URL(file, dir).href)) as { migration?: Migration };
-    if (!mod.migration) {
-      throw new Error(
-        `Migration file ${file} does not export a \`migration\` const. ` +
-          `Every m_*.ts file in apps/atlasd/src/migrations/ must export ` +
-          `\`export const migration: Migration = { id: "...", ... }\`.`,
-      );
-    }
-    migrations.push(mod.migration);
-  }
-  return migrations;
+/**
+ * Static manifest. Ordered by id ascending — keep new entries in
+ * lexicographic position. `runMigrations` re-sorts defensively, so
+ * an accidentally out-of-order insert is benign, but a missing entry
+ * is silently broken on shipped binaries (the dynamic loader before
+ * this change hid the same class of failure for `deno compile`).
+ */
+const MIGRATIONS: readonly Migration[] = [
+  m_20260501_120000_chat_to_jetstream,
+  m_20260501_120100_memory_to_jetstream,
+  m_20260502_140000_sessions_stream_upgrade,
+  m_20260502_140100_delete_activity_db,
+  m_20260502_140200_mcp_registry_to_jetstream,
+  m_20260502_140300_cron_timers_to_jetstream,
+  m_20260502_140400_workspace_registry_to_jetstream,
+  m_20260502_140500_scratchpad_to_jetstream,
+  m_20260502_140600_artifacts_to_jetstream,
+  m_20260502_140700_drop_legacy_storage_db,
+  m_20260503_100000_repair_artifact_object_store,
+  m_20260503_110000_workspace_state_to_jetstream,
+  m_20260503_110100_skills_to_jetstream,
+  m_20260503_110200_document_store_to_jetstream,
+  m_20260503_110250_remove_legacy_sessions_stream,
+  m_20260503_110300_sessions_v2_to_jetstream,
+  m_20260504_025000_provision_users_bucket,
+  m_20260504_025500_rekey_default_user_chats,
+  m_20260505_120000_elicitations_bootstrap,
+  m_20260507_120000_drop_scratchpad_kv,
+  m_20260511_110800_provision_workspace_members,
+  m_20260511_120000_cleanup_userid_as_name,
+];
+
+/**
+ * Return every migration in id order. Async-shaped for back-compat
+ * with the previous `readdir + dynamic import` loader; daemon and CLI
+ * both `await` it.
+ */
+export function getAllMigrations(): Promise<Migration[]> {
+  return Promise.resolve([...MIGRATIONS].sort((a, b) => a.id.localeCompare(b.id)));
 }

--- a/apps/atlasd/src/migrations/index.ts
+++ b/apps/atlasd/src/migrations/index.ts
@@ -58,10 +58,12 @@ import { migration as m_20260511_120000_cleanup_userid_as_name } from "./m_20260
 
 /**
  * Static manifest. Ordered by id ascending — keep new entries in
- * lexicographic position. `runMigrations` re-sorts defensively, so
- * an accidentally out-of-order insert is benign, but a missing entry
- * is silently broken on shipped binaries (the dynamic loader before
- * this change hid the same class of failure for `deno compile`).
+ * lexicographic position. `getAllMigrations()` re-sorts by id before
+ * returning, so an accidentally out-of-order insert here is benign;
+ * `runMigrations` itself iterates the array in input order. A
+ * missing entry, in contrast, is silently broken on shipped binaries
+ * (the dynamic loader before this change hid the same class of
+ * failure for `deno compile`).
  */
 const MIGRATIONS: readonly Migration[] = [
   m_20260501_120000_chat_to_jetstream,


### PR DESCRIPTION
## Summary
- Replace `readdir + dynamic import` migration discovery with a static manifest. The dynamic loader silently returned `[]` inside `deno compile` binaries, so freshly installed daemons reported `ran 0 migration(s); skipped 0 already applied` and downstream bootstrap (notably `m_20260511_110800_provision_workspace_members`) never wrote owner rows — every workspace-scoped route 403'd.
- Add an `index.test.ts` guard that every `m_*.ts` file appears in the static manifest (import + array entry), so a future migration that's added but not registered trips CI rather than shipping a silent no-op.

## Test plan
- [x] `vitest run apps/atlasd/src/migrations/index.test.ts` — 4/4 pass
- [x] Negative test: remove a manifest entry, guard fails with a clear message naming the missing file
- [x] `deno task atlas migrate --dry-run --json` — enumerates all 22 migrations (uncompiled)
- [x] `deno compile` with release flags + `migrate --dry-run --json` on the compiled binary — all 22 enumerate (`skipped` length = 22, vs. 0 on `main` in the shipped installer)