### PR TITLE
Clear chat input when switching chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Chat input clears when switching between chats in agent-playground.** `ChatInput` (`tools/agent-playground/src/lib/components/chat/chat-input.svelte`) owned its own `value` / `images` `$state` and only cleared on submit. Switching chats in the sidebar reuses the same `UserChat` instance (same `/platform/.../chat/:chatId` route, only the prop changes), so the unsent draft text and attached images leaked from the old chat into the new one. Wrapped `<ChatInput>` in `{#key chatId}` inside `user-chat.svelte` so Svelte remounts the component on every chat switch, uniformly resetting all seven pieces of its local `$state` without lifting state into the parent or adding a reset prop. Matches the established `{#key id}` reset-on-entity-switch pattern already used by activity-view's elicitation detail, the workspace agent sidebar, the chat page's `workspaceId` wrapper, and agent workbench. (#287, fixes #222)
+- **Chat input clears when switching chats in agent-playground.** `ChatInput` owned its own `value` / `images` `$state` that only cleared on submit, and `UserChat` is reused across chat switches (same route, different `chatId` prop) — so unsent drafts and attached images leaked between chats. Wrapped `<ChatInput>` in `{#key chatId}` so Svelte remounts it on every switch, resetting all of its local state. (#287, fixes #222)
 
 ## [0.1.7] - 2026-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Chat input clears when switching between chats in agent-playground.** `ChatInput` (`tools/agent-playground/src/lib/components/chat/chat-input.svelte`) owned its own `value` / `images` `$state` and only cleared on submit. Switching chats in the sidebar reuses the same `UserChat` instance (same `/platform/.../chat/:chatId` route, only the prop changes), so the unsent draft text and attached images leaked from the old chat into the new one. Wrapped `<ChatInput>` in `{#key chatId}` inside `user-chat.svelte` so Svelte remounts the component on every chat switch, uniformly resetting all seven pieces of its local `$state` without lifting state into the parent or adding a reset prop. Matches the established `{#key id}` reset-on-entity-switch pattern already used by activity-view's elicitation detail, the workspace agent sidebar, the chat page's `workspaceId` wrapper, and agent workbench. (#287, fixes #222)
+
 ## [0.1.7] - 2026-05-12
 
 Delegate sub-agent answers stop double-decoding through artifact pre-return lift (#271); the new `@friday/using-elicitations` skill documents the HITL surface job authors have had to discover by reading source (#275); a static migration manifest unblocks `deno compile` binaries that were silently enumerating zero migrations (#277). Cleanup pass on stale `FRIDAY_LOCAL_ONLY` references missed by #265 (#274).

--- a/tools/agent-playground/src/lib/components/chat/user-chat.svelte
+++ b/tools/agent-playground/src/lib/components/chat/user-chat.svelte
@@ -1404,14 +1404,16 @@
               : `${queuedMessages.length} messages queued — will send when the assistant finishes`}
           </div>
         {/if}
-        <ChatInput
-          onsubmit={handleSubmit}
-          {streaming}
-          {stopping}
-          onstop={handleStop}
-          {ttsEnabled}
-          onttsToggle={ttsSupported ? toggleTts : undefined}
-        />
+        {#key chatId}
+          <ChatInput
+            onsubmit={handleSubmit}
+            {streaming}
+            {stopping}
+            onstop={handleStop}
+            {ttsEnabled}
+            onttsToggle={ttsSupported ? toggleTts : undefined}
+          />
+        {/key}
       </div>
     </div>
 


### PR DESCRIPTION
## Summary

- `ChatInput` owns its own `value`/`images` state and only clears on submit. Switching chats reuses the same `UserChat` instance (same route, different `chatId`), so the unsent draft and attachments bled across chats.
- Wrap `<ChatInput>` in `{#key chatId}` so Svelte remounts it on every chat switch. Resets all of ChatInput's 7 pieces of local `$state` uniformly — no new props, no lifted state, no parent/child coupling.
- Matches the `{#key id}` reset-on-entity-switch pattern already established in this app (activity-view elicitation detail, workspace agent sidebar, chat page workspaceId wrapper, agent workbench).

Fixes #222

## Test Plan

- [ ] `deno task playground` → open a chat, type text, switch to a different chat → input is empty
- [ ] Same flow but attach an image first, then switch → image attachment is gone
- [ ] Type in chat A, switch to chat B, type something else, switch back to chat A → both inputs stay scoped to their own chat (no leak in either direction)
- [ ] Submit a message in chat A, switch to chat B mid-stream, return to chat A → streaming still resumes correctly (verifies the remount doesn't disturb UserChat's per-chat rehydration `$effect`)