### PR TITLE
Workspace bundle: include user agents referenced by workspace.yml

### DIFF
--- a/apps/atlasd/routes/workspaces/bundle-all.test.ts
+++ b/apps/atlasd/routes/workspaces/bundle-all.test.ts
@@ -189,12 +189,17 @@ describe("bundle-all endpoints (end-to-end)", () => {
     await seedWorkspaceDir(wsA, "alpha");
     await seedWorkspaceDir(wsB, "beta");
     mockFetchLinkCredential.mockReset();
+    // `/bundle-all?include=global-skills` is gated behind `requireDevEnv`;
+    // the runner sets DEV_MODE/LINK_DEV_MODE but not FRIDAY_ENV, so opt in
+    // here for the duration of the test.
+    vi.stubEnv("FRIDAY_ENV", "dev");
   });
 
   afterEach(async () => {
     await rm(wsA, { recursive: true, force: true });
     await rm(wsB, { recursive: true, force: true });
     await rm(homeDir, { recursive: true, force: true });
+    vi.unstubAllEnvs();
   });
 
   test("GET /bundle-all returns a zip-of-zips with every on-disk workspace", async () => {

--- a/apps/atlasd/routes/workspaces/bundle-helpers.ts
+++ b/apps/atlasd/routes/workspaces/bundle-helpers.ts
@@ -119,8 +119,8 @@ export async function buildWorkspaceBundleBytes(
  * installed source dir under `<userAgentsDir>/<id>@<version>/` so it can be
  * embedded in the bundle. Skipped when the workspace already ships a
  * same-named agent under `<workspacePath>/agents/<id>/` (workspace-local
- * wins). Unresolvable refs log a warning and are left out — the bundle
- * still exports, but is not portable for that agent.
+ * wins). Throws if any referenced user agent can't be resolved — silently
+ * partial bundles fail much later on the import side, so surface it here.
  */
 async function resolveExternalUserAgents(opts: {
   config: WorkspaceConfig;
@@ -139,6 +139,7 @@ async function resolveExternalUserAgents(opts: {
 
   const adapter = new UserAdapter(opts.userAgentsDir);
   const resolved: { name: string; sourceDir: string }[] = [];
+  const missing: string[] = [];
   for (const id of userAgentIds) {
     try {
       await stat(join(opts.workspacePath, "agents", id));
@@ -149,12 +150,14 @@ async function resolveExternalUserAgents(opts: {
     try {
       const source = await adapter.loadAgent(id);
       resolved.push({ name: id, sourceDir: source.metadata.sourceLocation });
-    } catch (error) {
-      opts.logger.warn(
-        "User agent referenced by workspace.yml could not be resolved; bundle will not include it",
-        { agentId: id, userAgentsDir: opts.userAgentsDir, error },
-      );
+    } catch {
+      missing.push(id);
     }
+  }
+  if (missing.length > 0) {
+    throw new Error(
+      `Workspace references user agent(s) that could not be resolved under ${opts.userAgentsDir}: ${missing.join(", ")}`,
+    );
   }
   return resolved;
 }

--- a/apps/atlasd/routes/workspaces/bundle-helpers.ts
+++ b/apps/atlasd/routes/workspaces/bundle-helpers.ts
@@ -12,12 +12,14 @@ import {
   stripCredentialRefs,
   toProviderRefs,
 } from "@atlas/config/mutations";
+import { UserAdapter } from "@atlas/core/agent-loader/user-adapter";
 import {
   fetchLinkCredential,
   LinkCredentialExpiredError,
   LinkCredentialNotFoundError,
 } from "@atlas/core/mcp-registry/credential-resolver";
 import type { Logger } from "@atlas/logger";
+import { getFridayHome } from "@atlas/utils/paths.server";
 import { stringify } from "@std/yaml";
 import { injectBundledAgentRefs } from "./inject-bundled-agents.ts";
 
@@ -33,6 +35,12 @@ export interface BuildWorkspaceBundleInput {
    * (`~/.friday/local/memory/<workspaceId>/`). Only honored in `mode: migration`.
    */
   memoryDir?: string;
+  /**
+   * Root directory holding installed user agents (layout
+   * `<dir>/<id>@<version>/`). Defaults to `<atlasHome>/agents`. Override is
+   * primarily for tests.
+   */
+  userAgentsDir?: string;
 }
 
 export interface BuildWorkspaceBundleResult {
@@ -87,15 +95,68 @@ export async function buildWorkspaceBundleBytes(
   const name = portableConfig.workspace.name ?? input.workspaceName;
   const version = (portableConfig.version as string | undefined) ?? "1.0.0";
 
+  const externalAgents = await resolveExternalUserAgents({
+    config: configWithAgentRefs,
+    workspacePath: input.workspacePath,
+    userAgentsDir: input.userAgentsDir ?? join(getFridayHome(), "agents"),
+    logger: input.logger,
+  });
+
   const bundleBytes = await exportBundle({
     workspaceDir: input.workspacePath,
     workspaceYml,
     mode: input.mode,
     workspace: { name, version },
+    ...(externalAgents.length > 0 ? { externalAgents } : {}),
     ...(input.mode === "migration" && input.memoryDir ? { memoryDir: input.memoryDir } : {}),
   });
 
   return { bundleBytes, name, version };
+}
+
+/**
+ * For every `type: user` agent referenced by `workspace.yml`, locate its
+ * installed source dir under `<userAgentsDir>/<id>@<version>/` so it can be
+ * embedded in the bundle. Skipped when the workspace already ships a
+ * same-named agent under `<workspacePath>/agents/<id>/` (workspace-local
+ * wins). Unresolvable refs log a warning and are left out — the bundle
+ * still exports, but is not portable for that agent.
+ */
+async function resolveExternalUserAgents(opts: {
+  config: WorkspaceConfig;
+  workspacePath: string;
+  userAgentsDir: string;
+  logger: Logger;
+}): Promise<{ name: string; sourceDir: string }[]> {
+  const agents = opts.config.agents;
+  if (!agents) return [];
+
+  const userAgentIds = new Set<string>();
+  for (const entry of Object.values(agents)) {
+    if (entry.type === "user") userAgentIds.add(entry.agent);
+  }
+  if (userAgentIds.size === 0) return [];
+
+  const adapter = new UserAdapter(opts.userAgentsDir);
+  const resolved: { name: string; sourceDir: string }[] = [];
+  for (const id of userAgentIds) {
+    try {
+      await stat(join(opts.workspacePath, "agents", id));
+      continue;
+    } catch {
+      // Not present workspace-locally — fall through to resolve externally.
+    }
+    try {
+      const source = await adapter.loadAgent(id);
+      resolved.push({ name: id, sourceDir: source.metadata.sourceLocation });
+    } catch (error) {
+      opts.logger.warn(
+        "User agent referenced by workspace.yml could not be resolved; bundle will not include it",
+        { agentId: id, userAgentsDir: opts.userAgentsDir, error },
+      );
+    }
+  }
+  return resolved;
 }
 
 /**

--- a/apps/atlasd/routes/workspaces/bundle.test.ts
+++ b/apps/atlasd/routes/workspaces/bundle.test.ts
@@ -93,12 +93,14 @@ function createApp(opts: {
         lastSeen: new Date().toISOString(),
         metadata: {},
       }),
-    getWorkspaceConfig: vi.fn().mockResolvedValue(
-      opts.workspaceConfig ?? {
-        atlas: null,
-        workspace: { version: "1.0", workspace: { name: "demo-space" } },
-      },
-    ),
+    getWorkspaceConfig: vi
+      .fn()
+      .mockResolvedValue(
+        opts.workspaceConfig ?? {
+          atlas: null,
+          workspace: { version: "1.0", workspace: { name: "demo-space" } },
+        },
+      ),
     registerWorkspace: registerSpy,
     list: vi.fn().mockResolvedValue([]),
     deleteWorkspace: vi.fn(),

--- a/apps/atlasd/routes/workspaces/bundle.test.ts
+++ b/apps/atlasd/routes/workspaces/bundle.test.ts
@@ -65,6 +65,7 @@ function createApp(opts: {
   workspaceId?: string;
   homeDir: string;
   registeredWorkspace?: { id: string; name: string; path: string };
+  workspaceConfig?: unknown;
 }): { app: Hono<AppVariables>; registerSpy: ReturnType<typeof vi.fn> } {
   const workspaceId = opts.workspaceId ?? "ws-demo";
   const registerSpy = vi
@@ -92,12 +93,12 @@ function createApp(opts: {
         lastSeen: new Date().toISOString(),
         metadata: {},
       }),
-    getWorkspaceConfig: vi
-      .fn()
-      .mockResolvedValue({
+    getWorkspaceConfig: vi.fn().mockResolvedValue(
+      opts.workspaceConfig ?? {
         atlas: null,
         workspace: { version: "1.0", workspace: { name: "demo-space" } },
-      }),
+      },
+    ),
     registerWorkspace: registerSpy,
     list: vi.fn().mockResolvedValue([]),
     deleteWorkspace: vi.fn(),
@@ -207,6 +208,51 @@ describe("workspace bundle endpoints (end-to-end)", () => {
     await access(join(registeredPath, "skills", "hello", "SKILL.md"));
     const yml = await readFile(join(registeredPath, "workspace.yml"), "utf-8");
     expect(yml).toContain("demo-space");
+  });
+
+  test("GET /:id/bundle includes user agents installed under <atlasHome>/agents", async () => {
+    // User agent referenced by workspace.yml lives globally at
+    // <atlasHome>/agents/<id>@<version>/ — bundle-helpers must resolve it.
+    const agentSrc = join(homeDir, "agents", "spritesheet-normalizer@1.0.0");
+    await mkdir(agentSrc, { recursive: true });
+    await writeFile(
+      join(agentSrc, "metadata.json"),
+      JSON.stringify({
+        id: "spritesheet-normalizer",
+        version: "1.0.0",
+        description: "Normalizes a spritesheet",
+      }),
+    );
+    await writeFile(join(agentSrc, "agent.py"), "print('normalize')\n");
+
+    const { app } = createApp({
+      workspaceDir,
+      homeDir,
+      workspaceConfig: {
+        atlas: null,
+        workspace: {
+          version: "1.0",
+          workspace: { name: "demo-space" },
+          agents: {
+            "spritesheet-normalizer": {
+              type: "user",
+              agent: "spritesheet-normalizer",
+              description: "Normalizes a spritesheet",
+            },
+          },
+        },
+      },
+    });
+
+    const response = await app.request("/ws-demo/bundle");
+    expect(response.status).toBe(200);
+
+    const zip = await JSZip.loadAsync(new Uint8Array(await response.arrayBuffer()));
+    expect(zip.file("agents/spritesheet-normalizer/agent.py")).toBeTruthy();
+    expect(zip.file("agents/spritesheet-normalizer/metadata.json")).toBeTruthy();
+    const lockfile = await zip.file("workspace.lock")?.async("string");
+    expect(lockfile).toContain("spritesheet-normalizer");
+    expect(lockfile).toContain("agents/spritesheet-normalizer");
   });
 
   test("POST /import-bundle rejects a tampered bundle", async () => {

--- a/apps/atlasd/routes/workspaces/bundle.test.ts
+++ b/apps/atlasd/routes/workspaces/bundle.test.ts
@@ -257,6 +257,36 @@ describe("workspace bundle endpoints (end-to-end)", () => {
     expect(lockfile).toContain("agents/spritesheet-normalizer");
   });
 
+  test("GET /:id/bundle fails when a referenced user agent isn't installed", async () => {
+    // Nothing seeded under <homeDir>/agents/ — referenced user agent is
+    // unresolvable, export should fail loudly instead of producing a
+    // half-empty bundle.
+    const { app } = createApp({
+      workspaceDir,
+      homeDir,
+      workspaceConfig: {
+        atlas: null,
+        workspace: {
+          version: "1.0",
+          workspace: { name: "demo-space" },
+          agents: {
+            ghost: {
+              type: "user",
+              agent: "ghost",
+              description: "agent that does not exist on disk",
+            },
+          },
+        },
+      },
+    });
+
+    const response = await app.request("/ws-demo/bundle");
+    expect(response.status).toBe(500);
+    const body = (await response.json()) as { error: string };
+    expect(body.error).toMatch(/user agent.*could not be resolved/i);
+    expect(body.error).toContain("ghost");
+  });
+
   test("POST /import-bundle rejects a tampered bundle", async () => {
     const { app: exportApp } = createApp({ workspaceDir, homeDir });
     const exportResponse = await exportApp.request("/ws-demo/bundle");

--- a/packages/bundle/src/bundle.test.ts
+++ b/packages/bundle/src/bundle.test.ts
@@ -117,6 +117,67 @@ describe("exportBundle + importBundle round-trip", () => {
     expect(result.ok).toBe(false);
     expect(result.mismatches).toEqual(["skill:hello"]);
   });
+
+  it("embeds externalAgents into the bundle and pins them in the lockfile", async () => {
+    const externalDir = await mkdtemp(join(tmpdir(), "bundle-ext-agent-"));
+    try {
+      await writeFile(
+        join(externalDir, "metadata.json"),
+        JSON.stringify({
+          id: "user-agent-a",
+          version: "1.2.3",
+          description: "external user agent",
+        }),
+      );
+      await writeFile(join(externalDir, "agent.py"), "print('hi')\n");
+
+      const zipBytes = await exportBundle({
+        workspaceDir: workDir,
+        workspaceYml: await readFile(join(workDir, "workspace.yml"), "utf-8"),
+        mode: "definition",
+        workspace: { name: "demo", version: "1.0.0" },
+        externalAgents: [{ name: "user-agent-a", sourceDir: externalDir }],
+      });
+
+      const result = await importBundle({ zipBytes, targetDir: importDir });
+
+      expect(result.primitives).toContainEqual({
+        kind: "agent",
+        name: "user-agent-a",
+        path: "agents/user-agent-a",
+      });
+
+      const py = await readFile(join(importDir, "agents", "user-agent-a", "agent.py"), "utf-8");
+      expect(py).toContain("print");
+      const metaBytes = await readFile(
+        join(importDir, "agents", "user-agent-a", "metadata.json"),
+        "utf-8",
+      );
+      expect(JSON.parse(metaBytes)).toMatchObject({ id: "user-agent-a", version: "1.2.3" });
+    } finally {
+      await rm(externalDir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an externalAgents entry that collides with a workspace-local agent", async () => {
+    await mkdir(join(workDir, "agents", "dupe"), { recursive: true });
+    await writeFile(join(workDir, "agents", "dupe", "agent.py"), "local\n");
+    const externalDir = await mkdtemp(join(tmpdir(), "bundle-ext-collide-"));
+    try {
+      await writeFile(join(externalDir, "agent.py"), "external\n");
+      await expect(
+        exportBundle({
+          workspaceDir: workDir,
+          workspaceYml: await readFile(join(workDir, "workspace.yml"), "utf-8"),
+          mode: "definition",
+          workspace: { name: "demo", version: "1.0.0" },
+          externalAgents: [{ name: "dupe", sourceDir: externalDir }],
+        }),
+      ).rejects.toThrow(/collides with workspace-local agent/);
+    } finally {
+      await rm(externalDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("exportBundle/importBundle memory (migration mode)", () => {

--- a/packages/bundle/src/bundle.ts
+++ b/packages/bundle/src/bundle.ts
@@ -21,6 +21,15 @@ export interface ExportOptions {
    * narrative in `snapshots.memory`.
    */
   memoryDir?: string;
+  /**
+   * Agents that live outside `<workspaceDir>/agents/` and need to be embedded
+   * so the bundle is self-contained. Typical case: `type: user` agents
+   * referenced by `workspace.yml` but installed globally at
+   * `<atlasHome>/agents/<id>@<version>/`. Each entry is included in the zip
+   * under `agents/<name>/...` and pinned in the lockfile like a workspace-local
+   * agent. Throws on a name collision with a workspace-local agent.
+   */
+  externalAgents?: { name: string; sourceDir: string }[];
 }
 
 export interface ImportOptions {
@@ -88,6 +97,22 @@ export async function exportBundle(opts: ExportOptions): Promise<Uint8Array> {
     for (const rel of files) {
       const content = await readFile(join(primitiveDir, ...rel.split("/")));
       zip.file(`agents/${name}/${rel}`, content);
+    }
+  }
+
+  for (const ext of opts.externalAgents ?? []) {
+    if (agents[ext.name]) {
+      throw new Error(
+        `exportBundle: externalAgents entry "${ext.name}" collides with workspace-local agent of the same name`,
+      );
+    }
+    const { hash } = await hashPrimitive(ext.sourceDir);
+    agents[ext.name] = { hash, path: `agents/${ext.name}` };
+    const files: string[] = [];
+    await walkFilesRecursive(ext.sourceDir, ext.sourceDir, files);
+    for (const rel of files) {
+      const content = await readFile(join(ext.sourceDir, ...rel.split("/")));
+      zip.file(`agents/${ext.name}/${rel}`, content);
     }
   }
 


### PR DESCRIPTION
## Summary
- `exportBundle` only walked `<workspaceDir>/agents/`, so workspaces that reference globally-installed user agents (e.g. `type: user` entries that resolve to `<atlasHome>/agents/<id>@<version>/`) bundled the reference but **no definition** — the lockfile recorded `primitives.agents: {}` and the bundle was unusable on import for those agents.
- Add an optional `externalAgents: { name, sourceDir }[]` to `ExportOptions` so callers can pin agents from outside the workspace dir.
- `buildWorkspaceBundleBytes` now resolves every `type: user` entry via `UserAdapter` against `<atlasHome>/agents/`. Workspace-local agents still win on name collision; unresolvable refs log a warning and the export proceeds without that agent.

Repro: download a workspace whose `workspace.yml` references a user agent that lives under `~/.atlas/agents/<id>@<version>/`. Before the fix, the zip contained `workspace.yml` + `workspace.lock` only. After the fix, it contains `agents/<id>/...` and the lockfile pins the agent hash.

Note: this is the export side only. On import the agent files land in `<workspaceDir>/agents/<id>/` (workspace-local). Re-installing them into `<atlasHome>/agents/<id>@<version>/` so the global resolver finds them is a follow-up.

## Test plan
- [x] `deno task test packages/bundle/` — 40 tests pass (incl. new round-trip + collision tests for `externalAgents`)
- [x] `deno task test apps/atlasd/routes/workspaces/` — 275 tests pass (incl. new e2e test seeding `<homeDir>/agents/spritesheet-normalizer@1.0.0/` and asserting the zip contains `agents/spritesheet-normalizer/...`)
- [x] `deno check` clean on changed files