### PR TITLE
Migrations: make Pattern-B migrations self-contained so CLI migrate works

### DIFF
--- a/apps/atlasd/src/migrations/m_20260504_025000_provision_users_bucket.ts
+++ b/apps/atlasd/src/migrations/m_20260504_025000_provision_users_bucket.ts
@@ -19,7 +19,7 @@
  */
 
 import { JetStreamNarrativeStore } from "@atlas/adapters-md";
-import { ONBOARDING_VERSION, UserStorage } from "@atlas/core/users/storage";
+import { createJetStreamUserBackend, ONBOARDING_VERSION } from "@atlas/core/users/storage";
 import type { Migration } from "jetstream";
 
 const NAME_EXTRACT = /(?:name is|call me)\s+(.+)/i;
@@ -32,13 +32,20 @@ export const migration: Migration = {
     "type:name-declined entries authored by the legacy onboarding flow, and " +
     "populate the local user's USERS record so onboarding doesn't re-ask.",
   async run({ nc, logger }) {
-    const localUserResult = await UserStorage.resolveLocalUserId();
+    // Construct a local backend from `nc` rather than reaching for the
+    // `UserStorage.*` facade — the facade requires `initUserStorage(nc)`
+    // to have been called at daemon startup, which the standalone CLI
+    // `atlas migrate` path doesn't do. Self-contained migrations work
+    // from either runner.
+    const users = createJetStreamUserBackend(nc);
+
+    const localUserResult = await users.resolveLocalUserId();
     if (!localUserResult.ok) {
       throw new Error(`Failed to resolve local user id: ${localUserResult.error}`);
     }
     const localUserId = localUserResult.data;
 
-    const userResult = await UserStorage.getUser(localUserId);
+    const userResult = await users.getUser(localUserId);
     if (!userResult.ok) {
       throw new Error(`Failed to read local user: ${userResult.error}`);
     }
@@ -82,14 +89,14 @@ export const migration: Migration = {
     }
 
     if (resolved.kind === "provided") {
-      const set = await UserStorage.setUserIdentity(localUserId, {
+      const set = await users.setUserIdentity(localUserId, {
         name: resolved.name,
         nameStatus: "provided",
       });
       if (!set.ok) throw new Error(`setUserIdentity failed: ${set.error}`);
       logger.info("Backfilled identity (name provided)", { name: resolved.name });
     } else {
-      const set = await UserStorage.setUserIdentity(localUserId, {
+      const set = await users.setUserIdentity(localUserId, {
         nameStatus: "declined",
         declinedAt: new Date().toISOString(),
       });
@@ -97,7 +104,7 @@ export const migration: Migration = {
       logger.info("Backfilled identity (name declined)");
     }
 
-    const mark = await UserStorage.markOnboardingComplete(localUserId, ONBOARDING_VERSION);
+    const mark = await users.markOnboardingComplete(localUserId, ONBOARDING_VERSION);
     if (!mark.ok) throw new Error(`markOnboardingComplete failed: ${mark.error}`);
   },
 };

--- a/apps/atlasd/src/migrations/m_20260504_025500_rekey_default_user_chats.ts
+++ b/apps/atlasd/src/migrations/m_20260504_025500_rekey_default_user_chats.ts
@@ -17,7 +17,7 @@
  */
 
 import { ensureChatsKVBucket } from "@atlas/core/chat/storage";
-import { UserStorage } from "@atlas/core/users/storage";
+import { createJetStreamUserBackend } from "@atlas/core/users/storage";
 import type { Migration } from "jetstream";
 
 const LEGACY_USER_ID = "default-user";
@@ -33,7 +33,10 @@ export const migration: Migration = {
     "stay (they are workspace/chatId, not user-prefixed). Message stream " +
     "contents are unchanged.",
   async run({ nc, logger }) {
-    const localUserResult = await UserStorage.resolveLocalUserId();
+    // Self-contained backend from `nc` — see provision_users_bucket for
+    // the rationale (CLI migrate path doesn't init the facade).
+    const users = createJetStreamUserBackend(nc);
+    const localUserResult = await users.resolveLocalUserId();
     if (!localUserResult.ok) {
       throw new Error(`Failed to resolve local user id: ${localUserResult.error}`);
     }

--- a/apps/atlasd/src/migrations/m_20260511_110800_provision_workspace_members.ts
+++ b/apps/atlasd/src/migrations/m_20260511_110800_provision_workspace_members.ts
@@ -16,8 +16,8 @@
  * untouched.
  */
 
-import { UserStorage } from "@atlas/core/users/storage";
-import { WorkspaceMemberStorage } from "@atlas/core/workspace-members/storage";
+import { createJetStreamUserBackend } from "@atlas/core/users/storage";
+import { createJetStreamWorkspaceMemberBackend } from "@atlas/core/workspace-members/storage";
 import { createRegistryStorageJS } from "@atlas/workspace";
 import type { Migration } from "jetstream";
 
@@ -29,7 +29,13 @@ export const migration: Migration = {
     "workspace, derived from metadata.createdBy with a local-user-id fallback " +
     "when createdBy is unset (single-tenant local mode).",
   async run({ nc, logger }) {
-    const localUserResult = await UserStorage.resolveLocalUserId();
+    // Self-contained backends from `nc` — the `UserStorage` /
+    // `WorkspaceMemberStorage` facades require daemon-side init that
+    // the standalone CLI `atlas migrate` path doesn't perform.
+    const users = createJetStreamUserBackend(nc);
+    const members = createJetStreamWorkspaceMemberBackend(nc);
+
+    const localUserResult = await users.resolveLocalUserId();
     if (!localUserResult.ok) {
       throw new Error(`Failed to resolve local user id: ${localUserResult.error}`);
     }
@@ -45,7 +51,7 @@ export const migration: Migration = {
 
     for (const ws of workspaces) {
       const ownerUserId = ws.metadata?.createdBy ?? localUserId;
-      const result = await WorkspaceMemberStorage.putIfAbsent({
+      const result = await members.putIfAbsent({
         userId: ownerUserId,
         wsId: ws.id,
         role: "owner",

--- a/apps/atlasd/src/migrations/pattern-b-self-contained.test.ts
+++ b/apps/atlasd/src/migrations/pattern-b-self-contained.test.ts
@@ -18,6 +18,8 @@
  */
 
 import { startNatsTestServer, type TestNatsServer } from "@atlas/core/test-utils/nats-test-server";
+import { UserStorage } from "@atlas/core/users/storage";
+import { WorkspaceMemberStorage } from "@atlas/core/workspace-members/storage";
 import type { Logger } from "@atlas/logger";
 import { createJetStreamFacade } from "jetstream";
 import { connect, type NatsConnection } from "nats";
@@ -42,6 +44,21 @@ const noopLogger: Logger = {
 beforeAll(async () => {
   server = await startNatsTestServer();
   nc = await connect({ servers: server.url });
+
+  // Pin the regression-guard contract: the facade singletons MUST be
+  // uninitialized when this file runs. Today this holds because Vitest's
+  // default `pool: "forks"` + `fileParallelism: true` gives each .test.ts
+  // file its own worker (so a sibling test's `initUserStorage(nc)` can't
+  // leak in). If that config ever flips (e.g. `pool: "threads"` with
+  // `isolate: false`), these assertions fail loudly instead of letting
+  // the regression guard silently pass against a populated singleton.
+  // `getCachedLocalUserId` / `get` both call the internal `b()` guard
+  // synchronously before returning, so a null backend throws here
+  // regardless of the methods' async return types.
+  expect(() => UserStorage.getCachedLocalUserId()).toThrow(/UserStorage not initialized/);
+  expect(() => WorkspaceMemberStorage.get("u", "w")).toThrow(
+    /WorkspaceMemberStorage not initialized/,
+  );
 }, 30_000);
 
 afterAll(async () => {

--- a/apps/atlasd/src/migrations/pattern-b-self-contained.test.ts
+++ b/apps/atlasd/src/migrations/pattern-b-self-contained.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Regression guard: migrations that historically reached for the
+ * `UserStorage` / `WorkspaceMemberStorage` singleton facades must now
+ * be self-contained — i.e. they construct their backends from the `nc`
+ * passed via `Migration.run({ nc, logger })`, not from a daemon-side
+ * `initUserStorage(nc)` / `initWorkspaceMemberStorage(nc)` call.
+ *
+ * Why: the standalone CLI `atlas migrate` path (and the installer's
+ * pre-launcher invocation that drives it) does not init those facades.
+ * Pre-#277 the bug was hidden because compiled binaries enumerated zero
+ * migrations; once #277 made the manifest static, every install/upgrade
+ * surfaced "UserStorage not initialized" on the first Pattern-B entry.
+ *
+ * Each case below intentionally skips `initUserStorage` /
+ * `initWorkspaceMemberStorage` and asserts the migration completes
+ * cleanly. If a future migration is added that reaches for either
+ * facade, this test will throw the original error and fail.
+ */
+
+import { startNatsTestServer, type TestNatsServer } from "@atlas/core/test-utils/nats-test-server";
+import type { Logger } from "@atlas/logger";
+import { createJetStreamFacade } from "jetstream";
+import { connect, type NatsConnection } from "nats";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { migration as provisionUsersBucket } from "./m_20260504_025000_provision_users_bucket.ts";
+import { migration as rekeyDefaultUserChats } from "./m_20260504_025500_rekey_default_user_chats.ts";
+import { migration as provisionWorkspaceMembers } from "./m_20260511_110800_provision_workspace_members.ts";
+
+let server: TestNatsServer;
+let nc: NatsConnection;
+
+const noopLogger: Logger = {
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+  child: () => noopLogger,
+};
+
+beforeAll(async () => {
+  server = await startNatsTestServer();
+  nc = await connect({ servers: server.url });
+}, 30_000);
+
+afterAll(async () => {
+  await nc.drain();
+  await server.stop();
+});
+
+async function wipeAllStreams(): Promise<void> {
+  const jsm = await nc.jetstreamManager();
+  const streams = await jsm.streams.list().next();
+  for (const info of streams) {
+    try {
+      await jsm.streams.delete(info.config.name);
+    } catch {
+      // best-effort
+    }
+  }
+}
+
+beforeEach(async () => {
+  await wipeAllStreams();
+});
+
+describe("Pattern-B migrations are self-contained", () => {
+  it("provision_users_bucket runs without initUserStorage", async () => {
+    const js = createJetStreamFacade(nc);
+    await expect(provisionUsersBucket.run({ nc, js, logger: noopLogger })).resolves.toBeUndefined();
+  });
+
+  it("rekey_default_user_chats runs without initUserStorage", async () => {
+    const js = createJetStreamFacade(nc);
+    await expect(
+      rekeyDefaultUserChats.run({ nc, js, logger: noopLogger }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("provision_workspace_members runs without init{User,WorkspaceMember}Storage", async () => {
+    const js = createJetStreamFacade(nc);
+    await expect(
+      provisionWorkspaceMembers.run({ nc, js, logger: noopLogger }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/core/src/users/storage.ts
+++ b/packages/core/src/users/storage.ts
@@ -18,8 +18,15 @@ import {
   type UserIdentity,
 } from "./jetstream-backend.ts";
 
-export type { NameStatus, OnboardingState, User, UserIdentity } from "./jetstream-backend.ts";
+export type {
+  JetStreamUserBackend,
+  NameStatus,
+  OnboardingState,
+  User,
+  UserIdentity,
+} from "./jetstream-backend.ts";
 export {
+  createJetStreamUserBackend,
   ensureUsersKVBucket,
   ONBOARDING_VERSION,
   OnboardingSchema,

--- a/packages/core/src/workspace-members/storage.ts
+++ b/packages/core/src/workspace-members/storage.ts
@@ -14,8 +14,13 @@ import {
   type WorkspaceMembership,
 } from "./jetstream-backend.ts";
 
-export type { Role, WorkspaceMembership } from "./jetstream-backend.ts";
+export type {
+  JetStreamWorkspaceMemberBackend,
+  Role,
+  WorkspaceMembership,
+} from "./jetstream-backend.ts";
 export {
+  createJetStreamWorkspaceMemberBackend,
   ensureWorkspaceMembersKVBucket,
   RoleSchema,
   WorkspaceMembershipSchema,


### PR DESCRIPTION
## Summary

- Three migrations (`provision_users_bucket`, `rekey_default_user_chats`, `provision_workspace_members`) reached for the `UserStorage.*` / `WorkspaceMemberStorage.*` static facades, which require `initUserStorage(nc)` / `initWorkspaceMemberStorage(nc)` at daemon startup. The CLI's `atlas migrate` path doesn't do that init — so on a fresh install the installer's pre-launcher `friday migrate` step failed with `UserStorage not initialized — call initUserStorage(nc) at daemon startup` on `provision_users_bucket`. Pre-0.1.7 the bug was masked because compiled binaries enumerated `[]`; #277's static manifest unmasked it.
- Each of the three migrations now constructs its own backend inline from the `nc` passed via `Migration.run({ nc, logger })`, matching the convention of the 19 other migrations. Public re-exports for both factories added to `packages/core/src/users/storage.ts` and `packages/core/src/workspace-members/storage.ts`.
- New `apps/atlasd/src/migrations/pattern-b-self-contained.test.ts` runs each migration against a NATS test server WITHOUT calling either `init*Storage` and asserts they complete cleanly — regression guard against future Pattern-B reintroductions.

The daemon's startup path was already correct (it inits the facades before `runMigrations`) and transparently recovered the CLI failure on next boot, so the visible user-facing impact of 0.1.7 was a red ✗ on the installer's "Running migrations" row that didn't actually break anything. Operator recovery via standalone `atlas migrate` (the path the daemon's own error-log hint suggests) was the only genuinely-stuck case.

## Test plan

- [x] `deno task test apps/atlasd/src/migrations/` — 28/28 pass (existing 25 + 3 new regression-guard cases)
- [x] `deno task typecheck` — `COMPLETED 8408 FILES 0 ERRORS`
- [x] **End-to-end QA on the test VM with compiled binaries:** A/B'd shipped 0.1.7 against this branch with a clean `FRIDAY_HOME`, matching the installer's actual invocation (`<install_dir>/bin/friday migrate` with `<install_dir>/bin` on `PATH`):
  - Shipped: exit 1, `Error: 1 migration(s) failed: 20260504_025000_provision_users_bucket` — reproduces the production error exactly
  - This branch: exit 0, `✓ ran 22 migration(s); skipped 0 already applied`. Verified via NATS that all three Pattern-B audit records are `success:true`, `USERS` bucket has the `_local` pointer + user record.