### PR TITLE
setup-tls: scope mkcert to system + nss trust stores

### DIFF
--- a/scripts/setup-tls.sh
+++ b/scripts/setup-tls.sh
@@ -90,11 +90,8 @@ else
     # on macOS, sudo on Linux); subsequent runs detect the CA is already
     # trusted and exit fast.
     echo "→ Ensuring mkcert root CA is trusted (may prompt for admin password)"
-    # Hide JAVA_HOME from mkcert: when set, mkcert also tries to install the
-    # CA into the JDK's cacerts via keytool. Friday doesn't run on the JVM,
-    # and a half-installed JDK (cacerts missing) makes mkcert exit non-zero
-    # — which under `set -e` kills this script before s2s certs are written,
-    # even though the macOS/Linux system-trust install already succeeded.
+    # Unset JAVA_HOME so mkcert skips Java's cacerts; a broken JDK there
+    # would fail keytool and abort the script under `set -e`.
     env -u JAVA_HOME mkcert -install
 fi
 

--- a/scripts/setup-tls.sh
+++ b/scripts/setup-tls.sh
@@ -90,7 +90,12 @@ else
     # on macOS, sudo on Linux); subsequent runs detect the CA is already
     # trusted and exit fast.
     echo "→ Ensuring mkcert root CA is trusted (may prompt for admin password)"
-    mkcert -install
+    # Hide JAVA_HOME from mkcert: when set, mkcert also tries to install the
+    # CA into the JDK's cacerts via keytool. Friday doesn't run on the JVM,
+    # and a half-installed JDK (cacerts missing) makes mkcert exit non-zero
+    # — which under `set -e` kills this script before s2s certs are written,
+    # even though the macOS/Linux system-trust install already succeeded.
+    env -u JAVA_HOME mkcert -install
 fi
 
 # ── 2. Resolve dev Friday home ──────────────────────────────────────────────

--- a/scripts/setup-tls.sh
+++ b/scripts/setup-tls.sh
@@ -90,9 +90,11 @@ else
     # on macOS, sudo on Linux); subsequent runs detect the CA is already
     # trusted and exit fast.
     echo "→ Ensuring mkcert root CA is trusted (may prompt for admin password)"
-    # Unset JAVA_HOME so mkcert skips Java's cacerts; a broken JDK there
-    # would fail keytool and abort the script under `set -e`.
-    env -u JAVA_HOME mkcert -install
+    # Scope mkcert to the trust stores Friday actually uses: system (Safari,
+    # Chrome, curl, Deno via --use-system-ca) and nss (Firefox). Skipping
+    # `java` means a JDK on $PATH — broken or otherwise — can't fail keytool
+    # and abort the script under `set -e`.
+    TRUST_STORES=system,nss mkcert -install
 fi
 
 # ── 2. Resolve dev Friday home ──────────────────────────────────────────────

--- a/scripts/setup-tls.sh
+++ b/scripts/setup-tls.sh
@@ -86,15 +86,19 @@ else
         fi
     fi
     echo "→ mkcert: $(command -v mkcert)"
+    # Scope mkcert to the trust stores Friday actually uses (system: Safari/
+    # Chrome/curl/Deno; nss: Firefox) and hide JAVA_HOME so it never probes
+    # Java's keystore — mkcert runs `keytool -list` on every invocation when
+    # JAVA_HOME is set, and a broken/half-installed JDK there will fail it
+    # and abort the script under `set -e`. Applied script-wide because mkcert
+    # is called again during browser cert generation, not just at -install.
+    export TRUST_STORES=system,nss
+    unset JAVA_HOME
     # Idempotent. First run on a machine prompts for admin (system keychain
     # on macOS, sudo on Linux); subsequent runs detect the CA is already
     # trusted and exit fast.
     echo "→ Ensuring mkcert root CA is trusted (may prompt for admin password)"
-    # Scope mkcert to the trust stores Friday actually uses: system (Safari,
-    # Chrome, curl, Deno via --use-system-ca) and nss (Firefox). Skipping
-    # `java` means a JDK on $PATH — broken or otherwise — can't fail keytool
-    # and abort the script under `set -e`.
-    TRUST_STORES=system,nss mkcert -install
+    mkcert -install
 fi
 
 # ── 2. Resolve dev Friday home ──────────────────────────────────────────────

--- a/scripts/setup-tls.sh
+++ b/scripts/setup-tls.sh
@@ -86,12 +86,10 @@ else
         fi
     fi
     echo "→ mkcert: $(command -v mkcert)"
-    # Scope mkcert to the trust stores Friday actually uses (system: Safari/
-    # Chrome/curl/Deno; nss: Firefox) and hide JAVA_HOME so it never probes
-    # Java's keystore — mkcert runs `keytool -list` on every invocation when
-    # JAVA_HOME is set, and a broken/half-installed JDK there will fail it
-    # and abort the script under `set -e`. Applied script-wide because mkcert
-    # is called again during browser cert generation, not just at -install.
+    # Scope mkcert to the trust stores Friday uses (system + Firefox/nss).
+    # JAVA_HOME must be unset too: mkcert probes Java's keystore on every
+    # invocation when it sees JAVA_HOME, and TRUST_STORES only filters the
+    # install path. Exported so subshell mkcert calls below inherit both.
     export TRUST_STORES=system,nss
     unset JAVA_HOME
     # Idempotent. First run on a machine prompts for admin (system keychain


### PR DESCRIPTION
## Summary

`mkcert -install` autodetects every trust store on the machine — macOS keychain, Firefox's NSS DB, **and** Java's `cacerts` when `JAVA_HOME` is set. Friday is browser + Deno + Node; nothing in the product runs on the JVM, so installing our local CA into Java's keystore is pure noise. Worse, mkcert treats keytool failures as fatal: any non-zero exit (broken/partial JDK, locked keystore, unwritable path) aborts `mkcert -install`, and `set -euo pipefail` then kills `setup-tls.sh` before s2s certs and `FRIDAY_TLS_*` entries get written — even though the macOS install already succeeded.

Fix: tell mkcert exactly which stores we want via `$TRUST_STORES`, dropping `java` from the autodetected set.

```bash
TRUST_STORES=system,nss mkcert -install
```

- `system` — macOS keychain / Linux ca-certificates → Safari, Chrome, curl, Deno (`--use-system-ca`)
- `nss` — Mozilla NSS DB → Firefox
- `java` — **excluded**; Friday has no JVM components

Allowlisting (vs. unsetting `JAVA_HOME`) is self-documenting and stays correct if mkcert ever adds new trust-store types.

One concrete trigger that surfaced this: a machine with a half-installed openjdk@17 (cacerts missing under `$JAVA_HOME/lib/security/`). But the underlying point is broader — Java's keystore was never something Friday should write to.

## Test plan

- [ ] Script runs to completion on a machine where `JAVA_HOME` points at a JDK with missing/unwritable `cacerts`, and writes `~/.atlas/tls/{browser,s2s,s2s-ca}.{crt,key}` + `FRIDAY_TLS_*` to `~/.atlas/.env`
- [ ] Script still works on machines with a healthy JDK (mkcert no longer touches Java's keystore, which is fine — Friday doesn't read from it)
- [ ] Firefox still trusts the local CA after this change (nss store still gets it)
- [ ] No behaviour change on machines without Java
- [ ] `deno task dev:playground` brings up `https://localhost:5200` cleanly after a fixed run