### PR TITLE
ToolAccessGrants: server-aware grants + missing tests + LLM-readable response

### DIFF
--- a/packages/core/src/elicitations/tool-access-grants.test.ts
+++ b/packages/core/src/elicitations/tool-access-grants.test.ts
@@ -41,7 +41,7 @@ describe("JetStreamToolAccessGrantAdapter", () => {
     expect(otherWorkspace.data).toBe(false);
   });
 
-  it("listForWorkspace returns granted tool names scoped to the workspace", async () => {
+  it("listForWorkspace returns granted tool entries scoped to the workspace", async () => {
     const adapter = new JetStreamToolAccessGrantAdapter(nc);
     const wsA = `ws-list-a-${crypto.randomUUID()}`;
     const wsB = `ws-list-b-${crypto.randomUUID()}`;
@@ -56,11 +56,15 @@ describe("JetStreamToolAccessGrantAdapter", () => {
 
     const listA = await adapter.listForWorkspace({ workspaceId: wsA });
     expect.assert(listA.ok === true);
-    expect(listA.data.sort()).toEqual(["fs_write_file", "gmail/send_email"]);
+    const sortedA = [...listA.data].sort((a, b) => a.toolName.localeCompare(b.toolName));
+    expect(sortedA).toEqual([
+      { toolName: "fs_write_file", bareToolName: "fs_write_file" },
+      { toolName: "gmail/send_email", bareToolName: "send_email", serverId: "gmail" },
+    ]);
 
     const listB = await adapter.listForWorkspace({ workspaceId: wsB });
     expect.assert(listB.ok === true);
-    expect(listB.data).toEqual(["bash"]);
+    expect(listB.data).toEqual([{ toolName: "bash", bareToolName: "bash" }]);
   });
 
   it("listForWorkspace round-trips workspace ids containing reserved characters", async () => {
@@ -72,6 +76,44 @@ describe("JetStreamToolAccessGrantAdapter", () => {
 
     const list = await adapter.listForWorkspace({ workspaceId });
     expect.assert(list.ok === true);
-    expect(list.data).toEqual(["bash"]);
+    expect(list.data).toEqual([{ toolName: "bash", bareToolName: "bash" }]);
+  });
+
+  it("grantAlways derives serverId from a qualified toolName when caller doesn't pass it", async () => {
+    const adapter = new JetStreamToolAccessGrantAdapter(nc);
+    const workspaceId = `ws-derive-${crypto.randomUUID()}`;
+
+    const grant = await adapter.grantAlways({
+      workspaceId,
+      toolName: "google-calendar/list_events",
+    });
+    expect.assert(grant.ok === true);
+    expect(grant.data.serverId).toBe("google-calendar");
+
+    // hasGrant lookup by the original (qualified) name still resolves —
+    // the KV key is derived from `toolName`, not from `serverId/bareName`,
+    // so callers that look up by the LLM-facing string keep working.
+    const seen = await adapter.hasGrant({ workspaceId, toolName: "google-calendar/list_events" });
+    expect.assert(seen.ok === true);
+    expect(seen.data).toBe(true);
+  });
+
+  it("grantAlways accepts an explicit serverId that overrides toolName parsing", async () => {
+    const adapter = new JetStreamToolAccessGrantAdapter(nc);
+    const workspaceId = `ws-explicit-${crypto.randomUUID()}`;
+
+    const grant = await adapter.grantAlways({
+      workspaceId,
+      toolName: "send_email",
+      serverId: "gmail",
+    });
+    expect.assert(grant.ok === true);
+    expect(grant.data.serverId).toBe("gmail");
+
+    const list = await adapter.listForWorkspace({ workspaceId });
+    expect.assert(list.ok === true);
+    expect(list.data).toEqual([
+      { toolName: "send_email", bareToolName: "send_email", serverId: "gmail" },
+    ]);
   });
 });

--- a/packages/core/src/elicitations/tool-access-grants.ts
+++ b/packages/core/src/elicitations/tool-access-grants.ts
@@ -11,7 +11,20 @@ const HISTORY = 3;
 
 export const ToolAccessGrantSchema = z.object({
   workspaceId: z.string(),
+  /**
+   * LLM-facing tool name as it was originally requested. May be qualified
+   * (`serverId/bareName`) or bare. Stored as-given so `hasGrant` lookups
+   * remain compatible with both call shapes; back-compat with grants
+   * persisted before `serverId` existed depends on this stability.
+   */
   toolName: z.string(),
+  /**
+   * Source workspace MCP server. Set going forward for qualified tool
+   * names so `fsm-engine.buildTools` can eagerly load the server that
+   * carries the granted tool. Legacy grants don't have this — the read
+   * path infers it from the `toolName` shape when feasible.
+   */
+  serverId: z.string().optional(),
   scope: z.literal("workspace"),
   grantedAt: z.string().datetime({ offset: true }),
   sourceElicitationId: z.string().optional(),
@@ -19,6 +32,33 @@ export const ToolAccessGrantSchema = z.object({
 });
 
 export type ToolAccessGrant = z.infer<typeof ToolAccessGrantSchema>;
+
+/**
+ * Granted tool projection returned by `listForWorkspace`. `bareToolName`
+ * is what `mcpResult.tools` is keyed by; `serverId` is the source MCP
+ * server when known (set on new grants, inferred from qualified
+ * `toolName` shape for legacy ones).
+ */
+export interface ListedGrant {
+  /** Original LLM-facing name. */
+  toolName: string;
+  /** Bare tool name (post-`serverId/` strip). Matches `filtered` keys. */
+  bareToolName: string;
+  /** Source server when known; undefined if the grant predates `serverId`
+   * and `toolName` is unqualified. */
+  serverId?: string;
+}
+
+/**
+ * Parse a tool name into `(serverId, bareToolName)`. Returns
+ * `serverId === undefined` for bare names with no `/` separator.
+ * Defensive against pathological inputs (leading/trailing slashes).
+ */
+function parseToolName(toolName: string): { serverId?: string; bareToolName: string } {
+  const slash = toolName.indexOf("/");
+  if (slash <= 0 || slash === toolName.length - 1) return { bareToolName: toolName };
+  return { serverId: toolName.slice(0, slash), bareToolName: toolName.slice(slash + 1) };
+}
 
 function keySegment(s: string): string {
   const bytes = new TextEncoder().encode(s);
@@ -48,15 +88,26 @@ export class JetStreamToolAccessGrantAdapter {
   async grantAlways(input: {
     workspaceId: string;
     toolName: string;
+    /**
+     * Source MCP server for the granted tool. When omitted, derived from
+     * `toolName` if it's qualified (`serverId/bareName`). Persisting the
+     * server alongside the tool lets `fsm-engine.buildTools` eagerly
+     * load the carrying MCP server on future actions, so a grant for
+     * `gmail/send_email` works even when the action that benefits
+     * doesn't declare gmail in its `tools:` array.
+     */
+    serverId?: string;
     sourceElicitationId?: string;
     grantedBy?: string;
   }): Promise<Result<ToolAccessGrant, string>> {
     try {
+      const serverId = input.serverId ?? parseToolName(input.toolName).serverId;
       const grant: ToolAccessGrant = {
         workspaceId: input.workspaceId,
         toolName: input.toolName,
         scope: "workspace",
         grantedAt: new Date().toISOString(),
+        ...(serverId ? { serverId } : {}),
         ...(input.sourceElicitationId ? { sourceElicitationId: input.sourceElicitationId } : {}),
         ...(input.grantedBy ? { grantedBy: input.grantedBy } : {}),
       };
@@ -92,7 +143,7 @@ export class JetStreamToolAccessGrantAdapter {
     }
   }
 
-  async listForWorkspace(input: { workspaceId: string }): Promise<Result<string[], string>> {
+  async listForWorkspace(input: { workspaceId: string }): Promise<Result<ListedGrant[], string>> {
     try {
       const kv = await this.kv();
       const prefix = `${keySegment(input.workspaceId)}.`;
@@ -102,7 +153,7 @@ export class JetStreamToolAccessGrantAdapter {
       const keysIter = await kv.keys(`${keySegment(input.workspaceId)}.*`);
       const keys: string[] = [];
       for await (const key of keysIter) keys.push(key);
-      const out: string[] = [];
+      const out: ListedGrant[] = [];
       for (const key of keys) {
         if (!key.startsWith(prefix)) continue;
         const entry = await kv.get(key);
@@ -110,7 +161,17 @@ export class JetStreamToolAccessGrantAdapter {
         const parsed = ToolAccessGrantSchema.safeParse(JSON.parse(dec.decode(entry.value)));
         if (!parsed.success) continue;
         if (parsed.data.workspaceId !== input.workspaceId) continue;
-        out.push(parsed.data.toolName);
+        // Trust persisted `serverId` when present; otherwise infer from a
+        // qualified `toolName`. Legacy grants with bare names stay with
+        // `serverId: undefined` and fall back to bare-name matching in
+        // consumers.
+        const parsedShape = parseToolName(parsed.data.toolName);
+        const serverId = parsed.data.serverId ?? parsedShape.serverId;
+        out.push({
+          toolName: parsed.data.toolName,
+          bareToolName: parsedShape.bareToolName,
+          ...(serverId ? { serverId } : {}),
+        });
       }
       return success(out);
     } catch (err) {
@@ -142,12 +203,13 @@ export const ToolAccessGrants = {
   grantAlways: (input: {
     workspaceId: string;
     toolName: string;
+    serverId?: string;
     sourceElicitationId?: string;
     grantedBy?: string;
   }): Promise<Result<ToolAccessGrant, string>> => requireAdapter().grantAlways(input),
   hasGrant: (input: { workspaceId: string; toolName: string }): Promise<Result<boolean, string>> =>
     requireAdapter().hasGrant(input),
-  listForWorkspace: (input: { workspaceId: string }): Promise<Result<string[], string>> =>
+  listForWorkspace: (input: { workspaceId: string }): Promise<Result<ListedGrant[], string>> =>
     requireAdapter().listForWorkspace(input),
 };
 

--- a/packages/fsm-engine/fsm-engine.ts
+++ b/packages/fsm-engine/fsm-engine.ts
@@ -3236,6 +3236,42 @@ export class FSMEngine {
     const hasBareToolName = bareToolNames.size > 0;
     const hasNameAllowlist = hasBareToolName || [...serverAllow.values()].some((v) => v !== "all");
 
+    // Compute bypass + hoist the grant fetch BEFORE choosing effectiveConfigs
+    // so a grant for `gmail/send_email` can pull the gmail server into the
+    // MCP load even when the action declares only `google-calendar/...`.
+    // Resolution precedence is job > workspace > daemon env var —
+    // resolvePermissions is the canonical merge helper. Bypass skips the
+    // grant query entirely; it already widens past per-agent narrowing,
+    // so the union below is a no-op under bypass.
+    const effectivePermissions = resolvePermissions({
+      job: this.options.jobPermissions,
+      workspace: this.options.workspacePermissions,
+      daemonDangerouslySkipAllowlist:
+        typeof Deno !== "undefined"
+          ? Deno.env.get("FRIDAY_DANGEROUSLY_SKIP_PERMISSIONS") === "1"
+          : undefined,
+    });
+    const bypassActive = effectivePermissions.dangerouslySkipAllowlist === true;
+
+    const grantedServerIds = new Set<string>();
+    let listedGrants: { toolName: string; bareToolName: string; serverId?: string }[] = [];
+    if (!bypassActive) {
+      const grants = await ToolAccessGrants.listForWorkspace({
+        workspaceId: this.options.scope.workspaceId,
+      });
+      if (grants.ok) {
+        listedGrants = grants.data;
+        for (const g of grants.data) {
+          if (g.serverId) grantedServerIds.add(g.serverId);
+        }
+      } else {
+        logger.warn("Failed to read tool-access grants; skipping grant union", {
+          workspaceId: this.options.scope.workspaceId,
+          error: grants.error,
+        });
+      }
+    }
+
     // MCP tools: always include atlas-platform for ambient capabilities (webfetch,
     // artifacts) even when the action only uses FSM-defined tools. The connection
     // cost is one HTTP roundtrip + dispose per LLM action — acceptable tradeoff
@@ -3258,6 +3294,29 @@ export class FSMEngine {
           effectiveConfigs[id] = config;
         }
       }
+    }
+
+    // Eagerly load servers referenced by `allow_always` grants when the
+    // workspace declares them. Closes the "strictly-qualified action +
+    // grant for a different server's tool" gap that #280's first pass
+    // left behind. Defensively skip serverIds the workspace doesn't
+    // declare — grants can outlive workspace config edits.
+    const eagerlyLoaded: string[] = [];
+    for (const serverId of grantedServerIds) {
+      if (serverId === "atlas-platform") continue;
+      if (effectiveConfigs[serverId]) continue;
+      const config = this.options.mcpServerConfigs?.[serverId];
+      if (config) {
+        effectiveConfigs[serverId] = config;
+        eagerlyLoaded.push(serverId);
+      }
+    }
+    if (eagerlyLoaded.length > 0) {
+      logger.info("Eagerly loading MCP servers referenced by allow-always grants", {
+        jobName: this._definition.id,
+        actionId,
+        servers: eagerlyLoaded,
+      });
     }
 
     // Do not lift MCP results before the producer LLM sees them. Oversized
@@ -3305,23 +3364,12 @@ export class FSMEngine {
     // the source of the daily-memo "fetcher agents send their own emails"
     // bug.
     //
-    // Bypass — when the resolved permissions for this action declare
-    // `dangerouslySkipAllowlist`, skip the per-agent narrowing
-    // and pass every platform-allowlisted tool through to the LLM.
-    // Mirrors Claude Code's `--dangerously-skip-permissions`. Resolution
-    // precedence: job > workspace > FRIDAY_DANGEROUSLY_SKIP_PERMISSIONS
-    // env var. resolvePermissions is the canonical merge helper.
-    // Falls through to wrapPlatformToolsWithScope below so request_tool_access
+    // Bypass (computed above) — when the resolved permissions for this
+    // action declare `dangerouslySkipAllowlist`, skip the per-agent
+    // narrowing and pass every platform-allowlisted tool through to the
+    // LLM. Mirrors Claude Code's `--dangerously-skip-permissions`. Falls
+    // through to wrapPlatformToolsWithScope below so request_tool_access
     // and other scope-injected tools still receive sessionId/actionId/perms.
-    const effectivePermissions = resolvePermissions({
-      job: this.options.jobPermissions,
-      workspace: this.options.workspacePermissions,
-      daemonDangerouslySkipAllowlist:
-        typeof Deno !== "undefined"
-          ? Deno.env.get("FRIDAY_DANGEROUSLY_SKIP_PERMISSIONS") === "1"
-          : undefined,
-    });
-    const bypassActive = effectivePermissions.dangerouslySkipAllowlist === true;
     if (bypassActive) {
       logger.info("Bypassing per-agent tool allowlist (dangerouslySkipAllowlist)", {
         jobName: this._definition.id,
@@ -3361,30 +3409,34 @@ export class FSMEngine {
     // see #280. Grants only widen up to what `filtered` already contains,
     // so PLATFORM_TOOL_ALLOWLIST + workspace MCP load decisions still cap
     // the surface. Bypass already widens past per-agent narrowing, so the
-    // grant query would be redundant.
-    if (!bypassActive) {
-      const grants = await ToolAccessGrants.listForWorkspace({
-        workspaceId: this.options.scope.workspaceId,
-      });
-      if (grants.ok) {
-        const widened: string[] = [];
-        for (const name of grants.data) {
-          if (filtered[name] && !scoped[name]) {
-            scoped[name] = filtered[name];
-            widened.push(name);
-          }
+    // union is a no-op there (grantedServerIds is empty under bypass).
+    //
+    // Two matching strategies cover both new and legacy grants:
+    //   - With `serverId` known: confirm the bareToolName is actually
+    //     attributed to that server in `mcpResult.toolsByServer` before
+    //     widening. Guards against a grant being lit up by an unrelated
+    //     server that happens to export the same tool name (rare; defense
+    //     in depth).
+    //   - Without `serverId` (legacy bare-name grants): fall through to
+    //     the existing bareToolName-in-filtered check, same as the #302
+    //     first pass.
+    if (!bypassActive && listedGrants.length > 0) {
+      const widened: string[] = [];
+      for (const grant of listedGrants) {
+        const name = grant.bareToolName;
+        if (!filtered[name] || scoped[name]) continue;
+        if (grant.serverId) {
+          const names = mcpResult.toolsByServer[grant.serverId];
+          if (!names?.includes(name)) continue;
         }
-        if (widened.length > 0) {
-          logger.info("Allow-always grants widened action toolset", {
-            jobName: this._definition.id,
-            actionId,
-            widened,
-          });
-        }
-      } else {
-        logger.warn("Failed to read tool-access grants; skipping grant union", {
-          workspaceId: this.options.scope.workspaceId,
-          error: grants.error,
+        scoped[name] = filtered[name];
+        widened.push(grant.toolName);
+      }
+      if (widened.length > 0) {
+        logger.info("Allow-always grants widened action toolset", {
+          jobName: this._definition.id,
+          actionId,
+          widened,
         });
       }
     }

--- a/packages/fsm-engine/tests/grant-union.test.ts
+++ b/packages/fsm-engine/tests/grant-union.test.ts
@@ -20,7 +20,7 @@
 
 import type { AgentResult, ToolCall } from "@atlas/agent-sdk";
 import type { Tool } from "ai";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockFetch = vi.hoisted(() =>
   vi.fn<(input: string | URL | Request, init?: RequestInit) => Promise<Response>>(),
@@ -53,16 +53,24 @@ vi.mock("@atlas/oapi-client", () => ({
   getAtlasPlatformServerConfig: () => ({ transport: { type: "stdio", command: "noop", args: [] } }),
 }));
 
+type GrantsResult = { ok: true; data: string[] } | { ok: false; error: string };
+
 const grantState = vi.hoisted(() => ({
-  grants: [] as string[],
-  reset() {
-    this.grants = [];
-  },
+  // Default: empty success. Tests override per-call by reassigning
+  // `nextResult` before driving the engine. The mock itself is a vi.fn so
+  // tests can also assert on call count (bypass-skip case).
+  nextResult: { ok: true as const, data: [] as string[] } as GrantsResult,
 }));
+
+const mockListForWorkspace = vi.hoisted(() =>
+  vi.fn<(input: { workspaceId: string }) => Promise<GrantsResult>>(() =>
+    Promise.resolve(grantState.nextResult),
+  ),
+);
 
 vi.mock("@atlas/core/elicitations", () => ({
   ToolAccessGrants: {
-    listForWorkspace: () => Promise.resolve({ ok: true as const, data: [...grantState.grants] }),
+    listForWorkspace: mockListForWorkspace,
     hasGrant: () => Promise.resolve({ ok: true as const, data: false }),
     grantAlways: () => Promise.resolve({ ok: false as const, error: "not used in this suite" }),
   },
@@ -86,15 +94,33 @@ function fakeTool(name: string): Tool {
 }
 
 interface RunOptions {
-  declaredTools: string[];
-  grants: string[];
+  /**
+   * If undefined, the LLM action declares no `tools:` array — exercises
+   * the `hasNameAllowlist === false` path where buildTools skips per-server
+   * narrowing entirely. Pass an empty array to declare `tools: []`
+   * explicitly (also no narrowing) or a non-empty array to narrow.
+   */
+  declaredTools?: string[];
+  /**
+   * Grant result to be returned by `ToolAccessGrants.listForWorkspace`.
+   * Default: empty success. Pass `{ ok: false, error: "..." }` to exercise
+   * the warn-and-skip path.
+   */
+  grants?: GrantsResult;
   workspaceId?: string;
+  /**
+   * When set, threads `permissions.dangerouslySkipAllowlist: true` into
+   * the engine options so `bypassActive` is true inside buildTools. Used
+   * to assert the grant query is skipped under bypass.
+   */
+  bypass?: boolean;
 }
 
 async function runActionAndCaptureTools({
   declaredTools,
-  grants,
+  grants = { ok: true, data: [] },
   workspaceId = "ws-grant-union",
+  bypass = false,
 }: RunOptions): Promise<string[]> {
   mockFetch.mockImplementation(() => Promise.resolve(new Response("not found", { status: 404 })));
 
@@ -109,7 +135,7 @@ async function runActionAndCaptureTools({
     disconnectedIntegrations: [],
   });
 
-  grantState.grants = grants;
+  grantState.nextResult = grants;
 
   let observedToolNames: string[] = [];
   const mockLLMProvider: LLMProvider = {
@@ -146,7 +172,7 @@ async function runActionAndCaptureTools({
                 provider: "test",
                 model: "test-model",
                 prompt: "noop",
-                tools: declaredTools,
+                ...(declaredTools !== undefined && { tools: declaredTools }),
                 outputTo: "decision",
               },
             ],
@@ -161,6 +187,7 @@ async function runActionAndCaptureTools({
     documentStore: getDocumentStore(),
     scope: { workspaceId, sessionId: "sess-1" },
     llmProvider: mockLLMProvider,
+    ...(bypass && { jobPermissions: { dangerouslySkipAllowlist: true } }),
   });
   await engine.initialize();
   await engine.signal({ type: "RUN" }, { sessionId: "sess-1", workspaceId });
@@ -169,10 +196,14 @@ async function runActionAndCaptureTools({
 }
 
 describe("FSM LLM action — allow_always grants widen the tool surface (#280)", () => {
+  beforeEach(() => {
+    mockListForWorkspace.mockClear();
+  });
+
   it("unions a granted workspace MCP tool into the action's tool set when it isn't declared", async () => {
     const names = await runActionAndCaptureTools({
       declaredTools: ["workspace-mcp/keep_me"],
-      grants: ["grant_me"],
+      grants: { ok: true, data: ["grant_me"] },
     });
     expect(names).toContain("keep_me");
     expect(names).toContain("grant_me");
@@ -181,7 +212,7 @@ describe("FSM LLM action — allow_always grants widen the tool surface (#280)",
   it("does not include a workspace MCP tool when no grant exists", async () => {
     const names = await runActionAndCaptureTools({
       declaredTools: ["workspace-mcp/keep_me"],
-      grants: [],
+      grants: { ok: true, data: [] },
     });
     expect(names).toContain("keep_me");
     expect(names).not.toContain("grant_me");
@@ -193,8 +224,48 @@ describe("FSM LLM action — allow_always grants widen the tool surface (#280)",
     // action, or tool removed) doesn't materialize anything.
     const names = await runActionAndCaptureTools({
       declaredTools: ["workspace-mcp/keep_me"],
-      grants: ["unloaded_tool"],
+      grants: { ok: true, data: ["unloaded_tool"] },
     });
     expect(names).not.toContain("unloaded_tool");
+  });
+
+  it("skips the grant query entirely under permissions.dangerouslySkipAllowlist", async () => {
+    // Bypass already widens past per-agent narrowing — the grant union
+    // would be redundant work and noise in the operator log. Asserting
+    // `mockListForWorkspace` was never called locks in that branch.
+    const names = await runActionAndCaptureTools({
+      declaredTools: ["workspace-mcp/keep_me"],
+      grants: { ok: true, data: ["grant_me"] },
+      bypass: true,
+    });
+    expect(mockListForWorkspace).not.toHaveBeenCalled();
+    // Bypass surfaces every loaded tool regardless of declaration.
+    expect(names).toContain("keep_me");
+    expect(names).toContain("grant_me");
+  });
+
+  it("warns and continues with an un-widened toolset when the grant store read fails", async () => {
+    // KV down, deserialization edge case, etc. — fail safe: no widening,
+    // no crash. The declared-only toolset still reaches the LLM so the
+    // action can either complete or failStep gracefully.
+    const names = await runActionAndCaptureTools({
+      declaredTools: ["workspace-mcp/keep_me"],
+      grants: { ok: false, error: "kv unavailable" },
+    });
+    expect(names).toContain("keep_me");
+    expect(names).not.toContain("grant_me");
+  });
+
+  it("is a no-op when the action declares no tools (no per-server narrowing)", async () => {
+    // hasNameAllowlist === false → scoped stays as filtered → every loaded
+    // tool already flows through. The grant union should find every
+    // granted name already in scoped and add nothing. Most common ad-hoc
+    // LLM action shape; previously untested for grant-union behavior.
+    const names = await runActionAndCaptureTools({
+      declaredTools: undefined,
+      grants: { ok: true, data: ["grant_me"] },
+    });
+    expect(names).toContain("keep_me");
+    expect(names).toContain("grant_me");
   });
 });

--- a/packages/fsm-engine/tests/grant-union.test.ts
+++ b/packages/fsm-engine/tests/grant-union.test.ts
@@ -53,13 +53,18 @@ vi.mock("@atlas/oapi-client", () => ({
   getAtlasPlatformServerConfig: () => ({ transport: { type: "stdio", command: "noop", args: [] } }),
 }));
 
-type GrantsResult = { ok: true; data: string[] } | { ok: false; error: string };
+interface ListedGrantShape {
+  toolName: string;
+  bareToolName: string;
+  serverId?: string;
+}
+type GrantsResult = { ok: true; data: ListedGrantShape[] } | { ok: false; error: string };
 
 const grantState = vi.hoisted(() => ({
   // Default: empty success. Tests override per-call by reassigning
   // `nextResult` before driving the engine. The mock itself is a vi.fn so
   // tests can also assert on call count (bypass-skip case).
-  nextResult: { ok: true as const, data: [] as string[] } as GrantsResult,
+  nextResult: { ok: true as const, data: [] } as GrantsResult,
 }));
 
 const mockListForWorkspace = vi.hoisted(() =>
@@ -114,6 +119,22 @@ interface RunOptions {
    * to assert the grant query is skipped under bypass.
    */
   bypass?: boolean;
+}
+
+/**
+ * Build a `ListedGrant`-shaped entry from a bare or qualified tool name.
+ * Mirrors the storage adapter's parse so suites can pass natural strings.
+ */
+function grant(toolName: string): ListedGrantShape {
+  const slash = toolName.indexOf("/");
+  if (slash > 0 && slash < toolName.length - 1) {
+    return {
+      toolName,
+      bareToolName: toolName.slice(slash + 1),
+      serverId: toolName.slice(0, slash),
+    };
+  }
+  return { toolName, bareToolName: toolName };
 }
 
 async function runActionAndCaptureTools({
@@ -203,7 +224,7 @@ describe("FSM LLM action — allow_always grants widen the tool surface (#280)",
   it("unions a granted workspace MCP tool into the action's tool set when it isn't declared", async () => {
     const names = await runActionAndCaptureTools({
       declaredTools: ["workspace-mcp/keep_me"],
-      grants: { ok: true, data: ["grant_me"] },
+      grants: { ok: true, data: [grant("workspace-mcp/grant_me")] },
     });
     expect(names).toContain("keep_me");
     expect(names).toContain("grant_me");
@@ -224,7 +245,7 @@ describe("FSM LLM action — allow_always grants widen the tool surface (#280)",
     // action, or tool removed) doesn't materialize anything.
     const names = await runActionAndCaptureTools({
       declaredTools: ["workspace-mcp/keep_me"],
-      grants: { ok: true, data: ["unloaded_tool"] },
+      grants: { ok: true, data: [grant("workspace-mcp/unloaded_tool")] },
     });
     expect(names).not.toContain("unloaded_tool");
   });
@@ -235,7 +256,7 @@ describe("FSM LLM action — allow_always grants widen the tool surface (#280)",
     // `mockListForWorkspace` was never called locks in that branch.
     const names = await runActionAndCaptureTools({
       declaredTools: ["workspace-mcp/keep_me"],
-      grants: { ok: true, data: ["grant_me"] },
+      grants: { ok: true, data: [grant("workspace-mcp/grant_me")] },
       bypass: true,
     });
     expect(mockListForWorkspace).not.toHaveBeenCalled();
@@ -263,9 +284,227 @@ describe("FSM LLM action — allow_always grants widen the tool surface (#280)",
     // LLM action shape; previously untested for grant-union behavior.
     const names = await runActionAndCaptureTools({
       declaredTools: undefined,
-      grants: { ok: true, data: ["grant_me"] },
+      grants: { ok: true, data: [grant("workspace-mcp/grant_me")] },
     });
     expect(names).toContain("keep_me");
     expect(names).toContain("grant_me");
+  });
+
+  it("widens a granted tool when the grant's serverId matches its source server", async () => {
+    // serverId attribution adds defense in depth: even if two MCP servers
+    // happen to export tools with the same bare name, a grant for
+    // `gmail/send_email` only lights up `send_email` when it's attributed
+    // to `gmail` in mcpResult.toolsByServer.
+    const names = await runActionAndCaptureTools({
+      declaredTools: ["workspace-mcp/keep_me"],
+      grants: { ok: true, data: [grant("workspace-mcp/grant_me")] },
+    });
+    expect(names).toContain("grant_me");
+  });
+
+  it("does NOT widen when the grant's serverId mismatches mcpResult attribution", async () => {
+    // The default mock attributes `grant_me` to `workspace-mcp` only. A
+    // grant claiming source-server `gmail` for the same bare name should
+    // be rejected by the serverId-aware check.
+    const names = await runActionAndCaptureTools({
+      declaredTools: ["workspace-mcp/keep_me"],
+      grants: {
+        ok: true,
+        data: [{ toolName: "gmail/grant_me", bareToolName: "grant_me", serverId: "gmail" }],
+      },
+    });
+    expect(names).not.toContain("grant_me");
+  });
+});
+
+describe("FSM LLM action — eagerly loads MCP servers referenced by grants", () => {
+  beforeEach(() => {
+    mockListForWorkspace.mockClear();
+    mockCreateMCPTools.mockClear();
+  });
+
+  it("includes a grant-referenced workspace MCP server in effectiveConfigs even when the action doesn't declare it", async () => {
+    // Action declares only google-calendar; grant exists for gmail/send_email.
+    // Without eager-load, gmail isn't loaded → mcpResult doesn't include
+    // send_email → union finds nothing. With eager-load, gmail joins
+    // effectiveConfigs and the tool surfaces.
+    //
+    // The MCP mock returns BOTH servers' tools when called with both
+    // configs — that's how production createMCPTools behaves. We assert on
+    // the configs argument to confirm eager-load actually happened,
+    // independent of which tools the LLM ended up with.
+    const gmailTools = ["send_email"];
+    const calendarTools = ["list_events"];
+
+    mockCreateMCPTools.mockImplementation((configs) => {
+      const tools: Record<string, Tool> = {};
+      const toolsByServer: Record<string, string[]> = {};
+      if (configs["gmail"]) {
+        tools.send_email = fakeTool("send_email");
+        toolsByServer["gmail"] = gmailTools;
+      }
+      if (configs["google-calendar"]) {
+        tools.list_events = fakeTool("list_events");
+        toolsByServer["google-calendar"] = calendarTools;
+      }
+      return Promise.resolve({
+        tools,
+        toolsByServer,
+        dispose: () => Promise.resolve(),
+        disconnectedIntegrations: [],
+      });
+    });
+    grantState.nextResult = {
+      ok: true,
+      data: [{ toolName: "gmail/send_email", bareToolName: "send_email", serverId: "gmail" }],
+    };
+
+    let observedToolNames: string[] = [];
+    const mockLLMProvider: LLMProvider = {
+      call: (params) => {
+        observedToolNames = Object.keys(params.tools as Record<string, Tool>);
+        const envelope: AgentResult<string, FSMLLMOutput> = {
+          agentId: params.agentId,
+          timestamp: new Date().toISOString(),
+          input: params.prompt ?? "",
+          ok: true,
+          data: { response: "" },
+          toolCalls: [completeCall({ response: "done" })],
+          toolResults: [],
+          durationMs: 0,
+        };
+        return Promise.resolve(envelope);
+      },
+    };
+
+    const workspaceId = "ws-eager-load";
+    const fsm: FSMDefinition = {
+      id: `eager-load-test-${crypto.randomUUID()}`,
+      initial: "pending",
+      states: {
+        pending: {
+          on: {
+            RUN: {
+              target: "done",
+              actions: [
+                {
+                  type: "llm",
+                  provider: "test",
+                  model: "test-model",
+                  prompt: "noop",
+                  tools: ["google-calendar/list_events"],
+                  outputTo: "decision",
+                },
+              ],
+            },
+          },
+        },
+        done: { type: "final" },
+      },
+    };
+
+    const engine = new FSMEngine(fsm, {
+      documentStore: getDocumentStore(),
+      scope: { workspaceId, sessionId: "sess-1" },
+      llmProvider: mockLLMProvider,
+      mcpServerConfigs: {
+        gmail: { transport: { type: "stdio", command: "noop", args: [] } },
+        "google-calendar": { transport: { type: "stdio", command: "noop", args: [] } },
+      },
+    });
+    await engine.initialize();
+    await engine.signal({ type: "RUN" }, { sessionId: "sess-1", workspaceId });
+
+    const lastCall = mockCreateMCPTools.mock.calls.at(-1);
+    const configs = lastCall?.[0] as Record<string, unknown> | undefined;
+    expect(configs).toBeDefined();
+    expect(configs).toHaveProperty("gmail");
+    expect(configs).toHaveProperty("google-calendar");
+    expect(observedToolNames).toContain("list_events");
+    expect(observedToolNames).toContain("send_email");
+  });
+
+  it("skips eager-load for grant-referenced servers the workspace doesn't declare", async () => {
+    // Grants can outlive workspace config edits. A grant for `gmail/...`
+    // when the workspace has since dropped gmail must not try to load
+    // gmail (would surface a confusing MCP error). Behavior: server is
+    // silently skipped; the action's declared toolset still loads.
+    mockCreateMCPTools.mockImplementation((configs) => {
+      const tools: Record<string, Tool> = {};
+      const toolsByServer: Record<string, string[]> = {};
+      if (configs["google-calendar"]) {
+        tools.list_events = fakeTool("list_events");
+        toolsByServer["google-calendar"] = ["list_events"];
+      }
+      return Promise.resolve({
+        tools,
+        toolsByServer,
+        dispose: () => Promise.resolve(),
+        disconnectedIntegrations: [],
+      });
+    });
+    grantState.nextResult = {
+      ok: true,
+      data: [{ toolName: "gmail/send_email", bareToolName: "send_email", serverId: "gmail" }],
+    };
+
+    const mockLLMProvider: LLMProvider = {
+      call: (params) =>
+        Promise.resolve({
+          agentId: params.agentId,
+          timestamp: new Date().toISOString(),
+          input: params.prompt ?? "",
+          ok: true,
+          data: { response: "" },
+          toolCalls: [completeCall({ response: "done" })],
+          toolResults: [],
+          durationMs: 0,
+        } as AgentResult<string, FSMLLMOutput>),
+    };
+
+    const workspaceId = "ws-eager-load-skip";
+    const fsm: FSMDefinition = {
+      id: `eager-load-skip-${crypto.randomUUID()}`,
+      initial: "pending",
+      states: {
+        pending: {
+          on: {
+            RUN: {
+              target: "done",
+              actions: [
+                {
+                  type: "llm",
+                  provider: "test",
+                  model: "test-model",
+                  prompt: "noop",
+                  tools: ["google-calendar/list_events"],
+                  outputTo: "decision",
+                },
+              ],
+            },
+          },
+        },
+        done: { type: "final" },
+      },
+    };
+
+    const engine = new FSMEngine(fsm, {
+      documentStore: getDocumentStore(),
+      scope: { workspaceId, sessionId: "sess-1" },
+      llmProvider: mockLLMProvider,
+      // Workspace declares only google-calendar — gmail is "stale" relative
+      // to the grant.
+      mcpServerConfigs: {
+        "google-calendar": { transport: { type: "stdio", command: "noop", args: [] } },
+      },
+    });
+    await engine.initialize();
+    await engine.signal({ type: "RUN" }, { sessionId: "sess-1", workspaceId });
+
+    const lastCall = mockCreateMCPTools.mock.calls.at(-1);
+    const configs = lastCall?.[0] as Record<string, unknown> | undefined;
+    expect(configs).toBeDefined();
+    expect(configs).not.toHaveProperty("gmail");
+    expect(configs).toHaveProperty("google-calendar");
   });
 });

--- a/packages/mcp-server/src/tools/permissions/request-tool-access.test.ts
+++ b/packages/mcp-server/src/tools/permissions/request-tool-access.test.ts
@@ -153,7 +153,12 @@ describe("request_tool_access — bypass branch (Phase 1.C)", () => {
       jobPermissions: { dangerouslySkipAllowlist: true },
     });
     expect(result.isError).toBeFalsy();
-    expect(parseBody(result)).toEqual({ ok: true, granted: true, reason: "bypass" });
+    expect(parseBody(result)).toEqual({
+      ok: true,
+      granted: true,
+      persistent: false,
+      reason: "bypass",
+    });
     // Logs at info level — operators see bypass in ~/.atlas/logs/global.log
     expect((ctx.logger.info as unknown as MockInstance).mock.calls.length).toBeGreaterThan(0);
     // No elicitation created on bypass
@@ -335,7 +340,12 @@ describe("request_tool_access — elicitation branch (Phase 12.C)", () => {
 
     expect(result.isError).toBeFalsy();
     expect(mockState.creates).toHaveLength(0);
-    expect(parseBody(result)).toEqual({ ok: true, granted: true, reason: "persistent_allow" });
+    expect(parseBody(result)).toEqual({
+      ok: true,
+      granted: true,
+      persistent: true,
+      reason: "persistent_allow",
+    });
   });
 
   it("uses resolvedPermissions when provided, skipping raw resolution (review N2)", async () => {
@@ -352,7 +362,12 @@ describe("request_tool_access — elicitation branch (Phase 12.C)", () => {
     });
     expect(result.isError).toBeFalsy();
     expect(mockState.creates).toHaveLength(0); // no elicitation created
-    expect(parseBody(result)).toEqual({ ok: true, granted: true, reason: "bypass" });
+    expect(parseBody(result)).toEqual({
+      ok: true,
+      granted: true,
+      persistent: false,
+      reason: "bypass",
+    });
   });
 
   it("derives expiresAt from jobTimeoutMs when injected (review N3)", async () => {

--- a/packages/mcp-server/src/tools/permissions/request-tool-access.ts
+++ b/packages/mcp-server/src/tools/permissions/request-tool-access.ts
@@ -58,10 +58,14 @@ export function registerRequestToolAccessTool(server: McpServer, ctx: ToolContex
       description:
         "Request permission to call a tool that isn't in your allowlist. " +
         "Use this when you need a capability you don't currently have. " +
-        'Returns immediately with `{ granted: true, reason: "bypass" }` if the ' +
-        "current job/workspace has `permissions.dangerouslySkipAllowlist`. " +
+        'Returns immediately with `{ granted: true, persistent: false, reason: "bypass" }` ' +
+        "if the current job/workspace has `permissions.dangerouslySkipAllowlist`. " +
         "Otherwise emits a user-facing elicitation, blocks until it is answered, " +
-        "declined, or expired, and returns the terminal decision to the current run.",
+        "declined, or expired, and returns the terminal decision. " +
+        "Read `persistent` on the response: `true` means the tool will be " +
+        "available to future actions in this workspace without re-asking; " +
+        "`false` means this turn is the only effect — you still cannot call " +
+        "the requested tool in the current action and must route around.",
       inputSchema: {
         toolName: z.string().min(1).describe("Name of the tool you want to call"),
         reason: z
@@ -148,8 +152,14 @@ export function registerRequestToolAccessTool(server: McpServer, ctx: ToolContex
           workspaceId,
           sessionId,
           actionId,
+          grantType: "persistent_allow",
         });
-        return createSuccessResponse({ ok: true, granted: true, reason: "persistent_allow" });
+        return createSuccessResponse({
+          ok: true,
+          granted: true,
+          persistent: true,
+          reason: "persistent_allow",
+        });
       }
       if (!persistentGrant.ok) {
         ctx.logger.warn("request_tool_access persistent grant check failed", {
@@ -168,8 +178,14 @@ export function registerRequestToolAccessTool(server: McpServer, ctx: ToolContex
           workspaceId,
           sessionId,
           actionId,
+          grantType: "bypass",
         });
-        return createSuccessResponse({ ok: true, granted: true, reason: "bypass" });
+        return createSuccessResponse({
+          ok: true,
+          granted: true,
+          persistent: false,
+          reason: "bypass",
+        });
       }
 
       // Elicitation branch. Emit a tool-allowlist elicitation and block on
@@ -254,13 +270,26 @@ export function registerRequestToolAccessTool(server: McpServer, ctx: ToolContex
               });
             }
           }
+          // grantType in the log makes the user's choice auditable without
+          // joining against the elicitation store. The runtime difference
+          // matters: `allow_always` widens future actions via the grant
+          // union; `allow_once` is an approval signal only.
+          ctx.logger.info("request_tool_access answered", {
+            toolName,
+            workspaceId,
+            sessionId,
+            actionId,
+            elicitationId: created.data.id,
+            grantType: granted ? terminal.value : "deny",
+            persistent,
+          });
           return createSuccessResponse({
             ok: granted,
             granted,
+            persistent,
             elicitationId: created.data.id,
             answer: terminal.value,
             reason: granted ? "answered" : "declined",
-            ...(persistent ? { persistent: true } : {}),
             ...(terminal.note ? { note: terminal.note } : {}),
           });
         }

--- a/packages/mcp-server/src/tools/permissions/request-tool-access.ts
+++ b/packages/mcp-server/src/tools/permissions/request-tool-access.ts
@@ -256,9 +256,17 @@ export function registerRequestToolAccessTool(server: McpServer, ctx: ToolContex
           const granted = terminal.value === "allow_once" || terminal.value === "allow_always";
           let persistent = false;
           if (terminal.value === "allow_always") {
+            // Parse serverId so `buildTools` can eagerly load the source
+            // MCP server on future actions. For bare names the parser
+            // returns `serverId: undefined` and the grant store falls
+            // through to a back-compat read path.
+            const slash = toolName.indexOf("/");
+            const serverId =
+              slash > 0 && slash < toolName.length - 1 ? toolName.slice(0, slash) : undefined;
             const persisted = await ToolAccessGrants.grantAlways({
               workspaceId,
               toolName,
+              ...(serverId && { serverId }),
               sourceElicitationId: created.data.id,
             });
             persistent = persisted.ok;

--- a/packages/system/agents/workspace-chat/tools/request-tool-access.test.ts
+++ b/packages/system/agents/workspace-chat/tools/request-tool-access.test.ts
@@ -84,12 +84,7 @@ describe("createRequestToolAccessTool", () => {
     });
     const t = tools.request_tool_access as unknown as ToolWithExecute;
     const result = await t.execute({ toolName: "bash_run", reason: "shell" }, noopCtx);
-    expect(result).toEqual({
-      ok: true,
-      granted: true,
-      persistent: false,
-      reason: "bypass",
-    });
+    expect(result).toEqual({ ok: true, granted: true, persistent: false, reason: "bypass" });
     expect(create).not.toHaveBeenCalled();
   });
 
@@ -98,12 +93,7 @@ describe("createRequestToolAccessTool", () => {
     const tools = createRequestToolAccessTool(baseOpts);
     const t = tools.request_tool_access as unknown as ToolWithExecute;
     const result = await t.execute({ toolName: "bash_run", reason: "shell" }, noopCtx);
-    expect(result).toEqual({
-      ok: true,
-      granted: true,
-      persistent: false,
-      reason: "bypass",
-    });
+    expect(result).toEqual({ ok: true, granted: true, persistent: false, reason: "bypass" });
     expect(create).not.toHaveBeenCalled();
   });
 

--- a/packages/system/agents/workspace-chat/tools/request-tool-access.test.ts
+++ b/packages/system/agents/workspace-chat/tools/request-tool-access.test.ts
@@ -67,7 +67,12 @@ describe("createRequestToolAccessTool", () => {
     const t = tools.request_tool_access as unknown as ToolWithExecute;
     const result = await t.execute({ toolName: "bash_run", reason: "shell" }, noopCtx);
 
-    expect(result).toEqual({ ok: true, granted: true, reason: "persistent_allow" });
+    expect(result).toEqual({
+      ok: true,
+      granted: true,
+      persistent: true,
+      reason: "persistent_allow",
+    });
     expect(create).not.toHaveBeenCalled();
     expect(hasGrant).toHaveBeenCalledWith({ workspaceId: "ws_test", toolName: "bash_run" });
   });
@@ -79,7 +84,12 @@ describe("createRequestToolAccessTool", () => {
     });
     const t = tools.request_tool_access as unknown as ToolWithExecute;
     const result = await t.execute({ toolName: "bash_run", reason: "shell" }, noopCtx);
-    expect(result).toEqual({ ok: true, granted: true, reason: "bypass" });
+    expect(result).toEqual({
+      ok: true,
+      granted: true,
+      persistent: false,
+      reason: "bypass",
+    });
     expect(create).not.toHaveBeenCalled();
   });
 
@@ -88,7 +98,12 @@ describe("createRequestToolAccessTool", () => {
     const tools = createRequestToolAccessTool(baseOpts);
     const t = tools.request_tool_access as unknown as ToolWithExecute;
     const result = await t.execute({ toolName: "bash_run", reason: "shell" }, noopCtx);
-    expect(result).toEqual({ ok: true, granted: true, reason: "bypass" });
+    expect(result).toEqual({
+      ok: true,
+      granted: true,
+      persistent: false,
+      reason: "bypass",
+    });
     expect(create).not.toHaveBeenCalled();
   });
 

--- a/packages/system/agents/workspace-chat/tools/request-tool-access.ts
+++ b/packages/system/agents/workspace-chat/tools/request-tool-access.ts
@@ -53,12 +53,16 @@ export function createRequestToolAccessTool(opts: CreateRequestToolAccessToolOpt
       description:
         "Request permission to call a tool that isn't in your allowlist. " +
         "Use when you need a capability you don't currently have. " +
-        'Returns immediately with `{ granted: true, reason: "bypass" }` if the ' +
-        "current workspace has `permissions.dangerouslySkipAllowlist`. " +
+        'Returns immediately with `{ granted: true, persistent: false, reason: "bypass" }` ' +
+        "if the current workspace has `permissions.dangerouslySkipAllowlist`, or " +
+        '`{ granted: true, persistent: true, reason: "persistent_allow" }` if the ' +
+        "user has previously chosen Allow always for this tool. " +
         "Otherwise emits a user-facing elicitation (visible on the Activity " +
         'page) and returns `{ granted: false, reason: "pending_user_approval", ' +
         "elicitationId }` — acknowledge to the user and either route around " +
-        "the missing capability or wait for them to answer.",
+        "the missing capability or wait for them to answer. " +
+        "When `persistent` is `true` future actions in this workspace see the " +
+        "tool in their toolset automatically; `false` means no future-action effect.",
       inputSchema: RequestToolAccessInput,
       execute: async ({ toolName, reason }) => {
         const daemonDangerouslySkipAllowlist =
@@ -74,8 +78,9 @@ export function createRequestToolAccessTool(opts: CreateRequestToolAccessToolOpt
             toolName,
             workspaceId,
             sessionId,
+            grantType: "persistent_allow",
           });
-          return { ok: true, granted: true, reason: "persistent_allow" };
+          return { ok: true, granted: true, persistent: true, reason: "persistent_allow" };
         }
         if (!persistentGrant.ok) {
           logger.warn("request_tool_access persistent grant check failed (chat)", {
@@ -91,8 +96,9 @@ export function createRequestToolAccessTool(opts: CreateRequestToolAccessToolOpt
             reason,
             workspaceId,
             sessionId,
+            grantType: "bypass",
           });
-          return { ok: true, granted: true, reason: "bypass" };
+          return { ok: true, granted: true, persistent: false, reason: "bypass" };
         }
 
         const now = new Date();

--- a/packages/system/skills/writing-workspace-jobs/SKILL.md
+++ b/packages/system/skills/writing-workspace-jobs/SKILL.md
@@ -1136,6 +1136,23 @@ Three response shapes:
 Deny / expiry returns `granted: false`. Treat as a hard "stop", explain what
 was blocked, and finish safely.
 
+### Reading the response
+
+The response includes a top-level `persistent: boolean`. Branch on it
+rather than parsing `answer`:
+
+- `persistent: true` — user chose Allow always or you hit a previously-stored
+  grant. Future actions in this workspace will see the tool in their
+  toolset without re-asking. You can tell the user "this will keep
+  working" and proceed (route around in *this* action; the next run
+  gets the real capability).
+- `persistent: false` with `granted: true` — Allow once or bypass. The
+  grant has no effect on future runs. Use it as a signal only.
+
+Operator log lines now include a `grantType` field
+(`allow_once` / `allow_always` / `bypass` / `persistent_allow` / `deny`)
+so audits don't need to join against the elicitation store.
+
 Unknown tools are rejected without creating an elicitation. If
 `request_tool_access` returns `reason: "unknown_tool"`, stop guessing: call
 `list_capabilities` / `list_mcp_tools`, install/enable the correct server if


### PR DESCRIPTION
## Summary

Stacked on **#302**. Three follow-ups identified during that PR's review:

1. **Test gap** — bypass-skip non-invocation, grant-read-failure warn-and-continue, and the `hasNameAllowlist === false` shape (action without a `tools:` array).
2. **`allow_once` vs `allow_always` is now distinguishable to the LLM** — `persistent` is always present in the response envelope; `grantType` lands in the operator log; SKILL.md teaches the LLM to read it.
3. **Server-aware grants + eager load** — closes the "stale-grant for a server the action doesn't declare" gap. `ToolAccessGrantSchema` gains `serverId?`; new grants record it; `buildTools` eagerly loads grant-referenced workspace MCP servers before `createMCPTools`; the union now does serverId-aware attribution.

## Commits

- **`879113e`** — `fsm-engine: cover bypass-skip + grant-read-failure + no-narrowing test branches`
- **`fa97fc8`** — `request_tool_access: distinguish allow_once vs allow_always for LLM + logs`
- **`965c859`** — `ToolAccessGrants: record source serverId + eagerly load referenced MCP servers`

Each is self-contained; can be cherry-picked independently if the stack splits.

## Compat

- Schema change is additive. Existing grants deserialize cleanly; read-path infers `serverId` from a qualified `toolName` when feasible.
- `hasGrant` key derivation unchanged — lookups by the original LLM-facing string keep resolving both legacy and new grants.
- `request_tool_access` response gains `persistent: boolean` on every "answered / bypass / persistent_allow" shape. Previously present only when `true`; now first-class. Existing `toEqual({...})` tests updated; no production caller depends on the field's absence.

## Test plan

- [x] `deno task typecheck` — 0 errors
- [x] `deno task test` — 6495 / 6514 pass, no regressions
- [x] `deno run -A npm:@biomejs/biome check` — 0 errors
- [x] Storage tests cover serverId derivation + explicit-override + `ListedGrant` projection
- [x] fsm-engine tests cover: bypass-skip non-invocation, grant-read-failure warn-and-continue, no-`tools:` shape, serverId-aware widening, serverId-mismatch defense, eager-load happy path, eager-load skipped for stale grant

## Known limitations now resolved

The "strictly-qualified action + grant for a different server's tool" gap called out in #302's PR description is closed: the action no longer needs to pull in the granted-tool's server via a bare-name declaration. Grants whose source server has been dropped from the workspace config are silently skipped to avoid surfacing a confusing MCP error — the action still loads its declared servers normally.

## Base

Targets `fix/280-union-allow-always-grants` so the diff is just the follow-up delta. Once #302 lands, rebase onto main and re-target there.