### PR TITLE
Home-dir isolation: dev and prod each get their own NATS broker

### DIFF
--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -1,0 +1,293 @@
+# Environments
+
+> **Draft — describes post-home-isolation state.** This page reflects
+> the operator surface *after* Phase 3 of the home-isolation work
+> ships (alignment of `getFridayHome()`'s default to `~/.friday/local`,
+> explicit pinning of `FRIDAY_HOME=$HOME/.atlas` in the dev task). On
+> builds where that work hasn't landed yet, the `FRIDAY_HOME` default
+> for bare CLI and `deno task atlas` is `~/.atlas` — see the
+> "FRIDAY_HOME" section below for the transition note. Remove this
+> banner once Phase 3 ships and the description is accurate everywhere.
+
+Friday reads its configuration from a single `.env` file under its home
+directory. This page is the operator-facing reference: what each
+variable does, when to set it, and what the default is.
+
+## How Friday discovers config
+
+On every supervised process — daemon, link, webhook-tunnel,
+playground — Friday resolves its home directory once at boot, then
+reads `<home>/.env` for the rest. Resolution order:
+
+1. `FRIDAY_HOME` env var, if set, wins.
+2. Friday Studio's launcher pins this for every supervised child to
+   `FRIDAY_LAUNCHER_HOME` (or its default `~/.friday/local`).
+3. Bare CLI / `deno task atlas` invocations fall through to a default
+   that's set per-binary (see §"For everyone" below).
+4. The home directory holds your `.env`, `friday.yml` (optional model
+   overrides), NATS JetStream data (`<home>/nats/`), logs, workspaces,
+   chats, sessions, skills, and credentials.
+
+Override priority is **shell env > `.env` file > built-in default**.
+Shell variables you export before launching Friday always beat values
+in `.env`. This matters in CI and when debugging — exporting
+`FRIDAY_LOG_LEVEL=debug` in the same terminal as the launcher gives
+you a debug log without editing the file.
+
+`.env` is plain `KEY=VALUE` lines, one per line. Comments start with
+`#`. Values may be wrapped in single or double quotes; both are
+stripped on read. The Studio installer writes this file atomically
+during the API-Keys step.
+
+---
+
+## For everyone
+
+These are the two variables a Friday user is most likely to set.
+
+### `FRIDAY_HOME`
+
+What it does: the per-process root for everything Friday writes —
+workspaces, chats, sessions, skills database, memory, logs, NATS
+JetStream store, and `.env` itself.
+
+When to set it: when you want a Friday process to read and write a
+specific directory. Useful for running multiple isolated Friday
+instances on one machine (dev + prod, or per-project sandboxes).
+
+Default: Friday Studio.app uses `~/.friday/local` (the launcher pins
+`FRIDAY_HOME` for every supervised child). Bare `friday` binary
+and `deno task atlas` invocations resolve to a per-binary default
+that **differs across the home-isolation transition**:
+
+- **Current builds (pre-Phase 3):** bare CLI and `deno task atlas`
+  fall through to `~/.atlas` — the legacy default at
+  `packages/utils/src/paths.ts:83`. This mismatch with Studio.app's
+  `~/.friday/local` is the root cause the home-isolation plan
+  addresses.
+- **Post-Phase 3:** bare CLI defaults to `~/.friday/local` (matching
+  Studio.app). The dev `deno task atlas` task pins
+  `FRIDAY_HOME=$HOME/.atlas` explicitly in `deno.json` so dev
+  behavior is preserved with the inference made legible.
+
+Set `FRIDAY_HOME` to override.
+
+Example: `FRIDAY_HOME=/Users/alice/work/friday-project-a`
+
+### `FRIDAY_LAUNCHER_HOME`
+
+What it does: tells the Studio installer and the supervising launcher
+where to install / look for Friday's home. The installer can't read
+`FRIDAY_HOME` because that variable gets clobbered by every nested
+spawn; this one is launcher-scoped.
+
+When to set it: same case as `FRIDAY_HOME`, but for the
+Studio.app-managed install. Set this before launching the installer
+to relocate the whole tree away from `~/.friday/local`.
+
+Default: `~/.friday/local`.
+
+Example: `FRIDAY_LAUNCHER_HOME=/Volumes/External/friday`
+
+---
+
+## For installers and operators
+
+### Port remap
+
+Friday Studio reserves a non-default port range so it doesn't clash
+with another Friday instance, a bare `atlasd` from source, or any
+other tool already on the conventional `5200`/`8080`. These four
+vars are written by the installer to `<home>/.env`:
+
+| Var | What it controls | Default (installer) |
+|---|---|---|
+| `FRIDAY_PORT_FRIDAY` | Daemon HTTP API | `18080` |
+| `FRIDAY_PORT_LINK` | Credential service | `13100` |
+| `FRIDAY_PORT_WEBHOOK_TUNNEL` | Webhook tunnel | `19090` |
+| `FRIDAY_PORT_PLAYGROUND` | Studio UI | `15200` |
+
+Set these in `<home>/.env` to move a service off its default. The
+launcher reads each one and translates it into the right per-service
+knob — daemon `--port`, `LINK_PORT`, `TUNNEL_PORT`, `PLAYGROUND_PORT`.
+
+### URLs the UI needs
+
+The playground UI is served as static HTML with a
+`window.__FRIDAY_CONFIG__` object injected at request time. It needs
+to know the absolute URL of the daemon and the webhook tunnel
+(otherwise it tries to relative-path against the playground origin):
+
+| Var | What it controls | Default |
+|---|---|---|
+| `FRIDAYD_URL` | Daemon URL for CLI / launcher / sibling services | `http://localhost:8080` (installer writes `:18080`) |
+| `EXTERNAL_DAEMON_URL` | UI-facing daemon URL — what the browser hits | falls back to `FRIDAYD_URL` |
+| `EXTERNAL_TUNNEL_URL` | UI-facing webhook-tunnel URL | none |
+| `LINK_SERVICE_URL` | Where the daemon proxies `/api/link/*` | `http://localhost:3100` (installer writes `:13100`) |
+
+Set `EXTERNAL_DAEMON_URL` / `EXTERNAL_TUNNEL_URL` when you've placed
+a reverse proxy or tunnel in front of Friday and the browser needs
+the public address.
+
+### JetStream store directory
+
+| Var | What it controls | Default |
+|---|---|---|
+| `FRIDAY_JETSTREAM_STORE_DIR` | NATS JetStream `-sd` argument; where chat history, session events, KV data live on disk. | `<FRIDAY_HOME>/nats` |
+
+Set this only if you need the store on a different filesystem (e.g.
+fast SSD, larger volume). The launcher, the daemon's
+`readJetStreamConfig`, and `atlas migrate` all resolve the same
+default — keep them in agreement.
+
+### Provider API keys
+
+The installer's API-Keys step writes whichever of these you provided.
+They're plain `.env` entries, append-or-replace semantics on rerun.
+
+`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`,
+`GROQ_API_KEY`, `FIREWORKS_API_KEY`, `PARALLEL_API_KEY`,
+`TAVILY_API_KEY`, `BRAVE_SEARCH_API_KEY`.
+
+For non-Anthropic picks the installer also writes a `models:` block
+to `<home>/friday.yml` so the daemon's role resolver targets the
+right model IDs.
+
+### Friday environment mode
+
+| Var | What it controls | Default |
+|---|---|---|
+| `FRIDAY_ENV` | Setting this to `dev` enables the local-first session middleware (no remote credential fetch, auto-mint of a `/api/*` session). Any other value or unset = fail closed and require a valid Bearer / session cookie. | unset (fail closed) |
+| `FRIDAY_KEY` | Bearer token for outbound calls to Link / cypher / share / persona / search-gateway. **Not** a local-identity JWT. | unset (local-only mode) |
+
+The Studio installer writes `FRIDAY_ENV=dev` by default. Production
+hosted deployments leave it unset and supply `FRIDAY_KEY` via a
+credential service.
+
+### Log level
+
+| Var | What it controls | Default |
+|---|---|---|
+| `FRIDAY_LOG_LEVEL` | `trace`, `debug`, `info`, `warn`, `error`, `fatal` | `info` |
+| `FRIDAY_LOGS_DIR` | Override the logs directory | `<FRIDAY_HOME>/logs` |
+
+---
+
+## For CI and power users
+
+### Multi-tenant on one host
+
+Two Friday instances on the same machine need three things to coexist:
+
+1. Distinct home directories — different `FRIDAY_HOME` per process.
+2. Distinct HTTP / UI ports — different `FRIDAY_PORT_*` values in
+   each home's `.env`.
+3. NATS isolation: the spawning binary auto-allocates a free port
+   per home (see §"NATS port selection" below). You do **not** need
+   to set anything for this; the binary handles it.
+
+Example two-instance layout:
+```
+~/.friday/work/.env        FRIDAY_PORT_FRIDAY=18080  ...
+~/.friday/personal/.env    FRIDAY_PORT_FRIDAY=18180  ...
+```
+Then launch each with its `FRIDAY_HOME` exported.
+
+### Tool path overrides
+
+The launcher discovers these binaries at startup and injects the
+absolute paths so the daemon doesn't have to consult PATH. Set them
+yourself only if you're running outside the launcher (e.g.
+`deno task atlas`) and want to point at a specific build:
+
+`FRIDAY_CLAUDE_PATH`, `FRIDAY_NODE_PATH`, `FRIDAY_NPX_PATH`,
+`FRIDAY_UV_PATH`, `FRIDAY_UVX_PATH`, `FRIDAY_AGENT_BROWSER_PATH`,
+`FRIDAY_AGENT_PYTHON`.
+
+### Skill registry / kernel surface
+
+| Var | What it controls | Default |
+|---|---|---|
+| `FRIDAY_ALLOW_REMOTE_SKILLS` | Allow installing skills from remote registries. Set to `"false"` to lock down a hardened install. | enabled by default |
+| `FRIDAY_EXPOSE_KERNEL` | Show the internal kernel workspace in the picker. | `0` (hidden) |
+
+### JetStream tuning
+
+For unusual workloads. Defaults are fine for laptop and small-team
+use. Full list lives in `.env.example`: `FRIDAY_JETSTREAM_MAX_*`,
+`FRIDAY_JETSTREAM_DUPLICATE_WINDOW`, `FRIDAY_JETSTREAM_ACK_WAIT`.
+
+### Webhook tunnel knobs
+
+`TUNNEL_PORT` (default `9090`), `TUNNEL_TOKEN` (Cloudflare tunnel
+token), `NO_TUNNEL` (set to `true` to disable the cloudflared
+sidecar in CI), `WEBHOOK_SECRET` (HMAC verification — auto-generated
+if absent), `WEBHOOK_MAPPINGS_PATH` (override embedded mappings).
+
+### Link service overrides
+
+`LINK_PORT`, `LINK_DB_PATH`, `LINK_CALLBACK_BASE`,
+`LINK_ALLOW_INSECURE_HTTP`, `LINK_DEV_MODE`,
+`LINK_JWT_PUBLIC_KEY_FILE`, `LINK_STATE_SIGNING_KEY_FILE`. Most
+installs need none of these — the launcher defaults
+`LINK_DEV_MODE=true` because Studio has no Postgres backing.
+
+---
+
+## For cloud deployments
+
+Self-hosted multi-tenant or k8s installs read three extra knobs.
+
+### External NATS broker
+
+| Var | What it controls | Default |
+|---|---|---|
+| `FRIDAY_NATS_URL` | Connect to an existing NATS broker instead of spawning one. Cloud-with-shared-broker path: one NATS cluster, all tenants connect via this URL, tenant isolation via subject prefixes or NATS accounts. | unset; Friday spawns its own |
+
+### Persona and credential services
+
+| Var | What it controls | Default |
+|---|---|---|
+| `PERSONA_URL` | Fetch user identity from a remote persona service. Requires `FRIDAY_KEY` for outbound auth. | unset (local `UserStorage`) |
+| `USER_IDENTITY_ADAPTER` | Force-set to `local` to ignore `PERSONA_URL`. | unset |
+| `FRIDAY_URL` | Base URL for the hosted Atlas API (credentials fetch). | `https://atlas.tempestdx.com` |
+| `FRIDAY_CREDENTIALS_URL` | Override the credentials endpoint directly. | `${FRIDAY_URL}/api/credentials` |
+| `FRIDAY_GATEWAY_URL` | LLM / search-tool gateway. Pairs with `FRIDAY_KEY` for outbound auth. | unset |
+| `FRIDAY_ATLAS_PLATFORM_URL` | One shared `atlas-platform` pod fronted by an HTTP service, addressed by N daemons. | `${daemon_url}/mcp` (same-host fallback) |
+| `CYPHER_TOKEN_URL` | Where the daemon fetches `FRIDAY_KEY` from cypher at boot. | unset |
+| `FRIDAY_SYSTEM_MODE` | Set to `"true"` to put logs under `/var/log/atlas` and home under `/var/lib/atlas`. | unset |
+
+### NATS port selection (future)
+
+Friday picks the NATS port at spawn time. The spawning binary
+(launcher in prod, daemon in dev) iterates the reserved range
+`14222..14231` and binds the first free slot, falling back to an
+OS-assigned port only if all ten are taken. The chosen URL is
+written to `<home>/nats/url` so consumers (the daemon, `atlas
+migrate`, future tooling) can discover it without guessing.
+
+This means **the NATS port is not configured per-home in `.env`**.
+There's no `FRIDAY_NATS_PORT_FOR_THIS_HOME` knob — the binary owns
+the decision so two homes-on-one-machine can't both write the same
+port to two `.env`s and collide.
+
+For orchestrator-managed deployments (k8s, multi-tenant launcher)
+where one pod-per-tenant needs a deterministic port allocated
+externally, set `FRIDAY_NATS_PORT` in shell / launchd / systemd /
+pod env — not in `.env`. The spawner picks up the env value and
+binds there directly. Operator-set, inspectable above the home-dir
+layer.
+
+| Var | Source | What it controls |
+|---|---|---|
+| `FRIDAY_NATS_PORT` | shell / orchestrator env (NOT `.env`) | Skip the reserved-range iteration; bind at this port. Cloud-per-tenant only. |
+
+---
+
+## See also
+
+- `.env.example` at the repo root lists every supported variable with
+  inline comments. It's the canonical "what knobs exist" reference;
+  this page is the "when and why to set them" companion.
+- `plans/friday-env-audit.md` is the implementer-facing variant with
+  call-site citations and an internal-state-diff proposal.

--- a/apps/atlas-cli/src/commands/migrate.ts
+++ b/apps/atlas-cli/src/commands/migrate.ts
@@ -25,7 +25,6 @@ import {
   MigrationLockError,
   type MigrationRecord,
   readJetStreamConfig,
-  resolveNatsUrl,
   runMigrations,
 } from "jetstream";
 import { errorOutput, infoOutput, successOutput } from "../utils/output.ts";
@@ -123,14 +122,15 @@ export const handler = async (argv: MigrateArgs): Promise<void> => {
     }
   }
 
-  const url = resolveNatsUrl({ url: argv.natsUrl });
   const cfg = readJetStreamConfig();
