### PR TITLE
setup-tls: pin SHA-256 so LibreSSL-signed leaves verify in Node

### DIFF
--- a/scripts/setup-tls.sh
+++ b/scripts/setup-tls.sh
@@ -185,7 +185,11 @@ generate_s2s_chain() {
     if ! cert_is_fresh "$ca_crt"; then
         echo "  → Generating private CA at $ca_crt"
         openssl ecparam -name prime256v1 -genkey -noout -out "$ca_key"
-        openssl req -new -x509 -days 365 \
+        # `-sha256` is explicit because macOS's bundled LibreSSL defaults to
+        # SHA-1 here, which Node 18+ rejects as "CA signature digest algorithm
+        # too weak". OpenSSL 3.x defaults to SHA-256 already, so this is a
+        # no-op there.
+        openssl req -new -x509 -days 365 -sha256 \
             -key "$ca_key" \
             -out "$ca_crt" \
             -subj "/CN=Friday Local Dev CA/O=Friday Local Dev" \
@@ -213,7 +217,13 @@ keyUsage=critical,digitalSignature,keyEncipherment
 extendedKeyUsage=serverAuth,clientAuth
 subjectAltName=DNS:localhost,IP:127.0.0.1,IP:::1
 EOF
-    openssl x509 -req \
+    # `-sha256` is explicit because macOS's bundled LibreSSL defaults `x509
+    # -req` to SHA-1, which Node 18+ rejects as "CA signature digest algorithm
+    # too weak". OpenSSL 3.x defaults to SHA-256 already, so this is a no-op
+    # there. (LibreSSL's `req -new -x509` already defaults to SHA-256, which
+    # is why the CA above worked even before this fix and only the leaf was
+    # broken.)
+    openssl x509 -req -sha256 \
         -in "$leaf_csr" \
         -CA "$ca_crt" -CAkey "$ca_key" -CAcreateserial \
         -days 365 \


### PR DESCRIPTION
## Summary

- `scripts/setup-tls.sh` never specified a digest for `openssl x509 -req` (leaf) or `openssl req -new -x509` (CA), so it inherited whatever the local openssl defaulted to. On macOS's bundled LibreSSL 3.x, `x509 -req` defaults to **SHA-1** — Node 18+ then refuses the chain with `CA signature digest algorithm too weak`, and every SSR proxy fetch from the playground to the daemon comes back as a 502. Coworkers with Homebrew's OpenSSL 3.x earlier on PATH never hit it because OpenSSL 3.x defaults to SHA-256.
- Pin `-sha256` on both calls so the chain is SHA-256 regardless of which `openssl` wins on PATH. No-op on OpenSSL 3.x; fix on LibreSSL.
- Comments cite the LibreSSL/Node behavior so the next maintainer doesn't strip the flag thinking it's redundant.

## Test Plan

- [x] `openssl x509 -in ~/.atlas/tls/s2s.crt -noout -text | grep "Signature Algorithm"` → `ecdsa-with-SHA256` after rerun (was `ecdsa-with-SHA1`)
- [x] Stood up a temp Node 24 `https.createServer` with the regenerated leaf; `fetch('https://localhost:...')` with `NODE_EXTRA_CA_CERTS` returns 200 (was throwing `CA signature digest algorithm too weak`)
- [x] Reran `bash scripts/setup-tls.sh` end-to-end — idempotent, no spurious regeneration
- [ ] Coworker on Homebrew OpenSSL 3.x reruns the script and confirms their chain is still SHA-256 (no behavior change expected)