### PR TITLE
remove dev:playground:stable task

### DIFF
--- a/deno.compile.json
+++ b/deno.compile.json
@@ -36,7 +36,6 @@
     "start": "deno run --allow-all --unstable-worker-options --unstable-kv --unstable-raw-imports apps/atlas-cli/src/otel-bootstrap.ts",
     "dev": "deno task sync:svelte && FAST_DEVELOPMENT=true LINK_DEV_MODE=true deno run -A npm:concurrently -n daemon,link -c blue,green 'deno task atlas:dev daemon start' 'cd apps/link && deno task dev'",
     "dev:playground": "FAST_DEVELOPMENT=true LINK_DEV_MODE=true deno run -A npm:concurrently -n daemon,link,playground,tunnel -c blue,green,magenta,cyan 'deno task atlas:dev daemon start' 'cd apps/link && deno task dev' 'deno task playground' 'deno task webhook-tunnel'",
-    "dev:playground:stable": "FAST_DEVELOPMENT=true LINK_DEV_MODE=true deno run -A npm:concurrently -n daemon,link,playground,tunnel -c blue,green,magenta,cyan 'deno task atlas daemon start' 'cd apps/link && deno task dev' 'deno task playground' 'deno task webhook-tunnel'",
     "webhook-tunnel": "deno run --allow-all apps/webhook-tunnel/src/index.ts",
     "test": "OTEL_DENO=true DENO_TESTING=true LINK_DEV_MODE=true vitest run",
     "fmt": "deno run -A npm:@biomejs/biome format --write",

--- a/deno.json
+++ b/deno.json
@@ -38,7 +38,6 @@
     "atlas:dev": "FRIDAY_HOME=$HOME/.atlas deno run -q --allow-all --unstable-worker-options --unstable-kv --unstable-raw-imports --env-file scripts/dev-watcher.ts",
     "start": "FRIDAY_HOME=$HOME/.atlas deno run --allow-all --unstable-worker-options --unstable-kv --unstable-raw-imports apps/atlas-cli/src/otel-bootstrap.ts",
     "dev:playground": "FAST_DEVELOPMENT=true LINK_DEV_MODE=true deno run -A npm:concurrently@^9.2.1 -n daemon,link,playground,tunnel -c blue,green,magenta,cyan 'deno task atlas:dev daemon start' 'cd apps/link && deno task dev' 'deno task playground' 'deno task webhook-tunnel'",
-    "dev:playground:stable": "FAST_DEVELOPMENT=true LINK_DEV_MODE=true deno run -A npm:concurrently@^9.2.1 -n daemon,link,playground,tunnel -c blue,green,magenta,cyan 'deno task atlas daemon start' 'cd apps/link && deno task dev' 'deno task playground' 'deno task webhook-tunnel'",
     "webhook-tunnel": "go run ./tools/webhook-tunnel",
     "test": "OTEL_DENO=true DENO_TESTING=true LINK_DEV_MODE=true DEV_MODE=true vitest run",
     "fmt": "deno run -A npm:@biomejs/biome format --write",


### PR DESCRIPTION
## Summary

- The `:stable` variant booted the daemon via `deno task atlas` (runs `apps/atlas-cli/src/otel-bootstrap.ts` directly). The non-stable variant goes through `scripts/dev-watcher.ts`, which seeds `DENO_CERT` from `~/.atlas/.env` **before** Deno binds its RootCertStore.
- With private-CA s2s TLS turned on for local dev (`FRIDAY_TLS_CERT/_KEY`), the stable daemon boots with only the built-in webpki roots — outbound fetches it makes to its own TLS listener fail immediately with `invalid peer certificate: UnknownIssuer`, surfacing in chat as *"Security certificate verification failed. This may be a proxy or network configuration issue."*
- `dev:playground` covers the local-iteration use case. The compiled binary uses the installer's launch path, not these tasks.

## Test plan

- [x] `deno task dev:playground` boots and chat sends complete end-to-end
- [x] `rg 'dev:playground:stable'` returns no hits across the repo