-  const storeDir = cfg.server.storeDir.value ?? join(getFridayHome(), "nats");
+  const home = getFridayHome();
+  const storeDir = cfg.server.storeDir.value ?? join(home, "nats");
 
   let handle: ConnectionHandle;
   try {
     handle = await connectOrSpawn({
-      url,
+      url: argv.natsUrl,
+      home,
       name: "atlas-cli-migrate",
       storeDir,
       spawnFallback: !argv.noSpawn,
@@ -189,14 +189,15 @@ export const handler = async (argv: MigrateArgs): Promise<void> => {
 };
 
 async function handleList(argv: MigrateArgs): Promise<void> {
-  const url = resolveNatsUrl({ url: argv.natsUrl });
   const cfg = readJetStreamConfig();
-  const storeDir = cfg.server.storeDir.value ?? join(getFridayHome(), "nats");
+  const home = getFridayHome();
+  const storeDir = cfg.server.storeDir.value ?? join(home, "nats");
 
   let handle: ConnectionHandle;
   try {
     handle = await connectOrSpawn({
-      url,
+      url: argv.natsUrl,
+      home,
       name: "atlas-cli-migrate",
       storeDir,
       spawnFallback: !argv.noSpawn,

--- a/apps/atlasd/daemon-startup.test.ts
+++ b/apps/atlasd/daemon-startup.test.ts
@@ -10,6 +10,9 @@
  * Source: apps/atlasd/src/atlas-daemon.ts initialization flow (lines ~245-260)
  */
 
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import process from "node:process";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AtlasDaemon } from "./src/atlas-daemon.ts";
@@ -37,12 +40,20 @@ function setCredential(key: string, value: string) {
 }
 
 describe("daemon startup platform models", () => {
-  beforeEach(() => {
+  let tempHome: string | null = null;
+
+  beforeEach(async () => {
     resetEnv();
     vi.clearAllMocks();
+    // Pin FRIDAY_HOME to a tempdir so daemon.initialize() doesn't touch
+    // the developer's real `~/.friday/local/` (which is occupied if
+    // Studio.app is installed — nats-server file lock collides). The
+    // tempdir gets cleaned in afterEach.
+    tempHome = await mkdtemp(join(tmpdir(), "atlasd-startup-test-"));
+    process.env.FRIDAY_HOME = tempHome;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     // Restore original env
     Object.assign(process.env, ORIGINAL_ENV);
     // Clear out any new keys that were added
@@ -50,6 +61,10 @@ describe("daemon startup platform models", () => {
       if (!(key in ORIGINAL_ENV)) {
         delete process.env[key];
       }
+    }
+    if (tempHome) {
+      await rm(tempHome, { recursive: true, force: true });
+      tempHome = null;
     }
   });
 

--- a/apps/atlasd/daemon-startup.test.ts
+++ b/apps/atlasd/daemon-startup.test.ts
@@ -41,6 +41,12 @@ function setCredential(key: string, value: string) {
 
 describe("daemon startup platform models", () => {
   let tempHome: string | null = null;
+  // Defensive: tests that throw mid-run between initialize() and
+  // shutdown() would otherwise leak a child nats-server holding the
+  // reserved port. Tests assign `activeDaemon = ...` after construction;
+  // afterEach unconditionally shuts it down. The shutdown call is
+  // idempotent so explicit shutdown() inside a passing test is fine.
+  let activeDaemon: AtlasDaemon | null = null;
 
   beforeEach(async () => {
     resetEnv();
@@ -54,6 +60,18 @@ describe("daemon startup platform models", () => {
   });
 
   afterEach(async () => {
+    // Belt-and-suspenders: even if the test forgot or threw, kill any
+    // spawned nats-server tied to this test's home before nuking the
+    // tempdir. Errors are swallowed — the test framework will surface
+    // any actual assertion failure separately.
+    if (activeDaemon) {
+      try {
+        await activeDaemon.shutdown();
+      } catch {
+        // Already shut down or never fully initialized — fine.
+      }
+      activeDaemon = null;
+    }
     // Restore original env
     Object.assign(process.env, ORIGINAL_ENV);
     // Clear out any new keys that were added
@@ -75,7 +93,8 @@ describe("daemon startup platform models", () => {
         // Minimal valid config: just set ANTHROPIC_API_KEY for the default chain
         setCredential("ANTHROPIC_API_KEY", "test-key");
 
-        const daemon = new AtlasDaemon({ port: 0 }); // port 0 = random free port
+        const daemon = new AtlasDaemon({ port: 0 });
+        activeDaemon = daemon; // port 0 = random free port
 
         // Should initialize without throwing
         await daemon.initialize();
@@ -103,6 +122,7 @@ describe("daemon startup platform models", () => {
         setCredential("ANTHROPIC_API_KEY", "test-anthropic-key");
 
         const daemon = new AtlasDaemon({ port: 0 });
+        activeDaemon = daemon;
         await daemon.initialize();
 
         const platformModels = (
@@ -123,6 +143,7 @@ describe("daemon startup platform models", () => {
       async () => {
         // No credentials set - default chain will fail on missing ANTHROPIC_API_KEY
         const daemon = new AtlasDaemon({ port: 0 });
+        activeDaemon = daemon;
 
         await expect(daemon.initialize()).rejects.toThrow(
           /Platform model configuration failed validation/,
@@ -149,6 +170,7 @@ describe("daemon startup platform models", () => {
 
         try {
           const daemon = new AtlasDaemon({ port: 0 });
+          activeDaemon = daemon;
           await expect(daemon.initialize()).rejects.toThrow(
             /Platform model configuration failed validation/,
           );
@@ -174,6 +196,7 @@ describe("daemon startup platform models", () => {
 
         try {
           const daemon = new AtlasDaemon({ port: 0 });
+          activeDaemon = daemon;
           await expect(daemon.initialize()).rejects.toThrow(
             /Platform model configuration failed validation/,
           );
@@ -194,6 +217,7 @@ describe("daemon startup platform models", () => {
         setCredential("ANTHROPIC_API_KEY", "test-key");
 
         const daemon = new AtlasDaemon({ port: 0 });
+        activeDaemon = daemon;
         await daemon.initialize();
 
         const platformModels = (
@@ -214,6 +238,7 @@ describe("daemon startup platform models", () => {
         setCredential("ANTHROPIC_API_KEY", "test-anthropic-key");
 
         const daemon = new AtlasDaemon({ port: 0 });
+        activeDaemon = daemon;
         await daemon.initialize();
 
         const platformModels = (
@@ -240,6 +265,7 @@ describe("daemon startup platform models", () => {
         expect(process.env.GROQ_API_KEY).toBeUndefined();
 
         const daemon = new AtlasDaemon({ port: 0 });
+        activeDaemon = daemon;
         await daemon.initialize();
 
         // All roles should be resolvable with LITELLM proxy
@@ -272,6 +298,7 @@ describe("daemon startup platform models", () => {
 
         try {
           const daemon = new AtlasDaemon({ port: 0 });
+          activeDaemon = daemon;
           // Should NOT throw - LITELLM_API_KEY satisfies credential check for any provider
           await daemon.initialize();
 

--- a/apps/atlasd/src/nats-manager.test.ts
+++ b/apps/atlasd/src/nats-manager.test.ts
@@ -1,6 +1,9 @@
 // Real broker (not a mock): the contract under test is NATS.js drain/close
 // semantics — mocking that boundary would mask the bugs we care about.
 
+import { mkdtemp, readFile, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import process from "node:process";
 import { startNatsTestServer, type TestNatsServer } from "@atlas/core/test-utils/nats-test-server";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -77,5 +80,84 @@ describe("NatsManager.stop(signal)", () => {
     // close() fallback is removed and stop() hangs on the broken drain.
     expect(elapsed).toBeLessThan(2000);
     expect(nc.isClosed()).toBe(true);
+  }, 15_000);
+});
+
+describe("NatsManager — URL file is the rendezvous for out-of-env consumers", () => {
+  let server: TestNatsServer | undefined;
+  let mgr: NatsManager | undefined;
+  let originalNatsUrl: string | undefined;
+  let originalFridayHome: string | undefined;
+  let home: string | undefined;
+
+  beforeEach(async () => {
+    originalNatsUrl = process.env.FRIDAY_NATS_URL;
+    originalFridayHome = process.env.FRIDAY_HOME;
+    home = await mkdtemp(join(tmpdir(), "nats-manager-url-file-test-"));
+    process.env.FRIDAY_HOME = home;
+  });
+
+  afterEach(async () => {
+    if (mgr) {
+      try {
+        await mgr.stop();
+      } catch {
+        // best-effort
+      }
+      mgr = undefined;
+    }
+    if (server) {
+      try {
+        await server.stop();
+      } catch {
+        // best-effort
+      }
+      server = undefined;
+    }
+    if (home) {
+      await rm(home, { recursive: true, force: true });
+      home = undefined;
+    }
+    if (originalNatsUrl === undefined) {
+      delete process.env.FRIDAY_NATS_URL;
+    } else {
+      process.env.FRIDAY_NATS_URL = originalNatsUrl;
+    }
+    if (originalFridayHome === undefined) {
+      delete process.env.FRIDAY_HOME;
+    } else {
+      process.env.FRIDAY_HOME = originalFridayHome;
+    }
+  });
+
+  it("writes <home>/nats/url even when FRIDAY_NATS_URL is set (launcher-supervised path)", async () => {
+    // The launcher-supervised production case: launcher pre-spawned
+    // nats-server and pushed `FRIDAY_NATS_URL` into the daemon's env.
+    // Without the URL-file write on this branch, a CLI in a separate
+    // terminal — no inherited env — falls through to its own spawn
+    // and crashes on the JetStream store-dir file lock.
+    server = await startNatsTestServer();
+    process.env.FRIDAY_NATS_URL = server.url;
+    mgr = new NatsManager();
+    await mgr.start();
+
+    const urlFilePath = join(home as string, "nats", "url");
+    const written = (await readFile(urlFilePath, "utf-8")).trim();
+    expect(written).toBe(server.url);
+  }, 15_000);
+
+  it("deletes <home>/nats/url on stop()", async () => {
+    server = await startNatsTestServer();
+    process.env.FRIDAY_NATS_URL = server.url;
+    mgr = new NatsManager();
+    await mgr.start();
+
+    const urlFilePath = join(home as string, "nats", "url");
+    await stat(urlFilePath); // pre-condition: file exists
+
+    await mgr.stop();
+    mgr = undefined;
+
+    await expect(stat(urlFilePath)).rejects.toMatchObject({ code: "ENOENT" });
   }, 15_000);
 });

--- a/apps/atlasd/src/nats-manager.ts
+++ b/apps/atlasd/src/nats-manager.ts
@@ -43,7 +43,11 @@ import type { NatsConnection } from "nats";
 export class NatsManager {
   private spawned: SpawnedNats | null = null;
   private nc: NatsConnection | null = null;
-  /** Set when we own the URL file (i.e. we spawned the broker). */
+  /**
+   * Set after a successful start. The daemon is the canonical writer
+   * of `<home>/nats/url` — `stop()` deletes the file regardless of
+   * which path put us on the broker (env URL, cached URL, own spawn).
+   */
   private ownsUrlFile = false;
 
   async start(): Promise<NatsConnection> {
@@ -52,58 +56,76 @@ export class NatsManager {
     const cfg = readJetStreamConfig();
     logger.info(formatStartupLog(cfg));
 
+    const home = getFridayHome();
+    let url: string;
+
     const externalUrl = process.env.FRIDAY_NATS_URL;
     if (externalUrl) {
       logger.info("Using external NATS server", { url: externalUrl });
       this.nc = await connectToNats({ url: externalUrl, name: "atlasd" });
-      logger.info("NATS connection established", { url: externalUrl });
-      return this.nc;
-    }
+      url = externalUrl;
+    } else {
+      const cachedUrl = await readBrokerUrlFile(home);
+      const cachedLive =
+        cachedUrl != null &&
+        (await (async () => {
+          const port = portFromUrl(cachedUrl);
+          return port != null && (await tcpProbe(port));
+        })());
 
-    const home = getFridayHome();
-    const cachedUrl = await readBrokerUrlFile(home);
-    if (cachedUrl) {
-      const port = portFromUrl(cachedUrl);
-      const live = port != null && (await tcpProbe(port));
-      if (live) {
+      if (cachedUrl && cachedLive) {
         logger.info("Discovered live broker via URL file; connecting without spawning", {
           url: cachedUrl,
           urlFile: brokerUrlFilePath(home),
         });
         this.nc = await connectToNats({ url: cachedUrl, name: "atlasd" });
-        logger.info("NATS connection established", { url: cachedUrl });
-        return this.nc;
+        url = cachedUrl;
+      } else {
+        if (cachedUrl) {
+          logger.warn("Stale URL file detected; spawning fresh broker", {
+            cachedUrl,
+            urlFile: brokerUrlFilePath(home),
+          });
+        }
+        const storeDir = cfg.server.storeDir.value ?? join(home, "nats");
+        // Earlier daemon versions wrote JetStream data to nats-server's
+        // built-in default location (`$TMPDIR/nats/jetstream`). Operators
+        // upgrading past that change saw a fresh empty broker. Detect
+        // orphaned data and tell them how to recover before they panic.
+        await this.warnIfOrphanedJetStreamData(storeDir);
+
+        const port = await pickPort();
+        // Use the daemon's persistent config dir so re-launches reuse
+        // the same generated server.conf (vs the spawn helper's default
+        // tmpdir-based work dir, which is right for ephemeral CLI
+        // spawns but throwaway for the daemon).
+        this.spawned = await spawnNatsServer({
+          port,
+          workDir: join(home, "nats"),
+          storeDir,
+          logger,
+        });
+        url = this.spawned.url;
+        this.nc = await connectToNats({ url, name: "atlasd" });
       }
-      logger.warn("Stale URL file detected; spawning fresh broker", {
-        cachedUrl,
-        urlFile: brokerUrlFilePath(home),
-      });
     }
 
-    const storeDir = cfg.server.storeDir.value ?? join(home, "nats");
-    // Earlier daemon versions wrote JetStream data to nats-server's
-    // built-in default location (`$TMPDIR/nats/jetstream`). Operators
-    // upgrading past that change saw a fresh empty broker. Detect
-    // orphaned data and tell them how to recover before they panic.
-    await this.warnIfOrphanedJetStreamData(storeDir);
-
-    const port = await pickPort();
-    // Use the daemon's persistent config dir so re-launches reuse the
-    // same generated server.conf (vs the spawn helper's default
-    // tmpdir-based work dir, which is right for ephemeral CLI spawns
-    // but throwaway for the daemon).
-    this.spawned = await spawnNatsServer({ port, workDir: join(home, "nats"), storeDir, logger });
-
-    const url = this.spawned.url;
+    // Single chokepoint: daemon advertises the broker URL to
+    // out-of-env CLI consumers via `<home>/nats/url`, regardless of
+    // which path led here. Without this, the launcher-supervised
+    // path (FRIDAY_NATS_URL injected by `project.go` into supervised
+    // children) leaves the file unwritten. A CLI run from a separate
+    // terminal — no inherited env — would fall through to its own
+    // `pickPort()` + `spawnNatsServer`, hit the same `<home>/nats`
+    // store, and crash with "store directory in use".
     await writeBrokerUrlFile(home, url);
     this.ownsUrlFile = true;
     logger.info("Wrote broker URL file", { url, urlFile: brokerUrlFilePath(home) });
 
     if (process.env.FRIDAY_NATS_MONITOR === "1") {
-      logger.info(`NATS monitoring enabled at http://localhost:${DEFAULT_NATS_MONITOR_PORT}`);
+      logger.info(`NATS monitoring enabled at http://127.0.0.1:${DEFAULT_NATS_MONITOR_PORT}`);
     }
 
-    this.nc = await connectToNats({ url, name: "atlasd" });
     logger.info("NATS connection established", { url });
     return this.nc;
   }

--- a/apps/atlasd/src/nats-manager.ts
+++ b/apps/atlasd/src/nats-manager.ts
@@ -5,14 +5,18 @@ import process from "node:process";
 import { logger } from "@atlas/logger";
 import { getFridayHome } from "@atlas/utils/paths.server";
 import {
+  brokerUrlFilePath,
   connectToNats,
   DEFAULT_NATS_MONITOR_PORT,
-  DEFAULT_NATS_PORT,
+  deleteBrokerUrlFile,
   formatStartupLog,
+  pickPort,
+  readBrokerUrlFile,
   readJetStreamConfig,
   type SpawnedNats,
   spawnNatsServer,
   tcpProbe,
+  writeBrokerUrlFile,
 } from "jetstream";
 import type { NatsConnection } from "nats";
 
@@ -22,13 +26,16 @@ import type { NatsConnection } from "nats";
  * Three modes, decided at start():
  *
  * - **External NATS** (`FRIDAY_NATS_URL` set): connect to that broker
- *   and never spawn. Required for any deployment with more than one
- *   daemon process or for a managed-NATS topology.
- * - **Auto-detect existing**: if `localhost:4222` is already serving
- *   (e.g. an `atlas migrate` run by the operator left a broker up,
- *   or someone started nats-server by hand), reuse it.
- * - **Spawn child**: solo-dev fallback — spawn `nats-server` and own
- *   its lifetime. Stop kills the child.
+ *   and never spawn. Cloud-with-shared-broker path; tenant isolation
+ *   happens at the subject / NATS-account level.
+ * - **URL file rendezvous**: read `<home>/nats/url` and TCP-probe it.
+ *   If a broker is alive at that URL, reuse it. This is the
+ *   in-process discovery channel for any sibling already running for
+ *   this home (e.g. the launcher spawned `nats-server` before the
+ *   daemon booted).
+ * - **Spawn child**: solo-dev / launcher-fallback case. Pick a free
+ *   port from the Friday-reserved range, spawn `nats-server`, write
+ *   the URL to `<home>/nats/url` for siblings to discover.
  *
  * The actual spawn is delegated to `jetstream.spawnNatsServer`, which
  * is the same primitive the CLI uses for its ephemeral broker.
@@ -36,10 +43,12 @@ import type { NatsConnection } from "nats";
 export class NatsManager {
   private spawned: SpawnedNats | null = null;
   private nc: NatsConnection | null = null;
+  /** Set when we own the URL file (i.e. we spawned the broker). */
+  private ownsUrlFile = false;
 
   async start(): Promise<NatsConnection> {
     // Log resolved JetStream config + provenance unconditionally — applies
-    // to spawn, reuse-existing-broker, and external-broker paths.
+    // to spawn, URL-file reuse, and external-broker paths.
     const cfg = readJetStreamConfig();
     logger.info(formatStartupLog(cfg));
 
@@ -51,52 +60,51 @@ export class NatsManager {
       return this.nc;
     }
 
-    const alreadyUp = await tcpProbe(DEFAULT_NATS_PORT);
-    if (alreadyUp) {
-      logger.info("nats-server already running, connecting without spawning");
-      // FRIDAY_NATS_MONITOR only takes effect on the spawning process.
-      // Probe the monitor endpoint and warn if the operator expected it
-      // but the running broker doesn't have it enabled.
-      if (process.env.FRIDAY_NATS_MONITOR === "1") {
-        const monitorUp = await tcpProbe(DEFAULT_NATS_MONITOR_PORT);
-        if (monitorUp) {
-          logger.info(
-            `NATS monitoring detected on existing server at http://localhost:${DEFAULT_NATS_MONITOR_PORT}`,
-          );
-        } else {
-          logger.warn(
-            "FRIDAY_NATS_MONITOR=1 set but a nats-server was already running on " +
-              `${DEFAULT_NATS_PORT} without --http_port. Monitor flag ignored. Kill the ` +
-              "existing nats-server (e.g. `pkill nats-server`) and restart the " +
-              "daemon to enable monitoring.",
-          );
-        }
+    const home = getFridayHome();
+    const cachedUrl = await readBrokerUrlFile(home);
+    if (cachedUrl) {
+      const port = portFromUrl(cachedUrl);
+      const live = port != null && (await tcpProbe(port));
+      if (live) {
+        logger.info("Discovered live broker via URL file; connecting without spawning", {
+          url: cachedUrl,
+          urlFile: brokerUrlFilePath(home),
+        });
+        this.nc = await connectToNats({ url: cachedUrl, name: "atlasd" });
+        logger.info("NATS connection established", { url: cachedUrl });
+        return this.nc;
       }
-    } else {
-      const storeDir = cfg.server.storeDir.value ?? join(getFridayHome(), "nats");
-      // Earlier daemon versions wrote JetStream data to nats-server's
-      // built-in default location (`$TMPDIR/nats/jetstream`). Operators
-      // upgrading past that change saw a fresh empty broker. Detect
-      // orphaned data and tell them how to recover before they panic.
-      await this.warnIfOrphanedJetStreamData(storeDir);
-
-      // Use the daemon's persistent config dir so re-launches reuse the
-      // same generated server.conf (vs the spawn helper's default
-      // tmpdir-based work dir, which is right for ephemeral CLI spawns
-      // but throwaway for the daemon).
-      this.spawned = await spawnNatsServer({
-        port: DEFAULT_NATS_PORT,
-        workDir: join(getFridayHome(), "nats"),
-        storeDir,
-        logger,
+      logger.warn("Stale URL file detected; spawning fresh broker", {
+        cachedUrl,
+        urlFile: brokerUrlFilePath(home),
       });
-      if (process.env.FRIDAY_NATS_MONITOR === "1") {
-        logger.info(`NATS monitoring enabled at http://localhost:${DEFAULT_NATS_MONITOR_PORT}`);
-      }
     }
 
-    this.nc = await connectToNats({ url: `nats://localhost:${DEFAULT_NATS_PORT}`, name: "atlasd" });
-    logger.info("NATS connection established", { port: DEFAULT_NATS_PORT });
+    const storeDir = cfg.server.storeDir.value ?? join(home, "nats");
+    // Earlier daemon versions wrote JetStream data to nats-server's
+    // built-in default location (`$TMPDIR/nats/jetstream`). Operators
+    // upgrading past that change saw a fresh empty broker. Detect
+    // orphaned data and tell them how to recover before they panic.
+    await this.warnIfOrphanedJetStreamData(storeDir);
+
+    const port = await pickPort();
+    // Use the daemon's persistent config dir so re-launches reuse the
+    // same generated server.conf (vs the spawn helper's default
+    // tmpdir-based work dir, which is right for ephemeral CLI spawns
+    // but throwaway for the daemon).
+    this.spawned = await spawnNatsServer({ port, workDir: join(home, "nats"), storeDir, logger });
+
+    const url = this.spawned.url;
+    await writeBrokerUrlFile(home, url);
+    this.ownsUrlFile = true;
+    logger.info("Wrote broker URL file", { url, urlFile: brokerUrlFilePath(home) });
+
+    if (process.env.FRIDAY_NATS_MONITOR === "1") {
+      logger.info(`NATS monitoring enabled at http://localhost:${DEFAULT_NATS_MONITOR_PORT}`);
+    }
+
+    this.nc = await connectToNats({ url, name: "atlasd" });
+    logger.info("NATS connection established", { url });
     return this.nc;
   }
 
@@ -144,6 +152,11 @@ export class NatsManager {
     if (this.spawned) {
       await this.spawned.stop();
       this.spawned = null;
+    }
+
+    if (this.ownsUrlFile) {
+      await deleteBrokerUrlFile(getFridayHome());
+      this.ownsUrlFile = false;
     }
   }
 
@@ -205,5 +218,16 @@ export class NatsManager {
         "",
       ].join("\n"),
     );
+  }
+}
+
+/** Extract the TCP port from a `nats://host:port` URL, or null if unparseable. */
+function portFromUrl(url: string): number | null {
+  try {
+    const parsed = new URL(url);
+    const port = Number.parseInt(parsed.port, 10);
+    return Number.isFinite(port) && port > 0 ? port : null;
+  } catch {
+    return null;
   }
 }

--- a/deno.json
+++ b/deno.json
@@ -34,9 +34,9 @@
   "tasks": {
     "prepare": "deno run -A  npm:husky@^9",
     "lint-staged": "deno run -A npm:lint-staged@^16.4.0",
-    "atlas": "deno run -q --allow-all --unstable-worker-options --unstable-kv --unstable-raw-imports --env-file apps/atlas-cli/src/otel-bootstrap.ts",
-    "atlas:dev": "deno run -q --allow-all --unstable-worker-options --unstable-kv --unstable-raw-imports --env-file scripts/dev-watcher.ts",
-    "start": "deno run --allow-all --unstable-worker-options --unstable-kv --unstable-raw-imports apps/atlas-cli/src/otel-bootstrap.ts",
+    "atlas": "FRIDAY_HOME=$HOME/.atlas deno run -q --allow-all --unstable-worker-options --unstable-kv --unstable-raw-imports --env-file apps/atlas-cli/src/otel-bootstrap.ts",
+    "atlas:dev": "FRIDAY_HOME=$HOME/.atlas deno run -q --allow-all --unstable-worker-options --unstable-kv --unstable-raw-imports --env-file scripts/dev-watcher.ts",
+    "start": "FRIDAY_HOME=$HOME/.atlas deno run --allow-all --unstable-worker-options --unstable-kv --unstable-raw-imports apps/atlas-cli/src/otel-bootstrap.ts",
     "dev:playground": "FAST_DEVELOPMENT=true LINK_DEV_MODE=true deno run -A npm:concurrently@^9.2.1 -n daemon,link,playground,tunnel -c blue,green,magenta,cyan 'deno task atlas:dev daemon start' 'cd apps/link && deno task dev' 'deno task playground' 'deno task webhook-tunnel'",
     "dev:playground:stable": "FAST_DEVELOPMENT=true LINK_DEV_MODE=true deno run -A npm:concurrently@^9.2.1 -n daemon,link,playground,tunnel -c blue,green,magenta,cyan 'deno task atlas daemon start' 'cd apps/link && deno task dev' 'deno task playground' 'deno task webhook-tunnel'",
     "webhook-tunnel": "go run ./tools/webhook-tunnel",

--- a/deno.lock
+++ b/deno.lock
@@ -6,14 +6,17 @@
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/assert@^1.0.16": "1.0.19",
     "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/async@1.0.15": "1.0.15",
     "jsr:@std/async@^1.0.15": "1.3.0",
     "jsr:@std/async@^1.3.0": "1.3.0",
+    "jsr:@std/cli@^1.0.6": "1.0.29",
     "jsr:@std/data-structures@^1.0.11": "1.0.11",
     "jsr:@std/dotenv@~0.225.5": "0.225.6",
     "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/encoding@1.0.10": "1.0.10",
     "jsr:@std/fmt@1": "1.0.10",
     "jsr:@std/fs@1": "1.0.23",
+    "jsr:@std/fs@1.0.13": "1.0.13",
     "jsr:@std/fs@^1.0.23": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.13",
     "jsr:@std/internal@^1.0.13": "1.0.13",
@@ -140,6 +143,7 @@
     "npm:js-levenshtein@^1.1.6": "1.1.6",
     "npm:jsonrepair@^3.14.0": "3.14.0",
     "npm:jszip@^3.10.1": "3.10.1",
+    "npm:knip@*": "6.11.0_@emnapi+core@1.10.0_@emnapi+runtime@1.10.0",
     "npm:knip@6.11.0": "6.11.0_@emnapi+core@1.10.0_@emnapi+runtime@1.10.0",
     "npm:lint-staged@^16.4.0": "16.4.0",
     "npm:markdown-it@^14.1.1": "14.1.1",
@@ -147,6 +151,7 @@
     "npm:minimatch@^10.2.5": "10.2.5",
     "npm:nanoid@5.1.11": "5.1.11",
     "npm:nanoid@^5.1.6": "5.1.11",
+    "npm:nats@2": "2.29.3",
     "npm:nats@^2.29.3": "2.29.3",
     "npm:node-html-parser@^7.1.0": "7.1.0",
     "npm:oauth4webapi@3.8.6": "3.8.6",
@@ -174,13 +179,16 @@
     "npm:ulid@^3.0.2": "3.0.2",
     "npm:undici@^7.25.0": "7.25.0",
     "npm:vite@^7.3.2": "7.3.3_@types+node@25.6.2_yaml@2.8.4",
+    "npm:vitest@*": "4.1.5_@opentelemetry+api@1.9.1_@types+node@25.6.2_@vitest+coverage-v8@4.1.5_happy-dom@20.9.0_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4",
     "npm:vitest@^4.1.0": "4.1.5_@opentelemetry+api@1.9.1_@types+node@25.6.2_@vitest+coverage-v8@4.1.5_happy-dom@20.9.0_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4",
     "npm:vitest@^4.1.5": "4.1.5_@opentelemetry+api@1.9.1_@types+node@25.6.2_@vitest+coverage-v8@4.1.5_happy-dom@20.9.0_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4",
     "npm:xstate@^5.31.0": "5.31.0",
     "npm:yaml@^2.8.4": "2.8.4",
     "npm:yargs@18": "18.0.0",
+    "npm:zod@4": "4.4.3",
     "npm:zod@4.4.3": "4.4.3",
     "npm:zod@^4.2.1": "4.4.3",
+    "npm:zod@^4.3.5": "4.4.3",
     "npm:zod@^4.4.3": "4.4.3"
   },
   "jsr": {
@@ -206,11 +214,17 @@
         "jsr:@std/internal@^1.0.12"
       ]
     },
+    "@std/async@1.0.15": {
+      "integrity": "55d1d9d04f99403fe5730ab16bdcc3c47f658a6bf054cafb38a50f046238116e"
+    },
     "@std/async@1.3.0": {
       "integrity": "80485538a4f7baaa46bfe2246168069e02ed142b9f9079cd164f43bb060ad9e9",
       "dependencies": [
         "jsr:@std/data-structures"
       ]
+    },
+    "@std/cli@1.0.29": {
+      "integrity": "fa4ef29130baa834d8a13b7d138240c3a2fcfba740bfb7afa646a360a15ec84f"
     },
     "@std/data-structures@1.0.11": {
       "integrity": "53b98ed7efa61f107dfc14244bd2ec5557f7f7ee0bbaef6d449d7937facacb89"
@@ -223,6 +237,9 @@
     },
     "@std/fmt@1.0.10": {
       "integrity": "90dfba288802ac6de82fb31d0917eb9e4450b9925b954d5e51fc29ac07419db5"
+    },
+    "@std/fs@1.0.13": {
+      "integrity": "756d3ff0ade91c9e72b228e8012b6ff00c3d4a4ac9c642c4dac083536bf6c605"
     },
     "@std/fs@1.0.23": {
       "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",

--- a/packages/core/src/users/jetstream-backend.test.ts
+++ b/packages/core/src/users/jetstream-backend.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Regression tests for `resolveLocalUserId()` stability — Phase 1 of the
+ * friday-home-isolation plan.
+ *
+ * The resolver uses pointer-first CAS-create on the `_local` key of the
+ * USERS KV bucket. Within a single JetStream store, every process that
+ * resolves a local user id MUST return the same nanoid on every
+ * invocation, indefinitely. The four scenarios covered below match the
+ * Phase 1 gate verbatim:
+ *
+ *   1. Sequential boots against an empty store return byte-identical ids.
+ *   2. Two backends racing concurrently against an empty store agree on
+ *      the same id; only the winner's USERS record is written (no
+ *      orphan record under the loser's rejected candidate).
+ *   3. A "CLI" backend created against the same NATS connection while a
+ *      "daemon" backend already resolved sees the daemon's id.
+ *   4. A backend that resolved against a JetStream store, was dropped
+ *      cleanly, and then a second backend boots against the same store
+ *      (same NATS broker) sees the same id.
+ *
+ * Scenarios (3) and (4) collapse to the same primitive at the
+ * NATS-protocol layer — a new backend instance reading the store. The
+ * difference is operational (broker liveness across the gap), not
+ * semantic. We exercise both shapes anyway to lock in the contract the
+ * way callers reason about it.
+ */
+
+import { connect, type NatsConnection } from "nats";
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { startNatsTestServer, type TestNatsServer } from "../test-utils/nats-test-server.ts";
+import { createJetStreamUserBackend, ensureUsersKVBucket } from "./jetstream-backend.ts";
+
+let server: TestNatsServer;
+let nc: NatsConnection;
+
+beforeAll(async () => {
+  server = await startNatsTestServer();
+  nc = await connect({ servers: server.url });
+}, 30_000);
+
+afterAll(async () => {
+  await nc.drain();
+  await server.stop();
+});
+
+/**
+ * Wipe the USERS bucket so each scenario starts from a truly-empty
+ * store. The bucket is backed by the `KV_USERS` JetStream stream;
+ * deleting and re-creating it resets revision counters too, which is
+ * what we want for the "empty store on first boot" precondition.
+ */
+async function resetUsersBucket(): Promise<void> {
+  const jsm = await nc.jetstreamManager();
+  try {
+    await jsm.streams.delete("KV_USERS");
+  } catch {
+    // bucket may not exist yet
+  }
+  // Recreate via the same path the resolver uses, so options match prod.
+  await ensureUsersKVBucket(nc);
+}
+
+beforeEach(async () => {
+  await resetUsersBucket();
+});
+
+describe("resolveLocalUserId — stability within a single JetStream store", () => {
+  it("sequential boots against an empty store return the same id", async () => {
+    // First "boot": create backend, resolve, capture id, drop backend.
+    const first = createJetStreamUserBackend(nc);
+    const firstResult = await first.resolveLocalUserId();
+    expect(firstResult.ok).toBe(true);
+    if (!firstResult.ok) throw new Error("first resolve failed");
+    const firstId = firstResult.data;
+    expect(firstId).toMatch(/^[0-9A-Za-z]{12}$/);
+
+    // Second "boot": brand-new backend against the same KV.
+    const second = createJetStreamUserBackend(nc);
+    const secondResult = await second.resolveLocalUserId();
+    expect(secondResult.ok).toBe(true);
+    if (!secondResult.ok) throw new Error("second resolve failed");
+
+    expect(secondResult.data).toBe(firstId);
+
+    // Third boot — paranoia, lock in indefinite stability.
+    const third = createJetStreamUserBackend(nc);
+    const thirdResult = await third.resolveLocalUserId();
+    expect(thirdResult.ok).toBe(true);
+    if (!thirdResult.ok) throw new Error("third resolve failed");
+    expect(thirdResult.data).toBe(firstId);
+  });
+
+  it("two backends racing on first boot agree on the same id with no orphan records (N iterations)", async () => {
+    // Single-threaded event loop means `Promise.all` doesn't guarantee
+    // the CAS-conflict branch fires every iteration — micro-task
+    // scheduling can serialise the two backends. We loop N=20 fresh-
+    // bucket races so the conflict branch is hit by birthday-paradox
+    // at least once, and assert the invariants hold every iteration
+    // regardless of which path the resolver took.
+    const ITERATIONS = 20;
+    for (let i = 0; i < ITERATIONS; i++) {
+      // Reset the bucket each iteration so each race starts empty.
+      // beforeEach only fires once per `it` — manual reset for the loop.
+      await resetUsersBucket();
+
+      const a = createJetStreamUserBackend(nc);
+      const b = createJetStreamUserBackend(nc);
+
+      const [resultA, resultB] = await Promise.all([
+        a.resolveLocalUserId(),
+        b.resolveLocalUserId(),
+      ]);
+      expect(resultA.ok).toBe(true);
+      expect(resultB.ok).toBe(true);
+      if (!resultA.ok || !resultB.ok) throw new Error(`iter ${i}: concurrent resolve failed`);
+
+      expect(resultA.data).toBe(resultB.data);
+      const winnerId = resultA.data;
+
+      // Inspect the bucket directly — there must be exactly one User
+      // record (the winner) plus the `_local` pointer. A failure mode
+      // we explicitly guard against: the loser writing a User record
+      // under its (rejected) candidate nanoid before reading the
+      // winner's pointer.
+      const kv = await ensureUsersKVBucket(nc);
+      const keys: string[] = [];
+      const keysIter = await kv.keys();
+      for await (const k of keysIter) keys.push(k);
+      const userKeys = keys.filter((k) => k !== "_local");
+      expect(userKeys).toEqual([winnerId]);
+
+      const pointerEntry = await kv.get("_local");
+      expect(pointerEntry).not.toBeNull();
+      if (!pointerEntry) throw new Error(`iter ${i}: pointer missing`);
+      expect(new TextDecoder().decode(pointerEntry.value)).toBe(winnerId);
+    }
+  });
+
+  it("a CLI backend on the same broker as a running daemon sees the daemon's id", async () => {
+    // "Daemon" boots, resolves, populates `_local`.
+    const daemon = createJetStreamUserBackend(nc);
+    const daemonResult = await daemon.resolveLocalUserId();
+    expect(daemonResult.ok).toBe(true);
+    if (!daemonResult.ok) throw new Error("daemon resolve failed");
+    const daemonId = daemonResult.data;
+
+    // "CLI" connects to the same NATS server (same KV store), boots
+    // its own backend instance, resolves. Must see the daemon's id —
+    // not generate a fresh one, not race with the daemon's pointer.
+    const cli = createJetStreamUserBackend(nc);
+    const cliResult = await cli.resolveLocalUserId();
+    expect(cliResult.ok).toBe(true);
+    if (!cliResult.ok) throw new Error("cli resolve failed");
+    expect(cliResult.data).toBe(daemonId);
+  });
+
+  it("a second backend booted after the first was dropped sees the persisted id", async () => {
+    // Backend A: resolve, then drop (no explicit teardown — the
+    // resolver has no per-instance state on disk; the in-memory
+    // cache lives on the backend object that's about to be GC'd).
+    const backendA = createJetStreamUserBackend(nc);
+    const aResult = await backendA.resolveLocalUserId();
+    expect(aResult.ok).toBe(true);
+    if (!aResult.ok) throw new Error("backend A resolve failed");
+    const persistedId = aResult.data;
+
+    // Simulate "broker stays up but caller restarts." A fresh backend
+    // instance has zero in-memory state and must read the pointer
+    // from JetStream KV.
+    const backendB = createJetStreamUserBackend(nc);
+    const bResult = await backendB.resolveLocalUserId();
+    expect(bResult.ok).toBe(true);
+    if (!bResult.ok) throw new Error("backend B resolve failed");
+    expect(bResult.data).toBe(persistedId);
+
+    // The cached-on-instance accessor must reflect the same id —
+    // protects against a regression where the cache desyncs from the
+    // KV pointer (e.g. some future refactor that races cache writes
+    // against KV writes).
+    expect(backendB.getCachedLocalUserId()).toBe(persistedId);
+  });
+});

--- a/packages/jetstream/mod.ts
+++ b/packages/jetstream/mod.ts
@@ -43,12 +43,17 @@ export {
 } from "./src/migrations.ts";
 export { registerReconnectReset } from "./src/reconnect-registry.ts";
 export {
+  brokerUrlFilePath,
   DEFAULT_NATS_MONITOR_PORT,
   DEFAULT_NATS_PORT,
+  deleteBrokerUrlFile,
   findNatsServerBinary,
+  pickPort,
+  readBrokerUrlFile,
   type SpawnedNats,
   type SpawnNatsOptions,
   spawnNatsServer,
   tcpProbe,
+  writeBrokerUrlFile,
   writeServerConfig,
 } from "./src/spawn.ts";

--- a/packages/jetstream/src/connect.test.ts
+++ b/packages/jetstream/src/connect.test.ts
@@ -14,6 +14,7 @@
  */
 
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
@@ -21,6 +22,31 @@ import type { Logger } from "@atlas/logger";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { connectOrSpawn } from "./connect.ts";
 import { brokerUrlFilePath, pickPort, spawnNatsServer } from "./spawn.ts";
+
+/**
+ * Pick a port the OS just told us is free, then immediately release it.
+ * Tiny TOCTOU window where some other process could grab it, but for
+ * "nothing should be listening here" assertions this is dramatically
+ * more reliable than hardcoding 65530-ish (inside macOS's ephemeral
+ * range, where a parallel test or background process can legitimately
+ * be assigned the same port).
+ */
+function pickDeadPort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.unref();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const addr = srv.address();
+      if (addr && typeof addr === "object") {
+        const port = addr.port;
+        srv.close(() => resolve(port));
+      } else {
+        srv.close(() => reject(new Error("could not resolve dead port")));
+      }
+    });
+  });
+}
 
 const noopLogger: Logger = {
   trace: () => {},
@@ -122,11 +148,13 @@ describe("connectOrSpawn — spawnFallback=false honors the no-spawn contract", 
   });
 
   it("throws when explicit URL fails to connect and spawnFallback=false", async () => {
-    // Picks a port nothing is listening on (high in the ephemeral
-    // range). Direct connect fails; spawnFallback=false means no fallback.
+    // Direct connect fails; spawnFallback=false means no fallback. The
+    // port comes from pickDeadPort() so we know nothing else can have
+    // been assigned to it by the kernel in parallel.
+    const deadPort = await pickDeadPort();
     await expect(
       connectOrSpawn({
-        url: "nats://127.0.0.1:65530",
+        url: `nats://127.0.0.1:${deadPort}`,
         storeDir,
         spawnFallback: false,
         timeoutMs: 200,
@@ -139,7 +167,8 @@ describe("connectOrSpawn — spawnFallback=false honors the no-spawn contract", 
     // FRIDAY_NATS_URL is the operator's explicit declaration of an
     // external broker. If it fails, spawning silently would shadow the
     // operator's intent — throw even with spawnFallback=true.
-    process.env.FRIDAY_NATS_URL = "nats://127.0.0.1:65531";
+    const deadPort = await pickDeadPort();
+    process.env.FRIDAY_NATS_URL = `nats://127.0.0.1:${deadPort}`;
     try {
       await expect(
         connectOrSpawn({ storeDir, timeoutMs: 200, logger: noopLogger }),

--- a/packages/jetstream/src/connect.test.ts
+++ b/packages/jetstream/src/connect.test.ts
@@ -1,0 +1,167 @@
+/**
+ * Tests for `connectOrSpawn`'s URL-file rendezvous path.
+ *
+ * Phase 4's contract: when `home` is set, the broker URL lives at
+ * `<home>/nats/url`. Consumers (daemon, CLI, future tooling) discover
+ * the broker through that file rather than guessing the port. Stale
+ * URL files (daemon crashed without cleanup) are detected via TCP
+ * probe and treated as "no broker — spawn fresh."
+ *
+ * The single chokepoint these tests pin is `spawnFallback`: it must
+ * be honored on EVERY no-connect path, not just the explicit-URL
+ * branch. A prior refactor regressed this by moving the check into
+ * one source branch; these tests catch that class of bug.
+ */
+
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+import type { Logger } from "@atlas/logger";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { connectOrSpawn } from "./connect.ts";
+import { brokerUrlFilePath, pickPort, spawnNatsServer } from "./spawn.ts";
+
+const noopLogger: Logger = {
+  trace: () => {},
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  fatal: () => {},
+  child: () => noopLogger,
+};
+
+let home: string;
+let storeDir: string;
+
+beforeEach(async () => {
+  home = await mkdtemp(join(tmpdir(), "friday-connect-test-"));
+  storeDir = join(home, "nats");
+  await mkdir(storeDir, { recursive: true });
+  // The connectOrSpawn external-broker branch reads FRIDAY_NATS_URL from
+  // process.env. Clear it to avoid interference from the developer's
+  // shell environment.
+  delete process.env.FRIDAY_NATS_URL;
+});
+
+afterEach(async () => {
+  await rm(home, { recursive: true, force: true });
+});
+
+describe("connectOrSpawn — URL-file rendezvous (source: url-file)", () => {
+  it("reuses a live broker advertised by the URL file", async () => {
+    // Spawn a real broker on a free port, write its URL to <home>/nats/url
+    // as if a sibling daemon had done so. connectOrSpawn must reuse it
+    // (no second spawn against the same store dir — that would file-lock
+    // conflict).
+    const broker = await spawnNatsServer({ port: await pickPort(), storeDir, logger: noopLogger });
+    try {
+      await writeFile(brokerUrlFilePath(home), broker.url, "utf-8");
+
+      const handle = await connectOrSpawn({ home, storeDir, logger: noopLogger });
+      try {
+        // Real connection — drain works only against a live broker.
+        await handle.nc.flush();
+        expect(handle.nc.isClosed()).toBe(false);
+      } finally {
+        await handle.cleanup();
+      }
+    } finally {
+      await broker.stop();
+    }
+  });
+
+  it("falls through to spawn when the URL file points at a dead broker", async () => {
+    // Spawn + stop a broker, then write its now-dead URL to the file.
+    // connectOrSpawn must detect the stale URL (TCP probe fails) and
+    // spawn a fresh broker. spawnFallback defaults to true.
+    const dead = await spawnNatsServer({ port: await pickPort(), storeDir, logger: noopLogger });
+    const deadUrl = dead.url;
+    await dead.stop();
+    await writeFile(brokerUrlFilePath(home), deadUrl, "utf-8");
+
+    const handle = await connectOrSpawn({ home, storeDir, logger: noopLogger });
+    try {
+      // connectOrSpawn spawned a fresh broker — flush proves the
+      // connection is alive. We deliberately don't assert the new
+      // port differs from the dead one: pickPort can legitimately
+      // re-pick the same port if it's free again, and "alive" is
+      // the contract that matters.
+      await handle.nc.flush();
+      expect(handle.nc.isClosed()).toBe(false);
+    } finally {
+      await handle.cleanup();
+    }
+  });
+});
+
+describe("connectOrSpawn — spawnFallback=false honors the no-spawn contract", () => {
+  it("throws when URL file is stale and spawnFallback=false", async () => {
+    // The bug the prior review caught: stale URL file → previously
+    // would silently spawn even with spawnFallback=false because the
+    // source-tracking refactor moved the spawnFallback check into one
+    // source branch.
+    const dead = await spawnNatsServer({ port: await pickPort(), storeDir, logger: noopLogger });
+    const deadUrl = dead.url;
+    await dead.stop();
+    await writeFile(brokerUrlFilePath(home), deadUrl, "utf-8");
+
+    await expect(
+      connectOrSpawn({ home, storeDir, spawnFallback: false, logger: noopLogger }),
+    ).rejects.toThrow(/spawnFallback=false/);
+  });
+
+  it("throws when no URL is resolvable and spawnFallback=false", async () => {
+    // No opts.url, no FRIDAY_NATS_URL, no URL file under `home`. Without
+    // the spawn gate, the legacy code would spawn an ephemeral broker
+    // here. With it, the call throws.
+    await expect(
+      connectOrSpawn({ home, storeDir, spawnFallback: false, logger: noopLogger }),
+    ).rejects.toThrow(/spawnFallback=false/);
+  });
+
+  it("throws when explicit URL fails to connect and spawnFallback=false", async () => {
+    // Picks a port nothing is listening on (high in the ephemeral
+    // range). Direct connect fails; spawnFallback=false means no fallback.
+    await expect(
+      connectOrSpawn({
+        url: "nats://127.0.0.1:65530",
+        storeDir,
+        spawnFallback: false,
+        timeoutMs: 200,
+        logger: noopLogger,
+      }),
+    ).rejects.toThrow(/Failed to connect/);
+  });
+
+  it("throws on env URL connect failure regardless of spawnFallback", async () => {
+    // FRIDAY_NATS_URL is the operator's explicit declaration of an
+    // external broker. If it fails, spawning silently would shadow the
+    // operator's intent — throw even with spawnFallback=true.
+    process.env.FRIDAY_NATS_URL = "nats://127.0.0.1:65531";
+    try {
+      await expect(
+        connectOrSpawn({ storeDir, timeoutMs: 200, logger: noopLogger }),
+      ).rejects.toThrow(/Failed to connect/);
+    } finally {
+      delete process.env.FRIDAY_NATS_URL;
+    }
+  });
+});
+
+describe("connectOrSpawn — source: none (no URL anywhere, spawnFallback=true)", () => {
+  it("spawns an ephemeral broker when no URL is resolvable", async () => {
+    // No opts.url, no FRIDAY_NATS_URL, no URL file. With spawnFallback
+    // defaulting to true, the call should spawn ephemerally and return
+    // a working connection. Critically, it must NOT probe `:4222` and
+    // reuse whatever's there — that was the silent-attach bug.
+    const handle = await connectOrSpawn({ home, storeDir, logger: noopLogger });
+    try {
+      await handle.nc.flush();
+      expect(handle.nc.isClosed()).toBe(false);
+    } finally {
+      await handle.cleanup();
+    }
+  });
+});

--- a/packages/jetstream/src/connect.ts
+++ b/packages/jetstream/src/connect.ts
@@ -149,14 +149,14 @@ export interface ConnectOrSpawnOptions extends ConnectOptions {
 export async function connectOrSpawn(opts: ConnectOrSpawnOptions = {}): Promise<ConnectionHandle> {
   const spawnFallback = opts.spawnFallback ?? true;
 
-  // Resolve the URL in precedence order, tracking provenance. Provenance
-  // matters because we only TCP-probe-and-reuse for URLs that came from
-  // <home>/nats/url — a default-URL fallback must NOT reuse whatever
-  // happens to be listening on :4222 (the silent-attach bug Phase 4
-  // exists to close).
+  // Resolve the URL in precedence order. Source is tracked because it
+  // controls one decision: we only TCP-probe-and-reuse for URLs that
+  // came from <home>/nats/url. A no-URL fallback must NOT reuse
+  // whatever happens to be listening on :4222 (the silent-attach bug
+  // Phase 4 closes).
   const envUrl = process.env.FRIDAY_NATS_URL;
-  let resolvedUrl: string;
-  let source: "explicit" | "env" | "url-file" | "default";
+  let resolvedUrl: string | null = null;
+  let source: "explicit" | "env" | "url-file" | "none";
   if (opts.url) {
     resolvedUrl = opts.url;
     source = "explicit";
@@ -169,60 +169,62 @@ export async function connectOrSpawn(opts: ConnectOrSpawnOptions = {}): Promise<
       resolvedUrl = fromFile;
       source = "url-file";
     } else {
-      resolvedUrl = DEFAULT_NATS_URL;
-      source = "default";
+      source = "none";
     }
   } else {
-    resolvedUrl = DEFAULT_NATS_URL;
-    source = "default";
+    source = "none";
   }
 
-  if (source === "url-file") {
-    // The home wrote this URL — trust it but probe to catch stale entries.
+  // Try the resolved URL. Each branch either returns a ConnectionHandle
+  // (success) or falls through to the spawn gate. The spawn gate is the
+  // single chokepoint that enforces `spawnFallback` regardless of how
+  // we got here — keeping the contract impossible to forget when
+  // adding a fourth precedence path later.
+  if (source === "url-file" && resolvedUrl) {
     const port = portFromUrl(resolvedUrl);
     const live = port != null && (await tcpProbe(port));
     if (live) {
       return openHandle(resolvedUrl, opts);
     }
-    // Stale URL file: the daemon that wrote it crashed or shut down
-    // without cleaning up. Fall through to spawn (CLI use case).
     opts.logger?.warn?.("URL file present but broker not responding; falling through to spawn", {
       cachedUrl: resolvedUrl,
       urlFile: brokerUrlFilePath(opts.home as string),
     });
-  } else if (source !== "default") {
+  } else if (resolvedUrl) {
     // Explicit URL or env URL — try a direct connect.
     try {
-      const nc = await connect({
-        servers: resolvedUrl,
-        name: opts.name ?? "friday-client",
-        timeout: opts.timeoutMs ?? 5_000,
-      });
-      return {
-        nc,
-        cleanup: async () => {
-          try {
-            await nc.drain();
-          } catch {
-            // Already closed / draining.
-          }
-        },
-      };
+      return await openHandle(resolvedUrl, opts);
     } catch (err) {
-      if (!spawnFallback) throw rethrowConnectError(resolvedUrl, err);
       if (source === "env") {
-        // External-broker mode — refuse to spawn; the operator told us
-        // explicitly where the broker lives.
+        // External-broker mode — refuse to spawn regardless of
+        // spawnFallback. The operator told us explicitly where the
+        // broker lives; spawning would silently shadow it.
+        throw rethrowConnectError(resolvedUrl, err);
+      }
+      if (!spawnFallback) {
         throw rethrowConnectError(resolvedUrl, err);
       }
       // Explicit URL with spawnFallback=true — fall through to spawn.
     }
   }
-  // source === "default" falls straight through to spawn — we never
-  // probe-and-reuse the legacy :4222 because that's the silent-attach
-  // failure mode Phase 4 closes.
+  // source === "none" falls straight through to spawn.
 
-  // 3. Spawn an ephemeral broker (CLI fallback path).
+  // Spawn gate: applies to all fall-through paths. Without this check,
+  // a caller passing `spawnFallback: false` (e.g. `friday migrate
+  // --no-spawn`) would silently spawn anyway when the URL file is
+  // stale or no URL was resolvable — defeating the documented contract.
+  if (!spawnFallback) {
+    const detail =
+      source === "url-file"
+        ? "URL file points at a dead broker"
+        : "no URL resolvable (no FRIDAY_NATS_URL, no opts.url, no `<home>/nats/url`)";
+    throw new Error(
+      `NATS broker not reachable: ${detail}; spawnFallback=false.\n` +
+        "  - Start the daemon: `atlas daemon start`\n" +
+        "  - Or set FRIDAY_NATS_URL to point at an external broker",
+    );
+  }
+
   if (!opts.storeDir) {
     throw new Error(
       "connectOrSpawn requires `storeDir` to spawn a broker. " +

--- a/packages/jetstream/src/connect.ts
+++ b/packages/jetstream/src/connect.ts
@@ -12,7 +12,14 @@
 import process from "node:process";
 import type { Logger } from "@atlas/logger";
 import { connect, type NatsConnection } from "nats";
-import { DEFAULT_NATS_PORT, type SpawnedNats, spawnNatsServer, tcpProbe } from "./spawn.ts";
+import {
+  brokerUrlFilePath,
+  pickPort,
+  readBrokerUrlFile,
+  type SpawnedNats,
+  spawnNatsServer,
+  tcpProbe,
+} from "./spawn.ts";
 
 export const DEFAULT_NATS_URL = "nats://localhost:4222";
 
@@ -35,21 +42,36 @@ export interface ConnectOptions {
 }
 
 /**
- * Resolve the NATS URL from explicit option → env → default. Exported
- * so callers can log "where am I trying to connect" before actually
- * attempting the connection.
+ * Resolve the NATS URL from explicit option → `FRIDAY_NATS_URL` env →
+ * URL file at `<home>/nats/url` (when `home` is provided) → default
+ * `DEFAULT_NATS_URL`. Exported so callers can log "where am I trying
+ * to connect" before actually attempting the connection.
+ *
+ * Async because the URL-file lookup reads from disk.
  */
-export function resolveNatsUrl(opts: { url?: string } = {}): string {
-  return opts.url ?? process.env.FRIDAY_NATS_URL ?? DEFAULT_NATS_URL;
+export async function resolveNatsUrl(opts: { url?: string; home?: string } = {}): Promise<string> {
+  if (opts.url) return opts.url;
+  const envUrl = process.env.FRIDAY_NATS_URL;
+  if (envUrl) return envUrl;
+  if (opts.home) {
+    const fromFile = await readBrokerUrlFile(opts.home);
+    if (fromFile) return fromFile;
+  }
+  return DEFAULT_NATS_URL;
 }
 
 /**
  * Open a NATS connection. Throws with a recovery hint if the broker
  * isn't reachable — most common failure mode for short-lived clients
  * (CLI commands, migration scripts) that don't manage broker lifecycle.
+ *
+ * Resolves the URL via `resolveNatsUrl` (explicit → env → URL file
+ * when `home` is provided → default).
  */
-export async function connectToNats(opts: ConnectOptions = {}): Promise<NatsConnection> {
-  const url = resolveNatsUrl(opts);
+export async function connectToNats(
+  opts: ConnectOptions & { home?: string } = {},
+): Promise<NatsConnection> {
+  const url = await resolveNatsUrl(opts);
   const name = opts.name ?? "friday-client";
   try {
     return await connect({ servers: url, name, timeout: opts.timeoutMs ?? 5_000 });
@@ -83,6 +105,13 @@ export interface ConnectOrSpawnOptions extends ConnectOptions {
    */
   storeDir?: string;
   /**
+   * Home dir for URL-file discovery. When set, `connectOrSpawn`
+   * first looks at `<home>/nats/url` and TCP-probes it before
+   * trying the env-resolved URL. This is how CLI clients reach a
+   * daemon-owned broker without guessing the port.
+   */
+  home?: string;
+  /**
    * If true (default), and the connection fails AND we're in solo-dev
    * mode (no `FRIDAY_NATS_URL`), spawn an ephemeral `nats-server`.
    * The returned `cleanup()` stops it. Set false to disable the
@@ -94,88 +123,119 @@ export interface ConnectOrSpawnOptions extends ConnectOptions {
 /**
  * Connect to NATS, spawning an ephemeral broker if needed.
  *
- * Three cases the function handles, in order:
+ * URL resolution (in order):
  *
- *   1. **Connection succeeds.** Existing broker (daemon-owned, external,
- *      or someone else's process). Returns `{ nc, cleanup }` where
- *      cleanup just drains `nc`.
- *   2. **Connection refused, `FRIDAY_NATS_URL` is set.** The operator
- *      declared an external broker; spawning would silently shadow it.
- *      Throw the original connection error with the recovery hint.
- *   3. **Connection refused, solo-dev mode.** Spawn `nats-server` with
- *      the daemon's store_dir, connect to it, return `{ nc, cleanup }`
- *      where cleanup drains the connection AND kills the spawn.
+ *   1. Explicit `opts.url`.
+ *   2. `FRIDAY_NATS_URL` env (external broker; never spawn).
+ *   3. `<home>/nats/url` file (when `opts.home` is provided and the
+ *      file exists). The launcher / daemon writes this file when it
+ *      spawns the broker. Stale entries are detected via TCP probe.
+ *   4. Spawn an ephemeral broker (CLI fallback). The ephemeral broker
+ *      uses a free port from the Friday-reserved range (`pickPort()`)
+ *      and does NOT write to `<home>/nats/url` — that file is
+ *      reserved for the long-lived daemon broker.
  *
- * The spawn uses the same `readJetStreamConfig()` env vars and the
- * same default store_dir as the daemon, so a CLI-spawned broker reads
- * the same JetStream data the daemon would have served. Single-writer
- * lock on the store_dir prevents the rare race where the daemon comes
- * up while the CLI is mid-migration — second spawn fails fast with
- * "store directory in use," which is the correct behavior.
+ * `FRIDAY_NATS_URL` short-circuits the URL-file path so cloud
+ * deployments connecting to a shared cluster never inadvertently
+ * spawn local brokers.
+ *
+ * Spawn uses the same `readJetStreamConfig()` env vars and store_dir
+ * as the daemon, so a CLI-spawned broker reads the same JetStream
+ * data the daemon would have served. The store-dir file lock
+ * prevents two brokers from opening the same store — the second
+ * spawn fails fast with "store directory in use," which is the
+ * correct behavior.
  */
 export async function connectOrSpawn(opts: ConnectOrSpawnOptions = {}): Promise<ConnectionHandle> {
-  const url = resolveNatsUrl(opts);
   const spawnFallback = opts.spawnFallback ?? true;
 
-  // 1. Try the existing broker first.
-  try {
-    const nc = await connect({
-      servers: url,
-      name: opts.name ?? "friday-client",
-      timeout: opts.timeoutMs ?? 5_000,
-    });
-    return {
-      nc,
-      cleanup: async () => {
-        try {
-          await nc.drain();
-        } catch {
-          // Already closed / draining.
-        }
-      },
-    };
-  } catch (err) {
-    if (!spawnFallback) throw rethrowConnectError(url, err);
-    if (process.env.FRIDAY_NATS_URL) {
-      // 2. External-broker mode — refuse to spawn; surface the error.
-      throw rethrowConnectError(url, err);
+  // Resolve the URL in precedence order, tracking provenance. Provenance
+  // matters because we only TCP-probe-and-reuse for URLs that came from
+  // <home>/nats/url — a default-URL fallback must NOT reuse whatever
+  // happens to be listening on :4222 (the silent-attach bug Phase 4
+  // exists to close).
+  const envUrl = process.env.FRIDAY_NATS_URL;
+  let resolvedUrl: string;
+  let source: "explicit" | "env" | "url-file" | "default";
+  if (opts.url) {
+    resolvedUrl = opts.url;
+    source = "explicit";
+  } else if (envUrl) {
+    resolvedUrl = envUrl;
+    source = "env";
+  } else if (opts.home) {
+    const fromFile = await readBrokerUrlFile(opts.home);
+    if (fromFile) {
+      resolvedUrl = fromFile;
+      source = "url-file";
+    } else {
+      resolvedUrl = DEFAULT_NATS_URL;
+      source = "default";
     }
+  } else {
+    resolvedUrl = DEFAULT_NATS_URL;
+    source = "default";
   }
 
-  // 3. Solo-dev fallback: spawn ephemerally.
+  if (source === "url-file") {
+    // The home wrote this URL — trust it but probe to catch stale entries.
+    const port = portFromUrl(resolvedUrl);
+    const live = port != null && (await tcpProbe(port));
+    if (live) {
+      return openHandle(resolvedUrl, opts);
+    }
+    // Stale URL file: the daemon that wrote it crashed or shut down
+    // without cleaning up. Fall through to spawn (CLI use case).
+    opts.logger?.warn?.("URL file present but broker not responding; falling through to spawn", {
+      cachedUrl: resolvedUrl,
+      urlFile: brokerUrlFilePath(opts.home as string),
+    });
+  } else if (source !== "default") {
+    // Explicit URL or env URL — try a direct connect.
+    try {
+      const nc = await connect({
+        servers: resolvedUrl,
+        name: opts.name ?? "friday-client",
+        timeout: opts.timeoutMs ?? 5_000,
+      });
+      return {
+        nc,
+        cleanup: async () => {
+          try {
+            await nc.drain();
+          } catch {
+            // Already closed / draining.
+          }
+        },
+      };
+    } catch (err) {
+      if (!spawnFallback) throw rethrowConnectError(resolvedUrl, err);
+      if (source === "env") {
+        // External-broker mode — refuse to spawn; the operator told us
+        // explicitly where the broker lives.
+        throw rethrowConnectError(resolvedUrl, err);
+      }
+      // Explicit URL with spawnFallback=true — fall through to spawn.
+    }
+  }
+  // source === "default" falls straight through to spawn — we never
+  // probe-and-reuse the legacy :4222 because that's the silent-attach
+  // failure mode Phase 4 closes.
+
+  // 3. Spawn an ephemeral broker (CLI fallback path).
   if (!opts.storeDir) {
     throw new Error(
       "connectOrSpawn requires `storeDir` to spawn a broker. " +
         "Caller must pass the same path the daemon would use " +
-        "(typically `<getFridayHome()>/jetstream`).",
+        "(typically `<getFridayHome()>/nats`).",
     );
   }
 
-  // Verify nothing's listening between our connect attempt and the
-  // spawn — a daemon could have come up in the gap, in which case
-  // re-connecting is correct.
-  if (await tcpProbe(DEFAULT_NATS_PORT)) {
-    const nc = await connect({
-      servers: url,
-      name: opts.name ?? "friday-client",
-      timeout: opts.timeoutMs ?? 5_000,
-    });
-    return {
-      nc,
-      cleanup: async () => {
-        try {
-          await nc.drain();
-        } catch {
-          // ignore
-        }
-      },
-    };
-  }
-
   opts.logger?.info?.("No broker reachable; spawning ephemeral nats-server");
+  const port = await pickPort();
   let spawned: SpawnedNats;
   try {
-    spawned = await spawnNatsServer({ storeDir: opts.storeDir, logger: opts.logger });
+    spawned = await spawnNatsServer({ port, storeDir: opts.storeDir, logger: opts.logger });
   } catch (spawnErr) {
     throw new Error(
       `Failed to spawn ephemeral nats-server: ${spawnErr instanceof Error ? spawnErr.message : String(spawnErr)}\n` +
@@ -202,6 +262,36 @@ export async function connectOrSpawn(opts: ConnectOrSpawnOptions = {}): Promise<
       await spawned.stop();
     },
   };
+}
+
+/** Open a connection-only handle (no spawn, no cleanup of a child process). */
+async function openHandle(url: string, opts: ConnectOptions): Promise<ConnectionHandle> {
+  const nc = await connect({
+    servers: url,
+    name: opts.name ?? "friday-client",
+    timeout: opts.timeoutMs ?? 5_000,
+  });
+  return {
+    nc,
+    cleanup: async () => {
+      try {
+        await nc.drain();
+      } catch {
+        // Already closed
+      }
+    },
+  };
+}
+
+/** Extract the TCP port from a `nats://host:port` URL, or null if unparseable. */
+function portFromUrl(url: string): number | null {
+  try {
+    const parsed = new URL(url);
+    const port = Number.parseInt(parsed.port, 10);
+    return Number.isFinite(port) && port > 0 ? port : null;
+  } catch {
+    return null;
+  }
 }
 
 function rethrowConnectError(url: string, err: unknown): Error {

--- a/packages/jetstream/src/spawn.ts
+++ b/packages/jetstream/src/spawn.ts
@@ -12,10 +12,10 @@
  */
 
 import { type ChildProcess, execFile, spawn } from "node:child_process";
-import { access, mkdir, writeFile } from "node:fs/promises";
-import { createConnection } from "node:net";
+import { access, mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { createConnection, createServer } from "node:net";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
 import type { Logger } from "@atlas/logger";
@@ -25,6 +25,21 @@ const execFileAsync = promisify(execFile);
 
 export const DEFAULT_NATS_PORT = 4222;
 export const DEFAULT_NATS_MONITOR_PORT = 8222;
+
+/**
+ * Friday-reserved port range for per-home auto-allocation. Sits
+ * alongside FRIDAY_PORT_FRIDAY=18080 / FRIDAY_PORT_LINK=13100 /
+ * FRIDAY_PORT_PLAYGROUND=15200 in the 1XXXX band, outside both the
+ * standard NATS port (4222) and the OS-ephemeral zone (49152+),
+ * specifically to avoid colliding with unrelated tools binding
+ * ephemeral ports.
+ *
+ * The Go launcher mirrors these constants at
+ * `tools/friday-launcher/project.go` — keep in sync.
+ */
+const FRIDAY_NATS_PORT_BASE = 14222;
+const FRIDAY_NATS_PORT_RANGE = 10;
+
 const READY_TIMEOUT_MS = 10_000;
 const READY_POLL_MS = 100;
 
@@ -89,6 +104,12 @@ export async function writeServerConfig(opts: {
 }): Promise<void> {
   const cfg = readJetStreamConfig();
   const lines = [
+    // Pin to loopback so `pickPort`'s `127.0.0.1` try-bind probe matches
+    // the bind nats-server actually attempts. Without this nats-server
+    // defaults to `0.0.0.0:<port>`, which overlaps with `127.0.0.1` and
+    // can cause "already in use" failures when pickPort's loopback
+    // check returned "free" microseconds earlier.
+    'host: "127.0.0.1"',
     `port: ${opts.port}`,
     "jetstream {",
     `  store_dir: "${opts.storeDir}"`,
@@ -115,6 +136,114 @@ export function tcpProbe(port: number, host: string = "127.0.0.1"): Promise<bool
       resolve(false);
     });
   });
+}
+
+/**
+ * Try to bind a TCP listener on `host:port`. Returns true if the bind
+ * succeeded (port is free) and closes the listener immediately; false
+ * if the kernel rejected (EADDRINUSE / EACCES / etc).
+ */
+function tryBind(port: number, host: string = "127.0.0.1"): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer();
+    server.unref();
+    server.once("error", () => resolve(false));
+    server.once("listening", () => {
+      server.close(() => resolve(true));
+    });
+    try {
+      server.listen(port, host);
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+/** Ask the kernel for any free port and return its number. */
+function pickEphemeralPort(host: string = "127.0.0.1"): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.once("error", reject);
+    server.listen(0, host, () => {
+      const addr = server.address();
+      if (addr && typeof addr === "object") {
+        const port = addr.port;
+        server.close(() => resolve(port));
+      } else {
+        server.close(() => reject(new Error("could not resolve ephemeral port")));
+      }
+    });
+  });
+}
+
+/**
+ * Pick a free port for a Friday NATS broker. Iterates the Friday-
+ * reserved range first (`FRIDAY_NATS_PORT_BASE..+FRIDAY_NATS_PORT_RANGE-1`),
+ * then falls back to an OS-assigned ephemeral port if all slots are
+ * occupied. The reserved range avoids the kernel ephemeral zone so
+ * Friday's broker doesn't squat on a port the user expected to be
+ * available for unrelated services.
+ *
+ * Returns the port that was free at probe time. Tiny TOCTOU window
+ * between probe and the subsequent `nats-server` bind — if a sibling
+ * grabs the port in between, the broker spawn surfaces the failure
+ * via stderr and the caller can retry.
+ */
+export async function pickPort(host: string = "127.0.0.1"): Promise<number> {
+  for (let offset = 0; offset < FRIDAY_NATS_PORT_RANGE; offset++) {
+    const port = FRIDAY_NATS_PORT_BASE + offset;
+    if (await tryBind(port, host)) return port;
+  }
+  return pickEphemeralPort(host);
+}
+
+/**
+ * Resolve the path to a home's broker URL file. Callers write this
+ * after a successful spawn; consumers read it to discover the live
+ * broker without guessing a port.
+ */
+export function brokerUrlFilePath(home: string): string {
+  return join(home, "nats", "url");
+}
+
+/**
+ * Write the broker URL atomically to `<home>/nats/url`. Tmp + rename
+ * so partial writes never leave a malformed file. No trailing newline
+ * to keep cross-language parsing trivial.
+ */
+export async function writeBrokerUrlFile(home: string, url: string): Promise<void> {
+  const target = brokerUrlFilePath(home);
+  await mkdir(dirname(target), { recursive: true });
+  const tmp = `${target}.tmp`;
+  await writeFile(tmp, url, "utf-8");
+  await rename(tmp, target);
+}
+
+/**
+ * Read the broker URL from `<home>/nats/url`, or null if the file
+ * doesn't exist. Caller is responsible for probing liveness — a stale
+ * file from a crashed daemon will still be readable.
+ */
+export async function readBrokerUrlFile(home: string): Promise<string | null> {
+  try {
+    return (await readFile(brokerUrlFilePath(home), "utf-8")).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Delete the broker URL file. Best-effort; missing file is fine. Call
+ * on clean shutdown so the next spawner doesn't need to TCP-probe a
+ * known-dead URL.
+ */
+export async function deleteBrokerUrlFile(home: string): Promise<void> {
+  try {
+    await unlink(brokerUrlFilePath(home));
+  } catch {
+    // ENOENT or other transient — fine.
+  }
 }
 
 /**

--- a/packages/mcp/src/create-mcp-tools.test.ts
+++ b/packages/mcp/src/create-mcp-tools.test.ts
@@ -941,7 +941,7 @@ describe("createMCPTools", () => {
       );
     });
 
-    it("falls back to ${HOME}/.atlas when FRIDAY_HOME is unset", async () => {
+    it("falls back to ${HOME}/.friday/local when FRIDAY_HOME is unset", async () => {
       const originalHome = process.env.HOME;
       const originalAtlasHome = process.env.FRIDAY_HOME;
       process.env.HOME = "/Users/test";
@@ -966,7 +966,7 @@ describe("createMCPTools", () => {
 
         expect(MockStdioTransport).toHaveBeenCalledWith(
           expect.objectContaining({
-            args: ["mcp-server-sqlite", "--db-path", "/Users/test/.atlas/kb.sqlite"],
+            args: ["mcp-server-sqlite", "--db-path", "/Users/test/.friday/local/kb.sqlite"],
           }),
         );
       } finally {

--- a/packages/utils/src/paths.ts
+++ b/packages/utils/src/paths.ts
@@ -6,13 +6,9 @@ import process from "node:process";
  * This module should only be loaded in server code because it relies
  * on the Node.js process namespace to be available - this will crash in browsers!
  */
-// Cache the working directory at startup since it never changes
-// This prevents EMFILE errors from concurrent process.cwd() calls
-// and improves performance by avoiding unnecessary syscalls
-const CACHED_CWD = process.cwd();
 
 /**
- * Check if Atlas is running as a system service
+ * Check if Friday is running as a system service
  */
 export function isSystemService(): boolean {
   // Check if running as system service by:
@@ -46,14 +42,20 @@ export function isSystemService(): boolean {
 }
 
 /**
- * Get the Atlas home directory
- * - System mode: /var/lib/atlas
- * - User mode: ~/.atlas
+ * Get the Friday home directory.
+ *
+ * - `FRIDAY_HOME` env wins when set.
+ * - System mode: `/var/lib/atlas`.
+ * - User mode: `~/.friday/local` (matches the launcher's
+ *   `friendlyHome()` default and the installer's
+ *   `friday_home_dir()` default). The dev `deno task atlas` task in
+ *   `deno.json` pins `FRIDAY_HOME=$HOME/.atlas` explicitly to keep
+ *   dev state at the legacy location with the inference made legible.
  */
 export function getFridayHome(): string {
-  const atlasHome = process.env.FRIDAY_HOME;
-  if (atlasHome) {
-    return atlasHome;
+  const fridayHome = process.env.FRIDAY_HOME;
+  if (fridayHome) {
+    return fridayHome;
   }
 
   // Check if running as system service
@@ -61,26 +63,13 @@ export function getFridayHome(): string {
     return "/var/lib/atlas";
   }
 
-  // Check if we're already running from within .atlas directory
-  // This handles the case where the compiled atlas binary runs from ~/.atlas/
-  const cwd = CACHED_CWD;
-  const sep = process.platform === "win32" ? "\\" : "/";
-  if (cwd.endsWith(".atlas") || cwd.includes(`.atlas${sep}`)) {
-    // We're in .atlas directory, return the parent .atlas directory
-    const parts = cwd.split(sep);
-    const atlasIndex = parts.lastIndexOf(".atlas");
-    if (atlasIndex > 0) {
-      return parts.slice(0, atlasIndex + 1).join(sep);
-    }
-  }
-
-  // User mode: use home directory
+  // User mode: default under the user's home directory.
   const homeDir = process.env.HOME || process.env.USERPROFILE;
   if (!homeDir) {
     throw new Error("Unable to determine home directory");
   }
 
-  return join(homeDir, ".atlas");
+  return join(homeDir, ".friday", "local");
 }
 
 /**

--- a/packages/workspace/src/__tests__/cross-home-filter.test.ts
+++ b/packages/workspace/src/__tests__/cross-home-filter.test.ts
@@ -1,0 +1,463 @@
+/**
+ * Tests for the cross-home registry filter.
+ *
+ * Background: `WORKSPACE_REGISTRY` is shared across home dirs whenever two
+ * daemons (e.g. dev and prod) end up backed by the same JetStream store.
+ * Once a cross-home entry lands in the registry, every subsequent daemon
+ * boot would walk those entries — watching directories under the wrong
+ * home, re-mounting workspaces that don't belong to this install, etc.
+ *
+ * The fix renders cross-home entries inert at runtime: `list()` filters
+ * them out, `find()` masks them, watchers never attach. The entries stay
+ * in KV — Phase 6 handles deletion. This file pins that contract.
+ */
+
+import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import process from "node:process";
+import { createKVStorage, type KVStorage } from "@atlas/storage";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WorkspaceManager } from "../manager.ts";
+import { RegistryStorageAdapter } from "../registry-storage-adapter.ts";
+import type { WorkspaceEntry } from "../types.ts";
+
+/**
+ * `MemoryKVStorage.initialize()` clears `data`. The manager calls
+ * `registry.initialize()` (and the KV under it) on every boot, which
+ * wipes any seed we set up before `manager.initialize`. Proxy the KV so
+ * subsequent inits are no-ops. Test-only; production KVs treat re-init
+ * as idempotent at the data layer.
+ */
+async function makeIdempotentMemoryKV(): Promise<KVStorage> {
+  const kv = await createKVStorage({ type: "memory" });
+  let inited = false;
+  return new Proxy(kv, {
+    get(target, prop, receiver) {
+      if (prop === "initialize") {
+        return async () => {
+          if (inited) return;
+          inited = true;
+          await target.initialize();
+        };
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+  });
+}
+
+const hoisted = vi.hoisted(() => ({ atlasHome: "/tmp/atlas-cross-home" }));
+
+vi.mock("@atlas/utils/paths.server", () => ({ getFridayHome: () => hoisted.atlasHome }));
+
+vi.mock("@atlas/system/workspaces", () => ({ SYSTEM_WORKSPACES: {} }));
+
+// Track every workspace passed to watchWorkspace() so we can assert nothing
+// from a foreign home ever gets a file watcher.
+const watcherSpy = vi.hoisted(() => ({ watched: [] as string[] }));
+
+vi.mock("../watchers/index.ts", () => ({
+  WorkspaceConfigWatcher: class {
+    watchWorkspace(entry: WorkspaceEntry) {
+      watcherSpy.watched.push(entry.id);
+      return Promise.resolve();
+    }
+    unwatchWorkspace() {}
+    stop() {}
+    shutdown() {
+      return Promise.resolve();
+    }
+  },
+}));
+
+// Spy on logger.warn so we can pin the "one warn per skipped entry per
+// filter call" contract.
+const mockLogger = vi.hoisted(() => {
+  const log = { warn: vi.fn(), debug: vi.fn(), info: vi.fn(), error: vi.fn(), child: vi.fn() };
+  log.child.mockReturnValue(log);
+  return log;
+});
+
+vi.mock("@atlas/logger", () => ({ logger: mockLogger, createLogger: vi.fn(() => mockLogger) }));
+
+function entry(overrides: Partial<WorkspaceEntry> & { id: string; path: string }): WorkspaceEntry {
+  return {
+    id: overrides.id,
+    name: overrides.name ?? overrides.id,
+    path: overrides.path,
+    configPath: overrides.configPath ?? join(overrides.path, "workspace.yml"),
+    status: overrides.status ?? "inactive",
+    createdAt: overrides.createdAt ?? new Date().toISOString(),
+    lastSeen: overrides.lastSeen ?? new Date().toISOString(),
+    metadata: overrides.metadata,
+  };
+}
+
+async function makeManager(
+  home: string,
+): Promise<{ manager: WorkspaceManager; registry: RegistryStorageAdapter }> {
+  hoisted.atlasHome = home;
+  const kv = await makeIdempotentMemoryKV();
+  const registry = new RegistryStorageAdapter(kv);
+  await registry.initialize();
+  return { manager: new WorkspaceManager(registry), registry };
+}
+
+/**
+ * Warn-log calls that came from the cross-home filter, with a stable
+ * fingerprint of the entry they fired on. Other warn calls (e.g. from
+ * `WorkspaceConfigSchema` parse failures elsewhere) are ignored.
+ */
+function crossHomeWarns(): Array<{ workspaceId: string; context: string }> {
+  return mockLogger.warn.mock.calls
+    .filter(
+      ([msg]) =>
+        msg === "Skipping workspace registry entry from different home dir" ||
+        msg === "Masking cross-home workspace lookup" ||
+        msg === "Masking cross-home workspace config lookup",
+    )
+    .map(([, payload]) => ({
+      workspaceId: (payload as { workspaceId: string }).workspaceId,
+      context: (payload as { context: string }).context,
+    }));
+}
+
+describe("WorkspaceManager cross-home filter — list()", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    // realpath: on macOS mkdtemp returns `/var/folders/...` but
+    // Deno.realPath() resolves to `/private/var/folders/...`. The filter
+    // compares the stored entry path (already realpath'd by
+    // registerWorkspace) against home, so canonicalise both sides.
+    home = await realpath(await mkdtemp(join(tmpdir(), "atlas-home-")));
+    process.env.DENO_TEST = "true";
+    mockLogger.warn.mockClear();
+    watcherSpy.watched.length = 0;
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("returns only the in-home entry from a three-entry seed", async () => {
+    const { manager, registry } = await makeManager(home);
+
+    const inHome = entry({ id: "in-home", path: join(home, "workspaces", "in-home") });
+    const foreignHome = entry({ id: "foreign-home", path: "/some/other/dir/workspaces/X" });
+    const tmpEntry = entry({ id: "tmp-entry", path: "/tmp/lives-here" });
+
+    await registry.registerWorkspace(inHome);
+    await registry.registerWorkspace(foreignHome);
+    await registry.registerWorkspace(tmpEntry);
+
+    const listed = await manager.list();
+
+    expect(listed.map((w) => w.id).sort()).toEqual(["in-home"]);
+  });
+
+  it("emits exactly one warn log per skipped entry per list() call", async () => {
+    const { manager, registry } = await makeManager(home);
+
+    await registry.registerWorkspace(entry({ id: "in", path: join(home, "ws", "in") }));
+    await registry.registerWorkspace(
+      entry({ id: "foreign-1", path: "/some/other/home/workspaces/A" }),
+    );
+    await registry.registerWorkspace(entry({ id: "foreign-2", path: "/tmp/elsewhere" }));
+
+    await manager.list();
+
+    const warns = crossHomeWarns().filter((w) => w.context === "list");
+    expect(warns.map((w) => w.workspaceId).sort()).toEqual(["foreign-1", "foreign-2"]);
+    expect(warns).toHaveLength(2);
+  });
+
+  it("re-emits warns on subsequent list() calls (per-call, not session-scoped)", async () => {
+    // The contract per the plan is "one warn per skipped entry per filter
+    // call" — multiple calls within a boot session each emit. This keeps
+    // the implementation simple (no manager-level seen set) and lets
+    // operators see the filter firing across boot, close(), and any
+    // intermediate list() calls.
+    const { manager, registry } = await makeManager(home);
+    await registry.registerWorkspace(entry({ id: "foreign", path: "/elsewhere/X" }));
+
+    await manager.list();
+    await manager.list();
+
+    const warns = crossHomeWarns().filter((w) => w.context === "list");
+    expect(warns).toHaveLength(2);
+  });
+});
+
+describe("WorkspaceManager cross-home filter — boot path watchers", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await realpath(await mkdtemp(join(tmpdir(), "atlas-home-watch-")));
+    process.env.DENO_TEST = "true";
+    mockLogger.warn.mockClear();
+    watcherSpy.watched.length = 0;
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("does not attach watchers to cross-home entries during initialize()", async () => {
+    const { manager, registry } = await makeManager(home);
+
+    // Seed a foreign-home entry directly (no fs presence — the filter is
+    // path-prefix only, no disk lookup). The boot path must skip this
+    // entry entirely: no list result, no config load, no watcher.
+    await registry.registerWorkspace(
+      entry({ id: "foreign", path: "/foreign/home/workspaces/Bad" }),
+    );
+
+    // Seed an in-home workspace with a valid workspace.yml so the boot
+    // loop actually reaches `fileWatcher.watchWorkspace()` for it,
+    // proving the watcher path runs for legitimate entries.
+    const inHomePath = join(home, "workspaces", "in-home");
+    const { mkdir } = await import("node:fs/promises");
+    await mkdir(inHomePath, { recursive: true });
+    await writeFile(
+      join(inHomePath, "workspace.yml"),
+      'version: "1.0"\nworkspace:\n  name: in-home\n',
+    );
+    await manager.registerWorkspace(inHomePath, { id: "in-home" });
+
+    // Clear any watch calls registerWorkspace already made — we only
+    // care about what initialize() does next.
+    watcherSpy.watched.length = 0;
+
+    await manager.initialize([]);
+
+    expect(watcherSpy.watched).toContain("in-home");
+    expect(watcherSpy.watched).not.toContain("foreign");
+  });
+});
+
+describe("WorkspaceManager cross-home filter — find() back-doors", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await realpath(await mkdtemp(join(tmpdir(), "atlas-home-find-")));
+    process.env.DENO_TEST = "true";
+    mockLogger.warn.mockClear();
+    watcherSpy.watched.length = 0;
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("find({ id }) returns null for cross-home entry and emits a warn", async () => {
+    const { manager, registry } = await makeManager(home);
+    await registry.registerWorkspace(entry({ id: "foreign", path: "/elsewhere/X" }));
+
+    const result = await manager.find({ id: "foreign" });
+
+    expect(result).toBeNull();
+    const warns = crossHomeWarns().filter((w) => w.workspaceId === "foreign");
+    expect(warns).toHaveLength(1);
+    expect(warns[0]?.context).toBe("find");
+  });
+
+  it("find({ name }) returns null for cross-home entry", async () => {
+    const { manager, registry } = await makeManager(home);
+    await registry.registerWorkspace(
+      entry({ id: "foreign", name: "Cross Home WS", path: "/elsewhere/Y" }),
+    );
+
+    const result = await manager.find({ name: "Cross Home WS" });
+
+    expect(result).toBeNull();
+  });
+
+  it("find({ path }) returns null when the path is cross-home", async () => {
+    const { manager, registry } = await makeManager(home);
+    await registry.registerWorkspace(entry({ id: "foreign", path: "/elsewhere/Z" }));
+
+    const result = await manager.find({ path: "/elsewhere/Z" });
+
+    expect(result).toBeNull();
+  });
+
+  it("getWorkspaceConfig() returns null for cross-home entry", async () => {
+    const { manager, registry } = await makeManager(home);
+    await registry.registerWorkspace(entry({ id: "foreign", path: "/elsewhere/Q" }));
+
+    const result = await manager.getWorkspaceConfig("foreign");
+
+    expect(result).toBeNull();
+    const warns = crossHomeWarns().filter(
+      (w) => w.workspaceId === "foreign" && w.context === "getWorkspaceConfig",
+    );
+    expect(warns).toHaveLength(1);
+  });
+});
+
+describe("WorkspaceManager cross-home filter — generateUniqueId still sees everything", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await realpath(await mkdtemp(join(tmpdir(), "atlas-home-uniq-")));
+    process.env.DENO_TEST = "true";
+    mockLogger.warn.mockClear();
+    watcherSpy.watched.length = 0;
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("queries the raw registry (not the filtered list), so cross-home IDs appear in the taken set", async () => {
+    // The behavioral assertion: generateUniqueId calls
+    // registry.listWorkspaces() directly, not the filtered manager.list().
+    // We spy on listWorkspaces and verify it returned the cross-home
+    // entries, proving they're in the namespace the unique-id walk sees.
+    const { manager, registry } = await makeManager(home);
+    const seeded: WorkspaceEntry[] = [
+      entry({ id: "in-home-X", path: join(home, "ws", "X") }),
+      entry({ id: "cross-home-COLLIDE", path: "/foreign/ws/Y" }),
+    ];
+    for (const e of seeded) await registry.registerWorkspace(e);
+
+    const listSpy = vi.spyOn(registry, "listWorkspaces");
+    const generate = (
+      manager as unknown as { generateUniqueId: () => Promise<string> }
+    ).generateUniqueId.bind(manager);
+    await generate();
+
+    expect(listSpy).toHaveBeenCalled();
+    const returned = (await listSpy.mock.results[0]?.value) as WorkspaceEntry[];
+    expect(returned.map((w) => w.id).sort()).toEqual(["cross-home-COLLIDE", "in-home-X"]);
+  });
+
+  it("does not mint an ID that collides with any seeded entry over many iterations", async () => {
+    const { manager, registry } = await makeManager(home);
+    const seeded: WorkspaceEntry[] = [
+      entry({ id: "a-in", path: join(home, "ws", "a") }),
+      entry({ id: "b-in", path: join(home, "ws", "b") }),
+      entry({ id: "c-foreign", path: "/foreign/ws/c" }),
+      entry({ id: "d-foreign", path: "/tmp/ws/d" }),
+    ];
+    for (const e of seeded) await registry.registerWorkspace(e);
+    const seededIds = new Set(seeded.map((e) => e.id));
+
+    const generate = (
+      manager as unknown as { generateUniqueId: () => Promise<string> }
+    ).generateUniqueId.bind(manager);
+    for (let i = 0; i < 50; i++) {
+      const id = await generate();
+      expect(seededIds.has(id)).toBe(false);
+    }
+  });
+});
+
+describe("WorkspaceManager cross-home filter — system workspaces bypass the filter", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await realpath(await mkdtemp(join(tmpdir(), "atlas-home-system-")));
+    process.env.DENO_TEST = "true";
+    mockLogger.warn.mockClear();
+    watcherSpy.watched.length = 0;
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("preserves system:// entries regardless of home prefix", async () => {
+    // `system://` paths are home-agnostic by construction — they're the
+    // bundled system workspaces, not user data on disk. The filter must
+    // not drop them even though `system://...` doesn't start with the
+    // active home.
+    const { manager, registry } = await makeManager(home);
+    await registry.registerWorkspace(
+      entry({ id: "fast-loop", path: "system://fast-loop", metadata: { system: true } }),
+    );
+
+    const listed = await manager.list({ includeSystem: true });
+
+    expect(listed.map((w) => w.id)).toContain("fast-loop");
+    expect(crossHomeWarns()).toHaveLength(0);
+  });
+
+  it("preserves metadata.system entries regardless of path prefix", async () => {
+    // Belt-and-suspenders: any entry tagged `metadata.system: true` is
+    // treated as home-agnostic even if its `path` is a real on-disk
+    // path under a foreign home. Same justification: system workspaces
+    // are bundled with the daemon binary, not per-home state.
+    const { manager, registry } = await makeManager(home);
+    await registry.registerWorkspace(
+      entry({
+        id: "sys-with-real-path",
+        path: "/some/other/install/system/fast-loop",
+        metadata: { system: true },
+      }),
+    );
+
+    const listed = await manager.list({ includeSystem: true });
+
+    expect(listed.map((w) => w.id)).toContain("sys-with-real-path");
+  });
+});
+
+describe("WorkspaceManager cross-home filter — initialize() sweeps are home-scoped", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await realpath(await mkdtemp(join(tmpdir(), "atlas-home-sweep-")));
+    process.env.DENO_TEST = "true";
+    mockLogger.warn.mockClear();
+    watcherSpy.watched.length = 0;
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("registerSystemWorkspaces orphan sweep does not unregister cross-home system rows", async () => {
+    // Phase 5 gate: a cross-home `system=true` row written by another
+    // daemon (or another install of the same version) isn't ours to
+    // garbage-collect. If the orphan sweep ran on it, two installs
+    // sharing a registry would wipe each other's system entries.
+    const { manager, registry } = await makeManager(home);
+    await registry.registerWorkspace(
+      entry({
+        id: "foreign-system",
+        path: "/foreign/install/system/foo",
+        metadata: { system: true },
+      }),
+    );
+
+    await manager.initialize([]);
+
+    // Survived the orphan sweep.
+    const survived = await registry.getWorkspace("foreign-system");
+    expect(survived).not.toBeNull();
+  });
+
+  it("migrateFastLoopToSystem does not touch cross-home fast-loop entries", async () => {
+    // Cross-home fast-loop migration would mutate a row owned by
+    // another install. The filter at the migration call site is what
+    // prevents that — without it, a stale "fast-loop" entry pointing at
+    // a foreign install would be rewritten on every boot.
+    const { manager, registry } = await makeManager(home);
+    await registry.registerWorkspace(
+      entry({
+        id: "foreign-fast-loop",
+        name: "fast-loop",
+        path: "/foreign/install/workspaces/fast-loop",
+      }),
+    );
+
+    await manager.initialize([]);
+
+    const survived = await registry.getWorkspace("foreign-fast-loop");
+    expect(survived).not.toBeNull();
+    // The cross-home entry's name is unchanged (no rewrite happened).
+    expect(survived?.name).toBe("fast-loop");
+  });
+});

--- a/packages/workspace/src/__tests__/cross-home-filter.test.ts
+++ b/packages/workspace/src/__tests__/cross-home-filter.test.ts
@@ -332,26 +332,6 @@ describe("WorkspaceManager cross-home filter — generateUniqueId still sees eve
     const returned = (await listSpy.mock.results[0]?.value) as WorkspaceEntry[];
     expect(returned.map((w) => w.id).sort()).toEqual(["cross-home-COLLIDE", "in-home-X"]);
   });
-
-  it("does not mint an ID that collides with any seeded entry over many iterations", async () => {
-    const { manager, registry } = await makeManager(home);
-    const seeded: WorkspaceEntry[] = [
-      entry({ id: "a-in", path: join(home, "ws", "a") }),
-      entry({ id: "b-in", path: join(home, "ws", "b") }),
-      entry({ id: "c-foreign", path: "/foreign/ws/c" }),
-      entry({ id: "d-foreign", path: "/tmp/ws/d" }),
-    ];
-    for (const e of seeded) await registry.registerWorkspace(e);
-    const seededIds = new Set(seeded.map((e) => e.id));
-
-    const generate = (
-      manager as unknown as { generateUniqueId: () => Promise<string> }
-    ).generateUniqueId.bind(manager);
-    for (let i = 0; i < 50; i++) {
-      const id = await generate();
-      expect(seededIds.has(id)).toBe(false);
-    }
-  });
 });
 
 describe("WorkspaceManager cross-home filter — system workspaces bypass the filter", () => {
@@ -459,5 +439,102 @@ describe("WorkspaceManager cross-home filter — initialize() sweeps are home-sc
     expect(survived).not.toBeNull();
     // The cross-home entry's name is unchanged (no rewrite happened).
     expect(survived?.name).toBe("fast-loop");
+  });
+});
+
+describe("WorkspaceManager cross-home filter — mutation paths refuse to touch", () => {
+  let home: string;
+
+  beforeEach(async () => {
+    home = await realpath(await mkdtemp(join(tmpdir(), "atlas-home-mutate-")));
+    process.env.DENO_TEST = "true";
+    mockLogger.warn.mockClear();
+    watcherSpy.watched.length = 0;
+  });
+
+  afterEach(async () => {
+    await rm(home, { recursive: true, force: true });
+  });
+
+  it("deleteWorkspace leaves cross-home entries intact and does not touch their path", async () => {
+    // The critical case from the prior review: removeDirectory=true on
+    // a cross-home id could `rm -rf` a directory under another Friday
+    // install. The guard at the top of deleteWorkspace must refuse
+    // BEFORE any registry unregister or filesystem rm runs.
+    const { manager, registry } = await makeManager(home);
+    await registry.registerWorkspace(
+      entry({ id: "foreign", path: "/some/foreign/install/workspaces/X" }),
+    );
+
+    await manager.deleteWorkspace("foreign", { removeDirectory: true });
+
+    // Entry still in registry — guard fired before the unregister call.
+    const survived = await registry.getWorkspace("foreign");
+    expect(survived).not.toBeNull();
+    // Warn was emitted with the right context.
+    const warns = mockLogger.warn.mock.calls.filter(
+      ([msg]) => msg === "Refusing to delete cross-home workspace",
+    );
+    expect(warns).toHaveLength(1);
+  });
+
+  it("renameWorkspace throws not-found for cross-home entries and does not rewrite the registry", async () => {
+    const { manager, registry } = await makeManager(home);
+    await registry.registerWorkspace(
+      entry({ id: "foreign", name: "Original Name", path: "/foreign/X" }),
+    );
+
+    await expect(manager.renameWorkspace("foreign", "New Name")).rejects.toThrow(
+      /Workspace not found/,
+    );
+
+    const survived = await registry.getWorkspace("foreign");
+    expect(survived?.name).toBe("Original Name");
+    const warns = mockLogger.warn.mock.calls.filter(
+      ([msg]) => msg === "Refusing to rename cross-home workspace",
+    );
+    expect(warns).toHaveLength(1);
+  });
+
+  it("updateWorkspacePersistence throws not-found for cross-home entries", async () => {
+    const { manager, registry } = await makeManager(home);
+    await registry.registerWorkspace(
+      entry({ id: "foreign", path: "/foreign/Y", configPath: "/foreign/Y/eph_workspace.yml" }),
+    );
+
+    await expect(manager.updateWorkspacePersistence("foreign", true)).rejects.toThrow(
+      /Workspace not found/,
+    );
+
+    // configPath unchanged — no rename happened.
+    const survived = await registry.getWorkspace("foreign");
+    expect(survived?.configPath).toBe("/foreign/Y/eph_workspace.yml");
+    const warns = mockLogger.warn.mock.calls.filter(
+      ([msg]) => msg === "Refusing to toggle persistence for cross-home workspace",
+    );
+    expect(warns).toHaveLength(1);
+  });
+
+  it("restartSignalsForWorkspace is a no-op for cross-home entries", async () => {
+    // Private method — reach in via cast. The signal-restart path runs
+    // when a workspace's config changes; for a cross-home entry, the
+    // guard must skip the unregister/register cycle (otherwise we'd
+    // mount signals for a workspace we don't own).
+    const { manager, registry } = await makeManager(home);
+    await registry.registerWorkspace(entry({ id: "foreign", path: "/foreign/Z" }));
+
+    const restart = (
+      manager as unknown as {
+        restartSignalsForWorkspace: (id: string, path: string, config: unknown) => Promise<void>;
+      }
+    ).restartSignalsForWorkspace.bind(manager);
+
+    // Minimal config shape — the guard fires before config is used.
+    await restart("foreign", "/foreign/Z", {} as unknown);
+
+    const warns = mockLogger.warn.mock.calls.filter(
+      ([msg]) => msg === "Refusing to restart signals for cross-home workspace",
+    );
+    expect(warns).toHaveLength(1);
   });
 });

--- a/packages/workspace/src/__tests__/cross-home-filter.test.ts
+++ b/packages/workspace/src/__tests__/cross-home-filter.test.ts
@@ -532,6 +532,13 @@ describe("WorkspaceManager cross-home filter — mutation paths refuse to touch"
     // Minimal config shape — the guard fires before config is used.
     await restart("foreign", "/foreign/Z", {} as unknown);
 
+    // Registry entry must be unchanged — guard fired before the
+    // unregister/register cycle could touch it. Mirrors the
+    // "no side effects" assertion from the other three mutation tests.
+    const survived = await registry.getWorkspace("foreign");
+    expect(survived).not.toBeNull();
+    expect(survived?.path).toBe("/foreign/Z");
+
     const warns = mockLogger.warn.mock.calls.filter(
       ([msg]) => msg === "Refusing to restart signals for cross-home workspace",
     );

--- a/packages/workspace/src/__tests__/first-run-bootstrap.test.ts
+++ b/packages/workspace/src/__tests__/first-run-bootstrap.test.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from "node:fs";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
@@ -46,7 +46,11 @@ describe("ensureDefaultUserWorkspace", () => {
   let manager: WorkspaceManager;
 
   beforeEach(async () => {
-    tempDir = await mkdtemp(join(tmpdir(), "atlas-first-run-"));
+    // realpath: on macOS tmpdir() returns the `/var/folders/...` symlink,
+    // but Deno.realPath() (used inside manager.registerWorkspace) resolves
+    // to `/private/var/folders/...`. The cross-home filter compares stored
+    // realpath against the mocked home — canonicalise here to match.
+    tempDir = await realpath(await mkdtemp(join(tmpdir(), "atlas-first-run-")));
     process.env.DENO_TEST = "true";
     const setup = await setupManager(tempDir);
     manager = setup.manager;

--- a/packages/workspace/src/__tests__/manager-canonical.test.ts
+++ b/packages/workspace/src/__tests__/manager-canonical.test.ts
@@ -6,10 +6,15 @@
  */
 
 import { createKVStorage } from "@atlas/storage/kv";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkspaceManager } from "../manager.ts";
 import { RegistryStorageAdapter } from "../registry-storage-adapter.ts";
 import type { WorkspaceEntry } from "../types.ts";
+
+// Pin `getFridayHome()` to `/tmp` so the cross-home filter accepts the
+// `/tmp/...` paths used in the non-canonical fixtures below. Without
+// this pin the filter defaults to `~/.atlas` and masks the entries.
+vi.mock("@atlas/utils/paths.server", () => ({ getFridayHome: () => "/tmp" }));
 
 async function createTestManager(): Promise<{
   manager: WorkspaceManager;

--- a/packages/workspace/src/manager.ts
+++ b/packages/workspace/src/manager.ts
@@ -26,6 +26,64 @@ import { WorkspaceConfigWatcher } from "./watchers/index.ts";
 export type RuntimeInvalidateCallback = (workspaceId: string) => Promise<void>;
 
 /**
+ * Strip trailing path separators so prefix comparisons aren't tripped up by
+ * `/foo` vs `/foo/`. We deliberately do NOT `realpath` either side: the
+ * registry stores absolute paths as recorded at registration time, and a
+ * disk-level resolve on every list() call would be wasted I/O.
+ */
+function trimTrailingSep(p: string): string {
+  if (p.length > 1 && (p.endsWith("/") || p.endsWith("\\"))) {
+    return p.slice(0, -1);
+  }
+  return p;
+}
+
+/**
+ * True if `entry.path` is inside `home` (or is a system workspace, which is
+ * home-agnostic by construction — `system://<id>`). Path-prefix only, no
+ * filesystem touch. The trailing-separator on the home boundary prevents
+ * `/foo/bar` from matching home `/foo/ba`.
+ *
+ * @internal Exported for direct unit tests of the predicate.
+ */
+export function isUnderHome(entry: WorkspaceEntry, home: string): boolean {
+  if (entry.metadata?.system) return true;
+  if (entry.path.startsWith("system://")) return true;
+
+  const homeNorm = trimTrailingSep(home);
+  const pathNorm = trimTrailingSep(entry.path);
+  if (pathNorm === homeNorm) return true;
+  return pathNorm.startsWith(`${homeNorm}/`) || pathNorm.startsWith(`${homeNorm}\\`);
+}
+
+/**
+ * Drop registry entries whose `path` falls outside the active Friday home.
+ * Emits one `level=warn` log per skipped entry. Registry IDs are unique by
+ * construction, so duplicate-skip suppression isn't required.
+ */
+function filterInHomeEntries(
+  entries: WorkspaceEntry[],
+  home: string,
+  context: string,
+): WorkspaceEntry[] {
+  const kept: WorkspaceEntry[] = [];
+  for (const entry of entries) {
+    if (isUnderHome(entry, home)) {
+      kept.push(entry);
+      continue;
+    }
+    logger.warn("Skipping workspace registry entry from different home dir", {
+      workspaceId: entry.id,
+      workspaceName: entry.name,
+      workspacePath: entry.path,
+      activeHome: home,
+      context,
+    });
+  }
+  return kept;
+}
+
+/**
  * Hook for stamping a workspace membership row when a workspace is
  * registered. Injected by the daemon at startup — the manager itself
  * stays storage-agnostic (no `@atlas/core` import).
@@ -432,9 +490,22 @@ export class WorkspaceManager {
       }
     }
 
-    const allWorkspaces = await this.registry.listWorkspaces();
+    // Orphan sweep is doubly scoped: filter to in-home entries first
+    // (filterInHomeEntries treats `metadata.system` as home-agnostic, so
+    // cross-home system rows would pass), then narrow to `system://` paths
+    // so we only sweep rows this install actually owns. A cross-home row
+    // tagged `metadata.system: true` with a real-disk path (i.e. written
+    // by another install of the same daemon) isn't ours to garbage-collect.
+    // Phase 6 handles deletion of cross-home rows explicitly.
+    const allWorkspaces = filterInHomeEntries(
+      await this.registry.listWorkspaces(),
+      getFridayHome(),
+      "registerSystemWorkspaces",
+    );
     for (const ws of allWorkspaces) {
-      if (ws.metadata?.system && !systemIds.has(ws.id)) {
+      const isOurSystemRow =
+        ws.metadata?.system && ws.path.startsWith("system://") && !systemIds.has(ws.id);
+      if (isOurSystemRow) {
         logger.info(`Removing orphaned system workspace: ${ws.id} (${ws.name})`);
         // Pair registry unregister with registrar cleanup so cron timers
         // (and fs watchers) for the orphaned workspace don't survive as
@@ -454,7 +525,15 @@ export class WorkspaceManager {
    * no fast-loop workspace exists or if system is already registered.
    */
   private async migrateFastLoopToSystem(): Promise<void> {
-    const allWorkspaces = await this.registry.listWorkspaces();
+    // Migration sweep is home-scoped: a cross-home fast-loop entry isn't
+    // ours to rewrite. Filtering here also keeps the warn-log emitted by
+    // the filter aligned with the rest of boot (one warn per skipped
+    // entry per call).
+    const allWorkspaces = filterInHomeEntries(
+      await this.registry.listWorkspaces(),
+      getFridayHome(),
+      "migrateFastLoopToSystem",
+    );
     const fastLoopEntry = allWorkspaces.find(
       (ws) =>
         ws.id.includes("fast-loop") ||
@@ -483,6 +562,17 @@ export class WorkspaceManager {
   async getWorkspaceConfig(workspaceId: string): Promise<MergedConfig | null> {
     const workspace = await this.registry.getWorkspace(workspaceId);
     if (!workspace) return null;
+
+    if (!isUnderHome(workspace, getFridayHome())) {
+      logger.warn("Masking cross-home workspace config lookup", {
+        workspaceId: workspace.id,
+        workspaceName: workspace.name,
+        workspacePath: workspace.path,
+        activeHome: getFridayHome(),
+        context: "getWorkspaceConfig",
+      });
+      return null;
+    }
 
     if (workspace.metadata?.system && workspace.id in SYSTEM_WORKSPACES) {
       const config = SYSTEM_WORKSPACES[workspace.id];
@@ -528,7 +618,13 @@ export class WorkspaceManager {
     }
   }
 
-  /** Find by id/name/path; reflect running status if a runtime is registered. */
+  /**
+   * Find by id/name/path; reflect running status if a runtime is registered.
+   *
+   * Cross-home entries are masked here too — otherwise `find({id})` and
+   * friends would re-surface what `list()` filters out, defeating the
+   * isolation contract.
+   */
   async find(query: { id?: string; name?: string; path?: string }): Promise<WorkspaceEntry | null> {
     let workspace: WorkspaceEntry | null = null;
 
@@ -541,6 +637,17 @@ export class WorkspaceManager {
       workspace = await this.registry.findWorkspaceByPath(normalizedPath);
     }
 
+    if (workspace && !isUnderHome(workspace, getFridayHome())) {
+      logger.warn("Masking cross-home workspace lookup", {
+        workspaceId: workspace.id,
+        workspaceName: workspace.name,
+        workspacePath: workspace.path,
+        activeHome: getFridayHome(),
+        context: "find",
+      });
+      return null;
+    }
+
     if (workspace) {
       const runtime = this.runtimes.get(workspace.id);
       if (runtime) {
@@ -551,12 +658,21 @@ export class WorkspaceManager {
     return workspace;
   }
 
-  /** List workspaces; filter by status; exclude system by default. */
+  /**
+   * List workspaces; filter by status; exclude system by default.
+   *
+   * Cross-home entries (registry rows whose `path` is outside the active
+   * `getFridayHome()`) are filtered out here — this is the chokepoint
+   * inherited by boot-time loading, close(), and every external caller
+   * that goes through list(). System workspaces (path `system://...`)
+   * are home-agnostic and always pass.
+   */
   async list(options?: {
     status?: WorkspaceStatus;
     includeSystem?: boolean;
   }): Promise<WorkspaceEntry[]> {
-    let workspaces = await this.registry.listWorkspaces();
+    const raw = await this.registry.listWorkspaces();
+    let workspaces = filterInHomeEntries(raw, getFridayHome(), "list");
 
     if (options?.status) {
       workspaces = workspaces.filter((w) => w.status === options.status);
@@ -582,6 +698,22 @@ export class WorkspaceManager {
     const workspace = await this.registry.getWorkspace(id);
     if (!workspace) {
       logger.info("Workspace already deleted", { id });
+      return;
+    }
+
+    // Cross-home guard: refuse to delete an entry whose path lives under
+    // a different Friday home. `removeDirectory=true` would otherwise
+    // `rm -rf` directories owned by another install. The KV row stays
+    // until Phase 6 recovery — this manager's job is to keep the active
+    // home isolated, not to clean up cross-home contamination.
+    if (!isUnderHome(workspace, getFridayHome())) {
+      logger.warn("Refusing to delete cross-home workspace", {
+        workspaceId: workspace.id,
+        workspaceName: workspace.name,
+        workspacePath: workspace.path,
+        activeHome: getFridayHome(),
+        context: "deleteWorkspace",
+      });
       return;
     }
 
@@ -633,6 +765,16 @@ export class WorkspaceManager {
       throw new Error(`Workspace not found: ${id}`);
     }
 
+    if (!isUnderHome(workspace, getFridayHome())) {
+      logger.warn("Refusing to rename cross-home workspace", {
+        workspaceId: workspace.id,
+        workspacePath: workspace.path,
+        activeHome: getFridayHome(),
+        context: "renameWorkspace",
+      });
+      throw new Error(`Workspace not found: ${id}`);
+    }
+
     if (workspace.metadata?.canonical === "system") {
       throw new Error(`Cannot rename system canonical workspace '${id}'.`);
     }
@@ -679,6 +821,13 @@ export class WorkspaceManager {
     await this.registry.updateWorkspaceStatus(workspaceId, status, updates);
   }
 
+  /**
+   * Walks the FULL raw registry on purpose — including cross-home entries.
+   * The cross-home filter that masks entries from list()/find() must NOT
+   * apply here: minting an ID that collides with a cross-home row would
+   * still corrupt the shared registry. Use `registry.listWorkspaces()`
+   * directly, not the filtered view.
+   */
   private async generateUniqueId(): Promise<string> {
     const existingWorkspaces = await this.registry.listWorkspaces();
     const existingIds = new Set(existingWorkspaces.map((w) => w.id));
@@ -1168,9 +1317,18 @@ export class WorkspaceManager {
     workspacePath: string,
     config: MergedConfig,
   ): Promise<void> {
-    // Skip for ephemeral workspaces
+    // Skip for ephemeral workspaces; refuse for cross-home entries.
     const ws = await this.registry.getWorkspace(workspaceId);
     if (ws?.metadata?.ephemeral) return;
+    if (ws && !isUnderHome(ws, getFridayHome())) {
+      logger.warn("Refusing to restart signals for cross-home workspace", {
+        workspaceId,
+        workspacePath: ws.path,
+        activeHome: getFridayHome(),
+        context: "restartSignalsForWorkspace",
+      });
+      return;
+    }
     try {
       await this.unregisterWithRegistrars(workspaceId);
     } catch (error) {
@@ -1231,6 +1389,16 @@ export class WorkspaceManager {
   async updateWorkspacePersistence(id: string, makePersistent: boolean): Promise<void> {
     const workspace = await this.registry.getWorkspace(id);
     if (!workspace) throw new Error(`Workspace not found: ${id}`);
+
+    if (!isUnderHome(workspace, getFridayHome())) {
+      logger.warn("Refusing to toggle persistence for cross-home workspace", {
+        workspaceId: workspace.id,
+        workspacePath: workspace.path,
+        activeHome: getFridayHome(),
+        context: "updateWorkspacePersistence",
+      });
+      throw new Error(`Workspace not found: ${id}`);
+    }
 
     const currentIsEphemeral =
       Boolean(workspace.metadata?.ephemeral) || workspace.configPath.endsWith("eph_workspace.yml");

--- a/packages/workspace/src/watcher-suppress.test.ts
+++ b/packages/workspace/src/watcher-suppress.test.ts
@@ -4,7 +4,7 @@
  * from killing in-flight agent sessions.
  */
 
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
@@ -12,6 +12,13 @@ import { createKVStorage } from "@atlas/storage";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkspaceManager } from "./manager.ts";
 import { RegistryStorageAdapter } from "./registry-storage-adapter.ts";
+
+// Pin `getFridayHome()` to the same tempDir we register workspaces under,
+// so the manager's cross-home filter treats them as in-home. Without this
+// pin the filter defaults to `~/.atlas` and masks every tmpdir-rooted
+// workspace as cross-home.
+const homePin = vi.hoisted(() => ({ home: "/tmp/atlas-watcher-suppress-default" }));
+vi.mock("@atlas/utils/paths.server", () => ({ getFridayHome: () => homePin.home }));
 
 // ---------------------------------------------------------------------------
 // Capture the watcher onConfigChange callback
@@ -81,7 +88,11 @@ function createMockRuntime(opts: { activeSessions?: boolean; activeExecutions?: 
 // Helpers
 // ---------------------------------------------------------------------------
 async function setupManager(): Promise<{ manager: WorkspaceManager; tempDir: string }> {
-  const tempDir = await mkdtemp(join(tmpdir(), "atlas-watcher-test-"));
+  // realpath: Deno.realPath() inside registerWorkspace canonicalises the
+  // path to /private/var/...; pin the mocked home to the same canonical
+  // form so the cross-home filter doesn't mask the just-registered ws.
+  const tempDir = await realpath(await mkdtemp(join(tmpdir(), "atlas-watcher-test-")));
+  homePin.home = tempDir;
   await writeFile(
     join(tempDir, "workspace.yml"),
     'version: "1.0"\nworkspace:\n  name: watcher-test\n',

--- a/scripts/clean.ts
+++ b/scripts/clean.ts
@@ -48,7 +48,7 @@ function resolveEmbeddedStoreDir(): string {
 }
 
 async function clearExternalBroker(force: boolean): Promise<void> {
-  const url = resolveNatsUrl();
+  const url = await resolveNatsUrl({ home: getFridayHome() });
   if (!isLocalhostUrl(url) && !force) {
     console.error(
       `Refusing to wipe streams on non-local broker ${url}. ` +

--- a/tools/friday-launcher/main.go
+++ b/tools/friday-launcher/main.go
@@ -371,6 +371,18 @@ func onReady() {
 		"source", jetstreamStoreSource,
 	)
 
+	// Pick the NATS port once at launcher startup. Iterates Friday's
+	// reserved range (14222..14231) and falls back to OS-assigned if
+	// all 10 slots are taken. The chosen port lands in the
+	// `natsServerPort` package-level so both `natsServerArgs` and
+	// `commonServiceEnv` see the same value when they build the
+	// nats-server spec and the child env respectively.
+	natsServerPort = pickNATSPort()
+	log.Info("nats-server port",
+		"port", natsServerPort,
+		"url", natsServerURL(),
+	)
+
 	// Build project + supervisor.
 	specs := supervisedProcesses(binDir)
 	project := newProjectFromSpecs(specs)

--- a/tools/friday-launcher/project.go
+++ b/tools/friday-launcher/project.go
@@ -68,8 +68,9 @@ func pickEphemeralPort() int {
 		// going with the legacy default and let nats-server fail loudly.
 		return 4222
 	}
-	defer l.Close()
-	return l.Addr().(*net.TCPAddr).Port
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close() // errcheck: best-effort; the port is returned regardless
+	return port
 }
 
 // natsServerURL returns the nats:// URL the broker should be reachable

--- a/tools/friday-launcher/project.go
+++ b/tools/friday-launcher/project.go
@@ -1,16 +1,86 @@
 package main
 
 import (
+	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 
 	"github.com/f1bonacc1/process-compose/src/command"
 	"github.com/f1bonacc1/process-compose/src/health"
 	"github.com/f1bonacc1/process-compose/src/types"
 )
+
+// fridayNATSPortBase is the start of Friday's reserved NATS port range.
+// Mirrors FRIDAY_NATS_PORT_BASE in packages/jetstream/src/spawn.ts —
+// keep in sync. Range is `[Base, Base+Range)` (10 slots).
+const (
+	fridayNATSPortBase  = 14222
+	fridayNATSPortRange = 10
+)
+
+// natsServerPort is picked once at launcher startup by pickNATSPort() and
+// reused for both the nats-server argv and the FRIDAY_NATS_URL env we
+// hand to every supervised child. Defaults to 0 to surface "forgot to
+// initialize" wiring bugs in tests rather than silently spawning on a
+// privileged port.
+var natsServerPort int
+
+// pickNATSPort tries to bind each port in the Friday-reserved range
+// (`fridayNATSPortBase..+Range`) and returns the first one that's free.
+// Falls back to an OS-assigned ephemeral port if all slots are taken
+// (extreme edge case). The chosen port lands in `natsServerPort` and
+// is used by both `natsServerArgs` and the `FRIDAY_NATS_URL` env that
+// the launcher injects into supervised children.
+//
+// TOCTOU: the port may be claimed between the listener close and
+// nats-server's bind. Acceptable — nats-server fails fast with a clear
+// stderr error in that case and process-compose surfaces it.
+func pickNATSPort() int {
+	for offset := 0; offset < fridayNATSPortRange; offset++ {
+		port := fridayNATSPortBase + offset
+		if tryBindTCP(port) {
+			return port
+		}
+	}
+	// All reserved slots taken. Ask the kernel for any free port.
+	return pickEphemeralPort()
+}
+
+func tryBindTCP(port int) bool {
+	addr := "127.0.0.1:" + strconv.Itoa(port)
+	l, err := net.Listen("tcp", addr)
+	if err != nil {
+		return false
+	}
+	_ = l.Close()
+	return true
+}
+
+func pickEphemeralPort() int {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		// Truly nothing free — shouldn't happen, but keep the launcher
+		// going with the legacy default and let nats-server fail loudly.
+		return 4222
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port
+}
+
+// natsServerURL returns the nats:// URL the broker should be reachable
+// at, based on the port picked by pickNATSPort(). Empty if not yet
+// initialized — caller should check.
+func natsServerURL() string {
+	if natsServerPort == 0 {
+		return ""
+	}
+	return fmt.Sprintf("nats://127.0.0.1:%d", natsServerPort)
+}
 
 // osGetenv is var-bound so tests can stub it.
 var osGetenv = os.Getenv
@@ -68,6 +138,21 @@ func commonServiceEnv() []string {
 	// installs; without this pin the daemon would never find that file
 	// and would crash at boot trying to resolve Anthropic credentials.
 	env = append(env, "FRIDAY_CONFIG_PATH="+friendlyHome())
+	// Pin the NATS URL so every supervised child connects to the broker
+	// the launcher just spawned, regardless of which Friday-reserved
+	// port pickNATSPort() landed on (could be 14222 normally, 14223+
+	// if a sibling install was already running, or an OS-assigned
+	// ephemeral if the whole range was exhausted). Without this pin
+	// the daemon would fall through to its own URL-file lookup, which
+	// is correct in dev but redundant here.
+	if url := natsServerURL(); url != "" {
+		// Respect an operator override only if the user set it in
+		// `.env` — that's an explicit "I have my own broker" signal.
+		// Otherwise the launcher's picked URL wins.
+		if _, ok := seen["FRIDAY_NATS_URL"]; !ok {
+			env = append(env, "FRIDAY_NATS_URL="+url)
+		}
+	}
 	return env
 }
 
@@ -321,10 +406,19 @@ func resolveJetStreamStoreDir() (storeDir, source string) {
 // process. Extracted as a pure function to keep the args layout (flag
 // order, store-dir position) trivially assertable in tests without
 // touching the surrounding spec wiring.
+//
+// `port` is the value picked by `pickNATSPort()` at launcher startup —
+// falls back to the legacy 4222 only if `pickNATSPort()` was never
+// called (typically a test that builds args without the full launcher
+// init path).
 func natsServerArgs(storeDir string) []string {
+	port := natsServerPort
+	if port == 0 {
+		port = 4222
+	}
 	return []string{
 		"--addr", "127.0.0.1",
-		"--port", "4222",
+		"--port", strconv.Itoa(port),
 		"--jetstream",
 		"-sd", storeDir,
 		"--http_port", "8222",

--- a/tools/friday-launcher/project_natsserver_test.go
+++ b/tools/friday-launcher/project_natsserver_test.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -16,7 +18,15 @@ import (
 // future refactor that quietly drops the flag is caught at the
 // unit level rather than at runtime when JetStream silently writes
 // to $TMPDIR again.
+//
+// When natsServerPort is unset (test default), natsServerArgs falls
+// back to the legacy 4222 — this test exercises that fallback path
+// since pickNATSPort() isn't called in unit tests.
 func TestNatsServerArgs_ContainsStoreDirInRightPosition(t *testing.T) {
+	prior := natsServerPort
+	natsServerPort = 0
+	defer func() { natsServerPort = prior }()
+
 	args := natsServerArgs("/tmp/some/store")
 	want := []string{
 		"--addr", "127.0.0.1",
@@ -27,6 +37,99 @@ func TestNatsServerArgs_ContainsStoreDirInRightPosition(t *testing.T) {
 	}
 	if !slices.Equal(args, want) {
 		t.Fatalf("natsServerArgs(/tmp/some/store) = %v\nwant %v", args, want)
+	}
+}
+
+// TestNatsServerArgs_HonorsPickedPort asserts that when
+// pickNATSPort() has landed a port in `natsServerPort`, natsServerArgs
+// passes that port to nats-server instead of the legacy 4222. Pins
+// the Phase 4 port-isolation contract: launcher and daemon agree on
+// the port because the launcher *chose* it.
+func TestNatsServerArgs_HonorsPickedPort(t *testing.T) {
+	prior := natsServerPort
+	natsServerPort = 14225
+	defer func() { natsServerPort = prior }()
+
+	args := natsServerArgs("/tmp/store")
+	want := []string{
+		"--addr", "127.0.0.1",
+		"--port", "14225",
+		"--jetstream",
+		"-sd", "/tmp/store",
+		"--http_port", "8222",
+	}
+	if !slices.Equal(args, want) {
+		t.Fatalf("natsServerArgs picked port = %v\nwant %v", args, want)
+	}
+}
+
+// TestPickNATSPort_StaysInReservedRangeWhenFree asserts the happy
+// path: when 14222 is free, pickNATSPort returns it. Avoids the
+// fallback-to-ephemeral case so the assertion is deterministic.
+func TestPickNATSPort_StaysInReservedRangeWhenFree(t *testing.T) {
+	port := pickNATSPort()
+	if port < fridayNATSPortBase || port >= fridayNATSPortBase+fridayNATSPortRange {
+		// Fell back to ephemeral — only valid if all reserved slots
+		// were occupied. Skip rather than fail; this is a host-state
+		// artifact, not a code regression.
+		t.Skipf("pickNATSPort returned %d (outside reserved range); reserved slots likely occupied on this host", port)
+	}
+}
+
+// TestNatsServerURL_FormatMatchesURLContract asserts the URL string
+// shape matches what the TS-side daemon's URL-file consumers and the
+// FRIDAY_NATS_URL env consumers expect. `nats://127.0.0.1:<port>`,
+// no trailing slash.
+func TestNatsServerURL_FormatMatchesURLContract(t *testing.T) {
+	prior := natsServerPort
+	natsServerPort = 14222
+	defer func() { natsServerPort = prior }()
+
+	got := natsServerURL()
+	want := "nats://127.0.0.1:14222"
+	if got != want {
+		t.Fatalf("natsServerURL() = %q, want %q", got, want)
+	}
+}
+
+// TestPickNATSPort_SkipsBoundPort exercises the actual Phase 4
+// isolation gate: when port 14222 is already bound (by a sibling
+// Friday install or any other tool), `pickNATSPort()` must iterate
+// to the next free slot in the reserved range.
+//
+// This is the two-daemon scenario in microcosm — launcher A's
+// nats-server holds 14222, launcher B picks up later and lands on
+// 14223 (or later). Confirms the iteration loop actually progresses
+// instead of, e.g., always returning the same port or short-circuiting
+// after the first try-bind failure.
+func TestPickNATSPort_SkipsBoundPort(t *testing.T) {
+	// Hold 14222 for the duration of the test. The listener gets
+	// closed via t.Cleanup so a flaky test doesn't leak the bind.
+	addr := "127.0.0.1:" + strconv.Itoa(fridayNATSPortBase)
+	hold, err := net.Listen("tcp", addr)
+	if err != nil {
+		// 14222 was already bound by something else — can't run this
+		// test deterministically. Skip rather than fail; this is a
+		// host-state artifact, not a code regression.
+		t.Skipf("could not bind %s for the test: %v", addr, err)
+	}
+	t.Cleanup(func() { _ = hold.Close() })
+
+	port := pickNATSPort()
+
+	if port == fridayNATSPortBase {
+		t.Fatalf("pickNATSPort returned %d while %d was held; expected iteration to next slot",
+			port, fridayNATSPortBase)
+	}
+	// Should still be in the reserved range (the next 9 slots are
+	// almost certainly free; fall-through to ephemeral would also
+	// pass this test, which is fine).
+	if port < fridayNATSPortBase || port >= fridayNATSPortBase+fridayNATSPortRange {
+		// Don't fail — it's legitimate for ephemeral fallback to land
+		// outside the range under pathological load. But warn so a
+		// CI signal surfaces if this ever becomes the common path.
+		t.Logf("pickNATSPort fell through to ephemeral (%d) — reserved slots beyond %d likely all taken on this host",
+			port, fridayNATSPortBase)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Running `deno task atlas` (dev) alongside Friday Studio.app (prod) on
  the same machine no longer cross-contaminates state. Each install
  picks its own NATS port from a Friday-reserved range (14222–14231)
  and writes the chosen URL to `<home>/nats/url` so siblings can find
  it. Daemon, CLI, and launcher all discover the broker through that
  file instead of hard-coding `:4222`.
- Workspaces registered under a different Friday home (the residue of
  historical cross-contamination) are now filtered out at runtime
  rather than mounted, watched, or operated on. Lookups by id / name /
  path mask cross-home entries; `deleteWorkspace`, `renameWorkspace`,
  `updateWorkspacePersistence`, and the signal-restart path all
  refuse to touch them. Entries stay in KV; the `generateUniqueId`
  walk still sees them so we never re-mint a colliding id.
- The default home for a bare `friday` binary is now `~/.friday/local`
  (matches the installer/launcher convention). `deno task atlas` pins
  `FRIDAY_HOME=\$HOME/.atlas` in `deno.json` so dev behavior is
  unchanged. The cwd-`.atlas` heuristic at the bottom of
  `getFridayHome()` is gone — it never fired in current layouts.
- `ENVIRONMENTS.md` lands as the operator-facing config reference.

## Env-var changes

| Var | Status | Notes |
|---|---|---|
| `FRIDAY_HOME` | semantics changed (var unchanged) | Default when unset flips from `~/.atlas` to `~/.friday/local`. The dev `atlas` / `atlas:dev` / `start` deno tasks now explicitly pin `FRIDAY_HOME=\$HOME/.atlas` so dev keeps writing to `~/.atlas`. Bare `friday` invocations now match the installer/launcher convention. |
| `FRIDAY_NATS_URL` | role tightened (var unchanged) | Still wins as the cloud-shared-broker override. Now short-circuits the URL-file rendezvous — the daemon connects directly and never writes the URL file. Operator-set in shell / k8s / launchd, never in per-home `.env`. |
| `FRIDAY_NATS_PORT` | new (reserved for future use) | Documented in `ENVIRONMENTS.md` as the cloud-with-per-tenant-broker hook for orchestrators (k8s, multi-tenant launcher) that want to pin a specific port. NOT consumed by code in this PR — auto-allocation via `pickPort()` covers today's needs. Reserved so adding the env later doesn't surprise anyone. |
| `FRIDAY_LOCAL_ONLY`, `FRIDAY_DUCKDB_PATH`, `FRIDAY_SQLITE3_PATH`, `AGENT_SOURCE_DIR` | confirmed dead (no code change) | Audited and confirmed to have zero readers in `apps/` / `tools/` / `packages/`. Documented for future cleanup; not removed in this PR. |

The new `pickPort()` reserved range (`14222..14231`) and `<home>/nats/url` discovery file are internal contracts, not env vars. Operators see them through logs (port number, URL file path) but never set them directly.

## Test plan

- [ ] Clean install: install Studio, confirm boot — broker lands on
      14222, daemon connects, workspaces auto-import.
- [ ] Dev alongside prod: with Studio running, \`deno task atlas
      daemon start\` in a checkout. Verify the dev daemon boots on a
      different port (likely 14223) and does not see prod's
      workspaces.
- [ ] Cross-home residue: on an existing install with cross-home
      registry entries, verify the daemon logs \`level=warn\` for each
      skipped entry and that the entries don't appear in the
      workspace list.
- [ ] \`atlas migrate\` while the daemon is up: discovers the broker
      via \`<home>/nats/url\` and runs as a connected client (no
      second broker spawn).

## Migration

None — data layout is unchanged. JetStream stores stay where they
are; the new daemon picks a different port but reads the same
on-disk store. Rollback to a pre-PR binary is safe: it re-binds
\`:4222\` against the same store dir and resumes.

## Notes

- Evals weren't run for this PR — the change is infrastructure
  (NATS port + URL-file rendezvous + workspace-registry filter),
  not agent behavior. Unit + integration coverage is extensive
  (cross-home filter, user-ID stability under N=20 races, two-
  daemon port-iteration in Go, daemon-startup with isolated home
  dirs, connectOrSpawn URL-file + spawnFallback contract).