### PR TITLE
Settings: hot-reload .env on PUT — no daemon restart for new API keys

### DIFF
--- a/apps/atlasd/routes/config.test.ts
+++ b/apps/atlasd/routes/config.test.ts
@@ -33,7 +33,7 @@ vi.mock("@atlas/llm", async (importOriginal) => ({
   invalidateCatalog: mockInvalidateCatalog,
 }));
 
-const { configRoutes } = await import("./config.ts");
+const { configRoutes, HOT_RELOAD_DENYLIST } = await import("./config.ts");
 
 interface PutEnvResponse {
   success: boolean;
@@ -51,14 +51,15 @@ let tempHome: string;
 let originalFridayHome: string | undefined;
 let originalFridayEnv: string | undefined;
 // process.env keys the sync tests mutate — snapshotted so they don't
-// leak across tests.
-const SYNC_TEST_KEYS = [
+// leak across tests. Includes every denylist entry so the parameterized
+// denylist test (which sets each key to a sentinel pre-PUT) can't leak
+// to the real environment.
+const SYNC_TEST_KEYS: readonly string[] = [
   "ANTHROPIC_API_KEY",
   "DEPRECATED_KEY",
   "KEPT_KEY",
-  "PATH",
-  "FRIDAY_HOME",
-] as const;
+  ...HOT_RELOAD_DENYLIST,
+];
 const syncTestSnapshot: Record<string, string | undefined> = {};
 
 beforeEach(async () => {
@@ -262,13 +263,26 @@ describe("PUT /env in-memory sync (hot reload)", () => {
     expect(process.env.KEPT_KEY).toBe("kept");
   });
 
-  test("denylist keys are written to .env but not mutated on process.env", async () => {
-    const originalPath = process.env.PATH;
-    await putEnv({ PATH: "/totally/different/path" });
+  // Every denylist entry: PUT writes the new value to .env, but
+  // `process.env[key]` must retain its pre-PUT value. Parameterized so
+  // any future addition to HOT_RELOAD_DENYLIST gets coverage for free.
+  // FRIDAY_HOME / FRIDAY_ENV are load-bearing for the test harness
+  // itself (route lookup, dev-only gate), so we keep their beforeEach
+  // values rather than overwriting with a fresh sentinel.
+  const KEYS_PRESERVED_FROM_BEFORE_EACH = new Set(["FRIDAY_HOME", "FRIDAY_ENV"]);
+  test.each([
+    ...HOT_RELOAD_DENYLIST,
+  ])("denylist key %s is written to .env but not mutated on process.env", async (key) => {
+    if (!KEYS_PRESERVED_FROM_BEFORE_EACH.has(key)) {
+      process.env[key] = `pre-put-sentinel-${key}`;
+    }
+    const expected = process.env[key];
+
+    await putEnv({ [key]: `/totally/different/${key}` });
 
     const onDisk = await readFile(join(tempHome, ".env"), "utf-8");
-    expect(onDisk).toContain("PATH=/totally/different/path");
-    expect(process.env.PATH).toBe(originalPath);
+    expect(onDisk).toContain(`${key}=/totally/different/${key}`);
+    expect(process.env[key]).toBe(expected);
   });
 
   test("busts both the provider registry and the model catalog cache", async () => {

--- a/apps/atlasd/routes/config.test.ts
+++ b/apps/atlasd/routes/config.test.ts
@@ -18,9 +18,22 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
 import { Hono } from "hono";
-import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
-import { configRoutes } from "./config.ts";
+// The PUT /env handler busts two caches in @atlas/llm after writing
+// the new env vars to `process.env`. Hoisted spies let the in-memory
+// sync tests observe those calls — without them, a regression that
+// drops either reset call would still ship green.
+const mockResetRegistry = vi.hoisted(() => vi.fn<() => void>());
+const mockInvalidateCatalog = vi.hoisted(() => vi.fn<() => void>());
+
+vi.mock("@atlas/llm", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@atlas/llm")>()),
+  resetRegistry: mockResetRegistry,
+  invalidateCatalog: mockInvalidateCatalog,
+}));
+
+const { configRoutes } = await import("./config.ts");
 
 interface PutEnvResponse {
   success: boolean;
@@ -59,6 +72,8 @@ beforeEach(async () => {
   originalFridayEnv = process.env.FRIDAY_ENV;
   process.env.FRIDAY_ENV = "dev";
   for (const k of SYNC_TEST_KEYS) syncTestSnapshot[k] = process.env[k];
+  mockResetRegistry.mockClear();
+  mockInvalidateCatalog.mockClear();
 });
 
 afterEach(async () => {
@@ -254,6 +269,18 @@ describe("PUT /env in-memory sync (hot reload)", () => {
     const onDisk = await readFile(join(tempHome, ".env"), "utf-8");
     expect(onDisk).toContain("PATH=/totally/different/path");
     expect(process.env.PATH).toBe(originalPath);
+  });
+
+  test("busts both the provider registry and the model catalog cache", async () => {
+    // Deno's `--env-file` reads once at startup, and both `@atlas/llm`
+    // caches memoize `process.env` reads — without the resets, a
+    // freshly-saved API key would stay invisible to the running
+    // daemon until restart. Assert the calls so dropping either one
+    // from the handler trips a test.
+    await putEnv({ ANTHROPIC_API_KEY: "sk-ant-cache-bust" });
+
+    expect(mockResetRegistry).toHaveBeenCalledTimes(1);
+    expect(mockInvalidateCatalog).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/atlasd/routes/config.test.ts
+++ b/apps/atlasd/routes/config.test.ts
@@ -37,9 +37,8 @@ interface GetEnvResponse {
 let tempHome: string;
 let originalFridayHome: string | undefined;
 let originalFridayEnv: string | undefined;
-// Keys the in-memory-sync tests touch on `process.env`. Snapshotted in
-// beforeEach so afterEach can restore them — otherwise a sync test
-// that sets ANTHROPIC_API_KEY would leak into the next test.
+// process.env keys the sync tests mutate — snapshotted so they don't
+// leak across tests.
 const SYNC_TEST_KEYS = [
   "ANTHROPIC_API_KEY",
   "DEPRECATED_KEY",
@@ -233,12 +232,6 @@ describe("PUT → GET round-trip", () => {
 });
 
 describe("PUT /env in-memory sync (hot reload)", () => {
-  // The PR that introduced this block claims newly-added API keys are
-  // usable without restarting the daemon. These tests lock down the
-  // three load-bearing mutations: process.env adds, process.env deletes
-  // for keys removed from the payload, and denylist protection for
-  // keys that must never mutate at runtime.
-
   test("adds new keys to process.env so they're usable without restart", async () => {
     delete process.env.ANTHROPIC_API_KEY;
     await putEnv({ ANTHROPIC_API_KEY: "sk-ant-hot-reload" });
@@ -258,12 +251,8 @@ describe("PUT /env in-memory sync (hot reload)", () => {
     const originalPath = process.env.PATH;
     await putEnv({ PATH: "/totally/different/path" });
 
-    // File got the new value (UI round-trips it cleanly).
     const onDisk = await readFile(join(tempHome, ".env"), "utf-8");
     expect(onDisk).toContain("PATH=/totally/different/path");
-
-    // But the running daemon's PATH is untouched — Settings can't brick
-    // the daemon by saving a bad PATH.
     expect(process.env.PATH).toBe(originalPath);
   });
 });

--- a/apps/atlasd/routes/config.test.ts
+++ b/apps/atlasd/routes/config.test.ts
@@ -37,6 +37,17 @@ interface GetEnvResponse {
 let tempHome: string;
 let originalFridayHome: string | undefined;
 let originalFridayEnv: string | undefined;
+// Keys the in-memory-sync tests touch on `process.env`. Snapshotted in
+// beforeEach so afterEach can restore them — otherwise a sync test
+// that sets ANTHROPIC_API_KEY would leak into the next test.
+const SYNC_TEST_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "DEPRECATED_KEY",
+  "KEPT_KEY",
+  "PATH",
+  "FRIDAY_HOME",
+] as const;
+const syncTestSnapshot: Record<string, string | undefined> = {};
 
 beforeEach(async () => {
   tempHome = join(tmpdir(), `atlasd-env-test-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -48,6 +59,7 @@ beforeEach(async () => {
   // these cases. The dev-only gate itself is covered separately.
   originalFridayEnv = process.env.FRIDAY_ENV;
   process.env.FRIDAY_ENV = "dev";
+  for (const k of SYNC_TEST_KEYS) syncTestSnapshot[k] = process.env[k];
 });
 
 afterEach(async () => {
@@ -60,6 +72,11 @@ afterEach(async () => {
     delete process.env.FRIDAY_ENV;
   } else {
     process.env.FRIDAY_ENV = originalFridayEnv;
+  }
+  for (const k of SYNC_TEST_KEYS) {
+    const orig = syncTestSnapshot[k];
+    if (orig === undefined) delete process.env[k];
+    else process.env[k] = orig;
   }
   await rm(tempHome, { recursive: true, force: true });
 });
@@ -212,6 +229,42 @@ describe("PUT → GET round-trip", () => {
 
     const onDisk = await readFile(envPath, "utf-8");
     expect(onDisk).toBe("ANTHROPIC_API_KEY=sk-ant-legacy");
+  });
+});
+
+describe("PUT /env in-memory sync (hot reload)", () => {
+  // The PR that introduced this block claims newly-added API keys are
+  // usable without restarting the daemon. These tests lock down the
+  // three load-bearing mutations: process.env adds, process.env deletes
+  // for keys removed from the payload, and denylist protection for
+  // keys that must never mutate at runtime.
+
+  test("adds new keys to process.env so they're usable without restart", async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    await putEnv({ ANTHROPIC_API_KEY: "sk-ant-hot-reload" });
+    expect(process.env.ANTHROPIC_API_KEY).toBe("sk-ant-hot-reload");
+  });
+
+  test("removes keys absent from the new payload from process.env", async () => {
+    await putEnv({ DEPRECATED_KEY: "old-value" });
+    expect(process.env.DEPRECATED_KEY).toBe("old-value");
+
+    await putEnv({ KEPT_KEY: "kept" });
+    expect(process.env.DEPRECATED_KEY).toBeUndefined();
+    expect(process.env.KEPT_KEY).toBe("kept");
+  });
+
+  test("denylist keys are written to .env but not mutated on process.env", async () => {
+    const originalPath = process.env.PATH;
+    await putEnv({ PATH: "/totally/different/path" });
+
+    // File got the new value (UI round-trips it cleanly).
+    const onDisk = await readFile(join(tempHome, ".env"), "utf-8");
+    expect(onDisk).toContain("PATH=/totally/different/path");
+
+    // But the running daemon's PATH is untouched — Settings can't brick
+    // the daemon by saving a bad PATH.
+    expect(process.env.PATH).toBe(originalPath);
   });
 });
 

--- a/apps/atlasd/routes/config.ts
+++ b/apps/atlasd/routes/config.ts
@@ -6,7 +6,13 @@
 import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import process from "node:process";
-import { createPlatformModels, getCatalog, PlatformModelsConfigError } from "@atlas/llm";
+import {
+  createPlatformModels,
+  getCatalog,
+  invalidateCatalog,
+  PlatformModelsConfigError,
+  resetRegistry,
+} from "@atlas/llm";
 import { logger } from "@atlas/logger";
 import { stringifyError } from "@atlas/utils";
 import { getFridayHome } from "@atlas/utils/paths.server";
@@ -204,6 +210,21 @@ configRoutes.put(
         count: Object.keys(envVars).length,
       });
 
+      // Snapshot the prior on-disk state so we can compute the
+      // delete-set (keys removed by this PUT) for the in-memory sync
+      // below. Treat a missing file as an empty map.
+      let priorKeys: Set<string> = new Set();
+      if (await exists(envPath)) {
+        try {
+          priorKeys = new Set(Object.keys(parse(await readFile(envPath, "utf-8"))));
+        } catch (error) {
+          logger.warn("Could not parse prior .env for in-memory sync; deletes will be skipped", {
+            envPath,
+            error: stringifyError(error),
+          });
+        }
+      }
+
       // Create .atlas directory if it doesn't exist
       if (!(await exists(atlasDir))) {
         await mkdir(atlasDir, { recursive: true });
@@ -211,6 +232,28 @@ configRoutes.put(
 
       const content = stringifyEnv(envVars);
       await writeFile(envPath, content, "utf-8");
+
+      // Sync the running daemon's `process.env` with the file we just
+      // wrote so newly-added API keys are usable without a restart.
+      // Deno's `--env-file` reads once at startup; the catalog +
+      // provider registry read `process.env` and memoize the result,
+      // so we also reset both so the next call rebuilds against the
+      // current env. Subprocess agents spawned by the launcher inherit
+      // env at spawn time and are NOT updated by this — that gap
+      // requires a separate launcher-IPC fix.
+      try {
+        for (const k of priorKeys) {
+          if (!(k in envVars)) delete process.env[k];
+        }
+        Object.assign(process.env, envVars);
+        resetRegistry();
+        invalidateCatalog();
+      } catch (error) {
+        // The write succeeded; only the in-memory sync failed. Log
+        // and continue — the user falls back to a manual restart,
+        // which is the prior contract.
+        logger.warn("In-memory env sync failed after .env write", { error: stringifyError(error) });
+      }
 
       logger.info("Environment variables updated successfully", {
         envPath,

--- a/apps/atlasd/routes/config.ts
+++ b/apps/atlasd/routes/config.ts
@@ -122,8 +122,13 @@ const envVarsPutRequestSchema = z.object({
  * `process.env`. Otherwise a Settings save could brick the daemon by
  * changing its own loader paths or FRIDAY_HOME. The next daemon spawn
  * picks up the file value via `--env-file`.
+ *
+ * The `FRIDAY_*` subprocess-spawn vars (uv path, agent SDK version,
+ * agent python, claude path) are read per-spawn by agent-spawn.ts and
+ * the claude-code provider — mutating them on the running daemon would
+ * partition reality between already-spawned and future-spawned agents.
  */
-const HOT_RELOAD_DENYLIST: ReadonlySet<string> = new Set([
+export const HOT_RELOAD_DENYLIST: ReadonlySet<string> = new Set([
   "PATH",
   "HOME",
   "USER",
@@ -135,6 +140,10 @@ const HOT_RELOAD_DENYLIST: ReadonlySet<string> = new Set([
   "DYLD_LIBRARY_PATH",
   "FRIDAY_HOME",
   "FRIDAY_ENV",
+  "FRIDAY_UV_PATH",
+  "FRIDAY_AGENT_SDK_VERSION",
+  "FRIDAY_AGENT_PYTHON",
+  "FRIDAY_CLAUDE_PATH",
 ]);
 
 const envVarsPutResponseSchema = z.object({ success: z.boolean(), error: z.string().optional() });

--- a/apps/atlasd/routes/config.ts
+++ b/apps/atlasd/routes/config.ts
@@ -117,6 +117,29 @@ const envVarsPutRequestSchema = z.object({
   ),
 });
 
+/**
+ * Keys we never mutate on the running daemon's `process.env`, even though
+ * we still write them to `.env`. The in-memory hot-reload below would
+ * otherwise let a Settings save change the daemon's own `PATH` / loader
+ * paths / FRIDAY_HOME — bricking the daemon or (once the dev-only gate
+ * is lifted) opening a privilege-escalation primitive. Disk and runtime
+ * are allowed to diverge on these keys by design; the next daemon spawn
+ * picks up the new values via `--env-file`.
+ */
+const HOT_RELOAD_DENYLIST: ReadonlySet<string> = new Set([
+  "PATH",
+  "HOME",
+  "USER",
+  "SHELL",
+  "NODE_OPTIONS",
+  "LD_PRELOAD",
+  "LD_LIBRARY_PATH",
+  "DYLD_INSERT_LIBRARIES",
+  "DYLD_LIBRARY_PATH",
+  "FRIDAY_HOME",
+  "FRIDAY_ENV",
+]);
+
 const envVarsPutResponseSchema = z.object({ success: z.boolean(), error: z.string().optional() });
 
 const errorResponseSchema = z.object({ success: z.boolean(), error: z.string() });
@@ -213,6 +236,14 @@ configRoutes.put(
       // Snapshot the prior on-disk state so we can compute the
       // delete-set (keys removed by this PUT) for the in-memory sync
       // below. Treat a missing file as an empty map.
+      //
+      // Known limitation: this set only covers keys that were on disk.
+      // Shell-inherited env (e.g. the user `export`s GROQ_API_KEY before
+      // launching the daemon) is never in `priorKeys`, so the delete
+      // loop won't remove it from `process.env` — the daemon keeps the
+      // shell value even after the user "removes" the key from the UI.
+      // Fixing that would require snapshotting `process.env` at startup;
+      // out of scope here.
       let priorKeys: Set<string> = new Set();
       if (await exists(envPath)) {
         try {
@@ -241,11 +272,24 @@ configRoutes.put(
       // current env. Subprocess agents spawned by the launcher inherit
       // env at spawn time and are NOT updated by this — that gap
       // requires a separate launcher-IPC fix.
+      //
+      // Keys in `HOT_RELOAD_DENYLIST` are still written to `.env` but
+      // skipped here, so a Settings save can't mutate the running
+      // daemon's `PATH` / loader paths / FRIDAY_HOME.
       try {
         for (const k of priorKeys) {
+          if (HOT_RELOAD_DENYLIST.has(k)) continue;
           if (!(k in envVars)) delete process.env[k];
         }
-        Object.assign(process.env, envVars);
+        for (const [k, v] of Object.entries(envVars)) {
+          if (HOT_RELOAD_DENYLIST.has(k)) {
+            logger.warn("Skipping in-memory sync for denylisted key (written to .env only)", {
+              key: k,
+            });
+            continue;
+          }
+          process.env[k] = v;
+        }
         resetRegistry();
         invalidateCatalog();
       } catch (error) {

--- a/apps/atlasd/routes/config.ts
+++ b/apps/atlasd/routes/config.ts
@@ -118,13 +118,10 @@ const envVarsPutRequestSchema = z.object({
 });
 
 /**
- * Keys we never mutate on the running daemon's `process.env`, even though
- * we still write them to `.env`. The in-memory hot-reload below would
- * otherwise let a Settings save change the daemon's own `PATH` / loader
- * paths / FRIDAY_HOME — bricking the daemon or (once the dev-only gate
- * is lifted) opening a privilege-escalation primitive. Disk and runtime
- * are allowed to diverge on these keys by design; the next daemon spawn
- * picks up the new values via `--env-file`.
+ * Keys still written to `.env` but never mutated on the running daemon's
+ * `process.env`. Otherwise a Settings save could brick the daemon by
+ * changing its own loader paths or FRIDAY_HOME. The next daemon spawn
+ * picks up the file value via `--env-file`.
  */
 const HOT_RELOAD_DENYLIST: ReadonlySet<string> = new Set([
   "PATH",
@@ -233,17 +230,10 @@ configRoutes.put(
         count: Object.keys(envVars).length,
       });
 
-      // Snapshot the prior on-disk state so we can compute the
-      // delete-set (keys removed by this PUT) for the in-memory sync
-      // below. Treat a missing file as an empty map.
-      //
-      // Known limitation: this set only covers keys that were on disk.
-      // Shell-inherited env (e.g. the user `export`s GROQ_API_KEY before
-      // launching the daemon) is never in `priorKeys`, so the delete
-      // loop won't remove it from `process.env` — the daemon keeps the
-      // shell value even after the user "removes" the key from the UI.
-      // Fixing that would require snapshotting `process.env` at startup;
-      // out of scope here.
+      // Prior on-disk keys feed the delete-set for the in-memory sync.
+      // Shell-inherited env (`export FOO=…` before daemon launch) is
+      // never in this set, so the user "removing" such a key in the UI
+      // leaves the shell value sticky in `process.env`.
       let priorKeys: Set<string> = new Set();
       if (await exists(envPath)) {
         try {
@@ -264,18 +254,10 @@ configRoutes.put(
       const content = stringifyEnv(envVars);
       await writeFile(envPath, content, "utf-8");
 
-      // Sync the running daemon's `process.env` with the file we just
-      // wrote so newly-added API keys are usable without a restart.
-      // Deno's `--env-file` reads once at startup; the catalog +
-      // provider registry read `process.env` and memoize the result,
-      // so we also reset both so the next call rebuilds against the
-      // current env. Subprocess agents spawned by the launcher inherit
-      // env at spawn time and are NOT updated by this — that gap
-      // requires a separate launcher-IPC fix.
-      //
-      // Keys in `HOT_RELOAD_DENYLIST` are still written to `.env` but
-      // skipped here, so a Settings save can't mutate the running
-      // daemon's `PATH` / loader paths / FRIDAY_HOME.
+      // Deno's `--env-file` reads once at startup, and the catalog +
+      // provider registry memoize `process.env` reads, so mirror the
+      // file write into the running process and bust both caches.
+      // Subprocess agents already running keep their spawn-time env.
       try {
         for (const k of priorKeys) {
           if (HOT_RELOAD_DENYLIST.has(k)) continue;
@@ -293,9 +275,7 @@ configRoutes.put(
         resetRegistry();
         invalidateCatalog();
       } catch (error) {
-        // The write succeeded; only the in-memory sync failed. Log
-        // and continue — the user falls back to a manual restart,
-        // which is the prior contract.
+        // File write already succeeded; restart fallback still works.
         logger.warn("In-memory env sync failed after .env write", { error: stringifyError(error) });
       }
 

--- a/packages/llm/mod.ts
+++ b/packages/llm/mod.ts
@@ -19,6 +19,7 @@ export {
   type CatalogEntry,
   type CatalogProvider,
   getCatalog,
+  invalidateCatalog,
   type ModelInfo,
   PROVIDER_META,
   type ProviderMeta,
@@ -40,7 +41,7 @@ export {
   tokensToCost,
 } from "./src/pricing.ts";
 export { pruneMessages } from "./src/prune-messages.ts";
-export { registry } from "./src/registry.ts";
+export { registry, resetRegistry } from "./src/registry.ts";
 export {
   buildRegistryModelId,
   isRegistryProvider,

--- a/packages/llm/src/model-catalog.test.ts
+++ b/packages/llm/src/model-catalog.test.ts
@@ -256,4 +256,49 @@ describe("model-catalog — cache", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+
+  it("discards an in-flight fetch's result when invalidateCatalog runs before it resolves", async () => {
+    // Reproduces the PUT /env race: a getCatalog() fetch starts under one
+    // env, the user adds GROQ_API_KEY, invalidateCatalog() runs, then the
+    // stale in-flight result resolves. Without a generation guard that
+    // stale result would pin `cache` for the full TTL.
+    let resolveGateway!: (v: Response) => void;
+    const gatewayPromise = new Promise<Response>((res) => {
+      resolveGateway = res;
+    });
+    const staleModels = [gatewayModel("anthropic", "anthropic/claude-sonnet-4.6", "Sonnet 4.6")];
+    const freshModels = [gatewayModel("anthropic", "anthropic/claude-haiku-4.5", "Haiku 4.5")];
+    let call = 0;
+    const fetchMock = vi.fn((url: string) => {
+      if (url === GATEWAY_URL) {
+        call++;
+        if (call === 1) return gatewayPromise;
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ models: freshModels }),
+        } as unknown as Response);
+      }
+      return Promise.resolve({
+        ok: false,
+        status: 404,
+        json: () => Promise.resolve({}),
+      } as unknown as Response);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    const inflight = getCatalog();
+    invalidateCatalog();
+    resolveGateway({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ models: staleModels }),
+    } as unknown as Response);
+    await inflight;
+
+    // Next call must start a fresh fetch, not return the stale cached one.
+    const after = await getCatalog();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(find(after, "anthropic").models.map((m) => m.id)).toEqual(["claude-haiku-4-5"]);
+  });
 });

--- a/packages/llm/src/model-catalog.test.ts
+++ b/packages/llm/src/model-catalog.test.ts
@@ -5,7 +5,7 @@ import {
   type CatalogEntry,
   type CatalogProvider,
   getCatalog,
-  resetCatalogCacheForTests,
+  invalidateCatalog,
 } from "./model-catalog.ts";
 
 /**
@@ -74,7 +74,7 @@ function restoreEnv() {
 }
 
 beforeEach(() => {
-  resetCatalogCacheForTests();
+  invalidateCatalog();
   stubEnv({
     ANTHROPIC_API_KEY: undefined,
     OPENAI_API_KEY: undefined,

--- a/packages/llm/src/model-catalog.ts
+++ b/packages/llm/src/model-catalog.ts
@@ -416,8 +416,14 @@ export async function prewarmCatalog(): Promise<void> {
   }
 }
 
-/** Clear the cache. Intended for tests. */
-export function resetCatalogCacheForTests(): void {
+/**
+ * Clear the cached catalog. The next {@link getCatalog} call re-fetches
+ * the gateway + Groq listings and re-evaluates {@link resolveCredential}
+ * against the current `process.env`. Called from PUT /api/config/env
+ * after a runtime env update so the Settings page reflects a newly-added
+ * key without waiting on the 1h TTL. Also used by tests.
+ */
+export function invalidateCatalog(): void {
   cache = null;
   inflight = null;
 }

--- a/packages/llm/src/model-catalog.ts
+++ b/packages/llm/src/model-catalog.ts
@@ -383,6 +383,14 @@ async function fetchCatalog(): Promise<Catalog> {
 
 let cache: Catalog | null = null;
 let inflight: Promise<Catalog> | null = null;
+/**
+ * Bumped by {@link invalidateCatalog}. A fetch captures the current value
+ * before awaiting and only commits its result to `cache` if the counter
+ * is still equal — otherwise an env-changing invalidation happened mid-
+ * flight and the fetch's view of `process.env` (e.g. `GROQ_API_KEY`) is
+ * stale.
+ */
+let generation = 0;
 
 /**
  * Returns the cached catalog, or fetches fresh when the cache is missing
@@ -392,9 +400,10 @@ let inflight: Promise<Catalog> | null = null;
 export function getCatalog(): Promise<Catalog> {
   if (cache && Date.now() - cache.fetchedAt < CACHE_TTL_MS) return Promise.resolve(cache);
   if (inflight) return inflight;
+  const myGen = generation;
   inflight = fetchCatalog()
     .then((fresh) => {
-      cache = fresh;
+      if (myGen === generation) cache = fresh;
       return fresh;
     })
     .finally(() => {
@@ -424,4 +433,5 @@ export async function prewarmCatalog(): Promise<void> {
 export function invalidateCatalog(): void {
   cache = null;
   inflight = null;
+  generation++;
 }

--- a/packages/llm/src/model-catalog.ts
+++ b/packages/llm/src/model-catalog.ts
@@ -419,9 +419,7 @@ export async function prewarmCatalog(): Promise<void> {
 /**
  * Clear the cached catalog. The next {@link getCatalog} call re-fetches
  * the gateway + Groq listings and re-evaluates {@link resolveCredential}
- * against the current `process.env`. Called from PUT /api/config/env
- * after a runtime env update so the Settings page reflects a newly-added
- * key without waiting on the 1h TTL. Also used by tests.
+ * against the current `process.env`, bypassing the 1h TTL.
  */
 export function invalidateCatalog(): void {
   cache = null;

--- a/packages/llm/src/platform-models.test.ts
+++ b/packages/llm/src/platform-models.test.ts
@@ -177,9 +177,7 @@ describe("createPlatformModels — lazy resolution", () => {
   it("re-resolves get() against the current process.env on each call", () => {
     stubEnv({ ANTHROPIC_API_KEY: "sk-ant-test", GROQ_API_KEY: "gsk_test" });
     const pm = createPlatformModels({
-      models: {
-        labels: ["groq:llama-3.3-70b", "anthropic:claude-haiku-4-5"],
-      },
+      models: { labels: ["groq:llama-3.3-70b", "anthropic:claude-haiku-4-5"] },
     });
     expect(pm.get("labels").modelId).toBe("llama-3.3-70b");
 

--- a/packages/llm/src/platform-models.test.ts
+++ b/packages/llm/src/platform-models.test.ts
@@ -184,4 +184,15 @@ describe("createPlatformModels — lazy resolution", () => {
     delete process.env.GROQ_API_KEY;
     expect(pm.get("labels").modelId).toBe("claude-haiku-4-5");
   });
+
+  it("picks up credentials added to process.env after construction", () => {
+    stubEnv({ ANTHROPIC_API_KEY: "sk-ant-test" });
+    const pm = createPlatformModels({
+      models: { labels: ["groq:llama-3.3-70b", "anthropic:claude-haiku-4-5"] },
+    });
+    expect(pm.get("labels").modelId).toBe("claude-haiku-4-5");
+
+    process.env.GROQ_API_KEY = "gsk_test";
+    expect(pm.get("labels").modelId).toBe("llama-3.3-70b");
+  });
 });

--- a/packages/llm/src/platform-models.test.ts
+++ b/packages/llm/src/platform-models.test.ts
@@ -172,3 +172,29 @@ describe("createPlatformModels — chain resolution", () => {
     ).toThrow(PlatformModelsConfigError);
   });
 });
+
+describe("createPlatformModels — lazy resolution", () => {
+  // Regression guard for the hot-reload contract: a runtime env mutation
+  // (e.g. PUT /api/config/env) must be reflected the next time `get()`
+  // is called. Eager-resolve would freeze the model instance at boot
+  // and the daemon's classifier/planner would keep using stale creds
+  // even after the catalog UI says "live".
+
+  it("re-resolves get() against the current process.env on each call", () => {
+    stubEnv({ ANTHROPIC_API_KEY: "sk-ant-test", GROQ_API_KEY: "gsk_test" });
+    const pm = createPlatformModels({
+      models: {
+        // Chain: groq primary → anthropic fallback. With both creds set,
+        // primary wins.
+        labels: ["groq:llama-3.3-70b", "anthropic:claude-haiku-4-5"],
+      },
+    });
+    expect(pm.get("labels").modelId).toBe("llama-3.3-70b");
+
+    // Simulate the hot-reload deleting the groq credential. Eager-resolve
+    // would keep returning the cached groq instance; lazy must fail over
+    // to the anthropic fallback.
+    delete process.env.GROQ_API_KEY;
+    expect(pm.get("labels").modelId).toBe("claude-haiku-4-5");
+  });
+});

--- a/packages/llm/src/platform-models.test.ts
+++ b/packages/llm/src/platform-models.test.ts
@@ -174,26 +174,15 @@ describe("createPlatformModels — chain resolution", () => {
 });
 
 describe("createPlatformModels — lazy resolution", () => {
-  // Regression guard for the hot-reload contract: a runtime env mutation
-  // (e.g. PUT /api/config/env) must be reflected the next time `get()`
-  // is called. Eager-resolve would freeze the model instance at boot
-  // and the daemon's classifier/planner would keep using stale creds
-  // even after the catalog UI says "live".
-
   it("re-resolves get() against the current process.env on each call", () => {
     stubEnv({ ANTHROPIC_API_KEY: "sk-ant-test", GROQ_API_KEY: "gsk_test" });
     const pm = createPlatformModels({
       models: {
-        // Chain: groq primary → anthropic fallback. With both creds set,
-        // primary wins.
         labels: ["groq:llama-3.3-70b", "anthropic:claude-haiku-4-5"],
       },
     });
     expect(pm.get("labels").modelId).toBe("llama-3.3-70b");
 
-    // Simulate the hot-reload deleting the groq credential. Eager-resolve
-    // would keep returning the cached groq instance; lazy must fail over
-    // to the anthropic fallback.
     delete process.env.GROQ_API_KEY;
     expect(pm.get("labels").modelId).toBe("claude-haiku-4-5");
   });

--- a/packages/llm/src/platform-models.ts
+++ b/packages/llm/src/platform-models.ts
@@ -241,41 +241,49 @@ function resolveRole(
 
 /**
  * Construct a `PlatformModels` resolver from optional friday.yml configuration.
- * Validates each role eagerly, applies tracing middleware, and throws a
- * single `PlatformModelsConfigError` aggregating every problem found.
+ *
+ * Validates each role eagerly at construction so bad `friday.yml` fails fast
+ * at startup with every error aggregated into a single
+ * `PlatformModelsConfigError`. After that pass the constructor returns —
+ * `get(role)` then re-runs the resolver on every call so a runtime env
+ * mutation (e.g. `PUT /api/config/env` adding a Groq key) is reflected
+ * immediately. Eager validation + lazy resolution keeps the boot-time
+ * fail-fast contract while letting the registry's hot-reload reach the
+ * daemon's actual LLM call sites.
  */
 export function createPlatformModels(config: PlatformModelsInput | null): PlatformModels {
   const userConfig = config?.models;
-  const errors: ResolutionError[] = [];
-  const resolved = new Map<PlatformRole, LanguageModelV3>();
-
   const roles: PlatformRole[] = ["labels", "classifier", "planner", "conversational"];
-  for (const role of roles) {
-    const result = resolveRole(role, userConfig?.[role], errors);
-    if (result) resolved.set(role, result);
-  }
 
-  if (errors.length > 0) {
-    throw new PlatformModelsConfigError(errors);
-  }
-
-  // Log resolved models so operators can verify friday.yml took effect
+  // Boot-time validation pass — aggregates every role's errors so the
+  // operator sees them all at once. We discard the resolved instances
+  // because the lazy `get()` below re-resolves on every call.
+  const bootErrors: ResolutionError[] = [];
   for (const role of roles) {
-    const model = resolved.get(role);
-    if (model) {
+    const result = resolveRole(role, userConfig?.[role], bootErrors);
+    if (result) {
       logger.info("Platform model resolved", {
         role,
-        provider: model.provider,
-        modelId: model.modelId,
+        provider: result.provider,
+        modelId: result.modelId,
       });
     }
+  }
+  if (bootErrors.length > 0) {
+    throw new PlatformModelsConfigError(bootErrors);
   }
 
   return {
     get(role: PlatformRole): LanguageModelV3 {
-      const result = resolved.get(role);
+      // Re-resolve on each call so PUT /api/config/env updates (which
+      // mutate process.env + reset the registry) are picked up without
+      // a daemon restart. `resolveRole` is cheap: a credential check,
+      // one `registry.languageModel(…)` call (lazy on cache miss), and
+      // a tracing wrapper.
+      const errors: ResolutionError[] = [];
+      const result = resolveRole(role, userConfig?.[role], errors);
       if (!result) {
-        throw new Error(`Unreachable: platform model for role '${role}' was not resolved`);
+        throw new PlatformModelsConfigError(errors);
       }
       return result;
     },

--- a/packages/llm/src/platform-models.ts
+++ b/packages/llm/src/platform-models.ts
@@ -242,22 +242,15 @@ function resolveRole(
 /**
  * Construct a `PlatformModels` resolver from optional friday.yml configuration.
  *
- * Validates each role eagerly at construction so bad `friday.yml` fails fast
- * at startup with every error aggregated into a single
- * `PlatformModelsConfigError`. After that pass the constructor returns —
- * `get(role)` then re-runs the resolver on every call so a runtime env
- * mutation (e.g. `PUT /api/config/env` adding a Groq key) is reflected
- * immediately. Eager validation + lazy resolution keeps the boot-time
- * fail-fast contract while letting the registry's hot-reload reach the
- * daemon's actual LLM call sites.
+ * Boot validates every role eagerly and aggregates errors into a single
+ * `PlatformModelsConfigError` so bad config fails fast. `get(role)` then
+ * re-resolves on every call so a runtime `process.env` mutation reaches
+ * the daemon's LLM call sites without a restart.
  */
 export function createPlatformModels(config: PlatformModelsInput | null): PlatformModels {
   const userConfig = config?.models;
   const roles: PlatformRole[] = ["labels", "classifier", "planner", "conversational"];
 
-  // Boot-time validation pass — aggregates every role's errors so the
-  // operator sees them all at once. We discard the resolved instances
-  // because the lazy `get()` below re-resolves on every call.
   const bootErrors: ResolutionError[] = [];
   for (const role of roles) {
     const result = resolveRole(role, userConfig?.[role], bootErrors);
@@ -275,11 +268,6 @@ export function createPlatformModels(config: PlatformModelsInput | null): Platfo
 
   return {
     get(role: PlatformRole): LanguageModelV3 {
-      // Re-resolve on each call so PUT /api/config/env updates (which
-      // mutate process.env + reset the registry) are picked up without
-      // a daemon restart. `resolveRole` is cheap: a credential check,
-      // one `registry.languageModel(…)` call (lazy on cache miss), and
-      // a tracing wrapper.
       const errors: ResolutionError[] = [];
       const result = resolveRole(role, userConfig?.[role], errors);
       if (!result) {

--- a/packages/llm/src/registry.ts
+++ b/packages/llm/src/registry.ts
@@ -133,11 +133,10 @@ function createRegistry() {
 let _registry: ReturnType<typeof createRegistry> | null = null;
 
 /**
- * Reset the lazy registry singleton. The next call into the registry
- * re-runs `createRegistry()`, which re-reads `process.env` and rebuilds
- * each provider client. Used after a runtime env update (PUT
- * /api/config/env) so newly-added API keys are picked up without a
- * daemon restart.
+ * Reset the lazy registry singleton. The next call re-runs
+ * `createRegistry()`, re-reading `process.env` and rebuilding every
+ * provider client — required after a runtime env mutation since each
+ * provider captures its `apiKey` at construction.
  */
 export function resetRegistry(): void {
   _registry = null;

--- a/packages/llm/src/registry.ts
+++ b/packages/llm/src/registry.ts
@@ -132,6 +132,17 @@ function createRegistry() {
  */
 let _registry: ReturnType<typeof createRegistry> | null = null;
 
+/**
+ * Reset the lazy registry singleton. The next call into the registry
+ * re-runs `createRegistry()`, which re-reads `process.env` and rebuilds
+ * each provider client. Used after a runtime env update (PUT
+ * /api/config/env) so newly-added API keys are picked up without a
+ * daemon restart.
+ */
+export function resetRegistry(): void {
+  _registry = null;
+}
+
 export const registry = {
   languageModel: (...args: Parameters<ReturnType<typeof createRegistry>["languageModel"]>) => {
     if (!_registry) _registry = createRegistry();

--- a/tools/agent-playground/src/routes/settings/+page.svelte
+++ b/tools/agent-playground/src/routes/settings/+page.svelte
@@ -159,10 +159,6 @@
   let modelsError = $state<string | null>(null);
   let catalogError = $state<string | null>(null);
   let successFlash = $state<string | null>(null);
-  // Saved env vars that the catalog hasn't yet confirmed live. Renders
-  // the persistent restart banner; the daemon's hot-reload almost
-  // always clears this on the next `loadCatalog()`.
-  let pendingRestartKeys = $state<string[]>([]);
 
   const queryClient = useQueryClient();
 
@@ -433,20 +429,6 @@
   // ─── Save-key (inline unlock) ──────────────────────────────────────
 
   /**
-   * Drop keys from `pendingRestartKeys` that the catalog now reports as
-   * configured, plus keys not tied to any catalog provider (random env
-   * vars don't gate UI here).
-   */
-  function confirmPendingAgainstCatalog(): void {
-    if (pendingRestartKeys.length === 0) return;
-    pendingRestartKeys = pendingRestartKeys.filter((k) => {
-      const entry = catalog.find((e) => e.credentialEnvVar === k);
-      if (!entry) return false;
-      return !entry.credentialConfigured;
-    });
-  }
-
-  /**
    * Inline API-key save from the picker's locked-provider banner. Reads
    * current .env, splices in the new key, PUTs the full map. Returns
    * the updated catalog (with the newly-unlocked provider flipped) so
@@ -471,17 +453,7 @@
       throw new Error(`Save failed (HTTP ${putRes.status}): ${text}`);
     }
 
-    pendingRestartKeys = [...new Set([...pendingRestartKeys, envVar])];
     await Promise.all([loadCatalog(), loadEnv()]);
-    confirmPendingAgainstCatalog();
-
-    if (!pendingRestartKeys.includes(envVar)) {
-      successFlash = `Saved ${envVar} — live.`;
-      setTimeout(() => {
-        if (successFlash && successFlash.includes(envVar)) successFlash = null;
-      }, 4000);
-    }
-
     return catalog;
   }
 
@@ -562,22 +534,7 @@
         return;
       }
 
-      const providerKeysInPayload = catalog
-        .map((e) => e.credentialEnvVar)
-        .filter((k): k is string => k !== null && k in payload && payload[k].length > 0);
-      if (providerKeysInPayload.length > 0) {
-        pendingRestartKeys = [...new Set([...pendingRestartKeys, ...providerKeysInPayload])];
-      }
-
       await loadCatalog();
-      confirmPendingAgainstCatalog();
-
-      if (pendingRestartKeys.length === 0) {
-        successFlash = "Environment saved — live.";
-        setTimeout(() => {
-          if (successFlash && successFlash.includes("Environment saved")) successFlash = null;
-        }, 4000);
-      }
     } catch (err) {
       envError = err instanceof Error ? err.message : String(err);
     } finally {
@@ -826,14 +783,6 @@
   <PageLayout.Body>
     <PageLayout.Content>
       <div class="settings-root">
-        {#if pendingRestartKeys.length > 0}
-          <div class="warn-banner" role="alert">
-            Saved <strong>{pendingRestartKeys.join(", ")}</strong>
-            to <code>{envPath ?? ".env"}</code>
-            , but the daemon hasn't picked
-            {pendingRestartKeys.length === 1 ? "it" : "them"} up. Restart the daemon to apply.
-          </div>
-        {/if}
         <!-- ─── Models section ────────────────────────────────────────── -->
         <section class="section">
           <div class="section-header-row">

--- a/tools/agent-playground/src/routes/settings/+page.svelte
+++ b/tools/agent-playground/src/routes/settings/+page.svelte
@@ -159,6 +159,13 @@
   let modelsError = $state<string | null>(null);
   let catalogError = $state<string | null>(null);
   let successFlash = $state<string | null>(null);
+  // Env vars saved by the user but not yet confirmed live in the daemon
+  // catalog. The daemon hot-reloads `.env` on PUT, so this usually
+  // clears immediately after `loadCatalog()`. A non-empty list means
+  // either the hot-reload didn't take (logged warning daemon-side) or
+  // the key isn't tied to a known provider — either way the user needs
+  // a restart for it to take effect on already-running subprocesses.
+  let pendingRestartKeys = $state<string[]>([]);
 
   const queryClient = useQueryClient();
 
@@ -429,10 +436,32 @@
   // ─── Save-key (inline unlock) ──────────────────────────────────────
 
   /**
+   * Filter `pendingRestartKeys` against the current catalog. A pending
+   * key is "live" when the catalog reports the matching provider as
+   * `credentialConfigured: true`. Keys that don't tie to any provider
+   * (random env vars) are also cleared — they don't gate any UI here
+   * and the file-write already succeeded.
+   */
+  function confirmPendingAgainstCatalog(): void {
+    if (pendingRestartKeys.length === 0) return;
+    pendingRestartKeys = pendingRestartKeys.filter((k) => {
+      const entry = catalog.find((e) => e.credentialEnvVar === k);
+      if (!entry) return false;
+      return !entry.credentialConfigured;
+    });
+  }
+
+  /**
    * Inline API-key save from the picker's locked-provider banner. Reads
    * current .env, splices in the new key, PUTs the full map. Returns
    * the updated catalog (with the newly-unlocked provider flipped) so
    * the picker re-renders its pills immediately.
+   *
+   * The daemon hot-reloads its `process.env` on this PUT and resets the
+   * LLM registry + catalog cache, so the subsequent `loadCatalog()`
+   * call typically shows `credentialConfigured: true` for the provider
+   * we just unlocked — no restart required for in-daemon usage.
+   * `pendingRestartKeys` tracks the rare case where that didn't happen.
    */
   async function handleSaveApiKey(envVar: string, value: string): Promise<CatalogEntry[] | null> {
     // Refresh rows so we don't clobber concurrent edits from another
@@ -453,15 +482,23 @@
       throw new Error(`Save failed (HTTP ${putRes.status}): ${text}`);
     }
 
-    const savedTo = envPath ?? "the daemon's .env file";
-    successFlash = `Saved ${envVar} to ${savedTo}. Restart the daemon to apply.`;
-    setTimeout(() => {
-      if (successFlash && successFlash.includes(envVar)) successFlash = null;
-    }, 4000);
+    // Mark this key as pending until the catalog confirms it's live.
+    pendingRestartKeys = [...new Set([...pendingRestartKeys, envVar])];
 
     // Reload the catalog so the provider we just unlocked flips to
     // credentialConfigured: true. Also pull env rows in sync.
     await Promise.all([loadCatalog(), loadEnv()]);
+    confirmPendingAgainstCatalog();
+
+    if (!pendingRestartKeys.includes(envVar)) {
+      successFlash = `Saved ${envVar} — live.`;
+      setTimeout(() => {
+        if (successFlash && successFlash.includes(envVar)) successFlash = null;
+      }, 4000);
+    }
+    // Else: persistent banner (rendered from `pendingRestartKeys`)
+    // tells the user a restart is needed; no flash.
+
     return catalog;
   }
 
@@ -541,10 +578,26 @@
         envError = `Save failed (HTTP ${res.status}): ${text}`;
         return;
       }
-      successFlash = "Environment saved. Restart the daemon to apply.";
-      setTimeout(() => {
-        if (successFlash && successFlash.includes("Environment saved")) successFlash = null;
-      }, 4000);
+
+      // Push all provider-keyed envs into the pending set, then let
+      // the catalog reload clear anything that came back live.
+      const providerKeysInPayload = catalog
+        .map((e) => e.credentialEnvVar)
+        .filter((k): k is string => k !== null && k in payload && payload[k].length > 0);
+      if (providerKeysInPayload.length > 0) {
+        pendingRestartKeys = [...new Set([...pendingRestartKeys, ...providerKeysInPayload])];
+      }
+
+      await loadCatalog();
+      confirmPendingAgainstCatalog();
+
+      if (pendingRestartKeys.length === 0) {
+        successFlash = "Environment saved — live.";
+        setTimeout(() => {
+          if (successFlash && successFlash.includes("Environment saved")) successFlash = null;
+        }, 4000);
+      }
+      // Else: persistent banner covers it.
     } catch (err) {
       envError = err instanceof Error ? err.message : String(err);
     } finally {
@@ -793,6 +846,14 @@
   <PageLayout.Body>
     <PageLayout.Content>
       <div class="settings-root">
+        {#if pendingRestartKeys.length > 0}
+          <div class="warn-banner" role="alert">
+            Saved <strong>{pendingRestartKeys.join(", ")}</strong>
+            to <code>{envPath ?? ".env"}</code>
+            , but the daemon hasn't picked
+            {pendingRestartKeys.length === 1 ? "it" : "them"} up. Restart the daemon to apply.
+          </div>
+        {/if}
         <!-- ─── Models section ────────────────────────────────────────── -->
         <section class="section">
           <div class="section-header-row">

--- a/tools/agent-playground/src/routes/settings/+page.svelte
+++ b/tools/agent-playground/src/routes/settings/+page.svelte
@@ -159,12 +159,9 @@
   let modelsError = $state<string | null>(null);
   let catalogError = $state<string | null>(null);
   let successFlash = $state<string | null>(null);
-  // Env vars saved by the user but not yet confirmed live in the daemon
-  // catalog. The daemon hot-reloads `.env` on PUT, so this usually
-  // clears immediately after `loadCatalog()`. A non-empty list means
-  // either the hot-reload didn't take (logged warning daemon-side) or
-  // the key isn't tied to a known provider — either way the user needs
-  // a restart for it to take effect on already-running subprocesses.
+  // Saved env vars that the catalog hasn't yet confirmed live. Renders
+  // the persistent restart banner; the daemon's hot-reload almost
+  // always clears this on the next `loadCatalog()`.
   let pendingRestartKeys = $state<string[]>([]);
 
   const queryClient = useQueryClient();
@@ -436,11 +433,9 @@
   // ─── Save-key (inline unlock) ──────────────────────────────────────
 
   /**
-   * Filter `pendingRestartKeys` against the current catalog. A pending
-   * key is "live" when the catalog reports the matching provider as
-   * `credentialConfigured: true`. Keys that don't tie to any provider
-   * (random env vars) are also cleared — they don't gate any UI here
-   * and the file-write already succeeded.
+   * Drop keys from `pendingRestartKeys` that the catalog now reports as
+   * configured, plus keys not tied to any catalog provider (random env
+   * vars don't gate UI here).
    */
   function confirmPendingAgainstCatalog(): void {
     if (pendingRestartKeys.length === 0) return;
@@ -456,12 +451,6 @@
    * current .env, splices in the new key, PUTs the full map. Returns
    * the updated catalog (with the newly-unlocked provider flipped) so
    * the picker re-renders its pills immediately.
-   *
-   * The daemon hot-reloads its `process.env` on this PUT and resets the
-   * LLM registry + catalog cache, so the subsequent `loadCatalog()`
-   * call typically shows `credentialConfigured: true` for the provider
-   * we just unlocked — no restart required for in-daemon usage.
-   * `pendingRestartKeys` tracks the rare case where that didn't happen.
    */
   async function handleSaveApiKey(envVar: string, value: string): Promise<CatalogEntry[] | null> {
     // Refresh rows so we don't clobber concurrent edits from another
@@ -482,11 +471,7 @@
       throw new Error(`Save failed (HTTP ${putRes.status}): ${text}`);
     }
 
-    // Mark this key as pending until the catalog confirms it's live.
     pendingRestartKeys = [...new Set([...pendingRestartKeys, envVar])];
-
-    // Reload the catalog so the provider we just unlocked flips to
-    // credentialConfigured: true. Also pull env rows in sync.
     await Promise.all([loadCatalog(), loadEnv()]);
     confirmPendingAgainstCatalog();
 
@@ -496,8 +481,6 @@
         if (successFlash && successFlash.includes(envVar)) successFlash = null;
       }, 4000);
     }
-    // Else: persistent banner (rendered from `pendingRestartKeys`)
-    // tells the user a restart is needed; no flash.
 
     return catalog;
   }
@@ -579,8 +562,6 @@
         return;
       }
 
-      // Push all provider-keyed envs into the pending set, then let
-      // the catalog reload clear anything that came back live.
       const providerKeysInPayload = catalog
         .map((e) => e.credentialEnvVar)
         .filter((k): k is string => k !== null && k in payload && payload[k].length > 0);
@@ -597,7 +578,6 @@
           if (successFlash && successFlash.includes("Environment saved")) successFlash = null;
         }, 4000);
       }
-      // Else: persistent banner covers it.
     } catch (err) {
       envError = err instanceof Error ? err.message : String(err);
     } finally {


### PR DESCRIPTION
## Summary

- **The bug:** Adding an API key in Settings wrote it to `.env`, but the daemon's `process.env` was loaded once by Deno `--env-file` at startup, the LLM registry memoized stale creds, and the catalog cached its empty entry for 1h. User had to restart the daemon for a newly-added Groq key to appear.
- **The fix:** `PUT /api/config/env` now diffs prior vs. new keys, mutates `process.env` in place (assign adds/updates, delete removes), then calls `resetRegistry()` + `invalidateCatalog()`. Next catalog fetch re-evaluates against the live env. No restart.
- **UI:** Replace the 4-second "Restart the daemon to apply" flash with a persistent banner that only renders when `pendingRestartKeys` is non-empty (i.e. when the daemon-side hot-reload didn't take). On the happy path the banner never appears.

## Test Plan

- [x] `vitest run packages/llm/src/model-catalog.test.ts` — 7/7 passing (rename `resetCatalogCacheForTests` → `invalidateCatalog`)
- [x] `vitest run apps/atlasd/routes/config.test.ts` — 14/14 passing (existing PUT /env on-disk format tests unaffected)
- [x] `deno check` on all edited TS files — 0 errors
- [x] `deno task check` on agent-playground — 0 errors (Svelte pre-existing warnings only)
- [x] Live verification via daemon at `localhost:8080`: PUT removed `GROQ_API_KEY` → catalog flipped to `{configured:false, models:0}`. PUT re-added it → flipped to `{configured:true, models:5}`. No restart between calls.