### PR TITLE
Chat-UI: image drag-and-drop now works in Safari

### DIFF
--- a/tools/agent-playground/src/lib/components/chat/chat-input.svelte
+++ b/tools/agent-playground/src/lib/components/chat/chat-input.svelte
@@ -144,8 +144,18 @@
     }
   }
 
+  // Safari requires preventDefault on BOTH dragenter and dragover to register
+  // the element as a valid drop target; without dragenter prevention it falls
+  // back to its default file-open behavior on drop.
+  function handleDragEnter(e: DragEvent) {
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+    dragOver = true;
+  }
+
   function handleDragOver(e: DragEvent) {
     e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
     dragOver = true;
   }
 
@@ -182,6 +192,7 @@
   class="chat-input-wrapper"
   class:drag-over={dragOver}
   ondrop={handleDrop}
+  ondragenter={handleDragEnter}
   ondragover={handleDragOver}
   ondragleave={handleDragLeave}
   role="presentation"

--- a/tools/agent-playground/src/lib/components/chat/user-chat.svelte
+++ b/tools/agent-playground/src/lib/components/chat/user-chat.svelte
@@ -76,8 +76,18 @@
     }
   }
 
+  // Safari requires preventDefault on BOTH dragenter and dragover to register
+  // the element as a valid drop target; without dragenter prevention it falls
+  // back to its default file-open behavior on drop.
+  function handleChatDragEnter(e: DragEvent) {
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+    chatDragOver = true;
+  }
+
   function handleChatDragOver(e: DragEvent) {
     e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
     chatDragOver = true;
   }
 
@@ -1310,6 +1320,7 @@
   class="user-chat"
   class:chat-drag-over={chatDragOver}
   ondrop={handleChatDrop}
+  ondragenter={handleChatDragEnter}
   ondragover={handleChatDragOver}
   ondragleave={handleChatDragLeave}
   role="presentation"

--- a/tools/agent-playground/src/lib/components/shared/artifact-upload.svelte
+++ b/tools/agent-playground/src/lib/components/shared/artifact-upload.svelte
@@ -95,8 +95,19 @@
     if (droppedFile) handleFile(droppedFile);
   }
 
+  // Safari requires preventDefault on BOTH dragenter and dragover to register
+  // the element as a valid drop target; without dragenter prevention it falls
+  // back to its default file-open behavior on drop.
+  function handleDragEnter(e: DragEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+    dragOver = true;
+  }
+
   function handleDragOver(e: DragEvent) {
     e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
     dragOver = true;
   }
 
@@ -123,6 +134,7 @@
       class="dropzone"
       class:drag-over={dragOver}
       ondrop={handleDrop}
+      ondragenter={handleDragEnter}
       ondragover={handleDragOver}
       ondragleave={handleDragLeave}
     >

--- a/tools/agent-playground/src/lib/components/skills/skill-loader.svelte
+++ b/tools/agent-playground/src/lib/components/skills/skill-loader.svelte
@@ -36,8 +36,18 @@
    *  only have the raw blob and the suggested name — re-POST with ?namespace=. */
   let pendingArchive = $state<{ blob: Blob; filename: string; defaultName: string } | null>(null);
 
+  // Safari requires preventDefault on BOTH dragenter and dragover to register
+  // the element as a valid drop target; without dragenter prevention it falls
+  // back to its default file-open behavior on drop.
+  function handleDragEnter(e: DragEvent) {
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+    dragOver = true;
+  }
+
   function handleDragOver(e: DragEvent) {
     e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
     dragOver = true;
   }
 
@@ -377,6 +387,7 @@
     class="drop-zone"
     class:drag-over={dragOver}
     class:inline
+    ondragenter={handleDragEnter}
     ondragover={handleDragOver}
     ondragleave={handleDragLeave}
     ondrop={handleDrop}

--- a/tools/agent-playground/src/lib/components/workspace/workspace-loader.svelte
+++ b/tools/agent-playground/src/lib/components/workspace/workspace-loader.svelte
@@ -52,8 +52,18 @@
     return raw;
   }
 
+  // Safari requires preventDefault on BOTH dragenter and dragover to register
+  // the element as a valid drop target; without dragenter prevention it falls
+  // back to its default file-open behavior on drop.
+  function handleDragEnter(e: DragEvent) {
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+    dragOver = true;
+  }
+
   function handleDragOver(e: DragEvent) {
     e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
     dragOver = true;
   }
 
@@ -137,6 +147,7 @@
   class="drop-zone"
   class:drag-over={dragOver}
   class:inline
+  ondragenter={handleDragEnter}
   ondragover={handleDragOver}
   ondragleave={handleDragLeave}
   ondrop={handleDrop}


### PR DESCRIPTION
## Summary

- Safari treated dropped images on the chat input as a navigation: the window blinked and the image opened in a new tab. Chrome worked fine.
- Root cause: per the HTML5 drag-and-drop spec, an element only becomes a valid drop target when `preventDefault()` is called on **both `dragenter` and `dragover`**. The drop zones in `chat-input.svelte` and `user-chat.svelte` only handled `dragover`. Chrome is lenient and accepts this; Safari is strict and falls through to its default action (open the file).
- Fix: add a `dragenter` handler on both wrappers that calls `preventDefault()`, and set `dataTransfer.dropEffect = "copy"` in both `dragenter` and `dragover` so Safari keeps the area registered as a copy-drop target throughout the drag.

## Test plan

- [ ] Safari: drag an image from Finder onto the chat input — image attaches, no new tab/window
- [ ] Safari: drag an image onto the broader chat area (outside the input box) — image attaches via the `user-chat` overlay
- [ ] Chrome: same two flows still work
- [ ] Paste-from-clipboard image still works (unrelated handler, sanity check)