### PR TITLE
skills+TLS: route daemon-URL curl examples through $FRIDAYD_URL

### DIFF
--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -120,14 +120,24 @@ to know the absolute URL of the daemon and the webhook tunnel
 
 | Var | What it controls | Default |
 |---|---|---|
-| `FRIDAYD_URL` | Daemon URL for CLI / launcher / sibling services | `http://localhost:8080` (installer writes `:18080`) |
+| `FRIDAYD_URL` | Daemon URL for CLI / launcher / sibling services | `http://localhost:8080` (installer writes `:18080`; `scripts/setup-tls.sh` rewrites scheme to `https://`) |
 | `EXTERNAL_DAEMON_URL` | UI-facing daemon URL — what the browser hits | falls back to `FRIDAYD_URL` |
 | `EXTERNAL_TUNNEL_URL` | UI-facing webhook-tunnel URL | none |
 | `LINK_SERVICE_URL` | Where the daemon proxies `/api/link/*` | `http://localhost:3100` (installer writes `:13100`) |
+| `FRIDAY_TLS_CERT` / `FRIDAY_TLS_KEY` | Private-CA s2s cert + key. When both set, the daemon binds TLS and `getAtlasDaemonUrl()` auto-upgrades any `http://` `FRIDAYD_URL` to `https://`. | unset (plain HTTP) |
+| `FRIDAY_TLS_CA` | CA cert path passed to `curl --cacert` (and `urllib`/`fetch` via `DENO_CERT`) so processes trust the s2s leaf. | unset |
+| `DENO_CERT` / `NODE_EXTRA_CA_CERTS` | Mirror of `FRIDAY_TLS_CA` in the variables Deno and Node read at startup. | unset |
 
 Set `EXTERNAL_DAEMON_URL` / `EXTERNAL_TUNNEL_URL` when you've placed
 a reverse proxy or tunnel in front of Friday and the browser needs
 the public address.
+
+When TLS is enabled, source `~/.atlas/.env` once per shell so curl and
+ad-hoc scripts pick up the right scheme + CA cert:
+
+```bash
+set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+```
 
 ### JetStream store directory
 

--- a/ENVIRONMENTS.md
+++ b/ENVIRONMENTS.md
@@ -132,11 +132,17 @@ Set `EXTERNAL_DAEMON_URL` / `EXTERNAL_TUNNEL_URL` when you've placed
 a reverse proxy or tunnel in front of Friday and the browser needs
 the public address.
 
-When TLS is enabled, source `~/.atlas/.env` once per shell so curl and
-ad-hoc scripts pick up the right scheme + CA cert:
+When TLS is enabled, source the daemon `.env` once per shell so curl and
+ad-hoc scripts pick up the right scheme + CA cert. The block tries
+`${FRIDAY_HOME:-~/.friday/local}/.env` (installed Studio, written by the
+launcher) and falls back to `~/.atlas/.env` (dev convention, written by
+`scripts/setup-tls.sh`):
 
 ```bash
-set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+set -a
+. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
+  || . "$HOME/.atlas/.env" 2>/dev/null || true
+set +a
 ```
 
 ### JetStream store directory

--- a/README.md
+++ b/README.md
@@ -130,9 +130,15 @@ If you only need the API:
 
 ```bash
 deno task atlas daemon start --detached
-curl -sf http://localhost:8080/health && echo "  daemon ok"
+# atlas auto-loads ~/.atlas/.env, so this works on both plain-HTTP and
+# TLS-enabled installs (scheme/port follow FRIDAYD_URL).
+deno task atlas daemon status
 deno task atlas daemon stop
 ```
+
+> **TLS opt-in.** Run `bash scripts/setup-tls.sh` once to generate certs and
+> write `FRIDAYD_URL=https://…` plus `FRIDAY_TLS_CA` into `~/.atlas/.env`.
+> Every subcommand and skill example below switches scheme automatically.
 
 ## Examples
 
@@ -167,7 +173,11 @@ tools you used in a `workspace.yml` and bind it to a signal.
 git clone https://github.com/friday-platform/friday-studio-examples
 deno task atlas workspace add ./friday-studio-examples/github-pr-reviewer
 
-curl -X POST http://localhost:8080/review-pr \
+# Source ~/.atlas/.env once so $FRIDAYD_URL / $FRIDAY_TLS_CA are set on
+# TLS-enabled installs. Skip this if you haven't run `scripts/setup-tls.sh`.
+set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+curl -X POST ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
+  "${FRIDAYD_URL:-http://localhost:8080}/review-pr" \
   -d '{"pr_url": "https://github.com/your-org/your-repo/pull/42"}'
 ```
 

--- a/README.md
+++ b/README.md
@@ -130,14 +130,16 @@ If you only need the API:
 
 ```bash
 deno task atlas daemon start --detached
-# atlas auto-loads ~/.atlas/.env, so this works on both plain-HTTP and
+# atlas auto-loads the daemon .env, so this works on both plain-HTTP and
 # TLS-enabled installs (scheme/port follow FRIDAYD_URL).
 deno task atlas daemon status
 deno task atlas daemon stop
 ```
 
-> **TLS opt-in.** Run `bash scripts/setup-tls.sh` once to generate certs and
-> write `FRIDAYD_URL=https://…` plus `FRIDAY_TLS_CA` into `~/.atlas/.env`.
+> **TLS opt-in (dev).** Run `bash scripts/setup-tls.sh` once to generate
+> certs and write `FRIDAYD_URL=https://…` plus `FRIDAY_TLS_CA` into
+> `~/.atlas/.env`. Installed Studio gets the same vars written into
+> `${FRIDAY_HOME:-~/.friday/local}/.env` automatically by the launcher.
 > Every subcommand and skill example below switches scheme automatically.
 
 ## Examples
@@ -173,9 +175,14 @@ tools you used in a `workspace.yml` and bind it to a signal.
 git clone https://github.com/friday-platform/friday-studio-examples
 deno task atlas workspace add ./friday-studio-examples/github-pr-reviewer
 
-# Source ~/.atlas/.env once so $FRIDAYD_URL / $FRIDAY_TLS_CA are set on
-# TLS-enabled installs. Skip this if you haven't run `scripts/setup-tls.sh`.
-set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+# Source the daemon .env once so $FRIDAYD_URL / $FRIDAY_TLS_CA are set on
+# TLS-enabled installs. The chain tries the installed-Studio location first,
+# then the dev location written by `scripts/setup-tls.sh`. Skip this on
+# plain-HTTP installs.
+set -a
+. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
+  || . "$HOME/.atlas/.env" 2>/dev/null || true
+set +a
 curl -X POST ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
   "${FRIDAYD_URL:-http://localhost:8080}/review-pr" \
   -d '{"pr_url": "https://github.com/your-org/your-repo/pull/42"}'

--- a/README.md
+++ b/README.md
@@ -130,8 +130,6 @@ If you only need the API:
 
 ```bash
 deno task atlas daemon start --detached
-# atlas auto-loads the daemon .env, so this works on both plain-HTTP and
-# TLS-enabled installs (scheme/port follow FRIDAYD_URL).
 deno task atlas daemon status
 deno task atlas daemon stop
 ```
@@ -140,7 +138,15 @@ deno task atlas daemon stop
 > certs and write `FRIDAYD_URL=https://…` plus `FRIDAY_TLS_CA` into
 > `~/.atlas/.env`. Installed Studio gets the same vars written into
 > `${FRIDAY_HOME:-~/.friday/local}/.env` automatically by the launcher.
-> Every subcommand and skill example below switches scheme automatically.
+> Source the daemon `.env` once per shell so `deno task atlas` and the
+> skill examples below pick up the right scheme/port:
+>
+> ```bash
+> set -a
+> . "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
+>   || . "$HOME/.atlas/.env" 2>/dev/null || true
+> set +a
+> ```
 
 ## Examples
 

--- a/apps/atlas-cli/src/cli/commands/agent/register.ts
+++ b/apps/atlas-cli/src/cli/commands/agent/register.ts
@@ -2,6 +2,7 @@ import { access } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import process from "node:process";
 import { createLogger } from "@atlas/logger";
+import { getAtlasDaemonUrl } from "@atlas/oapi-client";
 import { define } from "gunshi";
 import { infoOutput, successOutput } from "../../../utils/output.ts";
 
@@ -37,13 +38,12 @@ export const registerCommand = define({
       process.exit(1);
     }
 
-    // FRIDAYD_URL is the canonical name (set by friday-launcher's .env load
-    // — see tools/friday-launcher/project.go). FRIDAY_DAEMON_URL kept as a
-    // legacy alias to match the resolution chain in
-    // packages/openapi-client/src/utils.ts:50. `||` (not `??`) so an
-    // explicitly-empty FRIDAYD_URL still falls through to the alias / default.
-    const daemonUrl =
-      process.env.FRIDAYD_URL || process.env.FRIDAY_DAEMON_URL || "http://localhost:8080";
+    // getAtlasDaemonUrl() owns the resolution chain (FRIDAYD_URL →
+    // FRIDAY_DAEMON_URL legacy alias → FRIDAY_PORT_FRIDAY → default) and
+    // auto-upgrades the scheme to https:// when FRIDAY_TLS_CERT is set.
+    // Inlining the chain here previously sent cleartext at a TLS-bound
+    // daemon — same bug the rest of PR #308 fixes.
+    const daemonUrl = getAtlasDaemonUrl();
 
     let response: Response;
     try {

--- a/apps/atlas-cli/src/commands/daemon/status.tsx
+++ b/apps/atlas-cli/src/commands/daemon/status.tsx
@@ -1,5 +1,6 @@
 import process from "node:process";
 import { client, parseResult } from "@atlas/client/v2";
+import { getAtlasDaemonUrl } from "@atlas/oapi-client";
 import { displayDaemonStatus } from "../../utils/daemon-status.ts";
 import { errorOutput } from "../../utils/output.ts";
 import type { YargsInstance } from "../../utils/yargs.ts";
@@ -27,15 +28,20 @@ export function builder(y: YargsInstance) {
 }
 
 export const handler = async (argv: StatusArgs): Promise<void> => {
+  // The hono client at @atlas/client/v2 is bound at module-load time to
+  // getAtlasDaemonUrl(), so the actual URL hit is driven by FRIDAYD_URL +
+  // FRIDAY_TLS_CERT — not the --port flag. Surface that URL in the
+  // failure message so a TLS-cert-verification error doesn't masquerade
+  // as "not running on port 8080".
+  const targetUrl = getAtlasDaemonUrl();
+  const port = argv.port || 8080;
   try {
-    const port = argv.port || 8080;
-
     const status = await parseResult(client.daemon.status.$get());
     if (!status.ok) {
       if (argv.json) {
-        console.log(JSON.stringify({ status: "not_running", port }, null, 2));
+        console.log(JSON.stringify({ status: "not_running", url: targetUrl, port }, null, 2));
       } else {
-        errorOutput(`Atlas daemon is not running on port ${port}`);
+        errorOutput(`Atlas daemon is not running at ${targetUrl}`);
       }
       process.exit(1);
     }
@@ -53,7 +59,8 @@ export const handler = async (argv: StatusArgs): Promise<void> => {
           {
             status: "error",
             error: error instanceof Error ? error.message : String(error),
-            port: argv.port || 8080,
+            url: targetUrl,
+            port,
           },
           null,
           2,
@@ -61,7 +68,9 @@ export const handler = async (argv: StatusArgs): Promise<void> => {
       );
     } else {
       errorOutput(
-        `Failed to check daemon status: ${error instanceof Error ? error.message : String(error)}`,
+        `Failed to check daemon status at ${targetUrl}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
       );
     }
     process.exit(1);

--- a/deno.lock
+++ b/deno.lock
@@ -23,6 +23,7 @@
     "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@1.0": "1.0.9",
+    "jsr:@std/path@^1.0.8": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
     "jsr:@std/streams@^1.0.17": "1.1.0",
     "jsr:@std/tar@~0.1.9": "0.1.10",
@@ -238,7 +239,10 @@
       "integrity": "90dfba288802ac6de82fb31d0917eb9e4450b9925b954d5e51fc29ac07419db5"
     },
     "@std/fs@1.0.13": {
-      "integrity": "756d3ff0ade91c9e72b228e8012b6ff00c3d4a4ac9c642c4dac083536bf6c605"
+      "integrity": "756d3ff0ade91c9e72b228e8012b6ff00c3d4a4ac9c642c4dac083536bf6c605",
+      "dependencies": [
+        "jsr:@std/path@^1.0.8"
+      ]
     },
     "@std/fs@1.0.23": {
       "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",

--- a/deno.lock
+++ b/deno.lock
@@ -3,44 +3,30 @@
   "specifiers": {
     "jsr:@db/sqlite@0.13": "0.13.0",
     "jsr:@denosaurs/plug@1": "1.1.0",
-    "jsr:@std/assert@1": "1.0.19",
-    "jsr:@std/assert@^1.0.16": "1.0.19",
-    "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/async@1.0.15": "1.0.15",
-    "jsr:@std/async@^1.0.15": "1.3.0",
-    "jsr:@std/async@^1.3.0": "1.3.0",
-    "jsr:@std/cli@^1.0.6": "1.0.29",
-    "jsr:@std/data-structures@^1.0.11": "1.0.11",
+    "jsr:@std/async@^1.0.15": "1.0.15",
     "jsr:@std/dotenv@~0.225.5": "0.225.6",
     "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/encoding@1.0.10": "1.0.10",
     "jsr:@std/fmt@1": "1.0.10",
     "jsr:@std/fs@1": "1.0.23",
-    "jsr:@std/fs@1.0.13": "1.0.13",
-    "jsr:@std/fs@^1.0.23": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.13",
-    "jsr:@std/internal@^1.0.13": "1.0.13",
     "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@1.0": "1.0.9",
-    "jsr:@std/path@^1.0.8": "1.1.4",
     "jsr:@std/path@^1.1.4": "1.1.4",
-    "jsr:@std/streams@^1.0.17": "1.1.0",
-    "jsr:@std/tar@~0.1.9": "0.1.10",
-    "jsr:@std/testing@1": "1.0.18",
-    "jsr:@std/testing@^1.0.16": "1.0.18",
     "jsr:@std/yaml@1": "1.1.0",
-    "npm:@ai-sdk/anthropic@^3.0.76": "3.0.76_zod@4.4.3",
+    "npm:@ai-sdk/anthropic@^3.0.76": "3.0.77_zod@4.4.3",
     "npm:@ai-sdk/fireworks@2.0.52": "2.0.52_zod@4.4.3",
-    "npm:@ai-sdk/google@^3.0.71": "3.0.71_zod@4.4.3",
+    "npm:@ai-sdk/google@^3.0.71": "3.0.73_zod@4.4.3",
     "npm:@ai-sdk/groq@3.0.39": "3.0.39_zod@4.4.3",
     "npm:@ai-sdk/groq@^3.0.39": "3.0.39_zod@4.4.3",
-    "npm:@ai-sdk/mcp@^1.0.41": "1.0.41_zod@4.4.3",
+    "npm:@ai-sdk/mcp@^1.0.41": "1.0.42_zod@4.4.3",
     "npm:@ai-sdk/openai@^3.0.63": "3.0.63_zod@4.4.3",
     "npm:@ai-sdk/provider@^3.0.10": "3.0.10",
-    "npm:@ai-sdk/svelte@^4.0.177": "4.0.177_svelte@5.55.5_zod@4.4.3",
-    "npm:@anthropic-ai/claude-agent-sdk@~0.2.137": "0.2.138_zod@4.4.3",
-    "npm:@biomejs/biome@*": "2.4.14",
+    "npm:@ai-sdk/svelte@^4.0.177": "4.0.180_svelte@5.55.5_zod@4.4.3",
+    "npm:@anthropic-ai/claude-agent-sdk@~0.2.137": "0.2.140_zod@4.4.3",
+    "npm:@biomejs/biome@*": "2.4.15",
     "npm:@chat-adapter/discord@4.28.1": "4.28.1",
     "npm:@chat-adapter/slack@4.28.1": "4.28.1",
     "npm:@chat-adapter/teams@4.28.1": "4.28.1",
@@ -63,7 +49,7 @@
     "npm:@hubspot/api-client@^13.4.0": "13.5.0",
     "npm:@hubspot/api-client@^13.5.0": "13.5.0",
     "npm:@ianvs/prettier-plugin-sort-imports@^4.7.1": "4.7.1_prettier@3.8.3",
-    "npm:@inkjs/ui@2": "2.0.0_ink@7.0.2__@types+react@19.2.14__react@19.2.6_@types+react@19.2.14_react@19.2.6",
+    "npm:@inkjs/ui@2": "2.0.0_ink@7.0.3__@types+react@19.2.14__react@19.2.6_@types+react@19.2.14_react@19.2.6",
     "npm:@jsr/db__sqlite@0.12": "0.12.0",
     "npm:@jsr/std__async@1.0.15": "1.0.15",
     "npm:@jsr/std__async@^1.0.14": "1.0.15",
@@ -85,14 +71,14 @@
     "npm:@opentelemetry/api@^1.9.0": "1.9.1",
     "npm:@opentelemetry/api@^1.9.1": "1.9.1",
     "npm:@sendgrid/helpers@8": "8.0.0",
-    "npm:@sveltejs/adapter-auto@^7.0.1": "7.0.1_@sveltejs+kit@2.59.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.55.5___vite@7.3.3____@types+node@25.6.2____yaml@2.8.4___@types+node@25.6.2___yaml@2.8.4__svelte@5.55.5__typescript@5.9.3__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4",
-    "npm:@sveltejs/adapter-static@^3.0.10": "3.0.10_@sveltejs+kit@2.59.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.55.5___vite@7.3.3____@types+node@25.6.2____yaml@2.8.4___@types+node@25.6.2___yaml@2.8.4__svelte@5.55.5__typescript@5.9.3__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4",
-    "npm:@sveltejs/kit@^2.59.0": "2.59.1_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_yaml@2.8.4",
+    "npm:@sveltejs/adapter-auto@^7.0.1": "7.0.1_@sveltejs+kit@2.59.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.55.5___vite@7.3.3____@types+node@25.7.0____yaml@2.9.0___@types+node@25.7.0___yaml@2.9.0__svelte@5.55.5__typescript@5.9.3__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_yaml@2.9.0",
+    "npm:@sveltejs/adapter-static@^3.0.10": "3.0.10_@sveltejs+kit@2.59.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.55.5___vite@7.3.3____@types+node@25.7.0____yaml@2.9.0___@types+node@25.7.0___yaml@2.9.0__svelte@5.55.5__typescript@5.9.3__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_yaml@2.9.0",
+    "npm:@sveltejs/kit@^2.59.0": "2.59.1_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_yaml@2.9.0",
     "npm:@sveltejs/package@^2.5.7": "2.5.7_svelte@5.55.5_typescript@5.9.3",
-    "npm:@sveltejs/vite-plugin-svelte@^6.2.4": "6.2.4_svelte@5.55.5_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_yaml@2.8.4",
-    "npm:@sveltejs/vite-plugin-svelte@~6.2.4": "6.2.4_svelte@5.55.5_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_yaml@2.8.4",
-    "npm:@tanstack/query-core@^5.100.8": "5.100.9",
-    "npm:@tanstack/svelte-query@^6.1.28": "6.1.28_svelte@5.55.5",
+    "npm:@sveltejs/vite-plugin-svelte@^6.2.4": "6.2.4_svelte@5.55.5_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_yaml@2.9.0",
+    "npm:@sveltejs/vite-plugin-svelte@~6.2.4": "6.2.4_svelte@5.55.5_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_yaml@2.9.0",
+    "npm:@tanstack/query-core@^5.100.8": "5.100.10",
+    "npm:@tanstack/svelte-query@^6.1.28": "6.1.29_svelte@5.55.5",
     "npm:@tanstack/svelte-table@9.0.0-alpha.41": "9.0.0-alpha.41_svelte@5.55.5",
     "npm:@tanstack/svelte-table@^9.0.0-alpha.41": "9.0.0-alpha.41_svelte@5.55.5",
     "npm:@tanstack/svelte-virtual@~3.13.24": "3.13.24_svelte@5.55.5",
@@ -102,26 +88,25 @@
     "npm:@total-typescript/ts-reset@~0.6.1": "0.6.1",
     "npm:@types/deno@2.5.0": "2.5.0",
     "npm:@types/markdown-it@^14.1.2": "14.1.2",
-    "npm:@types/node@25": "25.6.2",
+    "npm:@types/node@25": "25.7.0",
     "npm:@types/papaparse@^5.5.2": "5.5.2",
     "npm:@types/proper-lockfile@^4.1.4": "4.1.4",
     "npm:@types/react@^19.2.14": "19.2.14",
     "npm:@types/turndown@^5.0.6": "5.0.6",
-    "npm:@vitest/coverage-v8@4.1.5": "4.1.5_vitest@4.1.5_@opentelemetry+api@1.9.1_@types+node@25.6.2_happy-dom@20.9.0_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4",
+    "npm:@vitest/coverage-v8@4.1.5": "4.1.5_vitest@4.1.5_@opentelemetry+api@1.9.1_@types+node@25.7.0_happy-dom@20.9.0_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_yaml@2.9.0",
     "npm:@worker-tools/html-rewriter@0.1.0-pre.19": "0.1.0-pre.19",
     "npm:@worker-tools/html-rewriter@~0.1.0-pre.17": "0.1.0-pre.19",
     "npm:@xmldom/xmldom@~0.9.10": "0.9.10",
     "npm:ai-sdk-provider-claude-code@^3.4.4": "3.4.4_zod@4.4.3",
-    "npm:ai@^6.0.141": "6.0.177_zod@4.4.3",
-    "npm:ai@^6.0.177": "6.0.177_zod@4.4.3",
+    "npm:ai@^6.0.141": "6.0.180_zod@4.4.3",
+    "npm:ai@^6.0.177": "6.0.180_zod@4.4.3",
     "npm:chat@4.28.1": "4.28.1",
     "npm:chat@^4.28.1": "4.28.1",
     "npm:codemirror@^6.0.2": "6.0.2",
-    "npm:concurrently@^9.2.1": "9.2.1",
     "npm:cookie@^1.0.2": "1.1.1",
     "npm:cron-parser@^5.5.0": "5.5.0",
     "npm:diff@9": "9.0.0",
-    "npm:dompurify@^3.4.2": "3.4.2",
+    "npm:dompurify@^3.4.2": "3.4.3",
     "npm:dotenv@17.4.2": "17.4.2",
     "npm:dotenv@^17.4.2": "17.4.2",
     "npm:eslint-config-prettier@^10.1.8": "10.1.8_eslint@10.3.0",
@@ -132,10 +117,10 @@
     "npm:globals@^17.6.0": "17.6.0",
     "npm:gunshi@~0.29.5": "0.29.5",
     "npm:happy-dom@^20.9.0": "20.9.0",
-    "npm:hono-openapi@^1.3.0": "1.3.0_@hono+standard-validator@0.2.2__@standard-schema+spec@1.1.0__hono@4.12.18_hono@4.12.18_zod@4.4.3",
+    "npm:hono-openapi@^1.3.0": "1.3.0_@hono+standard-validator@0.2.2__@standard-schema+spec@1.1.0__hono@4.12.18_@standard-community+standard-json@0.3.5__@standard-schema+spec@1.1.0__@types+json-schema@7.0.15__quansync@0.2.11__zod@4.4.3_@standard-community+standard-openapi@0.2.9__@standard-community+standard-json@0.3.5___@standard-schema+spec@1.1.0___@types+json-schema@7.0.15___quansync@0.2.11___zod@4.4.3__@standard-schema+spec@1.1.0__openapi-types@12.1.3__zod@4.4.3__@types+json-schema@7.0.15__quansync@0.2.11_@types+json-schema@7.0.15_hono@4.12.18_openapi-types@12.1.3_@standard-schema+spec@1.1.0_quansync@0.2.11_zod@4.4.3",
     "npm:hono@4.12.18": "4.12.18",
     "npm:immer@^11.1.8": "11.1.8",
-    "npm:ink@^7.0.1": "7.0.2_@types+react@19.2.14_react@19.2.6",
+    "npm:ink@^7.0.1": "7.0.3_@types+react@19.2.14_react@19.2.6",
     "npm:isomorphic-dompurify@^2.16.0": "2.36.0",
     "npm:jira.js@^5.3.1": "5.3.1",
     "npm:jose@6.2.3": "6.2.3",
@@ -144,7 +129,6 @@
     "npm:js-levenshtein@^1.1.6": "1.1.6",
     "npm:jsonrepair@^3.14.0": "3.14.0",
     "npm:jszip@^3.10.1": "3.10.1",
-    "npm:knip@*": "6.11.0_@emnapi+core@1.10.0_@emnapi+runtime@1.10.0",
     "npm:knip@6.11.0": "6.11.0_@emnapi+core@1.10.0_@emnapi+runtime@1.10.0",
     "npm:lint-staged@^16.4.0": "16.4.0",
     "npm:markdown-it@^14.1.1": "14.1.1",
@@ -152,7 +136,6 @@
     "npm:minimatch@^10.2.5": "10.2.5",
     "npm:nanoid@5.1.11": "5.1.11",
     "npm:nanoid@^5.1.6": "5.1.11",
-    "npm:nats@2": "2.29.3",
     "npm:nats@^2.29.3": "2.29.3",
     "npm:oauth4webapi@3.8.6": "3.8.6",
     "npm:oauth4webapi@^3.8.3": "3.8.6",
@@ -163,10 +146,10 @@
     "npm:parallel-web@0.5.0": "0.5.0",
     "npm:postgres@3.4.9": "3.4.9",
     "npm:postgres@^3.4.7": "3.4.9",
-    "npm:prettier-plugin-svelte@^3.5.1": "3.5.1_prettier@3.8.3_svelte@5.55.5",
+    "npm:prettier-plugin-svelte@^3.5.1": "3.5.2_prettier@3.8.3_svelte@5.55.5",
     "npm:prettier@^3.8.3": "3.8.3",
     "npm:proper-lockfile@^4.1.2": "4.1.2",
-    "npm:publint@~0.3.18": "0.3.20",
+    "npm:publint@~0.3.18": "0.3.21",
     "npm:react@^19.2.5": "19.2.6",
     "npm:shiki@^4.0.2": "4.0.2",
     "npm:svelte-check@^4.4.7": "4.4.8_svelte@5.55.5_typescript@5.9.3",
@@ -174,18 +157,16 @@
     "npm:svelte@^5.55.5": "5.55.5",
     "npm:tar@^7.5.13": "7.5.15",
     "npm:turndown@7.2.4": "7.2.4",
-    "npm:typescript-eslint@^8.59.2": "8.59.2_eslint@10.3.0_typescript@5.9.3",
+    "npm:typescript-eslint@^8.59.2": "8.59.3_eslint@10.3.0_typescript@5.9.3",
     "npm:typescript@^5.9.3": "5.9.3",
     "npm:ulid@^3.0.2": "3.0.2",
     "npm:undici@^7.25.0": "7.25.0",
-    "npm:vite@^7.3.2": "7.3.3_@types+node@25.6.2_yaml@2.8.4",
-    "npm:vitest@*": "4.1.5_@opentelemetry+api@1.9.1_@types+node@25.6.2_@vitest+coverage-v8@4.1.5_happy-dom@20.9.0_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4",
-    "npm:vitest@^4.1.0": "4.1.5_@opentelemetry+api@1.9.1_@types+node@25.6.2_@vitest+coverage-v8@4.1.5_happy-dom@20.9.0_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4",
-    "npm:vitest@^4.1.5": "4.1.5_@opentelemetry+api@1.9.1_@types+node@25.6.2_@vitest+coverage-v8@4.1.5_happy-dom@20.9.0_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4",
-    "npm:xstate@^5.31.0": "5.31.0",
-    "npm:yaml@^2.8.4": "2.8.4",
+    "npm:vite@^7.3.2": "7.3.3_@types+node@25.7.0_yaml@2.9.0",
+    "npm:vitest@^4.1.0": "4.1.5_@opentelemetry+api@1.9.1_@types+node@25.7.0_@vitest+coverage-v8@4.1.5_happy-dom@20.9.0_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_yaml@2.9.0",
+    "npm:vitest@^4.1.5": "4.1.5_@opentelemetry+api@1.9.1_@types+node@25.7.0_@vitest+coverage-v8@4.1.5_happy-dom@20.9.0_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_yaml@2.9.0",
+    "npm:xstate@^5.31.0": "5.31.1",
+    "npm:yaml@^2.8.4": "2.9.0",
     "npm:yargs@18": "18.0.0",
-    "npm:zod@4": "4.4.3",
     "npm:zod@4.4.3": "4.4.3",
     "npm:zod@^4.2.1": "4.4.3",
     "npm:zod@^4.3.5": "4.4.3",
@@ -204,30 +185,12 @@
       "dependencies": [
         "jsr:@std/encoding@1",
         "jsr:@std/fmt",
-        "jsr:@std/fs@1",
+        "jsr:@std/fs",
         "jsr:@std/path@1"
-      ]
-    },
-    "@std/assert@1.0.19": {
-      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
-      "dependencies": [
-        "jsr:@std/internal@^1.0.12"
       ]
     },
     "@std/async@1.0.15": {
       "integrity": "55d1d9d04f99403fe5730ab16bdcc3c47f658a6bf054cafb38a50f046238116e"
-    },
-    "@std/async@1.3.0": {
-      "integrity": "80485538a4f7baaa46bfe2246168069e02ed142b9f9079cd164f43bb060ad9e9",
-      "dependencies": [
-        "jsr:@std/data-structures"
-      ]
-    },
-    "@std/cli@1.0.29": {
-      "integrity": "fa4ef29130baa834d8a13b7d138240c3a2fcfba740bfb7afa646a360a15ec84f"
-    },
-    "@std/data-structures@1.0.11": {
-      "integrity": "53b98ed7efa61f107dfc14244bd2ec5557f7f7ee0bbaef6d449d7937facacb89"
     },
     "@std/dotenv@0.225.6": {
       "integrity": "1d6f9db72f565bd26790fa034c26e45ecb260b5245417be76c2279e5734c421b"
@@ -238,16 +201,10 @@
     "@std/fmt@1.0.10": {
       "integrity": "90dfba288802ac6de82fb31d0917eb9e4450b9925b954d5e51fc29ac07419db5"
     },
-    "@std/fs@1.0.13": {
-      "integrity": "756d3ff0ade91c9e72b228e8012b6ff00c3d4a4ac9c642c4dac083536bf6c605",
-      "dependencies": [
-        "jsr:@std/path@^1.0.8"
-      ]
-    },
     "@std/fs@1.0.23": {
       "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
       "dependencies": [
-        "jsr:@std/internal@^1.0.12",
+        "jsr:@std/internal",
         "jsr:@std/path@^1.1.4"
       ]
     },
@@ -263,27 +220,7 @@
     "@std/path@1.1.4": {
       "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
-        "jsr:@std/internal@^1.0.12"
-      ]
-    },
-    "@std/streams@1.1.0": {
-      "integrity": "2f7024d841f343fd478afe0c958a3f0f068ef2a0d2bcc954f550f97ac1fa22e3"
-    },
-    "@std/tar@0.1.10": {
-      "integrity": "6bf907f3a4bc8bfef42973ba132d946756a6161ef6b914a9e1c06debe664db17",
-      "dependencies": [
-        "jsr:@std/streams"
-      ]
-    },
-    "@std/testing@1.0.18": {
-      "integrity": "d3152f57b11666bf6358d0e127c7e3488e91178b0c2d8fbf0793e1c53cd13cb1",
-      "dependencies": [
-        "jsr:@std/assert@^1.0.19",
-        "jsr:@std/async@^1.3.0",
-        "jsr:@std/data-structures",
-        "jsr:@std/fs@^1.0.23",
-        "jsr:@std/internal@^1.0.13",
-        "jsr:@std/path@^1.1.4"
+        "jsr:@std/internal"
       ]
     },
     "@std/yaml@1.1.0": {
@@ -294,8 +231,8 @@
     "@acemir/cssom@0.9.31": {
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="
     },
-    "@ai-sdk/anthropic@3.0.76_zod@4.4.3": {
-      "integrity": "sha512-kOuvT9e6PygFvgYpkr4v9gjvmcMPfJp79jaXjeRl9Gpoj2OXdtc3ero7o1ic+tiSBw5IMubxXFO68BCA/axGJA==",
+    "@ai-sdk/anthropic@3.0.77_zod@4.4.3": {
+      "integrity": "sha512-ML8C2M1YvPA1ulEx4TiyF0k1xvC2ikEiPBIC1PPQ0a5xELUGrO2lAaEzsTEoJ+eCeDd8PSBuFJjs+r+9yIwQXA==",
       "dependencies": [
         "@ai-sdk/provider",
         "@ai-sdk/provider-utils",
@@ -311,8 +248,8 @@
         "zod"
       ]
     },
-    "@ai-sdk/gateway@3.0.112_zod@4.4.3": {
-      "integrity": "sha512-jiBao9pR4owWyjo0BnuNc7WSQBGOD0thysE4AFgZXaG+zMFbISQXUkJr7ePw/phBvePy7jE5FSA2Lf7lwqUiiQ==",
+    "@ai-sdk/gateway@3.0.114_zod@4.4.3": {
+      "integrity": "sha512-MqkZ5sd+qiq6RgIxELkoFQXg2/JwK+WCMaot7U+rtrZpWJl3fSyYvc28SC03b256o4F7OXjQtdjTqs81B2w+dA==",
       "dependencies": [
         "@ai-sdk/provider",
         "@ai-sdk/provider-utils",
@@ -320,8 +257,8 @@
         "zod"
       ]
     },
-    "@ai-sdk/google@3.0.71_zod@4.4.3": {
-      "integrity": "sha512-G86UtqkCKM8mQcvsA4FQ1WCRN+w1gl/sxuoYl5CJX5DFSUSkrLNKmLcvi3TtnMvKth5li8W/1h3emQSl2K+qnA==",
+    "@ai-sdk/google@3.0.73_zod@4.4.3": {
+      "integrity": "sha512-o2MuIeyvZrFIeIbnbA8Thrr63irdyUBh0uWBZ2lY6yFeXuE/tcwyXF74bDKS4KvTu84uFpQfpbS/LXHGKKXz+g==",
       "dependencies": [
         "@ai-sdk/provider",
         "@ai-sdk/provider-utils",
@@ -336,8 +273,8 @@
         "zod"
       ]
     },
-    "@ai-sdk/mcp@1.0.41_zod@4.4.3": {
-      "integrity": "sha512-AfA0jb6tTnfcieLx1d6breTmuae0fz67UNcBrCgZqPqaZ1NIlJT5uyXx+78pgYOuDHo0GtHECVhI1a9lkZnzgA==",
+    "@ai-sdk/mcp@1.0.42_zod@4.4.3": {
+      "integrity": "sha512-ctRhX9vNLXvjGSFf+RlM+ZutIhlzIgMPWzo2BoJKfIW9JzLneA/57bZkkaUvWSdbYFu1FCyxMarNV/4D/pOUzA==",
       "dependencies": [
         "@ai-sdk/provider",
         "@ai-sdk/provider-utils",
@@ -376,8 +313,8 @@
         "json-schema"
       ]
     },
-    "@ai-sdk/svelte@4.0.177_svelte@5.55.5_zod@4.4.3": {
-      "integrity": "sha512-8TKa0UFeK9TRoK9TXwW4J/QOF0uA6zZyRBrOv1htKt3d8B8wnPIwjJVC8ufWLjHTGy7YQgQ6yHOnP9Ki0SrS4Q==",
+    "@ai-sdk/svelte@4.0.180_svelte@5.55.5_zod@4.4.3": {
+      "integrity": "sha512-learKGdmMX3qOmVR6KkipiSYab9UDTUGszj5nXuWCgB00PeCMhBTXX8R16Oa6K1FPHW1poVDudVk/JGX5Rn0FQ==",
       "dependencies": [
         "@ai-sdk/provider-utils",
         "ai",
@@ -387,52 +324,52 @@
     "@alcalzone/ansi-tokenize@0.3.0": {
       "integrity": "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==",
       "dependencies": [
-        "ansi-styles@6.2.3",
-        "is-fullwidth-code-point@5.1.0"
+        "ansi-styles",
+        "is-fullwidth-code-point"
       ]
     },
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.138": {
-      "integrity": "sha512-aObxJ/GeJ5UxT9N8XypUHPYQKpwYsRT5THiJl5E2pKEUk/Xt42gT55N5GV0TOjtgxVAnDMWjxTAgGCGoDzjgpg==",
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.140": {
+      "integrity": "sha512-zEbDsDKeoDO4DzbyX6wBVlcPhLy/gYiCrKzKnxmkOhyNtJBeshgiOTdr+M7WX1xcuI/M/UhEY+B9U6oo884lAQ==",
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.138": {
-      "integrity": "sha512-ou3i1/gAf2PEgVl2WYJb7ZdE+KGwoB1I46JRhWHSC3uD6lb9HMZam233T/rlKCVX9e5dzfkujUOnmCkmXjgVGQ==",
+    "@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.140": {
+      "integrity": "sha512-BFJGeZEksvERy7mMJ0mkNAWoMrZOgl6XN/mKPaunGnaC/i+1ykx7xih7e58bRhsrzKzo2mnUrwtjiFyF3MFNRQ==",
       "os": ["darwin"],
       "cpu": ["x64"]
     },
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.138": {
-      "integrity": "sha512-uZaEFND1pl7KD9tdYqj2hd6ktjlYizVmkHRgU2Aj/P1CC6WMDsKG+rqPP7dsVXO77gMXhL4xjjwwqMjxx83HkA==",
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.140": {
+      "integrity": "sha512-nG7xLL0nKb4ymFVnX0QhSGLoyhh9fuuDpBR+TYz5O4ZQc2RVUMSMqGusqcCNEIGxAKQSVKWCf0WgpCG/edAO9Q==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.138": {
-      "integrity": "sha512-jp8lmAVe9uI9X5o+IYWFajLbN+Z80XogVX7NeyaenLHdpHkxg29Yf8pb6Os4OvHMjJOAdwDhPpXajf6RtBeEDA==",
+    "@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.140": {
+      "integrity": "sha512-FauGGg3zikxrjAUnu+Pso6zD9Qv4Z2+QBiTiZqc12U+x4uoikNsplymUnsJ7MYD9VaTGmLJuZ9pCch0IiKrseQ==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.138": {
-      "integrity": "sha512-T16F8Vkikb98E781ZM6Cx84yEBk+loSCqAObjaZ1hzQ1eKcpnxzSTF4rH2bz6N91dhFuCfIjFaBfNYg+oQA+yQ==",
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.140": {
+      "integrity": "sha512-EZ7VzOGmvft/1ymh2rwts5v3yPnsGGlGrTJlY2Dqnr1ABF43JIhEm1NFYrLnXQWSN74s5Pj8tgkPbYS9x4BhFA==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@anthropic-ai/claude-agent-sdk-linux-x64@0.2.138": {
-      "integrity": "sha512-SLuUmu/nH1Wh0wnoXj/Bwh0nbDfEn9PgXqMsZHEUk3x1zxeR+6aRqFLjKZ8TawBey7xod7nfYUIjPnQx6IWDzg==",
+    "@anthropic-ai/claude-agent-sdk-linux-x64@0.2.140": {
+      "integrity": "sha512-7f627Tq2mIiwFoBYfCKTdEeZSP90r8UOWu/I5DezudTtwtoVl2zRaRCnJ8c4rW+Tzw+xWSfP/pHvR9bTQGXaOw==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.138": {
-      "integrity": "sha512-H/sD25fmMyEeJWamYmBKRS3E7jaIrg2S8KWxyR37P+xTZgkLe19sDTp7gYYywMXf1X9CJZJ8jJZ93qxINZoCeA==",
+    "@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.140": {
+      "integrity": "sha512-9EOozRF+LTt3UedeJtjJXC8pj9VTAFtPBuB+/YUmcpmDAEH9qcWWknWhf7NDKTapKtBWkNP/387x+18L15MLqg==",
       "os": ["win32"],
       "cpu": ["arm64"]
     },
-    "@anthropic-ai/claude-agent-sdk-win32-x64@0.2.138": {
-      "integrity": "sha512-cSOdTH1OfIamVdJit9laWZiXne81ewgdP8MGh5HzLLLci0NGHkME7YxCWd0lYkCNkfiOEcToKU9axaZ+84jGiw==",
+    "@anthropic-ai/claude-agent-sdk-win32-x64@0.2.140": {
+      "integrity": "sha512-puQyWoYiqosjDEYULWAS/lBJse1vzib0NmQj/bYTirWCbtiUcu6ixKMd4NmLbE+Si/DKTB8XNz6hVZ/KckqeoQ==",
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "@anthropic-ai/claude-agent-sdk@0.2.138_zod@4.4.3": {
-      "integrity": "sha512-rH6dFI3DBBsPBPcHTBdTZCHA14OCt2t4+6XYi2MJB/GlFrnZvlWmMIk2z9uxAiZ05Txg8YbftgSuE5A1qpAXwg==",
+    "@anthropic-ai/claude-agent-sdk@0.2.140_zod@4.4.3": {
+      "integrity": "sha512-Zq2L7YCoTdbxTUi3/soN1axrTqbG7GoKuc6Im8EpkBRdwaY0D1W9+Ux3vAbV/cX8Qk31Vck7DQLZz1lGEArdoQ==",
       "dependencies": [
         "@anthropic-ai/sdk",
         "@modelcontextprotocol/sdk@1.29.0_zod@4.4.3",
@@ -564,8 +501,8 @@
     "@bcoe/v8-coverage@1.0.2": {
       "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="
     },
-    "@biomejs/biome@2.4.14": {
-      "integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
+    "@biomejs/biome@2.4.15": {
+      "integrity": "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==",
       "optionalDependencies": [
         "@biomejs/cli-darwin-arm64",
         "@biomejs/cli-darwin-x64",
@@ -578,43 +515,43 @@
       ],
       "bin": true
     },
-    "@biomejs/cli-darwin-arm64@2.4.14": {
-      "integrity": "sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q==",
+    "@biomejs/cli-darwin-arm64@2.4.15": {
+      "integrity": "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg==",
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "@biomejs/cli-darwin-x64@2.4.14": {
-      "integrity": "sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q==",
+    "@biomejs/cli-darwin-x64@2.4.15": {
+      "integrity": "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ==",
       "os": ["darwin"],
       "cpu": ["x64"]
     },
-    "@biomejs/cli-linux-arm64-musl@2.4.14": {
-      "integrity": "sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A==",
+    "@biomejs/cli-linux-arm64-musl@2.4.15": {
+      "integrity": "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@biomejs/cli-linux-arm64@2.4.14": {
-      "integrity": "sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==",
+    "@biomejs/cli-linux-arm64@2.4.15": {
+      "integrity": "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@biomejs/cli-linux-x64-musl@2.4.14": {
-      "integrity": "sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==",
+    "@biomejs/cli-linux-x64-musl@2.4.15": {
+      "integrity": "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@biomejs/cli-linux-x64@2.4.14": {
-      "integrity": "sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==",
+    "@biomejs/cli-linux-x64@2.4.15": {
+      "integrity": "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@biomejs/cli-win32-arm64@2.4.14": {
-      "integrity": "sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==",
+    "@biomejs/cli-win32-arm64@2.4.15": {
+      "integrity": "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==",
       "os": ["win32"],
       "cpu": ["arm64"]
     },
-    "@biomejs/cli-win32-x64@2.4.14": {
-      "integrity": "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA==",
+    "@biomejs/cli-win32-x64@2.4.15": {
+      "integrity": "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ==",
       "os": ["win32"],
       "cpu": ["x64"]
     },
@@ -808,15 +745,15 @@
     "@csstools/color-helpers@6.0.2": {
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="
     },
-    "@csstools/css-calc@3.2.0_@csstools+css-parser-algorithms@4.0.0__@csstools+css-tokenizer@4.0.0_@csstools+css-tokenizer@4.0.0": {
-      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+    "@csstools/css-calc@3.2.1_@csstools+css-parser-algorithms@4.0.0__@csstools+css-tokenizer@4.0.0_@csstools+css-tokenizer@4.0.0": {
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
       "dependencies": [
         "@csstools/css-parser-algorithms",
         "@csstools/css-tokenizer"
       ]
     },
-    "@csstools/css-color-parser@4.1.0_@csstools+css-parser-algorithms@4.0.0__@csstools+css-tokenizer@4.0.0_@csstools+css-tokenizer@4.0.0": {
-      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+    "@csstools/css-color-parser@4.1.1_@csstools+css-parser-algorithms@4.0.0__@csstools+css-tokenizer@4.0.0_@csstools+css-tokenizer@4.0.0": {
+      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
       "dependencies": [
         "@csstools/color-helpers",
         "@csstools/css-calc",
@@ -830,8 +767,8 @@
         "@csstools/css-tokenizer"
       ]
     },
-    "@csstools/css-syntax-patches-for-csstree@1.1.3_css-tree@3.2.1": {
-      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+    "@csstools/css-syntax-patches-for-csstree@1.1.4_css-tree@3.2.1": {
+      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
       "dependencies": [
         "css-tree"
       ],
@@ -1232,10 +1169,10 @@
         "semver"
       ]
     },
-    "@inkjs/ui@2.0.0_ink@7.0.2__@types+react@19.2.14__react@19.2.6_@types+react@19.2.14_react@19.2.6": {
+    "@inkjs/ui@2.0.0_ink@7.0.3__@types+react@19.2.14__react@19.2.6_@types+react@19.2.14_react@19.2.6": {
       "integrity": "sha512-5+8fJmwtF9UvikzLfph9sA+LS+l37Ij/szQltkuXLOAXwNkBX9innfzh4pLGXIB59vKEQUtc6D4qGvhD7h3pAg==",
       "dependencies": [
-        "chalk@5.6.2",
+        "chalk",
         "cli-spinners",
         "deepmerge",
         "figures",
@@ -1506,7 +1443,7 @@
         "@hono/node-server",
         "ajv@8.20.0",
         "ajv-formats",
-        "content-type",
+        "content-type@1.0.5",
         "cors",
         "cross-spawn",
         "eventsource",
@@ -1528,7 +1465,7 @@
         "@hono/node-server",
         "ajv@8.20.0",
         "ajv-formats",
-        "content-type",
+        "content-type@1.0.5",
         "cors",
         "cross-spawn",
         "eventsource",
@@ -1577,9 +1514,6 @@
         "@nodelib/fs.scandir",
         "fastq"
       ]
-    },
-    "@opentelemetry/api@1.9.0": {
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
     },
     "@opentelemetry/api@1.9.1": {
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="
@@ -1817,7 +1751,7 @@
         "@redocly/ajv",
         "@redocly/config",
         "colorette@1.4.0",
-        "https-proxy-agent",
+        "https-proxy-agent@7.0.6",
         "js-levenshtein",
         "js-yaml",
         "minimatch@5.1.9",
@@ -2067,7 +2001,7 @@
         "retry@0.13.1"
       ]
     },
-    "@standard-community/standard-json@0.3.5_@types+json-schema@7.0.15_zod@4.4.3": {
+    "@standard-community/standard-json@0.3.5_@standard-schema+spec@1.1.0_@types+json-schema@7.0.15_quansync@0.2.11_zod@4.4.3": {
       "integrity": "sha512-4+ZPorwDRt47i+O7RjyuaxHRK/37QY/LmgxlGrRrSTLYoFatEOzvqIc85GTlM18SFZ5E91C+v0o/M37wZPpUHA==",
       "dependencies": [
         "@standard-schema/spec",
@@ -2079,7 +2013,7 @@
         "zod"
       ]
     },
-    "@standard-community/standard-openapi@0.2.9_@standard-community+standard-json@0.3.5__@types+json-schema@7.0.15__zod@4.4.3_openapi-types@12.1.3_zod@4.4.3": {
+    "@standard-community/standard-openapi@0.2.9_@standard-community+standard-json@0.3.5__@standard-schema+spec@1.1.0__@types+json-schema@7.0.15__quansync@0.2.11__zod@4.4.3_@standard-schema+spec@1.1.0_openapi-types@12.1.3_zod@4.4.3_@types+json-schema@7.0.15_quansync@0.2.11": {
       "integrity": "sha512-htj+yldvN1XncyZi4rehbf9kLbu8os2Ke/rfqoZHCMHuw34kiF3LP/yQPdA0tQ940y8nDq3Iou8R3wG+AGGyvg==",
       "dependencies": [
         "@standard-community/standard-json",
@@ -2109,22 +2043,22 @@
         "acorn"
       ]
     },
-    "@sveltejs/adapter-auto@7.0.1_@sveltejs+kit@2.59.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.55.5___vite@7.3.3____@types+node@25.6.2____yaml@2.8.4___@types+node@25.6.2___yaml@2.8.4__svelte@5.55.5__typescript@5.9.3__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4": {
+    "@sveltejs/adapter-auto@7.0.1_@sveltejs+kit@2.59.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.55.5___vite@7.3.3____@types+node@25.7.0____yaml@2.9.0___@types+node@25.7.0___yaml@2.9.0__svelte@5.55.5__typescript@5.9.3__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_yaml@2.9.0": {
       "integrity": "sha512-dvuPm1E7M9NI/+canIQ6KKQDU2AkEefEZ2Dp7cY6uKoPq9Z/PhOXABe526UdW2mN986gjVkuSLkOYIBnS/M2LQ==",
       "dependencies": [
         "@sveltejs/kit"
       ]
     },
-    "@sveltejs/adapter-static@3.0.10_@sveltejs+kit@2.59.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.55.5___vite@7.3.3____@types+node@25.6.2____yaml@2.8.4___@types+node@25.6.2___yaml@2.8.4__svelte@5.55.5__typescript@5.9.3__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4": {
+    "@sveltejs/adapter-static@3.0.10_@sveltejs+kit@2.59.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.55.5___vite@7.3.3____@types+node@25.7.0____yaml@2.9.0___@types+node@25.7.0___yaml@2.9.0__svelte@5.55.5__typescript@5.9.3__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_yaml@2.9.0": {
       "integrity": "sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew==",
       "dependencies": [
         "@sveltejs/kit"
       ]
     },
-    "@sveltejs/kit@2.59.1_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_yaml@2.8.4": {
+    "@sveltejs/kit@2.59.1_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_yaml@2.9.0": {
       "integrity": "sha512-d8OON70AphLdDesuTIl//M2O6fRTIicX8aYv8vhCiYEhTTI2OboKqey0Hu1A4VFhqwgqtq0vKDmPFGkw8kKmgw==",
       "dependencies": [
-        "@opentelemetry/api@1.9.1",
+        "@opentelemetry/api",
         "@standard-schema/spec",
         "@sveltejs/acorn-typescript",
         "@sveltejs/vite-plugin-svelte",
@@ -2143,7 +2077,7 @@
         "vite"
       ],
       "optionalPeers": [
-        "@opentelemetry/api@1.9.1",
+        "@opentelemetry/api",
         "typescript"
       ],
       "bin": true
@@ -2160,7 +2094,7 @@
       ],
       "bin": true
     },
-    "@sveltejs/vite-plugin-svelte-inspector@5.0.2_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_svelte@5.55.5_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_yaml@2.8.4": {
+    "@sveltejs/vite-plugin-svelte-inspector@5.0.2_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_svelte@5.55.5_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_yaml@2.9.0": {
       "integrity": "sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig==",
       "dependencies": [
         "@sveltejs/vite-plugin-svelte",
@@ -2169,7 +2103,7 @@
         "vite"
       ]
     },
-    "@sveltejs/vite-plugin-svelte@6.2.4_svelte@5.55.5_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_yaml@2.8.4": {
+    "@sveltejs/vite-plugin-svelte@6.2.4_svelte@5.55.5_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_yaml@2.9.0": {
       "integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
       "dependencies": [
         "@sveltejs/vite-plugin-svelte-inspector",
@@ -2187,14 +2121,14 @@
         "tslib"
       ]
     },
-    "@tanstack/query-core@5.100.9": {
-      "integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ=="
+    "@tanstack/query-core@5.100.10": {
+      "integrity": "sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w=="
     },
     "@tanstack/store@0.11.0": {
       "integrity": "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw=="
     },
-    "@tanstack/svelte-query@6.1.28_svelte@5.55.5": {
-      "integrity": "sha512-B4uh/fvn+t67LyWzY8Sb+yqyxJS2hc27Nwf+bfz7vy+ilzfJIHORoCm9/6Arsg4pdH8DCBMLMWZTvMgvSUd/pg==",
+    "@tanstack/svelte-query@6.1.29_svelte@5.55.5": {
+      "integrity": "sha512-qB6hv21JzGvUtKcqUFhbhYEp1qp2/x/PgBaeQVNCkz+BvygLCv/+OMnrzzi5hLoIDJgIbEtQSoX3xW85OYJ9JA==",
       "dependencies": [
         "@tanstack/query-core",
         "svelte"
@@ -2404,8 +2338,8 @@
         "form-data"
       ]
     },
-    "@types/node@25.6.2": {
-      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
+    "@types/node@25.7.0": {
+      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
       "dependencies": [
         "undici-types"
       ]
@@ -2449,8 +2383,8 @@
         "@types/node"
       ]
     },
-    "@typescript-eslint/eslint-plugin@8.59.2_@typescript-eslint+parser@8.59.2__eslint@10.3.0__typescript@5.9.3_eslint@10.3.0_typescript@5.9.3": {
-      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
+    "@typescript-eslint/eslint-plugin@8.59.3_@typescript-eslint+parser@8.59.3__eslint@10.3.0__typescript@5.9.3_eslint@10.3.0_typescript@5.9.3": {
+      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
       "dependencies": [
         "@eslint-community/regexpp",
         "@typescript-eslint/parser",
@@ -2465,8 +2399,8 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/parser@8.59.2_eslint@10.3.0_typescript@5.9.3": {
-      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
+    "@typescript-eslint/parser@8.59.3_eslint@10.3.0_typescript@5.9.3": {
+      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
       "dependencies": [
         "@typescript-eslint/scope-manager",
         "@typescript-eslint/types",
@@ -2477,8 +2411,8 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/project-service@8.59.2_typescript@5.9.3": {
-      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
+    "@typescript-eslint/project-service@8.59.3_typescript@5.9.3": {
+      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
       "dependencies": [
         "@typescript-eslint/tsconfig-utils",
         "@typescript-eslint/types",
@@ -2486,21 +2420,21 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/scope-manager@8.59.2": {
-      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
+    "@typescript-eslint/scope-manager@8.59.3": {
+      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
       "dependencies": [
         "@typescript-eslint/types",
         "@typescript-eslint/visitor-keys"
       ]
     },
-    "@typescript-eslint/tsconfig-utils@8.59.2_typescript@5.9.3": {
-      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
+    "@typescript-eslint/tsconfig-utils@8.59.3_typescript@5.9.3": {
+      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
       "dependencies": [
         "typescript"
       ]
     },
-    "@typescript-eslint/type-utils@8.59.2_eslint@10.3.0_typescript@5.9.3": {
-      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
+    "@typescript-eslint/type-utils@8.59.3_eslint@10.3.0_typescript@5.9.3": {
+      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
       "dependencies": [
         "@typescript-eslint/types",
         "@typescript-eslint/typescript-estree",
@@ -2511,11 +2445,11 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/types@8.59.2": {
-      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q=="
+    "@typescript-eslint/types@8.59.3": {
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg=="
     },
-    "@typescript-eslint/typescript-estree@8.59.2_typescript@5.9.3": {
-      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
+    "@typescript-eslint/typescript-estree@8.59.3_typescript@5.9.3": {
+      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
       "dependencies": [
         "@typescript-eslint/project-service",
         "@typescript-eslint/tsconfig-utils",
@@ -2529,8 +2463,8 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/utils@8.59.2_eslint@10.3.0_typescript@5.9.3": {
-      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
+    "@typescript-eslint/utils@8.59.3_eslint@10.3.0_typescript@5.9.3": {
+      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
       "dependencies": [
         "@eslint-community/eslint-utils",
         "@typescript-eslint/scope-manager",
@@ -2540,8 +2474,8 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/visitor-keys@8.59.2": {
-      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
+    "@typescript-eslint/visitor-keys@8.59.3": {
+      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
       "dependencies": [
         "@typescript-eslint/types",
         "eslint-visitor-keys@5.0.1"
@@ -2553,7 +2487,7 @@
     "@vercel/oidc@3.2.0": {
       "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="
     },
-    "@vitest/coverage-v8@4.1.5_vitest@4.1.5_@opentelemetry+api@1.9.1_@types+node@25.6.2_happy-dom@20.9.0_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4": {
+    "@vitest/coverage-v8@4.1.5_vitest@4.1.5_@opentelemetry+api@1.9.1_@types+node@25.7.0_happy-dom@20.9.0_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_yaml@2.9.0": {
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dependencies": [
         "@bcoe/v8-coverage",
@@ -2580,7 +2514,7 @@
         "tinyrainbow"
       ]
     },
-    "@vitest/mocker@4.1.5_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_yaml@2.8.4": {
+    "@vitest/mocker@4.1.5_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_yaml@2.9.0": {
       "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dependencies": [
         "@vitest/spy",
@@ -2661,6 +2595,12 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "bin": true
     },
+    "agent-base@6.0.2": {
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": [
+        "debug"
+      ]
+    },
     "agent-base@7.1.4": {
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
     },
@@ -2673,13 +2613,13 @@
         "zod"
       ]
     },
-    "ai@6.0.177_zod@4.4.3": {
-      "integrity": "sha512-1xQtbeWwNcLyyM86ixZhkKvT+WRXc1lvarIKqPVtsyn8F9NDikwUMBqYu+aQKDgMht50SMXh4qboYuU8MeHZZA==",
+    "ai@6.0.180_zod@4.4.3": {
+      "integrity": "sha512-tOyRbwD0PEjMZKGvYQcTsv95K2zktwwNhQ49QOUAh0g8MNprO7ELIO1SgANMuPc0BFtkP6Ny6OAdjq3TtxLCbQ==",
       "dependencies": [
         "@ai-sdk/gateway",
         "@ai-sdk/provider",
         "@ai-sdk/provider-utils",
-        "@opentelemetry/api@1.9.0",
+        "@opentelemetry/api",
         "zod"
       ]
     },
@@ -2719,17 +2659,8 @@
         "environment"
       ]
     },
-    "ansi-regex@5.0.1": {
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
-    },
     "ansi-regex@6.2.2": {
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="
-    },
-    "ansi-styles@4.3.0": {
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dependencies": [
-        "color-convert"
-      ]
     },
     "ansi-styles@6.2.3": {
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="
@@ -2765,11 +2696,12 @@
     "auto-bind@5.0.1": {
       "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="
     },
-    "axios@1.16.0": {
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+    "axios@1.16.1": {
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "dependencies": [
         "follow-redirects",
         "form-data",
+        "https-proxy-agent@5.0.1",
         "proxy-from-env"
       ]
     },
@@ -2795,7 +2727,7 @@
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "dependencies": [
         "bytes",
-        "content-type",
+        "content-type@1.0.5",
         "debug",
         "http-errors",
         "iconv-lite",
@@ -2854,13 +2786,6 @@
     },
     "chai@6.2.2": {
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="
-    },
-    "chalk@4.1.2": {
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dependencies": [
-        "ansi-styles@4.3.0",
-        "supports-color@7.2.0"
-      ]
     },
     "chalk@5.6.2": {
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
@@ -2936,19 +2861,11 @@
         "string-width@8.2.1"
       ]
     },
-    "cliui@8.0.1": {
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dependencies": [
-        "string-width@4.2.3",
-        "strip-ansi@6.0.1",
-        "wrap-ansi@7.0.0"
-      ]
-    },
     "cliui@9.0.1": {
       "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
       "dependencies": [
         "string-width@7.2.0",
-        "strip-ansi@7.2.0",
+        "strip-ansi",
         "wrap-ansi@9.0.2"
       ]
     },
@@ -2973,15 +2890,6 @@
         "@codemirror/view"
       ]
     },
-    "color-convert@2.0.1": {
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dependencies": [
-        "color-name"
-      ]
-    },
-    "color-name@1.1.4": {
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
     "colorette@1.4.0": {
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
     },
@@ -3000,23 +2908,14 @@
     "commander@14.0.3": {
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="
     },
-    "concurrently@9.2.1": {
-      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
-      "dependencies": [
-        "chalk@4.1.2",
-        "rxjs",
-        "shell-quote",
-        "supports-color@8.1.1",
-        "tree-kill",
-        "yargs@17.7.2"
-      ],
-      "bin": true
-    },
     "content-disposition@1.1.0": {
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="
     },
     "content-type@1.0.5": {
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
+    },
+    "content-type@2.0.0": {
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="
     },
     "convert-source-map@2.0.0": {
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
@@ -3165,8 +3064,8 @@
         "undici@6.24.1"
       ]
     },
-    "dompurify@3.4.2": {
-      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
+    "dompurify@3.4.3": {
+      "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
       "optionalDependencies": [
         "@types/trusted-types"
       ]
@@ -3193,9 +3092,6 @@
     },
     "emoji-regex@10.6.0": {
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
-    },
-    "emoji-regex@8.0.0": {
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "encodeurl@2.0.0": {
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
@@ -3403,8 +3299,8 @@
         "estraverse"
       ]
     },
-    "esrap@2.2.6": {
-      "integrity": "sha512-WN0clHt0a4mzC780UBVVBpsj4vSSjOFNRd2WjYtduB9HeKxm1sjHMNUwLEHVjI3FdCQD/Hurgz9ftbKEzP79Ow==",
+    "esrap@2.2.8": {
+      "integrity": "sha512-MPweq2EvEGj8jwOI7Hgycw/QIHzqA1EbAM8lG7p+FBfZbZq/hQ6h3AMsqnu/djzisH1KVWNzbb7LSgIVtMlPSg==",
       "dependencies": [
         "@jridgewell/sourcemap-codec"
       ]
@@ -3461,7 +3357,7 @@
         "accepts",
         "body-parser",
         "content-disposition",
-        "content-type",
+        "content-type@1.0.5",
         "cookie@0.7.2",
         "cookie-signature",
         "debug",
@@ -3741,7 +3637,7 @@
         "@types/hast"
       ]
     },
-    "hono-openapi@1.3.0_@hono+standard-validator@0.2.2__@standard-schema+spec@1.1.0__hono@4.12.18_hono@4.12.18_zod@4.4.3": {
+    "hono-openapi@1.3.0_@hono+standard-validator@0.2.2__@standard-schema+spec@1.1.0__hono@4.12.18_@standard-community+standard-json@0.3.5__@standard-schema+spec@1.1.0__@types+json-schema@7.0.15__quansync@0.2.11__zod@4.4.3_@standard-community+standard-openapi@0.2.9__@standard-community+standard-json@0.3.5___@standard-schema+spec@1.1.0___@types+json-schema@7.0.15___quansync@0.2.11___zod@4.4.3__@standard-schema+spec@1.1.0__openapi-types@12.1.3__zod@4.4.3__@types+json-schema@7.0.15__quansync@0.2.11_@types+json-schema@7.0.15_hono@4.12.18_openapi-types@12.1.3_@standard-schema+spec@1.1.0_quansync@0.2.11_zod@4.4.3": {
       "integrity": "sha512-xDvCWpWEIv0weEmnl3EjRQzqbHIO8LnfzMuYOCmbuyE5aes6aXxLg4vM3ybnoZD5TiTUkA6PuRQPJs3R7WRBig==",
       "dependencies": [
         "@hono/standard-validator",
@@ -3790,14 +3686,21 @@
     "http-proxy-agent@7.0.2": {
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dependencies": [
-        "agent-base",
+        "agent-base@7.1.4",
+        "debug"
+      ]
+    },
+    "https-proxy-agent@5.0.1": {
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": [
+        "agent-base@6.0.2",
         "debug"
       ]
     },
     "https-proxy-agent@7.0.6": {
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dependencies": [
-        "agent-base",
+        "agent-base@7.1.4",
         "debug"
       ]
     },
@@ -3834,15 +3737,15 @@
     "inherits@2.0.4": {
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "ink@7.0.2_@types+react@19.2.14_react@19.2.6": {
-      "integrity": "sha512-cnkE2SsDC/gieJ+BD8+gWpXrZPMInv7agBYN5gcKVlQZYp+IKa/FKM5bp1OIuJFp3ZIuRK7ZNxY4MZR3tUzyfQ==",
+    "ink@7.0.3_@types+react@19.2.14_react@19.2.6": {
+      "integrity": "sha512-5kxHkIj9+RuqCU3zyvP4qvYWNOSHP2TW/SHayHGHOmk87KwfVcZwvJGemi9ch+ci2gXUqerK/Eh2DGEDt5q45g==",
       "dependencies": [
         "@alcalzone/ansi-tokenize",
         "@types/react",
         "ansi-escapes",
-        "ansi-styles@6.2.3",
+        "ansi-styles",
         "auto-bind",
-        "chalk@5.6.2",
+        "chalk",
         "cli-boxes",
         "cli-cursor@4.0.0",
         "cli-truncate@6.0.0",
@@ -3880,9 +3783,6 @@
     },
     "is-extglob@2.1.1": {
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
-    },
-    "is-fullwidth-code-point@3.0.0": {
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-fullwidth-code-point@5.1.0": {
       "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
@@ -4001,7 +3901,7 @@
         "decimal.js",
         "html-encoding-sniffer",
         "http-proxy-agent",
-        "https-proxy-agent",
+        "https-proxy-agent@7.0.6",
         "is-potential-custom-element-name",
         "parse5",
         "saxes",
@@ -4124,7 +4024,7 @@
         "strip-json-comments",
         "tinyglobby",
         "unbash",
-        "yaml@2.8.4",
+        "yaml@2.9.0",
         "zod"
       ],
       "bin": true
@@ -4165,7 +4065,7 @@
         "picomatch@4.0.4",
         "string-argv",
         "tinyexec",
-        "yaml@2.8.4"
+        "yaml@2.9.0"
       ],
       "bin": true
     },
@@ -4228,7 +4128,7 @@
         "ansi-escapes",
         "cli-cursor@5.0.0",
         "slice-ansi@7.1.2",
-        "strip-ansi@7.2.0",
+        "strip-ansi",
         "wrap-ansi@9.0.2"
       ]
     },
@@ -5081,8 +4981,8 @@
     "prelude-ls@1.2.1": {
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
     },
-    "prettier-plugin-svelte@3.5.1_prettier@3.8.3_svelte@5.55.5": {
-      "integrity": "sha512-65+fr5+cgIKWKiqM1Doum4uX6bY8iFCdztvvp2RcF+AJoieaw9kJOFMNcJo/bkmKYsxFaM9OsVZK/gWauG/5mg==",
+    "prettier-plugin-svelte@3.5.2_prettier@3.8.3_svelte@5.55.5": {
+      "integrity": "sha512-ItFouLvzSFE3ulNl4DKoWM3BGcbDCNVpIyy/Y3F2gC3aNiGLxtFUdffVqO5Z5hhYG+DFT5KULWaxmeFFpdbvaQ==",
       "dependencies": [
         "prettier",
         "svelte"
@@ -5116,8 +5016,8 @@
     "proxy-from-env@2.1.0": {
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
     },
-    "publint@0.3.20": {
-      "integrity": "sha512-UWqFYP7VBVCe9l/leEEGJrDs6Am4K4KapLmLi5qbt+9fA+Ny38ghdW+bw1nYfVqCK8/3kgsxjjhFjTYqYYRpyw==",
+    "publint@0.3.21": {
+      "integrity": "sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==",
       "dependencies": [
         "@publint/pack",
         "package-manager-detector",
@@ -5242,9 +5142,6 @@
     "remend@1.3.0": {
       "integrity": "sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw=="
     },
-    "require-directory@2.1.1": {
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
-    },
     "require-from-string@2.0.2": {
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
@@ -5328,12 +5225,6 @@
         "queue-microtask"
       ]
     },
-    "rxjs@7.8.2": {
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dependencies": [
-        "tslib"
-      ]
-    },
     "sade@1.8.1": {
       "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
       "dependencies": [
@@ -5405,9 +5296,6 @@
     "shebang-regex@3.0.0": {
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
-    "shell-quote@1.8.3": {
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="
-    },
     "shiki@4.0.2": {
       "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
       "dependencies": [
@@ -5477,22 +5365,22 @@
     "slice-ansi@7.1.2": {
       "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
       "dependencies": [
-        "ansi-styles@6.2.3",
-        "is-fullwidth-code-point@5.1.0"
+        "ansi-styles",
+        "is-fullwidth-code-point"
       ]
     },
     "slice-ansi@8.0.0": {
       "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
       "dependencies": [
-        "ansi-styles@6.2.3",
-        "is-fullwidth-code-point@5.1.0"
+        "ansi-styles",
+        "is-fullwidth-code-point"
       ]
     },
     "slice-ansi@9.0.0": {
       "integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
       "dependencies": [
-        "ansi-styles@6.2.3",
-        "is-fullwidth-code-point@5.1.0"
+        "ansi-styles",
+        "is-fullwidth-code-point"
       ]
     },
     "smol-toml@1.6.1": {
@@ -5522,27 +5410,19 @@
     "string-argv@0.3.2": {
       "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="
     },
-    "string-width@4.2.3": {
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": [
-        "emoji-regex@8.0.0",
-        "is-fullwidth-code-point@3.0.0",
-        "strip-ansi@6.0.1"
-      ]
-    },
     "string-width@7.2.0": {
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dependencies": [
-        "emoji-regex@10.6.0",
+        "emoji-regex",
         "get-east-asian-width",
-        "strip-ansi@7.2.0"
+        "strip-ansi"
       ]
     },
     "string-width@8.2.1": {
       "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dependencies": [
         "get-east-asian-width",
-        "strip-ansi@7.2.0"
+        "strip-ansi"
       ]
     },
     "string_decoder@1.1.1": {
@@ -5558,16 +5438,10 @@
         "character-entities-legacy"
       ]
     },
-    "strip-ansi@6.0.1": {
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dependencies": [
-        "ansi-regex@5.0.1"
-      ]
-    },
     "strip-ansi@7.2.0": {
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dependencies": [
-        "ansi-regex@6.2.2"
+        "ansi-regex"
       ]
     },
     "strip-json-comments@5.0.3": {
@@ -5587,12 +5461,6 @@
     },
     "supports-color@7.2.0": {
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dependencies": [
-        "has-flag"
-      ]
-    },
-    "supports-color@8.1.1": {
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dependencies": [
         "has-flag"
       ]
@@ -5739,10 +5607,6 @@
         "punycode"
       ]
     },
-    "tree-kill@1.2.2": {
-      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
-      "bin": true
-    },
     "trim-lines@3.0.1": {
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="
     },
@@ -5788,16 +5652,16 @@
         "tagged-tag"
       ]
     },
-    "type-is@2.0.1": {
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+    "type-is@2.1.0": {
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "dependencies": [
-        "content-type",
+        "content-type@2.0.0",
         "media-typer",
         "mime-types@3.0.2"
       ]
     },
-    "typescript-eslint@8.59.2_eslint@10.3.0_typescript@5.9.3": {
-      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
+    "typescript-eslint@8.59.3_eslint@10.3.0_typescript@5.9.3": {
+      "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
       "dependencies": [
         "@typescript-eslint/eslint-plugin",
         "@typescript-eslint/parser",
@@ -5824,8 +5688,8 @@
     "unbash@3.0.0": {
       "integrity": "sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA=="
     },
-    "undici-types@7.19.2": {
-      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="
+    "undici-types@7.21.0": {
+      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="
     },
     "undici@6.24.1": {
       "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="
@@ -5915,7 +5779,7 @@
         "vfile-message"
       ]
     },
-    "vite@7.3.3_@types+node@25.6.2_yaml@2.8.4": {
+    "vite@7.3.3_@types+node@25.7.0_yaml@2.9.0": {
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dependencies": [
         "@types/node",
@@ -5925,18 +5789,18 @@
         "postcss",
         "rollup",
         "tinyglobby",
-        "yaml@2.8.4"
+        "yaml@2.9.0"
       ],
       "optionalDependencies": [
         "fsevents"
       ],
       "optionalPeers": [
         "@types/node",
-        "yaml@2.8.4"
+        "yaml@2.9.0"
       ],
       "bin": true
     },
-    "vitefu@1.1.3_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_yaml@2.8.4": {
+    "vitefu@1.1.3_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_yaml@2.9.0": {
       "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
       "dependencies": [
         "vite"
@@ -5945,10 +5809,10 @@
         "vite"
       ]
     },
-    "vitest@4.1.5_@opentelemetry+api@1.9.1_@types+node@25.6.2_@vitest+coverage-v8@4.1.5_happy-dom@20.9.0_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4": {
+    "vitest@4.1.5_@opentelemetry+api@1.9.1_@types+node@25.7.0_@vitest+coverage-v8@4.1.5_happy-dom@20.9.0_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_yaml@2.9.0": {
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dependencies": [
-        "@opentelemetry/api@1.9.1",
+        "@opentelemetry/api",
         "@types/node",
         "@vitest/coverage-v8",
         "@vitest/expect",
@@ -5974,7 +5838,7 @@
         "why-is-node-running"
       ],
       "optionalPeers": [
-        "@opentelemetry/api@1.9.1",
+        "@opentelemetry/api",
         "@types/node",
         "@vitest/coverage-v8",
         "happy-dom"
@@ -6047,32 +5911,24 @@
     "wrap-ansi@10.0.0": {
       "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
       "dependencies": [
-        "ansi-styles@6.2.3",
+        "ansi-styles",
         "string-width@8.2.1",
-        "strip-ansi@7.2.0"
-      ]
-    },
-    "wrap-ansi@7.0.0": {
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dependencies": [
-        "ansi-styles@4.3.0",
-        "string-width@4.2.3",
-        "strip-ansi@6.0.1"
+        "strip-ansi"
       ]
     },
     "wrap-ansi@9.0.2": {
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dependencies": [
-        "ansi-styles@6.2.3",
+        "ansi-styles",
         "string-width@7.2.0",
-        "strip-ansi@7.2.0"
+        "strip-ansi"
       ]
     },
     "wrappy@1.0.2": {
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
-    "ws@8.20.0": {
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="
+    "ws@8.20.1": {
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="
     },
     "xml-name-validator@5.0.0": {
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="
@@ -6080,8 +5936,8 @@
     "xmlchars@2.2.0": {
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
-    "xstate@5.31.0": {
-      "integrity": "sha512-5B+0DqC0uNUrcLUEY3pn3iNy+swvK2E0ZpYp5gnV3oxMX5y87vzXkU5YXv9CAtyG5c5FOJ1SzvTWHrwE8fMZNQ=="
+    "xstate@5.31.1": {
+      "integrity": "sha512-3P7t7GQ61BvLu+8Cj6Zq7rcS34vecL9pvfN2ucUWmIFIUG+rAREviOs4Xy4OO3BuJHSz6RLU8eqDXxSbVotjDQ=="
     },
     "y18n@5.0.8": {
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
@@ -6098,8 +5954,8 @@
     "yaml@1.10.3": {
       "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="
     },
-    "yaml@2.8.4": {
-      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+    "yaml@2.9.0": {
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
       "bin": true
     },
     "yargs-parser@21.1.1": {
@@ -6108,22 +5964,10 @@
     "yargs-parser@22.0.0": {
       "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="
     },
-    "yargs@17.7.2": {
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dependencies": [
-        "cliui@8.0.1",
-        "escalade",
-        "get-caller-file",
-        "require-directory",
-        "string-width@4.2.3",
-        "y18n",
-        "yargs-parser@21.1.1"
-      ]
-    },
     "yargs@18.0.0": {
       "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
       "dependencies": [
-        "cliui@9.0.1",
+        "cliui",
         "escalade",
         "get-caller-file",
         "string-width@7.2.0",

--- a/deno.lock
+++ b/deno.lock
@@ -3,30 +3,43 @@
   "specifiers": {
     "jsr:@db/sqlite@0.13": "0.13.0",
     "jsr:@denosaurs/plug@1": "1.1.0",
+    "jsr:@std/assert@1": "1.0.19",
+    "jsr:@std/assert@^1.0.16": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/async@1.0.15": "1.0.15",
-    "jsr:@std/async@^1.0.15": "1.0.15",
+    "jsr:@std/async@^1.0.15": "1.3.0",
+    "jsr:@std/async@^1.3.0": "1.3.0",
+    "jsr:@std/cli@^1.0.6": "1.0.29",
+    "jsr:@std/data-structures@^1.0.11": "1.0.11",
     "jsr:@std/dotenv@~0.225.5": "0.225.6",
     "jsr:@std/encoding@1": "1.0.10",
     "jsr:@std/encoding@1.0.10": "1.0.10",
     "jsr:@std/fmt@1": "1.0.10",
     "jsr:@std/fs@1": "1.0.23",
+    "jsr:@std/fs@1.0.13": "1.0.13",
+    "jsr:@std/fs@^1.0.23": "1.0.23",
     "jsr:@std/internal@^1.0.12": "1.0.13",
+    "jsr:@std/internal@^1.0.13": "1.0.13",
     "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/path@1": "1.1.4",
     "jsr:@std/path@1.0": "1.0.9",
     "jsr:@std/path@^1.1.4": "1.1.4",
+    "jsr:@std/streams@^1.0.17": "1.1.0",
+    "jsr:@std/tar@~0.1.9": "0.1.10",
+    "jsr:@std/testing@1": "1.0.18",
+    "jsr:@std/testing@^1.0.16": "1.0.18",
     "jsr:@std/yaml@1": "1.1.0",
-    "npm:@ai-sdk/anthropic@^3.0.76": "3.0.77_zod@4.4.3",
+    "npm:@ai-sdk/anthropic@^3.0.76": "3.0.76_zod@4.4.3",
     "npm:@ai-sdk/fireworks@2.0.52": "2.0.52_zod@4.4.3",
-    "npm:@ai-sdk/google@^3.0.71": "3.0.73_zod@4.4.3",
+    "npm:@ai-sdk/google@^3.0.71": "3.0.71_zod@4.4.3",
     "npm:@ai-sdk/groq@3.0.39": "3.0.39_zod@4.4.3",
     "npm:@ai-sdk/groq@^3.0.39": "3.0.39_zod@4.4.3",
-    "npm:@ai-sdk/mcp@^1.0.41": "1.0.42_zod@4.4.3",
+    "npm:@ai-sdk/mcp@^1.0.41": "1.0.41_zod@4.4.3",
     "npm:@ai-sdk/openai@^3.0.63": "3.0.63_zod@4.4.3",
     "npm:@ai-sdk/provider@^3.0.10": "3.0.10",
-    "npm:@ai-sdk/svelte@^4.0.177": "4.0.180_svelte@5.55.5_zod@4.4.3",
-    "npm:@anthropic-ai/claude-agent-sdk@~0.2.137": "0.2.140_zod@4.4.3",
-    "npm:@biomejs/biome@*": "2.4.15",
+    "npm:@ai-sdk/svelte@^4.0.177": "4.0.177_svelte@5.55.5_zod@4.4.3",
+    "npm:@anthropic-ai/claude-agent-sdk@~0.2.137": "0.2.138_zod@4.4.3",
+    "npm:@biomejs/biome@*": "2.4.14",
     "npm:@chat-adapter/discord@4.28.1": "4.28.1",
     "npm:@chat-adapter/slack@4.28.1": "4.28.1",
     "npm:@chat-adapter/teams@4.28.1": "4.28.1",
@@ -49,7 +62,7 @@
     "npm:@hubspot/api-client@^13.4.0": "13.5.0",
     "npm:@hubspot/api-client@^13.5.0": "13.5.0",
     "npm:@ianvs/prettier-plugin-sort-imports@^4.7.1": "4.7.1_prettier@3.8.3",
-    "npm:@inkjs/ui@2": "2.0.0_ink@7.0.3__@types+react@19.2.14__react@19.2.6_@types+react@19.2.14_react@19.2.6",
+    "npm:@inkjs/ui@2": "2.0.0_ink@7.0.2__@types+react@19.2.14__react@19.2.6_@types+react@19.2.14_react@19.2.6",
     "npm:@jsr/db__sqlite@0.12": "0.12.0",
     "npm:@jsr/std__async@1.0.15": "1.0.15",
     "npm:@jsr/std__async@^1.0.14": "1.0.15",
@@ -71,14 +84,14 @@
     "npm:@opentelemetry/api@^1.9.0": "1.9.1",
     "npm:@opentelemetry/api@^1.9.1": "1.9.1",
     "npm:@sendgrid/helpers@8": "8.0.0",
-    "npm:@sveltejs/adapter-auto@^7.0.1": "7.0.1_@sveltejs+kit@2.59.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.55.5___vite@7.3.3____@types+node@25.7.0____yaml@2.9.0___@types+node@25.7.0___yaml@2.9.0__svelte@5.55.5__typescript@5.9.3__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_yaml@2.9.0",
-    "npm:@sveltejs/adapter-static@^3.0.10": "3.0.10_@sveltejs+kit@2.59.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.55.5___vite@7.3.3____@types+node@25.7.0____yaml@2.9.0___@types+node@25.7.0___yaml@2.9.0__svelte@5.55.5__typescript@5.9.3__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_yaml@2.9.0",
-    "npm:@sveltejs/kit@^2.59.0": "2.59.1_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_yaml@2.9.0",
+    "npm:@sveltejs/adapter-auto@^7.0.1": "7.0.1_@sveltejs+kit@2.59.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.55.5___vite@7.3.3____@types+node@25.6.2____yaml@2.8.4___@types+node@25.6.2___yaml@2.8.4__svelte@5.55.5__typescript@5.9.3__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4",
+    "npm:@sveltejs/adapter-static@^3.0.10": "3.0.10_@sveltejs+kit@2.59.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.55.5___vite@7.3.3____@types+node@25.6.2____yaml@2.8.4___@types+node@25.6.2___yaml@2.8.4__svelte@5.55.5__typescript@5.9.3__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4",
+    "npm:@sveltejs/kit@^2.59.0": "2.59.1_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_yaml@2.8.4",
     "npm:@sveltejs/package@^2.5.7": "2.5.7_svelte@5.55.5_typescript@5.9.3",
-    "npm:@sveltejs/vite-plugin-svelte@^6.2.4": "6.2.4_svelte@5.55.5_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_yaml@2.9.0",
-    "npm:@sveltejs/vite-plugin-svelte@~6.2.4": "6.2.4_svelte@5.55.5_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_yaml@2.9.0",
-    "npm:@tanstack/query-core@^5.100.8": "5.100.10",
-    "npm:@tanstack/svelte-query@^6.1.28": "6.1.29_svelte@5.55.5",
+    "npm:@sveltejs/vite-plugin-svelte@^6.2.4": "6.2.4_svelte@5.55.5_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_yaml@2.8.4",
+    "npm:@sveltejs/vite-plugin-svelte@~6.2.4": "6.2.4_svelte@5.55.5_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_yaml@2.8.4",
+    "npm:@tanstack/query-core@^5.100.8": "5.100.9",
+    "npm:@tanstack/svelte-query@^6.1.28": "6.1.28_svelte@5.55.5",
     "npm:@tanstack/svelte-table@9.0.0-alpha.41": "9.0.0-alpha.41_svelte@5.55.5",
     "npm:@tanstack/svelte-table@^9.0.0-alpha.41": "9.0.0-alpha.41_svelte@5.55.5",
     "npm:@tanstack/svelte-virtual@~3.13.24": "3.13.24_svelte@5.55.5",
@@ -88,25 +101,26 @@
     "npm:@total-typescript/ts-reset@~0.6.1": "0.6.1",
     "npm:@types/deno@2.5.0": "2.5.0",
     "npm:@types/markdown-it@^14.1.2": "14.1.2",
-    "npm:@types/node@25": "25.7.0",
+    "npm:@types/node@25": "25.6.2",
     "npm:@types/papaparse@^5.5.2": "5.5.2",
     "npm:@types/proper-lockfile@^4.1.4": "4.1.4",
     "npm:@types/react@^19.2.14": "19.2.14",
     "npm:@types/turndown@^5.0.6": "5.0.6",
-    "npm:@vitest/coverage-v8@4.1.5": "4.1.5_vitest@4.1.5_@opentelemetry+api@1.9.1_@types+node@25.7.0_happy-dom@20.9.0_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_yaml@2.9.0",
+    "npm:@vitest/coverage-v8@4.1.5": "4.1.5_vitest@4.1.5_@opentelemetry+api@1.9.1_@types+node@25.6.2_happy-dom@20.9.0_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4",
     "npm:@worker-tools/html-rewriter@0.1.0-pre.19": "0.1.0-pre.19",
     "npm:@worker-tools/html-rewriter@~0.1.0-pre.17": "0.1.0-pre.19",
     "npm:@xmldom/xmldom@~0.9.10": "0.9.10",
     "npm:ai-sdk-provider-claude-code@^3.4.4": "3.4.4_zod@4.4.3",
-    "npm:ai@^6.0.141": "6.0.180_zod@4.4.3",
-    "npm:ai@^6.0.177": "6.0.180_zod@4.4.3",
+    "npm:ai@^6.0.141": "6.0.177_zod@4.4.3",
+    "npm:ai@^6.0.177": "6.0.177_zod@4.4.3",
     "npm:chat@4.28.1": "4.28.1",
     "npm:chat@^4.28.1": "4.28.1",
     "npm:codemirror@^6.0.2": "6.0.2",
+    "npm:concurrently@^9.2.1": "9.2.1",
     "npm:cookie@^1.0.2": "1.1.1",
     "npm:cron-parser@^5.5.0": "5.5.0",
     "npm:diff@9": "9.0.0",
-    "npm:dompurify@^3.4.2": "3.4.3",
+    "npm:dompurify@^3.4.2": "3.4.2",
     "npm:dotenv@17.4.2": "17.4.2",
     "npm:dotenv@^17.4.2": "17.4.2",
     "npm:eslint-config-prettier@^10.1.8": "10.1.8_eslint@10.3.0",
@@ -117,10 +131,10 @@
     "npm:globals@^17.6.0": "17.6.0",
     "npm:gunshi@~0.29.5": "0.29.5",
     "npm:happy-dom@^20.9.0": "20.9.0",
-    "npm:hono-openapi@^1.3.0": "1.3.0_@hono+standard-validator@0.2.2__@standard-schema+spec@1.1.0__hono@4.12.18_@standard-community+standard-json@0.3.5__@standard-schema+spec@1.1.0__@types+json-schema@7.0.15__quansync@0.2.11__zod@4.4.3_@standard-community+standard-openapi@0.2.9__@standard-community+standard-json@0.3.5___@standard-schema+spec@1.1.0___@types+json-schema@7.0.15___quansync@0.2.11___zod@4.4.3__@standard-schema+spec@1.1.0__openapi-types@12.1.3__zod@4.4.3__@types+json-schema@7.0.15__quansync@0.2.11_@types+json-schema@7.0.15_hono@4.12.18_openapi-types@12.1.3_@standard-schema+spec@1.1.0_quansync@0.2.11_zod@4.4.3",
+    "npm:hono-openapi@^1.3.0": "1.3.0_@hono+standard-validator@0.2.2__@standard-schema+spec@1.1.0__hono@4.12.18_hono@4.12.18_zod@4.4.3",
     "npm:hono@4.12.18": "4.12.18",
     "npm:immer@^11.1.8": "11.1.8",
-    "npm:ink@^7.0.1": "7.0.3_@types+react@19.2.14_react@19.2.6",
+    "npm:ink@^7.0.1": "7.0.2_@types+react@19.2.14_react@19.2.6",
     "npm:isomorphic-dompurify@^2.16.0": "2.36.0",
     "npm:jira.js@^5.3.1": "5.3.1",
     "npm:jose@6.2.3": "6.2.3",
@@ -129,6 +143,7 @@
     "npm:js-levenshtein@^1.1.6": "1.1.6",
     "npm:jsonrepair@^3.14.0": "3.14.0",
     "npm:jszip@^3.10.1": "3.10.1",
+    "npm:knip@*": "6.11.0_@emnapi+core@1.10.0_@emnapi+runtime@1.10.0",
     "npm:knip@6.11.0": "6.11.0_@emnapi+core@1.10.0_@emnapi+runtime@1.10.0",
     "npm:lint-staged@^16.4.0": "16.4.0",
     "npm:markdown-it@^14.1.1": "14.1.1",
@@ -136,6 +151,7 @@
     "npm:minimatch@^10.2.5": "10.2.5",
     "npm:nanoid@5.1.11": "5.1.11",
     "npm:nanoid@^5.1.6": "5.1.11",
+    "npm:nats@2": "2.29.3",
     "npm:nats@^2.29.3": "2.29.3",
     "npm:oauth4webapi@3.8.6": "3.8.6",
     "npm:oauth4webapi@^3.8.3": "3.8.6",
@@ -146,10 +162,10 @@
     "npm:parallel-web@0.5.0": "0.5.0",
     "npm:postgres@3.4.9": "3.4.9",
     "npm:postgres@^3.4.7": "3.4.9",
-    "npm:prettier-plugin-svelte@^3.5.1": "3.5.2_prettier@3.8.3_svelte@5.55.5",
+    "npm:prettier-plugin-svelte@^3.5.1": "3.5.1_prettier@3.8.3_svelte@5.55.5",
     "npm:prettier@^3.8.3": "3.8.3",
     "npm:proper-lockfile@^4.1.2": "4.1.2",
-    "npm:publint@~0.3.18": "0.3.21",
+    "npm:publint@~0.3.18": "0.3.20",
     "npm:react@^19.2.5": "19.2.6",
     "npm:shiki@^4.0.2": "4.0.2",
     "npm:svelte-check@^4.4.7": "4.4.8_svelte@5.55.5_typescript@5.9.3",
@@ -157,16 +173,18 @@
     "npm:svelte@^5.55.5": "5.55.5",
     "npm:tar@^7.5.13": "7.5.15",
     "npm:turndown@7.2.4": "7.2.4",
-    "npm:typescript-eslint@^8.59.2": "8.59.3_eslint@10.3.0_typescript@5.9.3",
+    "npm:typescript-eslint@^8.59.2": "8.59.2_eslint@10.3.0_typescript@5.9.3",
     "npm:typescript@^5.9.3": "5.9.3",
     "npm:ulid@^3.0.2": "3.0.2",
     "npm:undici@^7.25.0": "7.25.0",
-    "npm:vite@^7.3.2": "7.3.3_@types+node@25.7.0_yaml@2.9.0",
-    "npm:vitest@^4.1.0": "4.1.5_@opentelemetry+api@1.9.1_@types+node@25.7.0_@vitest+coverage-v8@4.1.5_happy-dom@20.9.0_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_yaml@2.9.0",
-    "npm:vitest@^4.1.5": "4.1.5_@opentelemetry+api@1.9.1_@types+node@25.7.0_@vitest+coverage-v8@4.1.5_happy-dom@20.9.0_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_yaml@2.9.0",
-    "npm:xstate@^5.31.0": "5.31.1",
-    "npm:yaml@^2.8.4": "2.9.0",
+    "npm:vite@^7.3.2": "7.3.3_@types+node@25.6.2_yaml@2.8.4",
+    "npm:vitest@*": "4.1.5_@opentelemetry+api@1.9.1_@types+node@25.6.2_@vitest+coverage-v8@4.1.5_happy-dom@20.9.0_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4",
+    "npm:vitest@^4.1.0": "4.1.5_@opentelemetry+api@1.9.1_@types+node@25.6.2_@vitest+coverage-v8@4.1.5_happy-dom@20.9.0_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4",
+    "npm:vitest@^4.1.5": "4.1.5_@opentelemetry+api@1.9.1_@types+node@25.6.2_@vitest+coverage-v8@4.1.5_happy-dom@20.9.0_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4",
+    "npm:xstate@^5.31.0": "5.31.0",
+    "npm:yaml@^2.8.4": "2.8.4",
     "npm:yargs@18": "18.0.0",
+    "npm:zod@4": "4.4.3",
     "npm:zod@4.4.3": "4.4.3",
     "npm:zod@^4.2.1": "4.4.3",
     "npm:zod@^4.3.5": "4.4.3",
@@ -185,12 +203,30 @@
       "dependencies": [
         "jsr:@std/encoding@1",
         "jsr:@std/fmt",
-        "jsr:@std/fs",
+        "jsr:@std/fs@1",
         "jsr:@std/path@1"
+      ]
+    },
+    "@std/assert@1.0.19": {
+      "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.12"
       ]
     },
     "@std/async@1.0.15": {
       "integrity": "55d1d9d04f99403fe5730ab16bdcc3c47f658a6bf054cafb38a50f046238116e"
+    },
+    "@std/async@1.3.0": {
+      "integrity": "80485538a4f7baaa46bfe2246168069e02ed142b9f9079cd164f43bb060ad9e9",
+      "dependencies": [
+        "jsr:@std/data-structures"
+      ]
+    },
+    "@std/cli@1.0.29": {
+      "integrity": "fa4ef29130baa834d8a13b7d138240c3a2fcfba740bfb7afa646a360a15ec84f"
+    },
+    "@std/data-structures@1.0.11": {
+      "integrity": "53b98ed7efa61f107dfc14244bd2ec5557f7f7ee0bbaef6d449d7937facacb89"
     },
     "@std/dotenv@0.225.6": {
       "integrity": "1d6f9db72f565bd26790fa034c26e45ecb260b5245417be76c2279e5734c421b"
@@ -204,7 +240,7 @@
     "@std/fs@1.0.23": {
       "integrity": "3ecbae4ce4fee03b180fa710caff36bb5adb66631c46a6460aaad49515565a37",
       "dependencies": [
-        "jsr:@std/internal",
+        "jsr:@std/internal@^1.0.12",
         "jsr:@std/path@^1.1.4"
       ]
     },
@@ -220,7 +256,27 @@
     "@std/path@1.1.4": {
       "integrity": "1d2d43f39efb1b42f0b1882a25486647cb851481862dc7313390b2bb044314b5",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.12"
+      ]
+    },
+    "@std/streams@1.1.0": {
+      "integrity": "2f7024d841f343fd478afe0c958a3f0f068ef2a0d2bcc954f550f97ac1fa22e3"
+    },
+    "@std/tar@0.1.10": {
+      "integrity": "6bf907f3a4bc8bfef42973ba132d946756a6161ef6b914a9e1c06debe664db17",
+      "dependencies": [
+        "jsr:@std/streams"
+      ]
+    },
+    "@std/testing@1.0.18": {
+      "integrity": "d3152f57b11666bf6358d0e127c7e3488e91178b0c2d8fbf0793e1c53cd13cb1",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.19",
+        "jsr:@std/async@^1.3.0",
+        "jsr:@std/data-structures",
+        "jsr:@std/fs@^1.0.23",
+        "jsr:@std/internal@^1.0.13",
+        "jsr:@std/path@^1.1.4"
       ]
     },
     "@std/yaml@1.1.0": {
@@ -231,8 +287,8 @@
     "@acemir/cssom@0.9.31": {
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA=="
     },
-    "@ai-sdk/anthropic@3.0.77_zod@4.4.3": {
-      "integrity": "sha512-ML8C2M1YvPA1ulEx4TiyF0k1xvC2ikEiPBIC1PPQ0a5xELUGrO2lAaEzsTEoJ+eCeDd8PSBuFJjs+r+9yIwQXA==",
+    "@ai-sdk/anthropic@3.0.76_zod@4.4.3": {
+      "integrity": "sha512-kOuvT9e6PygFvgYpkr4v9gjvmcMPfJp79jaXjeRl9Gpoj2OXdtc3ero7o1ic+tiSBw5IMubxXFO68BCA/axGJA==",
       "dependencies": [
         "@ai-sdk/provider",
         "@ai-sdk/provider-utils",
@@ -248,8 +304,8 @@
         "zod"
       ]
     },
-    "@ai-sdk/gateway@3.0.114_zod@4.4.3": {
-      "integrity": "sha512-MqkZ5sd+qiq6RgIxELkoFQXg2/JwK+WCMaot7U+rtrZpWJl3fSyYvc28SC03b256o4F7OXjQtdjTqs81B2w+dA==",
+    "@ai-sdk/gateway@3.0.112_zod@4.4.3": {
+      "integrity": "sha512-jiBao9pR4owWyjo0BnuNc7WSQBGOD0thysE4AFgZXaG+zMFbISQXUkJr7ePw/phBvePy7jE5FSA2Lf7lwqUiiQ==",
       "dependencies": [
         "@ai-sdk/provider",
         "@ai-sdk/provider-utils",
@@ -257,8 +313,8 @@
         "zod"
       ]
     },
-    "@ai-sdk/google@3.0.73_zod@4.4.3": {
-      "integrity": "sha512-o2MuIeyvZrFIeIbnbA8Thrr63irdyUBh0uWBZ2lY6yFeXuE/tcwyXF74bDKS4KvTu84uFpQfpbS/LXHGKKXz+g==",
+    "@ai-sdk/google@3.0.71_zod@4.4.3": {
+      "integrity": "sha512-G86UtqkCKM8mQcvsA4FQ1WCRN+w1gl/sxuoYl5CJX5DFSUSkrLNKmLcvi3TtnMvKth5li8W/1h3emQSl2K+qnA==",
       "dependencies": [
         "@ai-sdk/provider",
         "@ai-sdk/provider-utils",
@@ -273,8 +329,8 @@
         "zod"
       ]
     },
-    "@ai-sdk/mcp@1.0.42_zod@4.4.3": {
-      "integrity": "sha512-ctRhX9vNLXvjGSFf+RlM+ZutIhlzIgMPWzo2BoJKfIW9JzLneA/57bZkkaUvWSdbYFu1FCyxMarNV/4D/pOUzA==",
+    "@ai-sdk/mcp@1.0.41_zod@4.4.3": {
+      "integrity": "sha512-AfA0jb6tTnfcieLx1d6breTmuae0fz67UNcBrCgZqPqaZ1NIlJT5uyXx+78pgYOuDHo0GtHECVhI1a9lkZnzgA==",
       "dependencies": [
         "@ai-sdk/provider",
         "@ai-sdk/provider-utils",
@@ -313,8 +369,8 @@
         "json-schema"
       ]
     },
-    "@ai-sdk/svelte@4.0.180_svelte@5.55.5_zod@4.4.3": {
-      "integrity": "sha512-learKGdmMX3qOmVR6KkipiSYab9UDTUGszj5nXuWCgB00PeCMhBTXX8R16Oa6K1FPHW1poVDudVk/JGX5Rn0FQ==",
+    "@ai-sdk/svelte@4.0.177_svelte@5.55.5_zod@4.4.3": {
+      "integrity": "sha512-8TKa0UFeK9TRoK9TXwW4J/QOF0uA6zZyRBrOv1htKt3d8B8wnPIwjJVC8ufWLjHTGy7YQgQ6yHOnP9Ki0SrS4Q==",
       "dependencies": [
         "@ai-sdk/provider-utils",
         "ai",
@@ -324,52 +380,52 @@
     "@alcalzone/ansi-tokenize@0.3.0": {
       "integrity": "sha512-p+CMKJ93HFmLkjXKlXiVGlMQEuRb6H0MokBSwUsX+S6BRX8eV5naFZpQJFfJHjRZY0Hmnqy1/r6UWl3x+19zYA==",
       "dependencies": [
-        "ansi-styles",
-        "is-fullwidth-code-point"
+        "ansi-styles@6.2.3",
+        "is-fullwidth-code-point@5.1.0"
       ]
     },
-    "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.140": {
-      "integrity": "sha512-zEbDsDKeoDO4DzbyX6wBVlcPhLy/gYiCrKzKnxmkOhyNtJBeshgiOTdr+M7WX1xcuI/M/UhEY+B9U6oo884lAQ==",
+    "@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.138": {
+      "integrity": "sha512-aObxJ/GeJ5UxT9N8XypUHPYQKpwYsRT5THiJl5E2pKEUk/Xt42gT55N5GV0TOjtgxVAnDMWjxTAgGCGoDzjgpg==",
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.140": {
-      "integrity": "sha512-BFJGeZEksvERy7mMJ0mkNAWoMrZOgl6XN/mKPaunGnaC/i+1ykx7xih7e58bRhsrzKzo2mnUrwtjiFyF3MFNRQ==",
+    "@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.138": {
+      "integrity": "sha512-ou3i1/gAf2PEgVl2WYJb7ZdE+KGwoB1I46JRhWHSC3uD6lb9HMZam233T/rlKCVX9e5dzfkujUOnmCkmXjgVGQ==",
       "os": ["darwin"],
       "cpu": ["x64"]
     },
-    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.140": {
-      "integrity": "sha512-nG7xLL0nKb4ymFVnX0QhSGLoyhh9fuuDpBR+TYz5O4ZQc2RVUMSMqGusqcCNEIGxAKQSVKWCf0WgpCG/edAO9Q==",
+    "@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.138": {
+      "integrity": "sha512-uZaEFND1pl7KD9tdYqj2hd6ktjlYizVmkHRgU2Aj/P1CC6WMDsKG+rqPP7dsVXO77gMXhL4xjjwwqMjxx83HkA==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.140": {
-      "integrity": "sha512-FauGGg3zikxrjAUnu+Pso6zD9Qv4Z2+QBiTiZqc12U+x4uoikNsplymUnsJ7MYD9VaTGmLJuZ9pCch0IiKrseQ==",
+    "@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.138": {
+      "integrity": "sha512-jp8lmAVe9uI9X5o+IYWFajLbN+Z80XogVX7NeyaenLHdpHkxg29Yf8pb6Os4OvHMjJOAdwDhPpXajf6RtBeEDA==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.140": {
-      "integrity": "sha512-EZ7VzOGmvft/1ymh2rwts5v3yPnsGGlGrTJlY2Dqnr1ABF43JIhEm1NFYrLnXQWSN74s5Pj8tgkPbYS9x4BhFA==",
+    "@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.138": {
+      "integrity": "sha512-T16F8Vkikb98E781ZM6Cx84yEBk+loSCqAObjaZ1hzQ1eKcpnxzSTF4rH2bz6N91dhFuCfIjFaBfNYg+oQA+yQ==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@anthropic-ai/claude-agent-sdk-linux-x64@0.2.140": {
-      "integrity": "sha512-7f627Tq2mIiwFoBYfCKTdEeZSP90r8UOWu/I5DezudTtwtoVl2zRaRCnJ8c4rW+Tzw+xWSfP/pHvR9bTQGXaOw==",
+    "@anthropic-ai/claude-agent-sdk-linux-x64@0.2.138": {
+      "integrity": "sha512-SLuUmu/nH1Wh0wnoXj/Bwh0nbDfEn9PgXqMsZHEUk3x1zxeR+6aRqFLjKZ8TawBey7xod7nfYUIjPnQx6IWDzg==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.140": {
-      "integrity": "sha512-9EOozRF+LTt3UedeJtjJXC8pj9VTAFtPBuB+/YUmcpmDAEH9qcWWknWhf7NDKTapKtBWkNP/387x+18L15MLqg==",
+    "@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.138": {
+      "integrity": "sha512-H/sD25fmMyEeJWamYmBKRS3E7jaIrg2S8KWxyR37P+xTZgkLe19sDTp7gYYywMXf1X9CJZJ8jJZ93qxINZoCeA==",
       "os": ["win32"],
       "cpu": ["arm64"]
     },
-    "@anthropic-ai/claude-agent-sdk-win32-x64@0.2.140": {
-      "integrity": "sha512-puQyWoYiqosjDEYULWAS/lBJse1vzib0NmQj/bYTirWCbtiUcu6ixKMd4NmLbE+Si/DKTB8XNz6hVZ/KckqeoQ==",
+    "@anthropic-ai/claude-agent-sdk-win32-x64@0.2.138": {
+      "integrity": "sha512-cSOdTH1OfIamVdJit9laWZiXne81ewgdP8MGh5HzLLLci0NGHkME7YxCWd0lYkCNkfiOEcToKU9axaZ+84jGiw==",
       "os": ["win32"],
       "cpu": ["x64"]
     },
-    "@anthropic-ai/claude-agent-sdk@0.2.140_zod@4.4.3": {
-      "integrity": "sha512-Zq2L7YCoTdbxTUi3/soN1axrTqbG7GoKuc6Im8EpkBRdwaY0D1W9+Ux3vAbV/cX8Qk31Vck7DQLZz1lGEArdoQ==",
+    "@anthropic-ai/claude-agent-sdk@0.2.138_zod@4.4.3": {
+      "integrity": "sha512-rH6dFI3DBBsPBPcHTBdTZCHA14OCt2t4+6XYi2MJB/GlFrnZvlWmMIk2z9uxAiZ05Txg8YbftgSuE5A1qpAXwg==",
       "dependencies": [
         "@anthropic-ai/sdk",
         "@modelcontextprotocol/sdk@1.29.0_zod@4.4.3",
@@ -501,8 +557,8 @@
     "@bcoe/v8-coverage@1.0.2": {
       "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA=="
     },
-    "@biomejs/biome@2.4.15": {
-      "integrity": "sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==",
+    "@biomejs/biome@2.4.14": {
+      "integrity": "sha512-TmAvxOEgrpLypzVGJ8FulIZnlyA9TxrO1hyqYrCz9r+bwma9xXxuLA5IuYnj55XQneFx460KjRbx6SWGLkg3bQ==",
       "optionalDependencies": [
         "@biomejs/cli-darwin-arm64",
         "@biomejs/cli-darwin-x64",
@@ -515,43 +571,43 @@
       ],
       "bin": true
     },
-    "@biomejs/cli-darwin-arm64@2.4.15": {
-      "integrity": "sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg==",
+    "@biomejs/cli-darwin-arm64@2.4.14": {
+      "integrity": "sha512-XvgoE9XOawUOQPdmvs4J7wPhi/DLwSCGks3AlPJDmh34O0awRTqCED1HRcRDdpf1Zrp4us4MGOOdIxNpbqNF5Q==",
       "os": ["darwin"],
       "cpu": ["arm64"]
     },
-    "@biomejs/cli-darwin-x64@2.4.15": {
-      "integrity": "sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ==",
+    "@biomejs/cli-darwin-x64@2.4.14": {
+      "integrity": "sha512-jE7hKBCFhOx3uUh+ZkWBfOHxAcILPfhFplNkuID/eZeSTLHzfZzoZxW8fbqY9xXRnPi7jGNAf1iPVR+0yWsM/Q==",
       "os": ["darwin"],
       "cpu": ["x64"]
     },
-    "@biomejs/cli-linux-arm64-musl@2.4.15": {
-      "integrity": "sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ==",
+    "@biomejs/cli-linux-arm64-musl@2.4.14": {
+      "integrity": "sha512-/z+6gqAqqUQTHazwStxSXKHg9b8UvqBmDFRp+c4wYbq2KXhELQDon9EoC9RpmQ8JWkqQx/lIUy/cs+MhzDZp6A==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@biomejs/cli-linux-arm64@2.4.15": {
-      "integrity": "sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==",
+    "@biomejs/cli-linux-arm64@2.4.14": {
+      "integrity": "sha512-2TELhZnW5RSLL063l9rc5xLpA0ZIw0Ccwy/0q384rvNAgFw3yI76bd59547yxowdQr5MNPET/xDLrLuvgSeeWQ==",
       "os": ["linux"],
       "cpu": ["arm64"]
     },
-    "@biomejs/cli-linux-x64-musl@2.4.15": {
-      "integrity": "sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==",
+    "@biomejs/cli-linux-x64-musl@2.4.14": {
+      "integrity": "sha512-R6BWgJdQOwW9ulJatuTVrQkjnODjqHZkKNOqb1sz++3Noe5LYd0i3PchnOBUCYAPHoPWHhjJqbdZlHEu0hpjdA==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@biomejs/cli-linux-x64@2.4.15": {
-      "integrity": "sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==",
+    "@biomejs/cli-linux-x64@2.4.14": {
+      "integrity": "sha512-zHrlQZDBDUz4OLAraYpWKcnLS6HOewBFWYOzY91d1ZjdqZwibOyb6BEu6WuWLugyo0P3riCmsbV9UqV1cSXwQg==",
       "os": ["linux"],
       "cpu": ["x64"]
     },
-    "@biomejs/cli-win32-arm64@2.4.15": {
-      "integrity": "sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==",
+    "@biomejs/cli-win32-arm64@2.4.14": {
+      "integrity": "sha512-M3EH5hqOI/F/FUA2u4xcLoUgmxd218mvuj/6JL7Hv2toQvr2/AdOvKSpGkoRuWFCtQPVa+ZqkEV3Q5xBA9+XSA==",
       "os": ["win32"],
       "cpu": ["arm64"]
     },
-    "@biomejs/cli-win32-x64@2.4.15": {
-      "integrity": "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ==",
+    "@biomejs/cli-win32-x64@2.4.14": {
+      "integrity": "sha512-WL0EG5qE+EAKomGXbf2g6VnSKJhTL3tXC0QRzWRwA5VpjxNYa6H4P7ZWfymbGE4IhZZQi1KXQ2R0YjwInmz2fA==",
       "os": ["win32"],
       "cpu": ["x64"]
     },
@@ -745,15 +801,15 @@
     "@csstools/color-helpers@6.0.2": {
       "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="
     },
-    "@csstools/css-calc@3.2.1_@csstools+css-parser-algorithms@4.0.0__@csstools+css-tokenizer@4.0.0_@csstools+css-tokenizer@4.0.0": {
-      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+    "@csstools/css-calc@3.2.0_@csstools+css-parser-algorithms@4.0.0__@csstools+css-tokenizer@4.0.0_@csstools+css-tokenizer@4.0.0": {
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
       "dependencies": [
         "@csstools/css-parser-algorithms",
         "@csstools/css-tokenizer"
       ]
     },
-    "@csstools/css-color-parser@4.1.1_@csstools+css-parser-algorithms@4.0.0__@csstools+css-tokenizer@4.0.0_@csstools+css-tokenizer@4.0.0": {
-      "integrity": "sha512-eZ5XOtyhK+mggRafYUWzA0tvaYOFgdY8AkgQiCJF9qNAePnUo/zmsqqYubBBb3sQ8uNUaSKTY9s9klfRaAXL0g==",
+    "@csstools/css-color-parser@4.1.0_@csstools+css-parser-algorithms@4.0.0__@csstools+css-tokenizer@4.0.0_@csstools+css-tokenizer@4.0.0": {
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
       "dependencies": [
         "@csstools/color-helpers",
         "@csstools/css-calc",
@@ -767,8 +823,8 @@
         "@csstools/css-tokenizer"
       ]
     },
-    "@csstools/css-syntax-patches-for-csstree@1.1.4_css-tree@3.2.1": {
-      "integrity": "sha512-wgsqt92b7C7tQhIdPNxj0n9zuUbQlvAuI1exyzeNrOKOi62SD7ren8zqszmpVREjAOqg8cD2FqYhQfAuKjk4sw==",
+    "@csstools/css-syntax-patches-for-csstree@1.1.3_css-tree@3.2.1": {
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
       "dependencies": [
         "css-tree"
       ],
@@ -1169,10 +1225,10 @@
         "semver"
       ]
     },
-    "@inkjs/ui@2.0.0_ink@7.0.3__@types+react@19.2.14__react@19.2.6_@types+react@19.2.14_react@19.2.6": {
+    "@inkjs/ui@2.0.0_ink@7.0.2__@types+react@19.2.14__react@19.2.6_@types+react@19.2.14_react@19.2.6": {
       "integrity": "sha512-5+8fJmwtF9UvikzLfph9sA+LS+l37Ij/szQltkuXLOAXwNkBX9innfzh4pLGXIB59vKEQUtc6D4qGvhD7h3pAg==",
       "dependencies": [
-        "chalk",
+        "chalk@5.6.2",
         "cli-spinners",
         "deepmerge",
         "figures",
@@ -1443,7 +1499,7 @@
         "@hono/node-server",
         "ajv@8.20.0",
         "ajv-formats",
-        "content-type@1.0.5",
+        "content-type",
         "cors",
         "cross-spawn",
         "eventsource",
@@ -1465,7 +1521,7 @@
         "@hono/node-server",
         "ajv@8.20.0",
         "ajv-formats",
-        "content-type@1.0.5",
+        "content-type",
         "cors",
         "cross-spawn",
         "eventsource",
@@ -1514,6 +1570,9 @@
         "@nodelib/fs.scandir",
         "fastq"
       ]
+    },
+    "@opentelemetry/api@1.9.0": {
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="
     },
     "@opentelemetry/api@1.9.1": {
       "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="
@@ -1751,7 +1810,7 @@
         "@redocly/ajv",
         "@redocly/config",
         "colorette@1.4.0",
-        "https-proxy-agent@7.0.6",
+        "https-proxy-agent",
         "js-levenshtein",
         "js-yaml",
         "minimatch@5.1.9",
@@ -2001,7 +2060,7 @@
         "retry@0.13.1"
       ]
     },
-    "@standard-community/standard-json@0.3.5_@standard-schema+spec@1.1.0_@types+json-schema@7.0.15_quansync@0.2.11_zod@4.4.3": {
+    "@standard-community/standard-json@0.3.5_@types+json-schema@7.0.15_zod@4.4.3": {
       "integrity": "sha512-4+ZPorwDRt47i+O7RjyuaxHRK/37QY/LmgxlGrRrSTLYoFatEOzvqIc85GTlM18SFZ5E91C+v0o/M37wZPpUHA==",
       "dependencies": [
         "@standard-schema/spec",
@@ -2013,7 +2072,7 @@
         "zod"
       ]
     },
-    "@standard-community/standard-openapi@0.2.9_@standard-community+standard-json@0.3.5__@standard-schema+spec@1.1.0__@types+json-schema@7.0.15__quansync@0.2.11__zod@4.4.3_@standard-schema+spec@1.1.0_openapi-types@12.1.3_zod@4.4.3_@types+json-schema@7.0.15_quansync@0.2.11": {
+    "@standard-community/standard-openapi@0.2.9_@standard-community+standard-json@0.3.5__@types+json-schema@7.0.15__zod@4.4.3_openapi-types@12.1.3_zod@4.4.3": {
       "integrity": "sha512-htj+yldvN1XncyZi4rehbf9kLbu8os2Ke/rfqoZHCMHuw34kiF3LP/yQPdA0tQ940y8nDq3Iou8R3wG+AGGyvg==",
       "dependencies": [
         "@standard-community/standard-json",
@@ -2043,22 +2102,22 @@
         "acorn"
       ]
     },
-    "@sveltejs/adapter-auto@7.0.1_@sveltejs+kit@2.59.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.55.5___vite@7.3.3____@types+node@25.7.0____yaml@2.9.0___@types+node@25.7.0___yaml@2.9.0__svelte@5.55.5__typescript@5.9.3__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_yaml@2.9.0": {
+    "@sveltejs/adapter-auto@7.0.1_@sveltejs+kit@2.59.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.55.5___vite@7.3.3____@types+node@25.6.2____yaml@2.8.4___@types+node@25.6.2___yaml@2.8.4__svelte@5.55.5__typescript@5.9.3__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4": {
       "integrity": "sha512-dvuPm1E7M9NI/+canIQ6KKQDU2AkEefEZ2Dp7cY6uKoPq9Z/PhOXABe526UdW2mN986gjVkuSLkOYIBnS/M2LQ==",
       "dependencies": [
         "@sveltejs/kit"
       ]
     },
-    "@sveltejs/adapter-static@3.0.10_@sveltejs+kit@2.59.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.55.5___vite@7.3.3____@types+node@25.7.0____yaml@2.9.0___@types+node@25.7.0___yaml@2.9.0__svelte@5.55.5__typescript@5.9.3__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_yaml@2.9.0": {
+    "@sveltejs/adapter-static@3.0.10_@sveltejs+kit@2.59.1__@opentelemetry+api@1.9.1__@sveltejs+vite-plugin-svelte@6.2.4___svelte@5.55.5___vite@7.3.3____@types+node@25.6.2____yaml@2.8.4___@types+node@25.6.2___yaml@2.8.4__svelte@5.55.5__typescript@5.9.3__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4": {
       "integrity": "sha512-7D9lYFWJmB7zxZyTE/qxjksvMqzMuYrrsyh1f4AlZqeZeACPRySjbC3aFiY55wb1tWUaKOQG9PVbm74JcN2Iew==",
       "dependencies": [
         "@sveltejs/kit"
       ]
     },
-    "@sveltejs/kit@2.59.1_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_yaml@2.9.0": {
+    "@sveltejs/kit@2.59.1_@opentelemetry+api@1.9.1_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_svelte@5.55.5_typescript@5.9.3_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_yaml@2.8.4": {
       "integrity": "sha512-d8OON70AphLdDesuTIl//M2O6fRTIicX8aYv8vhCiYEhTTI2OboKqey0Hu1A4VFhqwgqtq0vKDmPFGkw8kKmgw==",
       "dependencies": [
-        "@opentelemetry/api",
+        "@opentelemetry/api@1.9.1",
         "@standard-schema/spec",
         "@sveltejs/acorn-typescript",
         "@sveltejs/vite-plugin-svelte",
@@ -2077,7 +2136,7 @@
         "vite"
       ],
       "optionalPeers": [
-        "@opentelemetry/api",
+        "@opentelemetry/api@1.9.1",
         "typescript"
       ],
       "bin": true
@@ -2094,7 +2153,7 @@
       ],
       "bin": true
     },
-    "@sveltejs/vite-plugin-svelte-inspector@5.0.2_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.7.0___yaml@2.9.0__@types+node@25.7.0__yaml@2.9.0_svelte@5.55.5_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_yaml@2.9.0": {
+    "@sveltejs/vite-plugin-svelte-inspector@5.0.2_@sveltejs+vite-plugin-svelte@6.2.4__svelte@5.55.5__vite@7.3.3___@types+node@25.6.2___yaml@2.8.4__@types+node@25.6.2__yaml@2.8.4_svelte@5.55.5_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_yaml@2.8.4": {
       "integrity": "sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig==",
       "dependencies": [
         "@sveltejs/vite-plugin-svelte",
@@ -2103,7 +2162,7 @@
         "vite"
       ]
     },
-    "@sveltejs/vite-plugin-svelte@6.2.4_svelte@5.55.5_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_yaml@2.9.0": {
+    "@sveltejs/vite-plugin-svelte@6.2.4_svelte@5.55.5_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_yaml@2.8.4": {
       "integrity": "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA==",
       "dependencies": [
         "@sveltejs/vite-plugin-svelte-inspector",
@@ -2121,14 +2180,14 @@
         "tslib"
       ]
     },
-    "@tanstack/query-core@5.100.10": {
-      "integrity": "sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w=="
+    "@tanstack/query-core@5.100.9": {
+      "integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ=="
     },
     "@tanstack/store@0.11.0": {
       "integrity": "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw=="
     },
-    "@tanstack/svelte-query@6.1.29_svelte@5.55.5": {
-      "integrity": "sha512-qB6hv21JzGvUtKcqUFhbhYEp1qp2/x/PgBaeQVNCkz+BvygLCv/+OMnrzzi5hLoIDJgIbEtQSoX3xW85OYJ9JA==",
+    "@tanstack/svelte-query@6.1.28_svelte@5.55.5": {
+      "integrity": "sha512-B4uh/fvn+t67LyWzY8Sb+yqyxJS2hc27Nwf+bfz7vy+ilzfJIHORoCm9/6Arsg4pdH8DCBMLMWZTvMgvSUd/pg==",
       "dependencies": [
         "@tanstack/query-core",
         "svelte"
@@ -2338,8 +2397,8 @@
         "form-data"
       ]
     },
-    "@types/node@25.7.0": {
-      "integrity": "sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==",
+    "@types/node@25.6.2": {
+      "integrity": "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw==",
       "dependencies": [
         "undici-types"
       ]
@@ -2383,8 +2442,8 @@
         "@types/node"
       ]
     },
-    "@typescript-eslint/eslint-plugin@8.59.3_@typescript-eslint+parser@8.59.3__eslint@10.3.0__typescript@5.9.3_eslint@10.3.0_typescript@5.9.3": {
-      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
+    "@typescript-eslint/eslint-plugin@8.59.2_@typescript-eslint+parser@8.59.2__eslint@10.3.0__typescript@5.9.3_eslint@10.3.0_typescript@5.9.3": {
+      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
       "dependencies": [
         "@eslint-community/regexpp",
         "@typescript-eslint/parser",
@@ -2399,8 +2458,8 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/parser@8.59.3_eslint@10.3.0_typescript@5.9.3": {
-      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
+    "@typescript-eslint/parser@8.59.2_eslint@10.3.0_typescript@5.9.3": {
+      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dependencies": [
         "@typescript-eslint/scope-manager",
         "@typescript-eslint/types",
@@ -2411,8 +2470,8 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/project-service@8.59.3_typescript@5.9.3": {
-      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
+    "@typescript-eslint/project-service@8.59.2_typescript@5.9.3": {
+      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
       "dependencies": [
         "@typescript-eslint/tsconfig-utils",
         "@typescript-eslint/types",
@@ -2420,21 +2479,21 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/scope-manager@8.59.3": {
-      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+    "@typescript-eslint/scope-manager@8.59.2": {
+      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
       "dependencies": [
         "@typescript-eslint/types",
         "@typescript-eslint/visitor-keys"
       ]
     },
-    "@typescript-eslint/tsconfig-utils@8.59.3_typescript@5.9.3": {
-      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
+    "@typescript-eslint/tsconfig-utils@8.59.2_typescript@5.9.3": {
+      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
       "dependencies": [
         "typescript"
       ]
     },
-    "@typescript-eslint/type-utils@8.59.3_eslint@10.3.0_typescript@5.9.3": {
-      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
+    "@typescript-eslint/type-utils@8.59.2_eslint@10.3.0_typescript@5.9.3": {
+      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
       "dependencies": [
         "@typescript-eslint/types",
         "@typescript-eslint/typescript-estree",
@@ -2445,11 +2504,11 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/types@8.59.3": {
-      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg=="
+    "@typescript-eslint/types@8.59.2": {
+      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q=="
     },
-    "@typescript-eslint/typescript-estree@8.59.3_typescript@5.9.3": {
-      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
+    "@typescript-eslint/typescript-estree@8.59.2_typescript@5.9.3": {
+      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
       "dependencies": [
         "@typescript-eslint/project-service",
         "@typescript-eslint/tsconfig-utils",
@@ -2463,8 +2522,8 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/utils@8.59.3_eslint@10.3.0_typescript@5.9.3": {
-      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
+    "@typescript-eslint/utils@8.59.2_eslint@10.3.0_typescript@5.9.3": {
+      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
       "dependencies": [
         "@eslint-community/eslint-utils",
         "@typescript-eslint/scope-manager",
@@ -2474,8 +2533,8 @@
         "typescript"
       ]
     },
-    "@typescript-eslint/visitor-keys@8.59.3": {
-      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+    "@typescript-eslint/visitor-keys@8.59.2": {
+      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
       "dependencies": [
         "@typescript-eslint/types",
         "eslint-visitor-keys@5.0.1"
@@ -2487,7 +2546,7 @@
     "@vercel/oidc@3.2.0": {
       "integrity": "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="
     },
-    "@vitest/coverage-v8@4.1.5_vitest@4.1.5_@opentelemetry+api@1.9.1_@types+node@25.7.0_happy-dom@20.9.0_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_yaml@2.9.0": {
+    "@vitest/coverage-v8@4.1.5_vitest@4.1.5_@opentelemetry+api@1.9.1_@types+node@25.6.2_happy-dom@20.9.0_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4": {
       "integrity": "sha512-38C0/Ddb7HcRG0Z4/DUem8x57d2p9jYgp18mkaYswEOQBGsI1CG4f/hjm0ZCeaJfWhSZ4k7jgs29V1Zom7Ki9A==",
       "dependencies": [
         "@bcoe/v8-coverage",
@@ -2514,7 +2573,7 @@
         "tinyrainbow"
       ]
     },
-    "@vitest/mocker@4.1.5_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_yaml@2.9.0": {
+    "@vitest/mocker@4.1.5_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_yaml@2.8.4": {
       "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
       "dependencies": [
         "@vitest/spy",
@@ -2595,12 +2654,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "bin": true
     },
-    "agent-base@6.0.2": {
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "dependencies": [
-        "debug"
-      ]
-    },
     "agent-base@7.1.4": {
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="
     },
@@ -2613,13 +2666,13 @@
         "zod"
       ]
     },
-    "ai@6.0.180_zod@4.4.3": {
-      "integrity": "sha512-tOyRbwD0PEjMZKGvYQcTsv95K2zktwwNhQ49QOUAh0g8MNprO7ELIO1SgANMuPc0BFtkP6Ny6OAdjq3TtxLCbQ==",
+    "ai@6.0.177_zod@4.4.3": {
+      "integrity": "sha512-1xQtbeWwNcLyyM86ixZhkKvT+WRXc1lvarIKqPVtsyn8F9NDikwUMBqYu+aQKDgMht50SMXh4qboYuU8MeHZZA==",
       "dependencies": [
         "@ai-sdk/gateway",
         "@ai-sdk/provider",
         "@ai-sdk/provider-utils",
-        "@opentelemetry/api",
+        "@opentelemetry/api@1.9.0",
         "zod"
       ]
     },
@@ -2659,8 +2712,17 @@
         "environment"
       ]
     },
+    "ansi-regex@5.0.1": {
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+    },
     "ansi-regex@6.2.2": {
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="
+    },
+    "ansi-styles@4.3.0": {
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": [
+        "color-convert"
+      ]
     },
     "ansi-styles@6.2.3": {
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="
@@ -2696,12 +2758,11 @@
     "auto-bind@5.0.1": {
       "integrity": "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="
     },
-    "axios@1.16.1": {
-      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
+    "axios@1.16.0": {
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
       "dependencies": [
         "follow-redirects",
         "form-data",
-        "https-proxy-agent@5.0.1",
         "proxy-from-env"
       ]
     },
@@ -2727,7 +2788,7 @@
       "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
       "dependencies": [
         "bytes",
-        "content-type@1.0.5",
+        "content-type",
         "debug",
         "http-errors",
         "iconv-lite",
@@ -2786,6 +2847,13 @@
     },
     "chai@6.2.2": {
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="
+    },
+    "chalk@4.1.2": {
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": [
+        "ansi-styles@4.3.0",
+        "supports-color@7.2.0"
+      ]
     },
     "chalk@5.6.2": {
       "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="
@@ -2861,11 +2929,19 @@
         "string-width@8.2.1"
       ]
     },
+    "cliui@8.0.1": {
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dependencies": [
+        "string-width@4.2.3",
+        "strip-ansi@6.0.1",
+        "wrap-ansi@7.0.0"
+      ]
+    },
     "cliui@9.0.1": {
       "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
       "dependencies": [
         "string-width@7.2.0",
-        "strip-ansi",
+        "strip-ansi@7.2.0",
         "wrap-ansi@9.0.2"
       ]
     },
@@ -2890,6 +2966,15 @@
         "@codemirror/view"
       ]
     },
+    "color-convert@2.0.1": {
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": [
+        "color-name"
+      ]
+    },
+    "color-name@1.1.4": {
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
     "colorette@1.4.0": {
       "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="
     },
@@ -2908,14 +2993,23 @@
     "commander@14.0.3": {
       "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="
     },
+    "concurrently@9.2.1": {
+      "integrity": "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng==",
+      "dependencies": [
+        "chalk@4.1.2",
+        "rxjs",
+        "shell-quote",
+        "supports-color@8.1.1",
+        "tree-kill",
+        "yargs@17.7.2"
+      ],
+      "bin": true
+    },
     "content-disposition@1.1.0": {
       "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="
     },
     "content-type@1.0.5": {
       "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="
-    },
-    "content-type@2.0.0": {
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="
     },
     "convert-source-map@2.0.0": {
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="
@@ -3064,8 +3158,8 @@
         "undici@6.24.1"
       ]
     },
-    "dompurify@3.4.3": {
-      "integrity": "sha512-VVwJidIJcp1hpg2OMXML3ZVRPYSZiq4aX7qBh83BSIpOaRDqI+qxhXjjIWnpzkOXhmp0L81lnoME1mnCc9H48A==",
+    "dompurify@3.4.2": {
+      "integrity": "sha512-lHeS9SA/IKeIFFyYciHBr2n0v1VMPlSj843HdLOwjb2OxNwdq9Xykxqhk+FE42MzAdHvInbAolSE4mhahPpjXA==",
       "optionalDependencies": [
         "@types/trusted-types"
       ]
@@ -3092,6 +3186,9 @@
     },
     "emoji-regex@10.6.0": {
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="
+    },
+    "emoji-regex@8.0.0": {
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "encodeurl@2.0.0": {
       "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="
@@ -3299,8 +3396,8 @@
         "estraverse"
       ]
     },
-    "esrap@2.2.8": {
-      "integrity": "sha512-MPweq2EvEGj8jwOI7Hgycw/QIHzqA1EbAM8lG7p+FBfZbZq/hQ6h3AMsqnu/djzisH1KVWNzbb7LSgIVtMlPSg==",
+    "esrap@2.2.6": {
+      "integrity": "sha512-WN0clHt0a4mzC780UBVVBpsj4vSSjOFNRd2WjYtduB9HeKxm1sjHMNUwLEHVjI3FdCQD/Hurgz9ftbKEzP79Ow==",
       "dependencies": [
         "@jridgewell/sourcemap-codec"
       ]
@@ -3357,7 +3454,7 @@
         "accepts",
         "body-parser",
         "content-disposition",
-        "content-type@1.0.5",
+        "content-type",
         "cookie@0.7.2",
         "cookie-signature",
         "debug",
@@ -3637,7 +3734,7 @@
         "@types/hast"
       ]
     },
-    "hono-openapi@1.3.0_@hono+standard-validator@0.2.2__@standard-schema+spec@1.1.0__hono@4.12.18_@standard-community+standard-json@0.3.5__@standard-schema+spec@1.1.0__@types+json-schema@7.0.15__quansync@0.2.11__zod@4.4.3_@standard-community+standard-openapi@0.2.9__@standard-community+standard-json@0.3.5___@standard-schema+spec@1.1.0___@types+json-schema@7.0.15___quansync@0.2.11___zod@4.4.3__@standard-schema+spec@1.1.0__openapi-types@12.1.3__zod@4.4.3__@types+json-schema@7.0.15__quansync@0.2.11_@types+json-schema@7.0.15_hono@4.12.18_openapi-types@12.1.3_@standard-schema+spec@1.1.0_quansync@0.2.11_zod@4.4.3": {
+    "hono-openapi@1.3.0_@hono+standard-validator@0.2.2__@standard-schema+spec@1.1.0__hono@4.12.18_hono@4.12.18_zod@4.4.3": {
       "integrity": "sha512-xDvCWpWEIv0weEmnl3EjRQzqbHIO8LnfzMuYOCmbuyE5aes6aXxLg4vM3ybnoZD5TiTUkA6PuRQPJs3R7WRBig==",
       "dependencies": [
         "@hono/standard-validator",
@@ -3686,21 +3783,14 @@
     "http-proxy-agent@7.0.2": {
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
       "dependencies": [
-        "agent-base@7.1.4",
-        "debug"
-      ]
-    },
-    "https-proxy-agent@5.0.1": {
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "dependencies": [
-        "agent-base@6.0.2",
+        "agent-base",
         "debug"
       ]
     },
     "https-proxy-agent@7.0.6": {
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "dependencies": [
-        "agent-base@7.1.4",
+        "agent-base",
         "debug"
       ]
     },
@@ -3737,15 +3827,15 @@
     "inherits@2.0.4": {
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
-    "ink@7.0.3_@types+react@19.2.14_react@19.2.6": {
-      "integrity": "sha512-5kxHkIj9+RuqCU3zyvP4qvYWNOSHP2TW/SHayHGHOmk87KwfVcZwvJGemi9ch+ci2gXUqerK/Eh2DGEDt5q45g==",
+    "ink@7.0.2_@types+react@19.2.14_react@19.2.6": {
+      "integrity": "sha512-cnkE2SsDC/gieJ+BD8+gWpXrZPMInv7agBYN5gcKVlQZYp+IKa/FKM5bp1OIuJFp3ZIuRK7ZNxY4MZR3tUzyfQ==",
       "dependencies": [
         "@alcalzone/ansi-tokenize",
         "@types/react",
         "ansi-escapes",
-        "ansi-styles",
+        "ansi-styles@6.2.3",
         "auto-bind",
-        "chalk",
+        "chalk@5.6.2",
         "cli-boxes",
         "cli-cursor@4.0.0",
         "cli-truncate@6.0.0",
@@ -3783,6 +3873,9 @@
     },
     "is-extglob@2.1.1": {
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
+    },
+    "is-fullwidth-code-point@3.0.0": {
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
     },
     "is-fullwidth-code-point@5.1.0": {
       "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
@@ -3901,7 +3994,7 @@
         "decimal.js",
         "html-encoding-sniffer",
         "http-proxy-agent",
-        "https-proxy-agent@7.0.6",
+        "https-proxy-agent",
         "is-potential-custom-element-name",
         "parse5",
         "saxes",
@@ -4024,7 +4117,7 @@
         "strip-json-comments",
         "tinyglobby",
         "unbash",
-        "yaml@2.9.0",
+        "yaml@2.8.4",
         "zod"
       ],
       "bin": true
@@ -4065,7 +4158,7 @@
         "picomatch@4.0.4",
         "string-argv",
         "tinyexec",
-        "yaml@2.9.0"
+        "yaml@2.8.4"
       ],
       "bin": true
     },
@@ -4128,7 +4221,7 @@
         "ansi-escapes",
         "cli-cursor@5.0.0",
         "slice-ansi@7.1.2",
-        "strip-ansi",
+        "strip-ansi@7.2.0",
         "wrap-ansi@9.0.2"
       ]
     },
@@ -4981,8 +5074,8 @@
     "prelude-ls@1.2.1": {
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
     },
-    "prettier-plugin-svelte@3.5.2_prettier@3.8.3_svelte@5.55.5": {
-      "integrity": "sha512-ItFouLvzSFE3ulNl4DKoWM3BGcbDCNVpIyy/Y3F2gC3aNiGLxtFUdffVqO5Z5hhYG+DFT5KULWaxmeFFpdbvaQ==",
+    "prettier-plugin-svelte@3.5.1_prettier@3.8.3_svelte@5.55.5": {
+      "integrity": "sha512-65+fr5+cgIKWKiqM1Doum4uX6bY8iFCdztvvp2RcF+AJoieaw9kJOFMNcJo/bkmKYsxFaM9OsVZK/gWauG/5mg==",
       "dependencies": [
         "prettier",
         "svelte"
@@ -5016,8 +5109,8 @@
     "proxy-from-env@2.1.0": {
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="
     },
-    "publint@0.3.21": {
-      "integrity": "sha512-OqejcnMV6E9zel2oCrUOJEiiFkGiAAni0A6ibfQNh1k9Gu5z4F+Yso8lllam7AzmV6Do0vp7u3UpZNRBwuXaHQ==",
+    "publint@0.3.20": {
+      "integrity": "sha512-UWqFYP7VBVCe9l/leEEGJrDs6Am4K4KapLmLi5qbt+9fA+Ny38ghdW+bw1nYfVqCK8/3kgsxjjhFjTYqYYRpyw==",
       "dependencies": [
         "@publint/pack",
         "package-manager-detector",
@@ -5142,6 +5235,9 @@
     "remend@1.3.0": {
       "integrity": "sha512-iIhggPkhW3hFImKtB10w0dz4EZbs28mV/dmbcYVonWEJ6UGHHpP+bFZnTh6GNWJONg5m+U56JrL+8IxZRdgWjw=="
     },
+    "require-directory@2.1.1": {
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="
+    },
     "require-from-string@2.0.2": {
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="
     },
@@ -5225,6 +5321,12 @@
         "queue-microtask"
       ]
     },
+    "rxjs@7.8.2": {
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dependencies": [
+        "tslib"
+      ]
+    },
     "sade@1.8.1": {
       "integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
       "dependencies": [
@@ -5296,6 +5398,9 @@
     "shebang-regex@3.0.0": {
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
+    "shell-quote@1.8.3": {
+      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="
+    },
     "shiki@4.0.2": {
       "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
       "dependencies": [
@@ -5365,22 +5470,22 @@
     "slice-ansi@7.1.2": {
       "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
       "dependencies": [
-        "ansi-styles",
-        "is-fullwidth-code-point"
+        "ansi-styles@6.2.3",
+        "is-fullwidth-code-point@5.1.0"
       ]
     },
     "slice-ansi@8.0.0": {
       "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
       "dependencies": [
-        "ansi-styles",
-        "is-fullwidth-code-point"
+        "ansi-styles@6.2.3",
+        "is-fullwidth-code-point@5.1.0"
       ]
     },
     "slice-ansi@9.0.0": {
       "integrity": "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA==",
       "dependencies": [
-        "ansi-styles",
-        "is-fullwidth-code-point"
+        "ansi-styles@6.2.3",
+        "is-fullwidth-code-point@5.1.0"
       ]
     },
     "smol-toml@1.6.1": {
@@ -5410,19 +5515,27 @@
     "string-argv@0.3.2": {
       "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="
     },
+    "string-width@4.2.3": {
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": [
+        "emoji-regex@8.0.0",
+        "is-fullwidth-code-point@3.0.0",
+        "strip-ansi@6.0.1"
+      ]
+    },
     "string-width@7.2.0": {
       "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
       "dependencies": [
-        "emoji-regex",
+        "emoji-regex@10.6.0",
         "get-east-asian-width",
-        "strip-ansi"
+        "strip-ansi@7.2.0"
       ]
     },
     "string-width@8.2.1": {
       "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dependencies": [
         "get-east-asian-width",
-        "strip-ansi"
+        "strip-ansi@7.2.0"
       ]
     },
     "string_decoder@1.1.1": {
@@ -5438,10 +5551,16 @@
         "character-entities-legacy"
       ]
     },
+    "strip-ansi@6.0.1": {
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": [
+        "ansi-regex@5.0.1"
+      ]
+    },
     "strip-ansi@7.2.0": {
       "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
       "dependencies": [
-        "ansi-regex"
+        "ansi-regex@6.2.2"
       ]
     },
     "strip-json-comments@5.0.3": {
@@ -5461,6 +5580,12 @@
     },
     "supports-color@7.2.0": {
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": [
+        "has-flag"
+      ]
+    },
+    "supports-color@8.1.1": {
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
       "dependencies": [
         "has-flag"
       ]
@@ -5607,6 +5732,10 @@
         "punycode"
       ]
     },
+    "tree-kill@1.2.2": {
+      "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
+      "bin": true
+    },
     "trim-lines@3.0.1": {
       "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="
     },
@@ -5652,16 +5781,16 @@
         "tagged-tag"
       ]
     },
-    "type-is@2.1.0": {
-      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+    "type-is@2.0.1": {
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
       "dependencies": [
-        "content-type@2.0.0",
+        "content-type",
         "media-typer",
         "mime-types@3.0.2"
       ]
     },
-    "typescript-eslint@8.59.3_eslint@10.3.0_typescript@5.9.3": {
-      "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
+    "typescript-eslint@8.59.2_eslint@10.3.0_typescript@5.9.3": {
+      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
       "dependencies": [
         "@typescript-eslint/eslint-plugin",
         "@typescript-eslint/parser",
@@ -5688,8 +5817,8 @@
     "unbash@3.0.0": {
       "integrity": "sha512-FeFPZ/WFT0mbRCuydiZzpPFlrYN8ZUpphQKoq4EeElVIYjYyGzPMxQR/simUwCOJIyVhpFk4RbtyO7RuMpMnHA=="
     },
-    "undici-types@7.21.0": {
-      "integrity": "sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ=="
+    "undici-types@7.19.2": {
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="
     },
     "undici@6.24.1": {
       "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="
@@ -5779,7 +5908,7 @@
         "vfile-message"
       ]
     },
-    "vite@7.3.3_@types+node@25.7.0_yaml@2.9.0": {
+    "vite@7.3.3_@types+node@25.6.2_yaml@2.8.4": {
       "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dependencies": [
         "@types/node",
@@ -5789,18 +5918,18 @@
         "postcss",
         "rollup",
         "tinyglobby",
-        "yaml@2.9.0"
+        "yaml@2.8.4"
       ],
       "optionalDependencies": [
         "fsevents"
       ],
       "optionalPeers": [
         "@types/node",
-        "yaml@2.9.0"
+        "yaml@2.8.4"
       ],
       "bin": true
     },
-    "vitefu@1.1.3_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_@types+node@25.7.0_yaml@2.9.0": {
+    "vitefu@1.1.3_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_@types+node@25.6.2_yaml@2.8.4": {
       "integrity": "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg==",
       "dependencies": [
         "vite"
@@ -5809,10 +5938,10 @@
         "vite"
       ]
     },
-    "vitest@4.1.5_@opentelemetry+api@1.9.1_@types+node@25.7.0_@vitest+coverage-v8@4.1.5_happy-dom@20.9.0_vite@7.3.3__@types+node@25.7.0__yaml@2.9.0_yaml@2.9.0": {
+    "vitest@4.1.5_@opentelemetry+api@1.9.1_@types+node@25.6.2_@vitest+coverage-v8@4.1.5_happy-dom@20.9.0_vite@7.3.3__@types+node@25.6.2__yaml@2.8.4_yaml@2.8.4": {
       "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
       "dependencies": [
-        "@opentelemetry/api",
+        "@opentelemetry/api@1.9.1",
         "@types/node",
         "@vitest/coverage-v8",
         "@vitest/expect",
@@ -5838,7 +5967,7 @@
         "why-is-node-running"
       ],
       "optionalPeers": [
-        "@opentelemetry/api",
+        "@opentelemetry/api@1.9.1",
         "@types/node",
         "@vitest/coverage-v8",
         "happy-dom"
@@ -5911,24 +6040,32 @@
     "wrap-ansi@10.0.0": {
       "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
       "dependencies": [
-        "ansi-styles",
+        "ansi-styles@6.2.3",
         "string-width@8.2.1",
-        "strip-ansi"
+        "strip-ansi@7.2.0"
+      ]
+    },
+    "wrap-ansi@7.0.0": {
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": [
+        "ansi-styles@4.3.0",
+        "string-width@4.2.3",
+        "strip-ansi@6.0.1"
       ]
     },
     "wrap-ansi@9.0.2": {
       "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
       "dependencies": [
-        "ansi-styles",
+        "ansi-styles@6.2.3",
         "string-width@7.2.0",
-        "strip-ansi"
+        "strip-ansi@7.2.0"
       ]
     },
     "wrappy@1.0.2": {
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
-    "ws@8.20.1": {
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w=="
+    "ws@8.20.0": {
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="
     },
     "xml-name-validator@5.0.0": {
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="
@@ -5936,8 +6073,8 @@
     "xmlchars@2.2.0": {
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
     },
-    "xstate@5.31.1": {
-      "integrity": "sha512-3P7t7GQ61BvLu+8Cj6Zq7rcS34vecL9pvfN2ucUWmIFIUG+rAREviOs4Xy4OO3BuJHSz6RLU8eqDXxSbVotjDQ=="
+    "xstate@5.31.0": {
+      "integrity": "sha512-5B+0DqC0uNUrcLUEY3pn3iNy+swvK2E0ZpYp5gnV3oxMX5y87vzXkU5YXv9CAtyG5c5FOJ1SzvTWHrwE8fMZNQ=="
     },
     "y18n@5.0.8": {
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
@@ -5954,8 +6091,8 @@
     "yaml@1.10.3": {
       "integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="
     },
-    "yaml@2.9.0": {
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+    "yaml@2.8.4": {
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
       "bin": true
     },
     "yargs-parser@21.1.1": {
@@ -5964,10 +6101,22 @@
     "yargs-parser@22.0.0": {
       "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="
     },
+    "yargs@17.7.2": {
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dependencies": [
+        "cliui@8.0.1",
+        "escalade",
+        "get-caller-file",
+        "require-directory",
+        "string-width@4.2.3",
+        "y18n",
+        "yargs-parser@21.1.1"
+      ]
+    },
     "yargs@18.0.0": {
       "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
       "dependencies": [
-        "cliui",
+        "cliui@9.0.1",
         "escalade",
         "get-caller-file",
         "string-width@7.2.0",
@@ -6363,7 +6512,8 @@
           "dependencies": [
             "npm:hono-openapi@^1.3.0",
             "npm:openapi-fetch@0.17",
-            "npm:openapi-typescript@^7.13.0"
+            "npm:openapi-typescript@^7.13.0",
+            "npm:vitest@^4.1.0"
           ]
         }
       },

--- a/packages/client/MIGRATION.md
+++ b/packages/client/MIGRATION.md
@@ -163,10 +163,13 @@ In `packages/client/v2/mod.ts`:
 ```typescript
 import type { ChatStorageRoutes } from "@atlas/atlasd";
 import type { AgentRoutes } from "@atlas/atlasd"; // Add import
+import { getAtlasDaemonUrl } from "@atlas/oapi-client";
+
+const base = getAtlasDaemonUrl(); // honors FRIDAYD_URL + FRIDAY_TLS_CERT
 
 export const client = {
-  chatStorage: hc<ChatStorageRoutes>("http://localhost:8080/api/chat-storage"),
-  agents: hc<AgentRoutes>("http://localhost:8080/api/agents"), // Add route
+  chatStorage: hc<ChatStorageRoutes>(`${base}/api/chat-storage`),
+  agents: hc<AgentRoutes>(`${base}/api/agents`), // Add route
 };
 ```
 

--- a/packages/client/README.md
+++ b/packages/client/README.md
@@ -127,7 +127,8 @@ export type ChatStorageRoutes = typeof chatStorageRoutes;
 
 // Client (packages/client/v2/mod.ts)
 import type { ChatStorageRoutes } from "@atlas/atlasd";
-const client = hc<ChatStorageRoutes>("http://localhost:8080/api/chat-storage");
+import { getAtlasDaemonUrl } from "@atlas/oapi-client";
+const client = hc<ChatStorageRoutes>(`${getAtlasDaemonUrl()}/api/chat-storage`);
 
 // Usage - fully typed!
 const res = await client[":streamId"].$get({ param: { streamId: "123" } });

--- a/packages/core/src/agent-server/README.md
+++ b/packages/core/src/agent-server/README.md
@@ -71,13 +71,16 @@ Manages suspended agent executions awaiting approval:
 import { AtlasAgentsMCPServer } from "@atlas/agent-server";
 import { MyAgentRegistry } from "./my-registry.ts";
 import { AtlasLogger } from "@atlas/core";
+import { getAtlasDaemonUrl } from "@atlas/oapi-client";
 
-// Create the MCP server
+// Create the MCP server. getAtlasDaemonUrl() picks the right scheme/port
+// from FRIDAYD_URL + FRIDAY_TLS_CERT so the server works on plain-HTTP and
+// TLS-enabled installs without per-env config.
 const server = new AtlasAgentsMCPServer({
   agentRegistry: new MyAgentRegistry(),
   logger: AtlasLogger.getInstance(),
   port: 8082,
-  daemonUrl: "http://localhost:8080",
+  daemonUrl: getAtlasDaemonUrl(),
 });
 
 // Start the server

--- a/packages/mcp-server/README.md
+++ b/packages/mcp-server/README.md
@@ -18,10 +18,13 @@ The platform server is instantiated by the Atlas daemon and exposed via the `/mc
 
 ```typescript
 import { PlatformMCPServer } from "@atlas/mcp-server";
+import { getAtlasDaemonUrl } from "@atlas/oapi-client";
 
-// Create platform server (typically done in atlasd)
+// Create platform server (typically done in atlasd).
+// getAtlasDaemonUrl() auto-resolves scheme/port from FRIDAYD_URL +
+// FRIDAY_TLS_CERT so this works on plain-HTTP and TLS-enabled installs.
 const platformServer = new PlatformMCPServer({
-  daemonUrl: "http://localhost:8080", // Daemon API endpoint
+  daemonUrl: getAtlasDaemonUrl(),
   logger: logger, // Logger instance
 });
 

--- a/packages/openapi-client/README.md
+++ b/packages/openapi-client/README.md
@@ -8,10 +8,13 @@
 ## Usage
 
 ```typescript
-import { createAtlasClient } from "@atlas/oapi-client";
+import { createAtlasClient, getAtlasDaemonUrl } from "@atlas/oapi-client";
 
+// getAtlasDaemonUrl() reads FRIDAYD_URL + FRIDAY_TLS_CERT and returns the
+// right scheme/port automatically. Pass an explicit baseUrl only when
+// targeting a non-local daemon.
 const client = createAtlasClient({
-  baseUrl: "http://localhost:8080",
+  baseUrl: getAtlasDaemonUrl(),
 });
 
 // Type-safe API calls

--- a/packages/openapi-client/package.json
+++ b/packages/openapi-client/package.json
@@ -6,5 +6,9 @@
   "exports": { ".": "./mod.ts" },
   "scripts": { "generate": "deno run -A scripts/build.ts" },
   "dependencies": { "openapi-fetch": "^0.17.0" },
-  "devDependencies": { "hono-openapi": "^1.3.0", "openapi-typescript": "^7.13.0" }
+  "devDependencies": {
+    "hono-openapi": "^1.3.0",
+    "openapi-typescript": "^7.13.0",
+    "vitest": "^4.1.0"
+  }
 }

--- a/packages/openapi-client/package.json
+++ b/packages/openapi-client/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "./mod.ts",
   "exports": { ".": "./mod.ts" },
-  "scripts": { "generate": "deno run -A scripts/build.ts" },
+  "scripts": { "generate": "deno run -A scripts/build.ts", "test": "vitest run" },
   "dependencies": { "openapi-fetch": "^0.17.0" },
   "devDependencies": {
     "hono-openapi": "^1.3.0",

--- a/packages/openapi-client/src/utils.test.ts
+++ b/packages/openapi-client/src/utils.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Unit tests for `getAtlasDaemonUrl()` — the central choke point that
+ * three new call sites (post-PR-#308) depend on:
+ *   - packages/workspace/src/variable-interpolation.ts (`{{platform_url}}`)
+ *   - packages/workspace/src/runtime.ts (`agentsServerUrl`)
+ *   - scripts/clean.ts (daemon health probe)
+ *
+ * The resolution chain has six branches (see the doc comment on the
+ * function) and a non-trivial TLS-upgrade transform on `explicit`. This
+ * file is the only place those branches are tested directly. Without
+ * these tests, a regression in the TLS-upgrade transform — the entire
+ * premise of PR #308 — would ship undetected because the call-site tests
+ * pin `FRIDAYD_URL` and only exercise the env-honoring path.
+ */
+
+import process from "node:process";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { getAtlasDaemonUrl, getAtlasPlatformServerConfig } from "./utils.ts";
+
+// The function reads several env vars; snapshot all of them per test so a
+// developer who has run setup-tls.sh in their shell doesn't see flaky
+// failures.
+const ENV_KEYS = [
+  "FRIDAYD_URL",
+  "FRIDAY_DAEMON_URL",
+  "FRIDAY_PORT_FRIDAY",
+  "FRIDAY_TLS_CERT",
+  "FRIDAY_TLS_KEY",
+  "FRIDAY_ATLAS_PLATFORM_URL",
+];
+
+describe("getAtlasDaemonUrl", () => {
+  const snapshot: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      snapshot[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (snapshot[k] === undefined) delete process.env[k];
+      else process.env[k] = snapshot[k];
+    }
+  });
+
+  it("no-env default is http://127.0.0.1:8080 (note: 127.0.0.1, not localhost)", () => {
+    expect(getAtlasDaemonUrl()).toBe("http://127.0.0.1:8080");
+  });
+
+  it("FRIDAYD_URL wins over everything else", () => {
+    process.env.FRIDAYD_URL = "http://example.test:9999";
+    process.env.FRIDAY_DAEMON_URL = "http://wrong:1111";
+    process.env.FRIDAY_PORT_FRIDAY = "2222";
+    expect(getAtlasDaemonUrl()).toBe("http://example.test:9999");
+  });
+
+  it("FRIDAY_DAEMON_URL is honored as legacy alias when FRIDAYD_URL is unset", () => {
+    process.env.FRIDAY_DAEMON_URL = "http://legacy.test:9999";
+    expect(getAtlasDaemonUrl()).toBe("http://legacy.test:9999");
+  });
+
+  it("FRIDAY_PORT_FRIDAY overrides only the port; scheme and host stay default", () => {
+    process.env.FRIDAY_PORT_FRIDAY = "18080";
+    expect(getAtlasDaemonUrl()).toBe("http://127.0.0.1:18080");
+  });
+
+  describe("TLS auto-upgrade (the entire premise of PR #308)", () => {
+    beforeEach(() => {
+      // Both cert + key required to flip the TLS bit — half-set should NOT
+      // upgrade. The runtime guards against half-configured TLS this way.
+      process.env.FRIDAY_TLS_CERT = "/tmp/fake.crt";
+      process.env.FRIDAY_TLS_KEY = "/tmp/fake.key";
+    });
+
+    it("upgrades explicit http://FRIDAYD_URL to https://", () => {
+      process.env.FRIDAYD_URL = "http://localhost:8080";
+      expect(getAtlasDaemonUrl()).toBe("https://localhost:8080");
+    });
+
+    it("upgrades explicit http://FRIDAY_DAEMON_URL legacy alias too", () => {
+      process.env.FRIDAY_DAEMON_URL = "http://localhost:8080";
+      expect(getAtlasDaemonUrl()).toBe("https://localhost:8080");
+    });
+
+    it("does NOT downgrade https://FRIDAYD_URL — user's explicit setting wins", () => {
+      process.env.FRIDAYD_URL = "https://example.test:9999";
+      expect(getAtlasDaemonUrl()).toBe("https://example.test:9999");
+    });
+
+    it("no-env default uses https:// scheme with port-override", () => {
+      process.env.FRIDAY_PORT_FRIDAY = "18080";
+      expect(getAtlasDaemonUrl()).toBe("https://127.0.0.1:18080");
+    });
+
+    it("no-env default uses https:// scheme without port-override", () => {
+      expect(getAtlasDaemonUrl()).toBe("https://127.0.0.1:8080");
+    });
+
+    it("does NOT upgrade when only CERT is set (half-configured)", () => {
+      delete process.env.FRIDAY_TLS_KEY;
+      process.env.FRIDAYD_URL = "http://localhost:8080";
+      expect(getAtlasDaemonUrl()).toBe("http://localhost:8080");
+    });
+
+    it("does NOT upgrade when only KEY is set (half-configured)", () => {
+      delete process.env.FRIDAY_TLS_CERT;
+      process.env.FRIDAYD_URL = "http://localhost:8080";
+      expect(getAtlasDaemonUrl()).toBe("http://localhost:8080");
+    });
+  });
+});
+
+describe("getAtlasPlatformServerConfig", () => {
+  const snapshot: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      snapshot[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (snapshot[k] === undefined) delete process.env[k];
+      else process.env[k] = snapshot[k];
+    }
+  });
+
+  it("derives /mcp URL from daemon URL by default", () => {
+    expect(getAtlasPlatformServerConfig()).toEqual({
+      transport: { type: "http", url: "http://127.0.0.1:8080/mcp" },
+    });
+  });
+
+  it("FRIDAY_ATLAS_PLATFORM_URL overrides for shared-deployment mode", () => {
+    process.env.FRIDAY_ATLAS_PLATFORM_URL = "https://platform.svc.cluster.local";
+    expect(getAtlasPlatformServerConfig()).toEqual({
+      transport: { type: "http", url: "https://platform.svc.cluster.local" },
+    });
+  });
+
+  it("follows the TLS upgrade of the daemon URL when override unset", () => {
+    process.env.FRIDAYD_URL = "http://localhost:8080";
+    process.env.FRIDAY_TLS_CERT = "/tmp/fake.crt";
+    process.env.FRIDAY_TLS_KEY = "/tmp/fake.key";
+    expect(getAtlasPlatformServerConfig()).toEqual({
+      transport: { type: "http", url: "https://localhost:8080/mcp" },
+    });
+  });
+});

--- a/packages/system/skills/friday-cli/SKILL.md
+++ b/packages/system/skills/friday-cli/SKILL.md
@@ -40,11 +40,19 @@ set +a
 friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
 ```
 
-**Rule: every daemon HTTP call below uses `friday_curl`, not `curl`.** The
-wrapper is what makes the example work on both plain-HTTP installs (where
-`$FRIDAY_TLS_CA` is empty and `--cacert` is omitted) and TLS installs
-(where `--cacert` is required — plain `curl` against `$FRIDAYD_URL` fails
-with `self signed certificate in certificate chain`).
+### Two load-bearing rules
+
+1. **Never hardcode the daemon URL — always use `$FRIDAYD_URL`.** Even
+   if the user mentions a specific host or port ("the daemon is on
+   `:18080`", "I have it on `https://localhost:8080`"), IGNORE that
+   detail and use `$FRIDAYD_URL` in the command. The variable already
+   resolves to the right value for the user's install.
+
+2. **Use the `friday_curl` wrapper, never plain `curl`.** The wrapper
+   makes examples work on both plain-HTTP installs (where
+   `$FRIDAY_TLS_CA` is empty and `--cacert` is omitted) and TLS installs
+   (where `--cacert` is required — plain `curl` against `$FRIDAYD_URL`
+   fails with `self signed certificate in certificate chain`).
 
 **Troubleshooting:** if `friday_curl` still fails with `SSL certificate
 problem: self signed certificate in certificate chain`, your

--- a/packages/system/skills/friday-cli/SKILL.md
+++ b/packages/system/skills/friday-cli/SKILL.md
@@ -27,16 +27,24 @@ set -a
 set +a
 # $FRIDAYD_URL → https://localhost:18080 (TLS) or http://localhost:8080 (plain)
 # $FRIDAY_TLS_CA → path to the private-CA cert (empty when TLS off)
+
+# Wrapper that adds --cacert exactly when TLS is on. Use this in place of
+# `curl` for every daemon call — never `curl` directly against $FRIDAYD_URL.
+friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
 ```
 
-Every curl below uses `${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"}` — that
-expansion is empty under plain HTTP, and adds `--cacert` exactly when needed.
+**Rule: every daemon HTTP call below uses `friday_curl`, not `curl`.** The
+wrapper is what makes the example work on both plain-HTTP installs (where
+`$FRIDAY_TLS_CA` is empty and `--cacert` is omitted) and TLS installs
+(where `--cacert` is required — plain `curl` against `$FRIDAYD_URL` fails
+with `self signed certificate in certificate chain`).
 
-**Troubleshooting:** if a curl call fails with `SSL certificate problem:
-self signed certificate in certificate chain`, your `FRIDAY_TLS_CA` is
-empty or stale (`set -a` exported an empty value, or the .env hasn't been
-re-sourced after a `setup-tls.sh` rerun). Check with `echo "$FRIDAY_TLS_CA"`
-and re-source the daemon `.env` from the same preamble above.
+**Troubleshooting:** if `friday_curl` still fails with `SSL certificate
+problem: self signed certificate in certificate chain`, your
+`FRIDAY_TLS_CA` is empty or stale (`set -a` exported an empty value, or
+the .env hasn't been re-sourced after a `setup-tls.sh` rerun). Check with
+`echo "$FRIDAY_TLS_CA"` and re-source the daemon `.env` from the same
+preamble above.
 
 ## When to use CLI vs HTTP
 
@@ -60,7 +68,7 @@ Before touching anything, confirm the daemon is up:
 ```bash
 deno task atlas daemon status
 # or (after sourcing the daemon .env — see preamble above):
-curl -sf ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
+friday_curl -sf \
   "${FRIDAYD_URL:-http://localhost:8080}/health" && echo OK
 ```
 
@@ -97,7 +105,7 @@ deno task atlas signal list -w <workspace-id-or-name> --json
 Or HTTP for full schema:
 
 ```bash
-curl -sf ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
+friday_curl -sf \
   "$FRIDAYD_URL/api/workspaces/<id>/signals" | jq
 ```
 
@@ -114,7 +122,7 @@ deno task atlas signal trigger -n <signal-name> -w <workspace> \
 Or via HTTP with SSE:
 
 ```bash
-curl -N -X POST ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
+friday_curl -N -X POST \
   "$FRIDAYD_URL/api/workspaces/<id>/signals/<signal-id>" \
   -H 'Content-Type: application/json' \
   -H 'Accept: text/event-stream' \
@@ -136,7 +144,7 @@ deno task atlas session get <session-id> --json  # full SessionView
 SSE replay/live stream (survives reconnect within the replay window):
 
 ```bash
-curl -N ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
+friday_curl -N \
   "$FRIDAYD_URL/api/sessions/<id>/stream" \
   -H 'Accept: text/event-stream'
 ```
@@ -146,7 +154,7 @@ human-readable summary + keyDetails (with URLs). Prefer it over walking
 `agentBlocks[]` when you just want "what happened":
 
 ```bash
-curl -sf ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
+friday_curl -sf \
   "$FRIDAYD_URL/api/sessions/<id>" | jq '.aiSummary'
 ```
 
@@ -161,7 +169,7 @@ JSON — convert from YAML inline:
 
 ```bash
 CONFIG=$(python3 -c "import yaml,json,sys; print(json.dumps(yaml.safe_load(open('$1'))))" workspaces/my-thing/workspace.yml)
-curl -sf -X POST ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
+friday_curl -sf -X POST \
   "$FRIDAYD_URL/api/workspaces/create" \
   -H 'Content-Type: application/json' \
   -d "{\"config\":$CONFIG,\"workspaceName\":\"My Thing\"}"

--- a/packages/system/skills/friday-cli/SKILL.md
+++ b/packages/system/skills/friday-cli/SKILL.md
@@ -18,49 +18,50 @@ auto-loads the daemon `.env` so it picks the right scheme) and the raw
 HTTP API (more endpoints, SSE streaming, the only option for many CRUD ops
 on workspace internals).
 
-## Daemon URL — copy-paste preamble for every curl block
+## Daemon URL — resolve before emitting curl commands
 
-Curl examples below assume `$FRIDAYD_URL` and (when TLS is on) `$FRIDAY_TLS_CA`
-are set. The daemon `.env` lives at `${FRIDAY_HOME:-~/.friday/local}/.env`
-on installed Friday Studio and `~/.atlas/.env` for dev (the dev `deno task
-atlas` pins `FRIDAY_HOME=$HOME/.atlas`). Source whichever exists once per
-shell:
+`$FRIDAYD_URL` is in the **Friday daemon's process env**, not the user's
+shell. If you emit a curl example with a literal `$FRIDAYD_URL`, the user
+pastes it into a shell that has no such variable and gets `curl: (3) URL
+rejected: No host part in the URL`.
 
-```bash
-set -a
-. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
-  || . "$HOME/.atlas/.env" 2>/dev/null || true
-set +a
-# $FRIDAYD_URL → https://… when TLS is on, http://… when plain HTTP.
-#                 Exact host/port comes from the daemon's bind — don't assume :8080.
-# $FRIDAY_TLS_CA → path to the private-CA cert (empty when TLS off)
+**Always resolve `$FRIDAYD_URL` to a concrete value before showing a
+command to the user.** Use `run_code` to read your own env:
 
-# Wrapper that adds --cacert exactly when TLS is on. Use this in place of
-# `curl` for every daemon call — never `curl` directly against $FRIDAYD_URL.
-friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
+```python
+import os
+print(os.environ["FRIDAYD_URL"])
 ```
+
+That prints a URL like `https://localhost:18080` (installed Studio with
+TLS) or `http://localhost:8080` (in-tree dev). Take whatever string the
+lookup returns and substitute it as a literal in the curl command.
 
 ### Two load-bearing rules
 
-1. **Never hardcode the daemon URL — always use `$FRIDAYD_URL`.** Even
-   if the user mentions a specific host or port ("the daemon is on
-   `:18080`", "I have it on `https://localhost:8080`"), IGNORE that
-   detail and use `$FRIDAYD_URL` in the command. The variable already
-   resolves to the right value for the user's install.
+1. **Resolve `$FRIDAYD_URL` first, emit the literal URL.** Never emit
+   `$FRIDAYD_URL` (the variable name) in a command the user is supposed
+   to paste — they don't have it in their env. Always run the lookup
+   above, then substitute. If the user mentions a host/port in their
+   message, IGNORE it and use the resolved value from your env — that's
+   the only one guaranteed to match the running daemon.
 
-2. **Use the `friday_curl` wrapper, never plain `curl`.** The wrapper
-   makes examples work on both plain-HTTP installs (where
-   `$FRIDAY_TLS_CA` is empty and `--cacert` is omitted) and TLS installs
-   (where `--cacert` is required — plain `curl` against `$FRIDAYD_URL`
-   fails with `self signed certificate in certificate chain`).
+   **Worked example.** Your `run_code` lookup returns
+   `FRIDAYD_URL=https://localhost:18080`. User asks "hit /health":
+   - ❌ Wrong: `curl -k "$FRIDAYD_URL/health"` (user's shell has no
+     `$FRIDAYD_URL`).
+   - ❌ Wrong: `curl -k "http://localhost:8080/health"` (guessed the
+     wrong port — user runs installed Studio, not dev).
+   - ✅ Right: `curl -k "https://localhost:18080/health"` (the literal
+     value from `os.environ["FRIDAYD_URL"]`).
 
-**Troubleshooting:** if `friday_curl` still fails with `SSL certificate
-problem: self signed certificate in certificate chain`, your
-`FRIDAY_TLS_CA` is empty or stale (`set -a` exported an empty value, or
-the .env was rewritten since you last sourced it — by the launcher's TLS
-renewer for installed Studio, or by a `scripts/setup-tls.sh` rerun for
-dev). Check with `echo "$FRIDAY_TLS_CA"` and re-source the daemon `.env`
-from the same preamble above.
+2. **Always use `curl -k` for daemon calls, never bare `curl`.** The
+   daemon ships a private-CA TLS cert that the system trust store
+   doesn't know about; plain `curl` against the daemon on a TLS install
+   fails with `self signed certificate in certificate chain`. `-k`
+   skips cert verification, which is fine here because the daemon
+   binds loopback only — anyone who can MitM `localhost` already owns
+   the machine.
 
 ## When to use CLI vs HTTP
 
@@ -84,7 +85,7 @@ Before touching anything, confirm the daemon is up:
 ```bash
 deno task atlas daemon status
 # or (after sourcing the daemon .env — see preamble above):
-friday_curl -sf "$FRIDAYD_URL/health" && echo OK
+curl -k -sf "$FRIDAYD_URL/health" && echo OK
 ```
 
 If it's not:
@@ -120,7 +121,7 @@ deno task atlas signal list -w <workspace-id-or-name> --json
 Or HTTP for full schema:
 
 ```bash
-friday_curl -sf \
+curl -k -sf \
   "$FRIDAYD_URL/api/workspaces/<id>/signals" | jq
 ```
 
@@ -137,7 +138,7 @@ deno task atlas signal trigger -n <signal-name> -w <workspace> \
 Or via HTTP with SSE:
 
 ```bash
-friday_curl -N -X POST \
+curl -k -N -X POST \
   "$FRIDAYD_URL/api/workspaces/<id>/signals/<signal-id>" \
   -H 'Content-Type: application/json' \
   -H 'Accept: text/event-stream' \
@@ -159,7 +160,7 @@ deno task atlas session get <session-id> --json  # full SessionView
 SSE replay/live stream (survives reconnect within the replay window):
 
 ```bash
-friday_curl -N \
+curl -k -N \
   "$FRIDAYD_URL/api/sessions/<id>/stream" \
   -H 'Accept: text/event-stream'
 ```
@@ -169,7 +170,7 @@ human-readable summary + keyDetails (with URLs). Prefer it over walking
 `agentBlocks[]` when you just want "what happened":
 
 ```bash
-friday_curl -sf \
+curl -k -sf \
   "$FRIDAYD_URL/api/sessions/<id>" | jq '.aiSummary'
 ```
 
@@ -184,7 +185,7 @@ JSON — convert from YAML inline:
 
 ```bash
 CONFIG=$(python3 -c "import yaml,json,sys; print(json.dumps(yaml.safe_load(open('$1'))))" workspaces/my-thing/workspace.yml)
-friday_curl -sf -X POST \
+curl -k -sf -X POST \
   "$FRIDAYD_URL/api/workspaces/create" \
   -H 'Content-Type: application/json' \
   -d "{\"config\":$CONFIG,\"workspaceName\":\"My Thing\"}"

--- a/packages/system/skills/friday-cli/SKILL.md
+++ b/packages/system/skills/friday-cli/SKILL.md
@@ -5,10 +5,26 @@ description: "Interact with a running Friday daemon via CLI and HTTP — list/cr
 
 # Friday CLI & HTTP
 
-Friday is orchestrated by a daemon on `localhost:8080`. There are two surfaces
-for interacting with it: the `deno task atlas` CLI (thin HTTP client, great for
-humans and shell scripts) and the raw HTTP API (more endpoints, SSE streaming,
+Friday is orchestrated by a daemon on `localhost:8080` (plain HTTP) or
+`https://localhost:8080` when TLS is enabled (`scripts/setup-tls.sh`). There
+are two surfaces for interacting with it: the `deno task atlas` CLI (thin HTTP
+client, great for humans and shell scripts — auto-loads `~/.atlas/.env` so it
+picks the right scheme) and the raw HTTP API (more endpoints, SSE streaming,
 the only option for many CRUD ops on workspace internals).
+
+## Daemon URL — copy-paste preamble for every curl block
+
+Curl examples below assume `$FRIDAYD_URL` and (when TLS is on) `$FRIDAY_TLS_CA`
+are set. Source `~/.atlas/.env` once per shell to pick them up:
+
+```bash
+set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+# $FRIDAYD_URL → https://localhost:18080 (TLS) or http://localhost:8080 (plain)
+# $FRIDAY_TLS_CA → path to the private-CA cert (empty when TLS off)
+```
+
+Every curl below uses `${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"}` — that
+expansion is empty under plain HTTP, and adds `--cacert` exactly when needed.
 
 ## When to use CLI vs HTTP
 
@@ -31,8 +47,9 @@ Before touching anything, confirm the daemon is up:
 
 ```bash
 deno task atlas daemon status
-# or:
-curl -sf http://localhost:8080/health && echo OK
+# or (after sourcing ~/.atlas/.env — see preamble above):
+curl -sf ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
+  "${FRIDAYD_URL:-http://localhost:8080}/health" && echo OK
 ```
 
 If it's not:
@@ -68,7 +85,8 @@ deno task atlas signal list -w <workspace-id-or-name> --json
 Or HTTP for full schema:
 
 ```bash
-curl -s http://localhost:8080/api/workspaces/<id>/signals | jq
+curl -sf ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
+  "$FRIDAYD_URL/api/workspaces/<id>/signals" | jq
 ```
 
 The signal's `schema` is a JSON Schema — your payload must match it or the
@@ -84,7 +102,8 @@ deno task atlas signal trigger -n <signal-name> -w <workspace> \
 Or via HTTP with SSE:
 
 ```bash
-curl -N -X POST http://localhost:8080/api/workspaces/<id>/signals/<signal-id> \
+curl -N -X POST ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
+  "$FRIDAYD_URL/api/workspaces/<id>/signals/<signal-id>" \
   -H 'Content-Type: application/json' \
   -H 'Accept: text/event-stream' \
   -d '{"payload":{"some":"value"}}'
@@ -105,7 +124,8 @@ deno task atlas session get <session-id> --json  # full SessionView
 SSE replay/live stream (survives reconnect within the replay window):
 
 ```bash
-curl -N http://localhost:8080/api/sessions/<id>/stream \
+curl -N ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
+  "$FRIDAYD_URL/api/sessions/<id>/stream" \
   -H 'Accept: text/event-stream'
 ```
 
@@ -114,7 +134,8 @@ human-readable summary + keyDetails (with URLs). Prefer it over walking
 `agentBlocks[]` when you just want "what happened":
 
 ```bash
-curl -s http://localhost:8080/api/sessions/<id> | jq '.aiSummary'
+curl -sf ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
+  "$FRIDAYD_URL/api/sessions/<id>" | jq '.aiSummary'
 ```
 
 Full shape + failure extraction recipes + log access + SSE event types →
@@ -128,7 +149,8 @@ JSON — convert from YAML inline:
 
 ```bash
 CONFIG=$(python3 -c "import yaml,json,sys; print(json.dumps(yaml.safe_load(open('$1'))))" workspaces/my-thing/workspace.yml)
-curl -s -X POST http://localhost:8080/api/workspaces/create \
+curl -sf -X POST ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
+  "$FRIDAYD_URL/api/workspaces/create" \
   -H 'Content-Type: application/json' \
   -d "{\"config\":$CONFIG,\"workspaceName\":\"My Thing\"}"
 ```

--- a/packages/system/skills/friday-cli/SKILL.md
+++ b/packages/system/skills/friday-cli/SKILL.md
@@ -9,14 +9,14 @@ Friday is orchestrated by a daemon at `$FRIDAYD_URL`. The exact scheme/port
 varies by install — installed Friday Studio runs on `:18080` (with TLS
 configured automatically by the launcher), in-tree dev runs on `:8080`
 (plain HTTP unless you opt in with `bash scripts/setup-tls.sh`), and
-`FRIDAY_PORT_FRIDAY` can override either. Don't hardcode the URL — source
-the daemon `.env` (preamble below) and use `$FRIDAYD_URL` everywhere.
+`FRIDAY_PORT_FRIDAY` can override either. Don't hardcode the URL — resolve
+`$FRIDAYD_URL` from your own process env via `run_code` (preamble below)
+and emit the resolved literal in every command you show the user.
 
 There are two surfaces for interacting with the daemon: the `deno task
-atlas` CLI (thin HTTP client, great for humans and shell scripts —
-auto-loads the daemon `.env` so it picks the right scheme) and the raw
-HTTP API (more endpoints, SSE streaming, the only option for many CRUD ops
-on workspace internals).
+atlas` CLI (thin HTTP client, great for humans and shell scripts) and the
+raw HTTP API (more endpoints, SSE streaming, the only option for many
+CRUD ops on workspace internals).
 
 ## Daemon URL — resolve before emitting curl commands
 
@@ -84,8 +84,9 @@ Before touching anything, confirm the daemon is up:
 
 ```bash
 deno task atlas daemon status
-# or (after sourcing the daemon .env — see preamble above):
-curl -k -sf "$FRIDAYD_URL/health" && echo OK
+# or (after resolving $FRIDAYD_URL via run_code and substituting the
+# literal value — see preamble above):
+curl -k -sf "<resolved-url>/health" && echo OK
 ```
 
 If it's not:

--- a/packages/system/skills/friday-cli/SKILL.md
+++ b/packages/system/skills/friday-cli/SKILL.md
@@ -1,16 +1,22 @@
 ---
 name: friday-cli
-description: "Interact with a running Friday daemon via CLI and HTTP — list/create/modify workspaces, trigger signals, watch sessions, publish skills and agents. Use whenever you need to poke at a local Friday daemon, inspect its state, fire a signal, drive the autopilot / self-modification flywheel, create a workspace programmatically, or validate that a workspace.yml you just authored actually runs. Also use when the task involves `localhost:8080`, `deno task atlas`, curl-ing the daemon, or automating Friday itself."
+description: "Interact with a running Friday daemon via CLI and HTTP — list/create/modify workspaces, trigger signals, watch sessions, publish skills and agents. Use whenever you need to poke at a local Friday daemon, inspect its state, fire a signal, drive the autopilot / self-modification flywheel, create a workspace programmatically, or validate that a workspace.yml you just authored actually runs. Also use when the task involves `$FRIDAYD_URL`, `deno task atlas`, curl-ing the daemon, or automating Friday itself."
 ---
 
 # Friday CLI & HTTP
 
-Friday is orchestrated by a daemon on `localhost:8080` (plain HTTP) or
-`https://localhost:8080` when TLS is enabled (`scripts/setup-tls.sh`). There
-are two surfaces for interacting with it: the `deno task atlas` CLI (thin HTTP
-client, great for humans and shell scripts — auto-loads the daemon `.env` so
-it picks the right scheme) and the raw HTTP API (more endpoints, SSE streaming,
-the only option for many CRUD ops on workspace internals).
+Friday is orchestrated by a daemon at `$FRIDAYD_URL`. The exact scheme/port
+varies by install — installed Friday Studio runs on `:18080` (with TLS
+configured automatically by the launcher), in-tree dev runs on `:8080`
+(plain HTTP unless you opt in with `bash scripts/setup-tls.sh`), and
+`FRIDAY_PORT_FRIDAY` can override either. Don't hardcode the URL — source
+the daemon `.env` (preamble below) and use `$FRIDAYD_URL` everywhere.
+
+There are two surfaces for interacting with the daemon: the `deno task
+atlas` CLI (thin HTTP client, great for humans and shell scripts —
+auto-loads the daemon `.env` so it picks the right scheme) and the raw
+HTTP API (more endpoints, SSE streaming, the only option for many CRUD ops
+on workspace internals).
 
 ## Daemon URL — copy-paste preamble for every curl block
 
@@ -25,7 +31,8 @@ set -a
 . "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
   || . "$HOME/.atlas/.env" 2>/dev/null || true
 set +a
-# $FRIDAYD_URL → https://localhost:18080 (TLS) or http://localhost:8080 (plain)
+# $FRIDAYD_URL → https://… when TLS is on, http://… when plain HTTP.
+#                 Exact host/port comes from the daemon's bind — don't assume :8080.
 # $FRIDAY_TLS_CA → path to the private-CA cert (empty when TLS off)
 
 # Wrapper that adds --cacert exactly when TLS is on. Use this in place of
@@ -42,9 +49,10 @@ with `self signed certificate in certificate chain`).
 **Troubleshooting:** if `friday_curl` still fails with `SSL certificate
 problem: self signed certificate in certificate chain`, your
 `FRIDAY_TLS_CA` is empty or stale (`set -a` exported an empty value, or
-the .env hasn't been re-sourced after a `setup-tls.sh` rerun). Check with
-`echo "$FRIDAY_TLS_CA"` and re-source the daemon `.env` from the same
-preamble above.
+the .env was rewritten since you last sourced it — by the launcher's TLS
+renewer for installed Studio, or by a `scripts/setup-tls.sh` rerun for
+dev). Check with `echo "$FRIDAY_TLS_CA"` and re-source the daemon `.env`
+from the same preamble above.
 
 ## When to use CLI vs HTTP
 
@@ -68,8 +76,7 @@ Before touching anything, confirm the daemon is up:
 ```bash
 deno task atlas daemon status
 # or (after sourcing the daemon .env — see preamble above):
-friday_curl -sf \
-  "${FRIDAYD_URL:-http://localhost:8080}/health" && echo OK
+friday_curl -sf "$FRIDAYD_URL/health" && echo OK
 ```
 
 If it's not:

--- a/packages/system/skills/friday-cli/SKILL.md
+++ b/packages/system/skills/friday-cli/SKILL.md
@@ -8,23 +8,35 @@ description: "Interact with a running Friday daemon via CLI and HTTP — list/cr
 Friday is orchestrated by a daemon on `localhost:8080` (plain HTTP) or
 `https://localhost:8080` when TLS is enabled (`scripts/setup-tls.sh`). There
 are two surfaces for interacting with it: the `deno task atlas` CLI (thin HTTP
-client, great for humans and shell scripts — auto-loads `~/.atlas/.env` so it
-picks the right scheme) and the raw HTTP API (more endpoints, SSE streaming,
+client, great for humans and shell scripts — auto-loads the daemon `.env` so
+it picks the right scheme) and the raw HTTP API (more endpoints, SSE streaming,
 the only option for many CRUD ops on workspace internals).
 
 ## Daemon URL — copy-paste preamble for every curl block
 
 Curl examples below assume `$FRIDAYD_URL` and (when TLS is on) `$FRIDAY_TLS_CA`
-are set. Source `~/.atlas/.env` once per shell to pick them up:
+are set. The daemon `.env` lives at `${FRIDAY_HOME:-~/.friday/local}/.env`
+on installed Friday Studio and `~/.atlas/.env` for dev (the dev `deno task
+atlas` pins `FRIDAY_HOME=$HOME/.atlas`). Source whichever exists once per
+shell:
 
 ```bash
-set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+set -a
+. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
+  || . "$HOME/.atlas/.env" 2>/dev/null || true
+set +a
 # $FRIDAYD_URL → https://localhost:18080 (TLS) or http://localhost:8080 (plain)
 # $FRIDAY_TLS_CA → path to the private-CA cert (empty when TLS off)
 ```
 
 Every curl below uses `${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"}` — that
 expansion is empty under plain HTTP, and adds `--cacert` exactly when needed.
+
+**Troubleshooting:** if a curl call fails with `SSL certificate problem:
+self signed certificate in certificate chain`, your `FRIDAY_TLS_CA` is
+empty or stale (`set -a` exported an empty value, or the .env hasn't been
+re-sourced after a `setup-tls.sh` rerun). Check with `echo "$FRIDAY_TLS_CA"`
+and re-source the daemon `.env` from the same preamble above.
 
 ## When to use CLI vs HTTP
 
@@ -47,7 +59,7 @@ Before touching anything, confirm the daemon is up:
 
 ```bash
 deno task atlas daemon status
-# or (after sourcing ~/.atlas/.env — see preamble above):
+# or (after sourcing the daemon .env — see preamble above):
 curl -sf ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
   "${FRIDAYD_URL:-http://localhost:8080}/health" && echo OK
 ```

--- a/packages/system/skills/friday-cli/references/cli.md
+++ b/packages/system/skills/friday-cli/references/cli.md
@@ -12,9 +12,14 @@ A few subcommands document HTTP fallback paths (notably `agent register`
 below — there is no CLI subcommand). For those, **use `curl -k`, never
 plain `curl`** — plain `curl` against `$FRIDAYD_URL` on a TLS-enabled
 install fails with `self signed certificate in certificate chain`. Source
-the daemon `.env` once per shell:
+the daemon `.env` once per shell — installed-Studio location first, dev
+location (written by `setup-tls.sh`) as fallback:
 
 ```bash
+set -a
+. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
+  || . "$HOME/.atlas/.env" 2>/dev/null || true
+set +a
 ```
 
 Conventions:

--- a/packages/system/skills/friday-cli/references/cli.md
+++ b/packages/system/skills/friday-cli/references/cli.md
@@ -182,10 +182,15 @@ Full agent config as JSON (type, prompt, model, tools, integrations).
 
 ### Registering a Python user agent
 
-There is no `atlas agent register` CLI subcommand — register via the daemon's HTTP API directly:
+There is no `atlas agent register` CLI subcommand — register via the daemon's
+HTTP API directly. Source `~/.atlas/.env` once per shell so the example
+works on TLS-enabled installs (see the SKILL.md "Daemon URL" preamble):
 
 ```bash
-curl -X POST http://localhost:8080/api/agents/register \
+set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
+
+friday_curl -X POST "$FRIDAYD_URL/api/agents/register" \
   -H 'Content-Type: application/json' \
   -d '{"entrypoint": "/abs/path/to/your-agent/agent.py"}'
 ```

--- a/packages/system/skills/friday-cli/references/cli.md
+++ b/packages/system/skills/friday-cli/references/cli.md
@@ -9,17 +9,12 @@ flag you need, drop to HTTP (`references/http.md`).
 ## Daemon URL preamble (required for raw HTTP)
 
 A few subcommands document HTTP fallback paths (notably `agent register`
-below — there is no CLI subcommand). For those, **use `friday_curl`, never
+below — there is no CLI subcommand). For those, **use `curl -k`, never
 plain `curl`** — plain `curl` against `$FRIDAYD_URL` on a TLS-enabled
 install fails with `self signed certificate in certificate chain`. Source
-the daemon `.env` and define the wrapper once per shell:
+the daemon `.env` once per shell:
 
 ```bash
-set -a
-. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
-  || . "$HOME/.atlas/.env" 2>/dev/null || true
-set +a
-friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
 ```
 
 Conventions:
@@ -204,18 +199,13 @@ There is no `atlas agent register` CLI subcommand — register via the daemon's
 HTTP API directly. Source the daemon `.env` once per shell so the example
 works on TLS-enabled installs (see the SKILL.md "Daemon URL" preamble).
 
-**Rule: use `friday_curl`, not plain `curl`.** Plain `curl` against
+**Rule: use `curl -k`, not plain `curl`.** Plain `curl` against
 `$FRIDAYD_URL` on a TLS install fails with `self signed certificate in
-certificate chain` — `friday_curl` adds `--cacert` automatically.
+certificate chain`. `-k` skips cert verification — safe because the
+daemon binds loopback only.
 
 ```bash
-set -a
-. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
-  || . "$HOME/.atlas/.env" 2>/dev/null || true
-set +a
-friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
-
-friday_curl -X POST "$FRIDAYD_URL/api/agents/register" \
+curl -k -X POST "$FRIDAYD_URL/api/agents/register" \
   -H 'Content-Type: application/json' \
   -d '{"entrypoint": "/abs/path/to/your-agent/agent.py"}'
 ```

--- a/packages/system/skills/friday-cli/references/cli.md
+++ b/packages/system/skills/friday-cli/references/cli.md
@@ -4,6 +4,22 @@ Complete reference for `deno task atlas <subcommand>`. The CLI is a thin HTTP
 client over `localhost:8080` — every subcommand maps to one or more daemon
 routes. When the CLI lacks a flag you need, drop to HTTP (`references/http.md`).
 
+## Daemon URL preamble (required for raw HTTP)
+
+A few subcommands document HTTP fallback paths (notably `agent register`
+below — there is no CLI subcommand). For those, **use `friday_curl`, never
+plain `curl`** — plain `curl` against `$FRIDAYD_URL` on a TLS-enabled
+install fails with `self signed certificate in certificate chain`. Source
+the daemon `.env` and define the wrapper once per shell:
+
+```bash
+set -a
+. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
+  || . "$HOME/.atlas/.env" 2>/dev/null || true
+set +a
+friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
+```
+
 Conventions:
 - `--json` on most commands → NDJSON (one object per line) + a final
   `cli-summary` line with continuation hints.
@@ -184,7 +200,11 @@ Full agent config as JSON (type, prompt, model, tools, integrations).
 
 There is no `atlas agent register` CLI subcommand — register via the daemon's
 HTTP API directly. Source the daemon `.env` once per shell so the example
-works on TLS-enabled installs (see the SKILL.md "Daemon URL" preamble):
+works on TLS-enabled installs (see the SKILL.md "Daemon URL" preamble).
+
+**Rule: use `friday_curl`, not plain `curl`.** Plain `curl` against
+`$FRIDAYD_URL` on a TLS install fails with `self signed certificate in
+certificate chain` — `friday_curl` adds `--cacert` automatically.
 
 ```bash
 set -a

--- a/packages/system/skills/friday-cli/references/cli.md
+++ b/packages/system/skills/friday-cli/references/cli.md
@@ -183,11 +183,14 @@ Full agent config as JSON (type, prompt, model, tools, integrations).
 ### Registering a Python user agent
 
 There is no `atlas agent register` CLI subcommand — register via the daemon's
-HTTP API directly. Source `~/.atlas/.env` once per shell so the example
+HTTP API directly. Source the daemon `.env` once per shell so the example
 works on TLS-enabled installs (see the SKILL.md "Daemon URL" preamble):
 
 ```bash
-set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+set -a
+. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
+  || . "$HOME/.atlas/.env" 2>/dev/null || true
+set +a
 friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
 
 friday_curl -X POST "$FRIDAYD_URL/api/agents/register" \

--- a/packages/system/skills/friday-cli/references/cli.md
+++ b/packages/system/skills/friday-cli/references/cli.md
@@ -1,8 +1,10 @@
 # Atlas CLI Reference
 
 Complete reference for `deno task atlas <subcommand>`. The CLI is a thin HTTP
-client over `localhost:8080` — every subcommand maps to one or more daemon
-routes. When the CLI lacks a flag you need, drop to HTTP (`references/http.md`).
+client over `$FRIDAYD_URL` (host/port and scheme vary by install — installed
+Friday Studio runs `:18080`, in-tree dev runs `:8080`, both can be on TLS).
+Every subcommand maps to one or more daemon routes. When the CLI lacks a
+flag you need, drop to HTTP (`references/http.md`).
 
 ## Daemon URL preamble (required for raw HTTP)
 

--- a/packages/system/skills/friday-cli/references/http.md
+++ b/packages/system/skills/friday-cli/references/http.md
@@ -14,6 +14,10 @@ installed-Studio location first (`${FRIDAY_HOME:-~/.friday/local}/.env`)
 then falls back to the dev location (`~/.atlas/.env`):
 
 ```bash
+set -a
+. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
+  || . "$HOME/.atlas/.env" 2>/dev/null || true
+set +a
 ```
 
 **Rule: every daemon HTTP call in this reference uses `curl -k`, not

--- a/packages/system/skills/friday-cli/references/http.md
+++ b/packages/system/skills/friday-cli/references/http.md
@@ -5,11 +5,16 @@ install, and switches to `https://localhost:8080` (or the
 `FRIDAY_PORT_FRIDAY`-overridden port) when `scripts/setup-tls.sh` has been
 run. No auth on localhost. JSON in/out unless noted.
 
-To run the curl examples in this file, source `~/.atlas/.env` once per shell
-so `$FRIDAYD_URL` and `$FRIDAY_TLS_CA` are exported:
+To run the curl examples in this file, source the daemon `.env` once per
+shell so `$FRIDAYD_URL` and `$FRIDAY_TLS_CA` are exported. The block below
+tries the installed-Studio location first (`${FRIDAY_HOME:-~/.friday/local}/.env`)
+then falls back to the dev location (`~/.atlas/.env`):
 
 ```bash
-set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+set -a
+. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
+  || . "$HOME/.atlas/.env" 2>/dev/null || true
+set +a
 ```
 
 All curl invocations should add `${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"}`

--- a/packages/system/skills/friday-cli/references/http.md
+++ b/packages/system/skills/friday-cli/references/http.md
@@ -1,9 +1,12 @@
 # Friday Daemon HTTP API
 
-Base: `$FRIDAYD_URL` — defaults to `http://localhost:8080` on a plain-HTTP
-install, and switches to `https://localhost:8080` (or the
-`FRIDAY_PORT_FRIDAY`-overridden port) when `scripts/setup-tls.sh` has been
-run. No auth on localhost. JSON in/out unless noted.
+Base: `$FRIDAYD_URL` — set by the launcher (installed Friday Studio,
+typically `:18080`) or `deno task atlas daemon start` (in-tree dev,
+typically `:8080`); `FRIDAY_PORT_FRIDAY` can override either. Scheme is
+`https://` when TLS is on (automatic for installed Studio; in-tree dev
+opts in via `bash scripts/setup-tls.sh`), otherwise `http://`. **Don't
+hardcode the URL — always use `$FRIDAYD_URL`.** No auth on localhost.
+JSON in/out unless noted.
 
 To run the curl examples in this file, source the daemon `.env` once per
 shell so `$FRIDAYD_URL` and `$FRIDAY_TLS_CA` are exported. The block below

--- a/packages/system/skills/friday-cli/references/http.md
+++ b/packages/system/skills/friday-cli/references/http.md
@@ -9,24 +9,17 @@ hardcode the URL — always use `$FRIDAYD_URL`.** No auth on localhost.
 JSON in/out unless noted.
 
 To run the curl examples in this file, source the daemon `.env` once per
-shell so `$FRIDAYD_URL` and `$FRIDAY_TLS_CA` are exported. The block below
-tries the installed-Studio location first (`${FRIDAY_HOME:-~/.friday/local}/.env`)
+shell so `$FRIDAYD_URL` is exported. The block below tries the
+installed-Studio location first (`${FRIDAY_HOME:-~/.friday/local}/.env`)
 then falls back to the dev location (`~/.atlas/.env`):
 
 ```bash
-set -a
-. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
-  || . "$HOME/.atlas/.env" 2>/dev/null || true
-set +a
-# Wrapper that adds --cacert exactly when TLS is on. Use this in place of
-# plain `curl` for every daemon call below.
-friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
 ```
 
-**Rule: every daemon HTTP call in this reference uses `friday_curl`, not
-plain `curl`.** The wrapper auto-adds `--cacert "$FRIDAY_TLS_CA"` when TLS
-is on; plain `curl` against `$FRIDAYD_URL` on a TLS install fails with
-`self signed certificate in certificate chain`.
+**Rule: every daemon HTTP call in this reference uses `curl -k`, not
+plain `curl`.** Plain `curl` against `$FRIDAYD_URL` on a TLS install
+fails with `self signed certificate in certificate chain`. `-k` skips
+cert verification — safe because the daemon binds loopback only.
 
 SSE: pass `Accept: text/event-stream`. Streams end with `data: [DONE]`.
 

--- a/packages/system/skills/friday-cli/references/http.md
+++ b/packages/system/skills/friday-cli/references/http.md
@@ -15,11 +15,15 @@ set -a
 . "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
   || . "$HOME/.atlas/.env" 2>/dev/null || true
 set +a
+# Wrapper that adds --cacert exactly when TLS is on. Use this in place of
+# plain `curl` for every daemon call below.
+friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
 ```
 
-All curl invocations should add `${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"}`
-— that expansion is empty under plain HTTP and adds `--cacert` exactly when
-the daemon is serving the private-CA s2s cert.
+**Rule: every daemon HTTP call in this reference uses `friday_curl`, not
+plain `curl`.** The wrapper auto-adds `--cacert "$FRIDAY_TLS_CA"` when TLS
+is on; plain `curl` against `$FRIDAYD_URL` on a TLS install fails with
+`self signed certificate in certificate chain`.
 
 SSE: pass `Accept: text/event-stream`. Streams end with `data: [DONE]`.
 

--- a/packages/system/skills/friday-cli/references/http.md
+++ b/packages/system/skills/friday-cli/references/http.md
@@ -1,6 +1,20 @@
 # Friday Daemon HTTP API
 
-Base: `http://localhost:8080`. No auth on localhost. JSON in/out unless noted.
+Base: `$FRIDAYD_URL` — defaults to `http://localhost:8080` on a plain-HTTP
+install, and switches to `https://localhost:8080` (or the
+`FRIDAY_PORT_FRIDAY`-overridden port) when `scripts/setup-tls.sh` has been
+run. No auth on localhost. JSON in/out unless noted.
+
+To run the curl examples in this file, source `~/.atlas/.env` once per shell
+so `$FRIDAYD_URL` and `$FRIDAY_TLS_CA` are exported:
+
+```bash
+set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+```
+
+All curl invocations should add `${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"}`
+— that expansion is empty under plain HTTP and adds `--cacert` exactly when
+the daemon is serving the private-CA s2s cert.
 
 SSE: pass `Accept: text/event-stream`. Streams end with `data: [DONE]`.
 

--- a/packages/system/skills/friday-cli/references/recipes.md
+++ b/packages/system/skills/friday-cli/references/recipes.md
@@ -8,7 +8,10 @@ End-to-end patterns for driving Friday via CLI + HTTP. Copy + adapt.
 > both plain-HTTP and TLS-enabled installs:
 >
 > ```bash
-> set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+> set -a
+> . "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
+>   || . "$HOME/.atlas/.env" 2>/dev/null || true
+> set +a
 > # Wrapper that adds --cacert exactly when TLS is on. Use in place of `curl`.
 > friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
 > ```

--- a/packages/system/skills/friday-cli/references/recipes.md
+++ b/packages/system/skills/friday-cli/references/recipes.md
@@ -2,6 +2,20 @@
 
 End-to-end patterns for driving Friday via CLI + HTTP. Copy + adapt.
 
+> **Preamble — source the daemon env once per shell.** Every curl-like
+> example below uses `$FRIDAYD_URL` and an injected `--cacert` flag (needed
+> when TLS is on). Paste this once and the examples below work as-is on
+> both plain-HTTP and TLS-enabled installs:
+>
+> ```bash
+> set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+> # Wrapper that adds --cacert exactly when TLS is on. Use in place of `curl`.
+> friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
+> ```
+>
+> See the `friday-cli` SKILL.md "Daemon URL" section for the full
+> explanation.
+
 ## Contents
 
 - Create workspace from yaml → fire smoke signal
@@ -30,17 +44,17 @@ End-to-end patterns for driving Friday via CLI + HTTP. Copy + adapt.
 CONFIG=$(python3 -c "import yaml,json; print(json.dumps(yaml.safe_load(open('workspaces/my-thing/workspace.yml'))))")
 
 # 2. Create. Capture workspaceId.
-RESP=$(curl -s -X POST http://localhost:8080/api/workspaces/create \
+RESP=$(friday_curl -s -X POST "$FRIDAYD_URL"/api/workspaces/create \
   -H 'Content-Type: application/json' \
   -d "{\"config\":$CONFIG,\"workspaceName\":\"My Thing\"}")
 WS_ID=$(echo "$RESP" | jq -r '.workspaceId')
 echo "Created: $WS_ID"
 
 # 3. Inspect signals.
-curl -s http://localhost:8080/api/workspaces/$WS_ID/signals | jq '.signals[].id'
+friday_curl -s "$FRIDAYD_URL"/api/workspaces/$WS_ID/signals | jq '.signals[].id'
 
 # 4. Fire smoke signal, stream events.
-curl -N -X POST http://localhost:8080/api/workspaces/$WS_ID/signals/smoke-test \
+friday_curl -N -X POST "$FRIDAYD_URL"/api/workspaces/$WS_ID/signals/smoke-test \
   -H 'Content-Type: application/json' \
   -H 'Accept: text/event-stream' \
   -d '{"payload":{}}'
@@ -58,7 +72,7 @@ deno task atlas workspace list --json | jq '.[] | select(.name=="My Thing")'
 ## Update signal cron schedule without rewriting workspace.yml
 
 ```bash
-curl -s -X PATCH http://localhost:8080/api/workspaces/$WS_ID/config/signals/autopilot-tick-cron \
+friday_curl -s -X PATCH "$FRIDAYD_URL"/api/workspaces/$WS_ID/config/signals/autopilot-tick-cron \
   -H 'Content-Type: application/json' \
   -d '{"config":{"schedule":"*/5 * * * *","timezone":"America/Los_Angeles"}}'
 ```
@@ -69,7 +83,7 @@ signal).
 ## Update agent prompt
 
 ```bash
-curl -s -X PUT http://localhost:8080/api/workspaces/$WS_ID/config/agents/autopilot-planner \
+friday_curl -s -X PUT "$FRIDAYD_URL"/api/workspaces/$WS_ID/config/agents/autopilot-planner \
   -H 'Content-Type: application/json' \
   -d '{"prompt":"New prompt text here."}'
 ```
@@ -80,10 +94,10 @@ Mutates workspace.yml directly.
 
 ```bash
 # Find cred refs:
-curl -s http://localhost:8080/api/workspaces/$WS_ID/config/credentials | jq
+friday_curl -s "$FRIDAYD_URL"/api/workspaces/$WS_ID/config/credentials | jq
 
 # Swap:
-curl -s -X PUT http://localhost:8080/api/workspaces/$WS_ID/config/credentials/agent:gh-agent:GITHUB_TOKEN \
+friday_curl -s -X PUT "$FRIDAYD_URL"/api/workspaces/$WS_ID/config/credentials/agent:gh-agent:GITHUB_TOKEN \
   -H 'Content-Type: application/json' \
   -d '{"credentialId":"cred_abc123"}'
 ```
@@ -102,20 +116,20 @@ deno task atlas signal trigger -n cross-session-reflect -w autopilot \
 HTTP version w/ session tracking:
 
 ```bash
-RESP=$(curl -s -X POST http://localhost:8080/api/workspaces/$WS_ID/signals/cross-session-reflect \
+RESP=$(friday_curl -s -X POST "$FRIDAYD_URL"/api/workspaces/$WS_ID/signals/cross-session-reflect \
   -H 'Content-Type: application/json' \
   -d '{"payload":{}}')
 SESSION=$(echo "$RESP" | jq -r '.sessionId')
 
 # Replay + live stream:
-curl -N http://localhost:8080/api/sessions/$SESSION/stream \
+friday_curl -N "$FRIDAYD_URL"/api/sessions/$SESSION/stream \
   -H 'Accept: text/event-stream'
 ```
 
 ## Read narrative memory (autopilot backlog pattern)
 
 ```bash
-curl -s "http://localhost:8080/api/memory/$WS_ID/narrative/autopilot-backlog?since=24h&limit=50" | jq
+friday_curl -s "$FRIDAYD_URL/api/memory/$WS_ID/narrative/autopilot-backlog?since=24h&limit=50" | jq
 ```
 
 Returns `NarrativeEntry[]`. Empty array on failure (check daemon logs).
@@ -142,9 +156,9 @@ Returns new version. Skill version auto-increments.
 ## Assign skill to workspace (scoping)
 
 ```bash
-SKILL_ID=$(curl -s 'http://localhost:8080/api/skills?namespace=tempest' | jq -r '.skills[]|select(.name=="my-skill")|.id')
+SKILL_ID=$(friday_curl -s "$FRIDAYD_URL/api/skills?namespace=tempest" | jq -r '.skills[]|select(.name=="my-skill")|.id')
 
-curl -s -X POST http://localhost:8080/api/skills/scoping/$SKILL_ID/assignments \
+friday_curl -s -X POST "$FRIDAYD_URL"/api/skills/scoping/$SKILL_ID/assignments \
   -H 'Content-Type: application/json' \
   -d "{\"workspaceIds\":[\"$WS_ID\"]}"
 ```
@@ -160,7 +174,7 @@ reference implementation.
 Register via HTTP (no build step — agent process is spawned per invocation):
 
 ```bash
-curl -X POST http://localhost:8080/api/agents/register \
+friday_curl -X POST "$FRIDAYD_URL"/api/agents/register \
   -H 'Content-Type: application/json' \
   -d '{"entrypoint": "/abs/path/to/agents/my-new-agent/agent.py"}'
 ```
@@ -172,7 +186,7 @@ collects metadata over NATS, and installs the source under
 ## Update env vars in daemon config
 
 ```bash
-curl -X PUT http://localhost:8080/api/config/env \
+friday_curl -X PUT "$FRIDAYD_URL"/api/config/env \
   -H 'Content-Type: application/json' \
   -d '{"envVars":{"ANTHROPIC_API_KEY":"sk-...","GITHUB_TOKEN":"ghp_..."}}'
 ```
@@ -200,7 +214,7 @@ scratchpad). Critical for "why did agent do X" debugging.
 deno task atlas workspace status -w $WS_ID --json
 
 # Delete directory + registration:
-curl -X DELETE http://localhost:8080/api/workspaces/$WS_ID
+friday_curl -X DELETE "$FRIDAYD_URL"/api/workspaces/$WS_ID
 ```
 
 403 on system workspace. Userland vanishes silently.
@@ -208,7 +222,7 @@ curl -X DELETE http://localhost:8080/api/workspaces/$WS_ID
 ## Export workspace as tarball (backup)
 
 ```bash
-curl -s http://localhost:8080/api/workspaces/$WS_ID/export > /tmp/$WS_ID.tar
+friday_curl -s "$FRIDAYD_URL"/api/workspaces/$WS_ID/export > /tmp/$WS_ID.tar
 ```
 
 workspace.yml + resource data. Restore via unpack + `workspace add`.
@@ -218,7 +232,7 @@ workspace.yml + resource data. Restore via unpack + `workspace add`.
 ```bash
 deno task atlas daemon status || deno task atlas daemon start --detached
 # or pure HTTP:
-curl -sf http://localhost:8080/health > /dev/null || echo "daemon down"
+friday_curl -sf "$FRIDAYD_URL"/health > /dev/null || echo "daemon down"
 ```
 
 ## SSE event shapes (for parsers)

--- a/packages/system/skills/friday-cli/references/recipes.md
+++ b/packages/system/skills/friday-cli/references/recipes.md
@@ -16,6 +16,8 @@ End-to-end patterns for driving Friday via CLI + HTTP. Copy + adapt.
 > friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
 > ```
 >
+
+**Rule: every daemon HTTP call below uses `friday_curl`, not `curl`.** Plain `curl` against `$FRIDAYD_URL` on a TLS install fails with `self signed certificate in certificate chain`.
 > See the `friday-cli` SKILL.md "Daemon URL" section for the full
 > explanation.
 

--- a/packages/system/skills/friday-cli/references/recipes.md
+++ b/packages/system/skills/friday-cli/references/recipes.md
@@ -3,21 +3,15 @@
 End-to-end patterns for driving Friday via CLI + HTTP. Copy + adapt.
 
 > **Preamble — source the daemon env once per shell.** Every curl-like
-> example below uses `$FRIDAYD_URL` and an injected `--cacert` flag (needed
-> when TLS is on). Paste this once and the examples below work as-is on
-> both plain-HTTP and TLS-enabled installs:
+> example below uses `$FRIDAYD_URL` and `curl -k`. Source the daemon
+> `.env` once so the variable is set. `-k` skips cert verification —
+> safe because the daemon binds loopback only.
 >
 > ```bash
-> set -a
-> . "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
->   || . "$HOME/.atlas/.env" 2>/dev/null || true
-> set +a
-> # Wrapper that adds --cacert exactly when TLS is on. Use in place of `curl`.
-> friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
 > ```
 >
 
-**Rule: every daemon HTTP call below uses `friday_curl`, not `curl`.** Plain `curl` against `$FRIDAYD_URL` on a TLS install fails with `self signed certificate in certificate chain`.
+**Rule: every daemon HTTP call below uses `curl -k`, not `curl`.** Plain `curl` against `$FRIDAYD_URL` on a TLS install fails with `self signed certificate in certificate chain`.
 > See the `friday-cli` SKILL.md "Daemon URL" section for the full
 > explanation.
 
@@ -49,17 +43,17 @@ End-to-end patterns for driving Friday via CLI + HTTP. Copy + adapt.
 CONFIG=$(python3 -c "import yaml,json; print(json.dumps(yaml.safe_load(open('workspaces/my-thing/workspace.yml'))))")
 
 # 2. Create. Capture workspaceId.
-RESP=$(friday_curl -s -X POST "$FRIDAYD_URL"/api/workspaces/create \
+RESP=$(curl -k -s -X POST "$FRIDAYD_URL"/api/workspaces/create \
   -H 'Content-Type: application/json' \
   -d "{\"config\":$CONFIG,\"workspaceName\":\"My Thing\"}")
 WS_ID=$(echo "$RESP" | jq -r '.workspaceId')
 echo "Created: $WS_ID"
 
 # 3. Inspect signals.
-friday_curl -s "$FRIDAYD_URL"/api/workspaces/$WS_ID/signals | jq '.signals[].id'
+curl -k -s "$FRIDAYD_URL"/api/workspaces/$WS_ID/signals | jq '.signals[].id'
 
 # 4. Fire smoke signal, stream events.
-friday_curl -N -X POST "$FRIDAYD_URL"/api/workspaces/$WS_ID/signals/smoke-test \
+curl -k -N -X POST "$FRIDAYD_URL"/api/workspaces/$WS_ID/signals/smoke-test \
   -H 'Content-Type: application/json' \
   -H 'Accept: text/event-stream' \
   -d '{"payload":{}}'
@@ -77,7 +71,7 @@ deno task atlas workspace list --json | jq '.[] | select(.name=="My Thing")'
 ## Update signal cron schedule without rewriting workspace.yml
 
 ```bash
-friday_curl -s -X PATCH "$FRIDAYD_URL"/api/workspaces/$WS_ID/config/signals/autopilot-tick-cron \
+curl -k -s -X PATCH "$FRIDAYD_URL"/api/workspaces/$WS_ID/config/signals/autopilot-tick-cron \
   -H 'Content-Type: application/json' \
   -d '{"config":{"schedule":"*/5 * * * *","timezone":"America/Los_Angeles"}}'
 ```
@@ -88,7 +82,7 @@ signal).
 ## Update agent prompt
 
 ```bash
-friday_curl -s -X PUT "$FRIDAYD_URL"/api/workspaces/$WS_ID/config/agents/autopilot-planner \
+curl -k -s -X PUT "$FRIDAYD_URL"/api/workspaces/$WS_ID/config/agents/autopilot-planner \
   -H 'Content-Type: application/json' \
   -d '{"prompt":"New prompt text here."}'
 ```
@@ -99,10 +93,10 @@ Mutates workspace.yml directly.
 
 ```bash
 # Find cred refs:
-friday_curl -s "$FRIDAYD_URL"/api/workspaces/$WS_ID/config/credentials | jq
+curl -k -s "$FRIDAYD_URL"/api/workspaces/$WS_ID/config/credentials | jq
 
 # Swap:
-friday_curl -s -X PUT "$FRIDAYD_URL"/api/workspaces/$WS_ID/config/credentials/agent:gh-agent:GITHUB_TOKEN \
+curl -k -s -X PUT "$FRIDAYD_URL"/api/workspaces/$WS_ID/config/credentials/agent:gh-agent:GITHUB_TOKEN \
   -H 'Content-Type: application/json' \
   -d '{"credentialId":"cred_abc123"}'
 ```
@@ -121,20 +115,20 @@ deno task atlas signal trigger -n cross-session-reflect -w autopilot \
 HTTP version w/ session tracking:
 
 ```bash
-RESP=$(friday_curl -s -X POST "$FRIDAYD_URL"/api/workspaces/$WS_ID/signals/cross-session-reflect \
+RESP=$(curl -k -s -X POST "$FRIDAYD_URL"/api/workspaces/$WS_ID/signals/cross-session-reflect \
   -H 'Content-Type: application/json' \
   -d '{"payload":{}}')
 SESSION=$(echo "$RESP" | jq -r '.sessionId')
 
 # Replay + live stream:
-friday_curl -N "$FRIDAYD_URL"/api/sessions/$SESSION/stream \
+curl -k -N "$FRIDAYD_URL"/api/sessions/$SESSION/stream \
   -H 'Accept: text/event-stream'
 ```
 
 ## Read narrative memory (autopilot backlog pattern)
 
 ```bash
-friday_curl -s "$FRIDAYD_URL/api/memory/$WS_ID/narrative/autopilot-backlog?since=24h&limit=50" | jq
+curl -k -s "$FRIDAYD_URL/api/memory/$WS_ID/narrative/autopilot-backlog?since=24h&limit=50" | jq
 ```
 
 Returns `NarrativeEntry[]`. Empty array on failure (check daemon logs).
@@ -161,9 +155,9 @@ Returns new version. Skill version auto-increments.
 ## Assign skill to workspace (scoping)
 
 ```bash
-SKILL_ID=$(friday_curl -s "$FRIDAYD_URL/api/skills?namespace=tempest" | jq -r '.skills[]|select(.name=="my-skill")|.id')
+SKILL_ID=$(curl -k -s "$FRIDAYD_URL/api/skills?namespace=tempest" | jq -r '.skills[]|select(.name=="my-skill")|.id')
 
-friday_curl -s -X POST "$FRIDAYD_URL"/api/skills/scoping/$SKILL_ID/assignments \
+curl -k -s -X POST "$FRIDAYD_URL"/api/skills/scoping/$SKILL_ID/assignments \
   -H 'Content-Type: application/json' \
   -d "{\"workspaceIds\":[\"$WS_ID\"]}"
 ```
@@ -179,7 +173,7 @@ reference implementation.
 Register via HTTP (no build step — agent process is spawned per invocation):
 
 ```bash
-friday_curl -X POST "$FRIDAYD_URL"/api/agents/register \
+curl -k -X POST "$FRIDAYD_URL"/api/agents/register \
   -H 'Content-Type: application/json' \
   -d '{"entrypoint": "/abs/path/to/agents/my-new-agent/agent.py"}'
 ```
@@ -191,7 +185,7 @@ collects metadata over NATS, and installs the source under
 ## Update env vars in daemon config
 
 ```bash
-friday_curl -X PUT "$FRIDAYD_URL"/api/config/env \
+curl -k -X PUT "$FRIDAYD_URL"/api/config/env \
   -H 'Content-Type: application/json' \
   -d '{"envVars":{"ANTHROPIC_API_KEY":"sk-...","GITHUB_TOKEN":"ghp_..."}}'
 ```
@@ -219,7 +213,7 @@ scratchpad). Critical for "why did agent do X" debugging.
 deno task atlas workspace status -w $WS_ID --json
 
 # Delete directory + registration:
-friday_curl -X DELETE "$FRIDAYD_URL"/api/workspaces/$WS_ID
+curl -k -X DELETE "$FRIDAYD_URL"/api/workspaces/$WS_ID
 ```
 
 403 on system workspace. Userland vanishes silently.
@@ -227,7 +221,7 @@ friday_curl -X DELETE "$FRIDAYD_URL"/api/workspaces/$WS_ID
 ## Export workspace as tarball (backup)
 
 ```bash
-friday_curl -s "$FRIDAYD_URL"/api/workspaces/$WS_ID/export > /tmp/$WS_ID.tar
+curl -k -s "$FRIDAYD_URL"/api/workspaces/$WS_ID/export > /tmp/$WS_ID.tar
 ```
 
 workspace.yml + resource data. Restore via unpack + `workspace add`.
@@ -237,7 +231,7 @@ workspace.yml + resource data. Restore via unpack + `workspace add`.
 ```bash
 deno task atlas daemon status || deno task atlas daemon start --detached
 # or pure HTTP:
-friday_curl -sf "$FRIDAYD_URL"/health > /dev/null || echo "daemon down"
+curl -k -sf "$FRIDAYD_URL"/health > /dev/null || echo "daemon down"
 ```
 
 ## SSE event shapes (for parsers)

--- a/packages/system/skills/friday-cli/references/recipes.md
+++ b/packages/system/skills/friday-cli/references/recipes.md
@@ -8,12 +8,13 @@ End-to-end patterns for driving Friday via CLI + HTTP. Copy + adapt.
 > safe because the daemon binds loopback only.
 >
 > ```bash
+> set -a
+> . "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
+>   || . "$HOME/.atlas/.env" 2>/dev/null || true
+> set +a
 > ```
->
 
-**Rule: every daemon HTTP call below uses `curl -k`, not `curl`.** Plain `curl` against `$FRIDAYD_URL` on a TLS install fails with `self signed certificate in certificate chain`.
-> See the `friday-cli` SKILL.md "Daemon URL" section for the full
-> explanation.
+**Rule: every daemon HTTP call below uses `curl -k`, not `curl`.** Plain `curl` against `$FRIDAYD_URL` on a TLS install fails with `self signed certificate in certificate chain`. See the `friday-cli` SKILL.md "Daemon URL" section for the full explanation.
 
 ## Contents
 

--- a/packages/system/skills/friday-cli/references/session-and-logs.md
+++ b/packages/system/skills/friday-cli/references/session-and-logs.md
@@ -102,10 +102,14 @@ deno task atlas session list --json | jq '[.[]|select(.status=="active")]'
 ### Bash check after triggering a signal
 
 ```bash
-# Source ~/.atlas/.env once per shell so $FRIDAYD_URL + $FRIDAY_TLS_CA are set
-# — required for TLS-enabled installs (curl rejects the daemon's private-CA
-# cert otherwise). See the friday-cli SKILL.md "Daemon URL" preamble.
-set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+# Source the daemon .env once per shell so $FRIDAYD_URL + $FRIDAY_TLS_CA are
+# set — required for TLS-enabled installs (curl rejects the daemon's
+# private-CA cert otherwise). The chain tries the installed-Studio location
+# first, then the dev location. See friday-cli SKILL.md "Daemon URL".
+set -a
+. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
+  || . "$HOME/.atlas/.env" 2>/dev/null || true
+set +a
 CURL_TLS=( ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} )
 
 # 1. Fire signal, capture sessionId

--- a/packages/system/skills/friday-cli/references/session-and-logs.md
+++ b/packages/system/skills/friday-cli/references/session-and-logs.md
@@ -102,21 +102,28 @@ deno task atlas session list --json | jq '[.[]|select(.status=="active")]'
 ### Bash check after triggering a signal
 
 ```bash
+# Source ~/.atlas/.env once per shell so $FRIDAYD_URL + $FRIDAY_TLS_CA are set
+# — required for TLS-enabled installs (curl rejects the daemon's private-CA
+# cert otherwise). See the friday-cli SKILL.md "Daemon URL" preamble.
+set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+CURL_TLS=( ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} )
+
 # 1. Fire signal, capture sessionId
-RESP=$(curl -s -X POST http://localhost:8080/api/workspaces/$WS_ID/signals/$SIG \
+RESP=$(curl -s "${CURL_TLS[@]}" -X POST \
+  "$FRIDAYD_URL/api/workspaces/$WS_ID/signals/$SIG" \
   -H 'Content-Type: application/json' \
   -d '{"payload":{}}')
 SID=$(echo "$RESP" | jq -r '.sessionId')
 
 # 2. Wait for completion (poll or stream — streaming covered below)
 while true; do
-  STATUS=$(curl -s http://localhost:8080/api/sessions/$SID | jq -r '.status')
+  STATUS=$(curl -s "${CURL_TLS[@]}" "$FRIDAYD_URL/api/sessions/$SID" | jq -r '.status')
   [ "$STATUS" != "active" ] && break
   sleep 2
 done
 
 # 3. Read summary
-curl -s http://localhost:8080/api/sessions/$SID | jq '{
+curl -s "${CURL_TLS[@]}" "$FRIDAYD_URL/api/sessions/$SID" | jq '{
   status,
   durationMs,
   error,
@@ -129,7 +136,7 @@ curl -s http://localhost:8080/api/sessions/$SID | jq '{
 ### Extract failure info
 
 ```bash
-curl -s http://localhost:8080/api/sessions/$SID | jq '
+curl -s "${CURL_TLS[@]}" "$FRIDAYD_URL/api/sessions/$SID" | jq '
   if .status == "failed" then
     {
       sessionError: .error,
@@ -148,7 +155,7 @@ curl -s http://localhost:8080/api/sessions/$SID | jq '
 ### Tool call inventory across session
 
 ```bash
-curl -s http://localhost:8080/api/sessions/$SID | jq '
+curl -s "${CURL_TLS[@]}" "$FRIDAYD_URL/api/sessions/$SID" | jq '
   [.agentBlocks[] | .toolCalls[] | {agent: input_filename, tool: .toolName, durMs: .durationMs}]'
 ```
 
@@ -211,11 +218,11 @@ Operator recipes:
 
 ```bash
 # Count blocking verdicts in a session run:
-curl -s http://localhost:8080/api/sessions/<id> \
+curl -s "${CURL_TLS[@]}" "$FRIDAYD_URL/api/sessions/<id>" \
   | jq '[.events[] | select(.type=="step:complete") | .validation | select(.verdict=="blocking")] | length'
 
 # See which actions skipped validation and why:
-curl -s http://localhost:8080/api/sessions/<id> \
+curl -s "${CURL_TLS[@]}" "$FRIDAYD_URL/api/sessions/<id>" \
   | jq '.events[] | select(.type=="step:complete") | .validation | select(.strategy=="skip") | .skipReason'
 ```
 

--- a/packages/system/skills/friday-cli/references/session-and-logs.md
+++ b/packages/system/skills/friday-cli/references/session-and-logs.md
@@ -110,10 +110,13 @@ set -a
 . "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
   || . "$HOME/.atlas/.env" 2>/dev/null || true
 set +a
-CURL_TLS=( ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} )
+# Use friday_curl for every daemon call below — never plain curl against
+# $FRIDAYD_URL (would fail with `self signed certificate in certificate
+# chain` on TLS-enabled installs).
+friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
 
 # 1. Fire signal, capture sessionId
-RESP=$(curl -s "${CURL_TLS[@]}" -X POST \
+RESP=$(friday_curl -s -X POST \
   "$FRIDAYD_URL/api/workspaces/$WS_ID/signals/$SIG" \
   -H 'Content-Type: application/json' \
   -d '{"payload":{}}')
@@ -121,13 +124,13 @@ SID=$(echo "$RESP" | jq -r '.sessionId')
 
 # 2. Wait for completion (poll or stream — streaming covered below)
 while true; do
-  STATUS=$(curl -s "${CURL_TLS[@]}" "$FRIDAYD_URL/api/sessions/$SID" | jq -r '.status')
+  STATUS=$(friday_curl -s "$FRIDAYD_URL/api/sessions/$SID" | jq -r '.status')
   [ "$STATUS" != "active" ] && break
   sleep 2
 done
 
 # 3. Read summary
-curl -s "${CURL_TLS[@]}" "$FRIDAYD_URL/api/sessions/$SID" | jq '{
+friday_curl -s "$FRIDAYD_URL/api/sessions/$SID" | jq '{
   status,
   durationMs,
   error,
@@ -140,7 +143,7 @@ curl -s "${CURL_TLS[@]}" "$FRIDAYD_URL/api/sessions/$SID" | jq '{
 ### Extract failure info
 
 ```bash
-curl -s "${CURL_TLS[@]}" "$FRIDAYD_URL/api/sessions/$SID" | jq '
+friday_curl -s "$FRIDAYD_URL/api/sessions/$SID" | jq '
   if .status == "failed" then
     {
       sessionError: .error,
@@ -159,7 +162,7 @@ curl -s "${CURL_TLS[@]}" "$FRIDAYD_URL/api/sessions/$SID" | jq '
 ### Tool call inventory across session
 
 ```bash
-curl -s "${CURL_TLS[@]}" "$FRIDAYD_URL/api/sessions/$SID" | jq '
+friday_curl -s "$FRIDAYD_URL/api/sessions/$SID" | jq '
   [.agentBlocks[] | .toolCalls[] | {agent: input_filename, tool: .toolName, durMs: .durationMs}]'
 ```
 
@@ -222,11 +225,11 @@ Operator recipes:
 
 ```bash
 # Count blocking verdicts in a session run:
-curl -s "${CURL_TLS[@]}" "$FRIDAYD_URL/api/sessions/<id>" \
+friday_curl -s "$FRIDAYD_URL/api/sessions/<id>" \
   | jq '[.events[] | select(.type=="step:complete") | .validation | select(.verdict=="blocking")] | length'
 
 # See which actions skipped validation and why:
-curl -s "${CURL_TLS[@]}" "$FRIDAYD_URL/api/sessions/<id>" \
+friday_curl -s "$FRIDAYD_URL/api/sessions/<id>" \
   | jq '.events[] | select(.type=="step:complete") | .validation | select(.strategy=="skip") | .skipReason'
 ```
 

--- a/packages/system/skills/friday-cli/references/session-and-logs.md
+++ b/packages/system/skills/friday-cli/references/session-and-logs.md
@@ -102,21 +102,11 @@ deno task atlas session list --json | jq '[.[]|select(.status=="active")]'
 ### Bash check after triggering a signal
 
 ```bash
-# Source the daemon .env once per shell so $FRIDAYD_URL + $FRIDAY_TLS_CA are
-# set — required for TLS-enabled installs (curl rejects the daemon's
-# private-CA cert otherwise). The chain tries the installed-Studio location
-# first, then the dev location. See friday-cli SKILL.md "Daemon URL".
-set -a
-. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
-  || . "$HOME/.atlas/.env" 2>/dev/null || true
-set +a
-# Use friday_curl for every daemon call below — never plain curl against
-# $FRIDAYD_URL (would fail with `self signed certificate in certificate
-# chain` on TLS-enabled installs).
-friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
-
+# Source the daemon .env once per shell so $FRIDAYD_URL is set. The
+# chain tries the installed-Studio location first, then the dev
+# location. See friday-cli SKILL.md "Daemon URL".
 # 1. Fire signal, capture sessionId
-RESP=$(friday_curl -s -X POST \
+RESP=$(curl -k -s -X POST \
   "$FRIDAYD_URL/api/workspaces/$WS_ID/signals/$SIG" \
   -H 'Content-Type: application/json' \
   -d '{"payload":{}}')
@@ -124,13 +114,13 @@ SID=$(echo "$RESP" | jq -r '.sessionId')
 
 # 2. Wait for completion (poll or stream — streaming covered below)
 while true; do
-  STATUS=$(friday_curl -s "$FRIDAYD_URL/api/sessions/$SID" | jq -r '.status')
+  STATUS=$(curl -k -s "$FRIDAYD_URL/api/sessions/$SID" | jq -r '.status')
   [ "$STATUS" != "active" ] && break
   sleep 2
 done
 
 # 3. Read summary
-friday_curl -s "$FRIDAYD_URL/api/sessions/$SID" | jq '{
+curl -k -s "$FRIDAYD_URL/api/sessions/$SID" | jq '{
   status,
   durationMs,
   error,
@@ -143,7 +133,7 @@ friday_curl -s "$FRIDAYD_URL/api/sessions/$SID" | jq '{
 ### Extract failure info
 
 ```bash
-friday_curl -s "$FRIDAYD_URL/api/sessions/$SID" | jq '
+curl -k -s "$FRIDAYD_URL/api/sessions/$SID" | jq '
   if .status == "failed" then
     {
       sessionError: .error,
@@ -162,7 +152,7 @@ friday_curl -s "$FRIDAYD_URL/api/sessions/$SID" | jq '
 ### Tool call inventory across session
 
 ```bash
-friday_curl -s "$FRIDAYD_URL/api/sessions/$SID" | jq '
+curl -k -s "$FRIDAYD_URL/api/sessions/$SID" | jq '
   [.agentBlocks[] | .toolCalls[] | {agent: input_filename, tool: .toolName, durMs: .durationMs}]'
 ```
 
@@ -225,11 +215,11 @@ Operator recipes:
 
 ```bash
 # Count blocking verdicts in a session run:
-friday_curl -s "$FRIDAYD_URL/api/sessions/<id>" \
+curl -k -s "$FRIDAYD_URL/api/sessions/<id>" \
   | jq '[.events[] | select(.type=="step:complete") | .validation | select(.verdict=="blocking")] | length'
 
 # See which actions skipped validation and why:
-friday_curl -s "$FRIDAYD_URL/api/sessions/<id>" \
+curl -k -s "$FRIDAYD_URL/api/sessions/<id>" \
   | jq '.events[] | select(.type=="step:complete") | .validation | select(.strategy=="skip") | .skipReason'
 ```
 

--- a/packages/system/skills/workspace-api/SKILL.md
+++ b/packages/system/skills/workspace-api/SKILL.md
@@ -211,7 +211,10 @@ All examples below use `$FRIDAYD_URL` and a `friday_curl` helper that adds
 examples work on both plain-HTTP and TLS-enabled installs:
 
 ```bash
-set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+set -a
+. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
+  || . "$HOME/.atlas/.env" 2>/dev/null || true
+set +a
 friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
 ```
 

--- a/packages/system/skills/workspace-api/SKILL.md
+++ b/packages/system/skills/workspace-api/SKILL.md
@@ -241,13 +241,18 @@ The failure mode this prevents: reaching for `agent_claude-code` as a panic butt
 ## CRUD reference — curl examples
 
 All examples below use `$FRIDAYD_URL`. Source the daemon `.env` once
-per shell so the variable is set:
+per shell so the variable is set — try the installed-Studio location
+first, then fall back to the dev location written by `setup-tls.sh`:
 
 ```bash
+set -a
+. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
+  || . "$HOME/.atlas/.env" 2>/dev/null || true
+set +a
 ```
 
-
 **Rule: every daemon HTTP call below uses `curl -k`, not `curl`.** Plain `curl` against `$FRIDAYD_URL` on a TLS install fails with `self signed certificate in certificate chain`.
+
 Confirm the daemon is up:
 
 ```bash

--- a/packages/system/skills/workspace-api/SKILL.md
+++ b/packages/system/skills/workspace-api/SKILL.md
@@ -7,14 +7,21 @@ description: "Create, list, update, delete, and clean up workspaces via the daem
 
 Create and manage Friday workspaces. This skill is where LLM judgment lives: when to use each tool, in what order, and how to recover when stuck. Companion skills: `friday-cli` (daemon lifecycle, signals, sessions) and `using-mcp-servers` (MCP catalog, install/enable, credentials).
 
-**Daemon HTTP rule (load-bearing for every curl example below).** All shell
-examples that hit the daemon use the `friday_curl` wrapper, never plain
-`curl`. The wrapper is defined in the "CRUD reference" preamble — it adds
-`--cacert` exactly when TLS is on. The daemon URL is `$FRIDAYD_URL`
-(varies by install — installed Friday Studio is typically `:18080`, dev
-`:8080`); the preamble below explains how to source it. Plain `curl`
-against `$FRIDAYD_URL` on a TLS install fails with `self signed
-certificate in certificate chain`.
+### Daemon HTTP rules (load-bearing for every curl example below)
+
+1. **Never hardcode the daemon URL — always use `$FRIDAYD_URL`.** Even if
+   the user mentions a specific host or port in their message ("the
+   daemon is on `:18080`", "I have it on `https://localhost:8080`"),
+   IGNORE that detail in the command you emit and use `$FRIDAYD_URL`.
+   The variable resolves to whatever the launcher (installed Friday
+   Studio, typically `:18080`) or `deno task atlas` (dev, typically
+   `:8080`) bound; `FRIDAY_PORT_FRIDAY` can override either. The user
+   shouldn't need to retype what they already have in their env.
+
+2. **Use the `friday_curl` wrapper, never plain `curl`.** The wrapper is
+   defined in the "CRUD reference" preamble — it adds `--cacert` exactly
+   when TLS is on. Plain `curl` against `$FRIDAYD_URL` on a TLS install
+   fails with `self signed certificate in certificate chain`.
 
 ## Cheat sheet
 

--- a/packages/system/skills/workspace-api/SKILL.md
+++ b/packages/system/skills/workspace-api/SKILL.md
@@ -9,19 +9,37 @@ Create and manage Friday workspaces. This skill is where LLM judgment lives: whe
 
 ### Daemon HTTP rules (load-bearing for every curl example below)
 
-1. **Never hardcode the daemon URL — always use `$FRIDAYD_URL`.** Even if
-   the user mentions a specific host or port in their message ("the
-   daemon is on `:18080`", "I have it on `https://localhost:8080`"),
-   IGNORE that detail in the command you emit and use `$FRIDAYD_URL`.
-   The variable resolves to whatever the launcher (installed Friday
-   Studio, typically `:18080`) or `deno task atlas` (dev, typically
-   `:8080`) bound; `FRIDAY_PORT_FRIDAY` can override either. The user
-   shouldn't need to retype what they already have in their env.
+1. **Resolve `$FRIDAYD_URL` first, then emit the literal value.**
+   `$FRIDAYD_URL` lives in the daemon's process env — not in the user's
+   shell. If you show them `curl "$FRIDAYD_URL/..."`, they'll paste it
+   into a shell where the variable is empty and get `URL rejected: No
+   host part in the URL`. Look up the actual value once via `run_code`,
+   then substitute:
 
-2. **Use the `friday_curl` wrapper, never plain `curl`.** The wrapper is
-   defined in the "CRUD reference" preamble — it adds `--cacert` exactly
-   when TLS is on. Plain `curl` against `$FRIDAYD_URL` on a TLS install
-   fails with `self signed certificate in certificate chain`.
+   ```python
+   import os
+   print(os.environ["FRIDAYD_URL"])
+   ```
+
+   That prints a URL like `https://localhost:18080` (installed Studio
+   with TLS) or `http://localhost:8080` (in-tree dev). Use the returned
+   string as a literal in the curl. Ignore any host/port the user
+   mentions in their message — your daemon env is the source of truth.
+
+   **Worked example.** `os.environ["FRIDAYD_URL"]` returns
+   `https://localhost:18080`. User asks "list workspaces":
+   - ❌ Wrong: `curl -k "$FRIDAYD_URL/api/workspaces"` (user's shell
+     has no `$FRIDAYD_URL`).
+   - ❌ Wrong: `curl -k "http://localhost:8080/api/workspaces"`
+     (guessed wrong port).
+   - ✅ Right: `curl -k "https://localhost:18080/api/workspaces" | jq`
+     (uses the resolved value).
+
+2. **Always use `curl -k` for daemon calls, never bare `curl`.** The
+   daemon ships a private-CA TLS cert that the system trust store
+   doesn't know about; plain `curl` on a TLS install fails with `self
+   signed certificate in certificate chain`. `-k` skips cert
+   verification — safe because the daemon binds loopback only.
 
 ## Cheat sheet
 
@@ -208,7 +226,7 @@ To abandon a draft: `discard_draft`.
 
 **For workspace shape changes (agents, jobs, signals, validation):** always use the dedicated tools (`create_workspace`, `upsert_*`, `validate_workspace`, `publish_draft`, etc.). They are typed, return structured diffs and issues, and handle draft/live switching automatically. Never shell out to curl for these.
 
-**For daemon CRUD (list workspaces, get config, delete workspace):** use `run_code` bash + `friday_curl` against `$FRIDAYD_URL` (see the preamble below). These are one-liners; the output is immediate and errors are obvious. Do not spawn `agent_claude-code` for a `DELETE` or a `GET`.
+**For daemon CRUD (list workspaces, get config, delete workspace):** use `run_code` bash + `curl -k` against `$FRIDAYD_URL` (see the preamble below). These are one-liners; the output is immediate and errors are obvious. Do not spawn `agent_claude-code` for a `DELETE` or a `GET`.
 
 **For MCP server questions (install vs enable, credentials, catalog search):** load the `using-mcp-servers` skill. `workspace-api` does not cover MCP scope.
 
@@ -222,36 +240,30 @@ The failure mode this prevents: reaching for `agent_claude-code` as a panic butt
 
 ## CRUD reference — curl examples
 
-All examples below use `$FRIDAYD_URL` and a `friday_curl` helper that adds
-`--cacert` when TLS is on. Paste this preamble once per shell so the
-examples work on both plain-HTTP and TLS-enabled installs:
+All examples below use `$FRIDAYD_URL`. Source the daemon `.env` once
+per shell so the variable is set:
 
 ```bash
-set -a
-. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
-  || . "$HOME/.atlas/.env" 2>/dev/null || true
-set +a
-friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
 ```
 
 
-**Rule: every daemon HTTP call below uses `friday_curl`, not `curl`.** Plain `curl` against `$FRIDAYD_URL` on a TLS install fails with `self signed certificate in certificate chain`.
+**Rule: every daemon HTTP call below uses `curl -k`, not `curl`.** Plain `curl` against `$FRIDAYD_URL` on a TLS install fails with `self signed certificate in certificate chain`.
 Confirm the daemon is up:
 
 ```bash
-friday_curl -sf "$FRIDAYD_URL/health" && echo OK
+curl -k -sf "$FRIDAYD_URL/health" && echo OK
 ```
 
 ### List workspaces
 
 ```bash
-friday_curl -s "$FRIDAYD_URL/api/workspaces" | jq
+curl -k -s "$FRIDAYD_URL/api/workspaces" | jq
 ```
 
 Resolve a display name to a runtime id:
 
 ```bash
-friday_curl -s "$FRIDAYD_URL/api/workspaces" | \
+curl -k -s "$FRIDAYD_URL/api/workspaces" | \
   jq -r '.[] | select(.name == "my-workspace") | .id'
 ```
 
@@ -259,16 +271,16 @@ friday_curl -s "$FRIDAYD_URL/api/workspaces" | \
 
 ```bash
 # Summary (id, name, status, path)
-friday_curl -s "$FRIDAYD_URL/api/workspaces/$WS" | jq
+curl -k -s "$FRIDAYD_URL/api/workspaces/$WS" | jq
 
 # Full parsed config
-friday_curl -s "$FRIDAYD_URL/api/workspaces/$WS/config" | jq
+curl -k -s "$FRIDAYD_URL/api/workspaces/$WS/config" | jq
 ```
 
 ### Update workspace (full replacement)
 
 ```bash
-friday_curl -s -X POST "$FRIDAYD_URL/api/workspaces/$WS/update" \
+curl -k -s -X POST "$FRIDAYD_URL/api/workspaces/$WS/update" \
   -H 'Content-Type: application/json' \
   -d '{"config": {"version":"1.0","workspace":{"name":"new-name"}}, "backup": true}'
 ```
@@ -280,7 +292,7 @@ Pass `backup: true` to preserve a timestamped `workspace.yml.backup-<ts>`. Pass 
 ### Delete a workspace (single)
 
 ```bash
-friday_curl -sf -X DELETE "$FRIDAYD_URL/api/workspaces/$WS"
+curl -k -sf -X DELETE "$FRIDAYD_URL/api/workspaces/$WS"
 ```
 
 **Rejects 403** for system workspaces (`system`, `user`, `thick_endive`). Resolve name → id first; never guess runtime IDs.
@@ -288,10 +300,10 @@ friday_curl -sf -X DELETE "$FRIDAYD_URL/api/workspaces/$WS"
 ### Delete workspaces (batch — by name prefix)
 
 ```bash
-friday_curl -s "$FRIDAYD_URL/api/workspaces" | \
+curl -k -s "$FRIDAYD_URL/api/workspaces" | \
   jq -r '.[] | select(.name | startswith("test-")) | .id' | \
   while read -r id; do
-    result=$(friday_curl -sf -X DELETE "$FRIDAYD_URL/api/workspaces/$id")
+    result=$(curl -k -sf -X DELETE "$FRIDAYD_URL/api/workspaces/$id")
     echo "$id: $result"
   done
 ```
@@ -299,7 +311,7 @@ friday_curl -s "$FRIDAYD_URL/api/workspaces" | \
 **Dry-run first** — list names before deleting:
 
 ```bash
-friday_curl -s "$FRIDAYD_URL/api/workspaces" | \
+curl -k -s "$FRIDAYD_URL/api/workspaces" | \
   jq -r '.[] | select(.name | startswith("test-")) | "\(.id)  \(.name)"'
 ```
 
@@ -307,7 +319,7 @@ friday_curl -s "$FRIDAYD_URL/api/workspaces" | \
 
 ```bash
 for id in layered_ham smoky_almond ripe_eggplant; do
-  result=$(friday_curl -sf -X DELETE "$FRIDAYD_URL/api/workspaces/$id")
+  result=$(curl -k -sf -X DELETE "$FRIDAYD_URL/api/workspaces/$id")
   echo "$id: $result"
 done
 ```

--- a/packages/system/skills/workspace-api/SKILL.md
+++ b/packages/system/skills/workspace-api/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: workspace-api
-description: "Create, list, update, delete, and clean up workspaces via the daemon HTTP API (localhost:8080). Use when the user asks to create, edit, delete, or list workspaces, spaces, projects, or environments; add or patch signals / agents / jobs / memory / skills; convert a workspace.yml into a live workspace; wire up triggers (HTTP webhooks, cron, fs-watch, Slack / Telegram / WhatsApp); or clean up test/scratch workspaces."
+description: "Create, list, update, delete, and clean up workspaces via the daemon HTTP API on localhost:8080 (or https://localhost:8080 when TLS is enabled via scripts/setup-tls.sh). Use when the user asks to create, edit, delete, or list workspaces, spaces, projects, or environments; add or patch signals / agents / jobs / memory / skills; convert a workspace.yml into a live workspace; wire up triggers (HTTP webhooks, cron, fs-watch, Slack / Telegram / WhatsApp); or clean up test/scratch workspaces."
 ---
 
 # Workspace API
@@ -206,22 +206,31 @@ The failure mode this prevents: reaching for `agent_claude-code` as a panic butt
 
 ## CRUD reference — curl examples
 
-All examples assume the daemon is on `localhost:8080`. Confirm first:
+All examples below use `$FRIDAYD_URL` and a `friday_curl` helper that adds
+`--cacert` when TLS is on. Paste this preamble once per shell so the
+examples work on both plain-HTTP and TLS-enabled installs:
 
 ```bash
-curl -sf http://localhost:8080/health && echo OK
+set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
+```
+
+Confirm the daemon is up:
+
+```bash
+friday_curl -sf "$FRIDAYD_URL/health" && echo OK
 ```
 
 ### List workspaces
 
 ```bash
-curl -s http://localhost:8080/api/workspaces | jq
+friday_curl -s "$FRIDAYD_URL/api/workspaces" | jq
 ```
 
 Resolve a display name to a runtime id:
 
 ```bash
-curl -s http://localhost:8080/api/workspaces | \
+friday_curl -s "$FRIDAYD_URL/api/workspaces" | \
   jq -r '.[] | select(.name == "my-workspace") | .id'
 ```
 
@@ -229,16 +238,16 @@ curl -s http://localhost:8080/api/workspaces | \
 
 ```bash
 # Summary (id, name, status, path)
-curl -s http://localhost:8080/api/workspaces/$WS | jq
+friday_curl -s "$FRIDAYD_URL/api/workspaces/$WS" | jq
 
 # Full parsed config
-curl -s http://localhost:8080/api/workspaces/$WS/config | jq
+friday_curl -s "$FRIDAYD_URL/api/workspaces/$WS/config" | jq
 ```
 
 ### Update workspace (full replacement)
 
 ```bash
-curl -s -X POST http://localhost:8080/api/workspaces/$WS/update \
+friday_curl -s -X POST "$FRIDAYD_URL/api/workspaces/$WS/update" \
   -H 'Content-Type: application/json' \
   -d '{"config": {"version":"1.0","workspace":{"name":"new-name"}}, "backup": true}'
 ```
@@ -250,7 +259,7 @@ Pass `backup: true` to preserve a timestamped `workspace.yml.backup-<ts>`. Pass 
 ### Delete a workspace (single)
 
 ```bash
-curl -sf -X DELETE http://localhost:8080/api/workspaces/$WS
+friday_curl -sf -X DELETE "$FRIDAYD_URL/api/workspaces/$WS"
 ```
 
 **Rejects 403** for system workspaces (`system`, `user`, `thick_endive`). Resolve name → id first; never guess runtime IDs.
@@ -258,10 +267,10 @@ curl -sf -X DELETE http://localhost:8080/api/workspaces/$WS
 ### Delete workspaces (batch — by name prefix)
 
 ```bash
-curl -s http://localhost:8080/api/workspaces | \
+friday_curl -s "$FRIDAYD_URL/api/workspaces" | \
   jq -r '.[] | select(.name | startswith("test-")) | .id' | \
   while read -r id; do
-    result=$(curl -sf -X DELETE "http://localhost:8080/api/workspaces/$id")
+    result=$(friday_curl -sf -X DELETE "$FRIDAYD_URL/api/workspaces/$id")
     echo "$id: $result"
   done
 ```
@@ -269,7 +278,7 @@ curl -s http://localhost:8080/api/workspaces | \
 **Dry-run first** — list names before deleting:
 
 ```bash
-curl -s http://localhost:8080/api/workspaces | \
+friday_curl -s "$FRIDAYD_URL/api/workspaces" | \
   jq -r '.[] | select(.name | startswith("test-")) | "\(.id)  \(.name)"'
 ```
 
@@ -277,7 +286,7 @@ curl -s http://localhost:8080/api/workspaces | \
 
 ```bash
 for id in layered_ham smoky_almond ripe_eggplant; do
-  result=$(curl -sf -X DELETE "http://localhost:8080/api/workspaces/$id")
+  result=$(friday_curl -sf -X DELETE "$FRIDAYD_URL/api/workspaces/$id")
   echo "$id: $result"
 done
 ```

--- a/packages/system/skills/workspace-api/SKILL.md
+++ b/packages/system/skills/workspace-api/SKILL.md
@@ -218,6 +218,8 @@ set +a
 friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
 ```
 
+
+**Rule: every daemon HTTP call below uses `friday_curl`, not `curl`.** Plain `curl` against `$FRIDAYD_URL` on a TLS install fails with `self signed certificate in certificate chain`.
 Confirm the daemon is up:
 
 ```bash

--- a/packages/system/skills/workspace-api/SKILL.md
+++ b/packages/system/skills/workspace-api/SKILL.md
@@ -1,11 +1,20 @@
 ---
 name: workspace-api
-description: "Create, list, update, delete, and clean up workspaces via the daemon HTTP API on localhost:8080 (or https://localhost:8080 when TLS is enabled via scripts/setup-tls.sh). Use when the user asks to create, edit, delete, or list workspaces, spaces, projects, or environments; add or patch signals / agents / jobs / memory / skills; convert a workspace.yml into a live workspace; wire up triggers (HTTP webhooks, cron, fs-watch, Slack / Telegram / WhatsApp); or clean up test/scratch workspaces."
+description: "Create, list, update, delete, and clean up workspaces via the daemon HTTP API at $FRIDAYD_URL. Use when the user asks to create, edit, delete, or list workspaces, spaces, projects, or environments; add or patch signals / agents / jobs / memory / skills; convert a workspace.yml into a live workspace; wire up triggers (HTTP webhooks, cron, fs-watch, Slack / Telegram / WhatsApp); or clean up test/scratch workspaces."
 ---
 
 # Workspace API
 
 Create and manage Friday workspaces. This skill is where LLM judgment lives: when to use each tool, in what order, and how to recover when stuck. Companion skills: `friday-cli` (daemon lifecycle, signals, sessions) and `using-mcp-servers` (MCP catalog, install/enable, credentials).
+
+**Daemon HTTP rule (load-bearing for every curl example below).** All shell
+examples that hit the daemon use the `friday_curl` wrapper, never plain
+`curl`. The wrapper is defined in the "CRUD reference" preamble — it adds
+`--cacert` exactly when TLS is on. The daemon URL is `$FRIDAYD_URL`
+(varies by install — installed Friday Studio is typically `:18080`, dev
+`:8080`); the preamble below explains how to source it. Plain `curl`
+against `$FRIDAYD_URL` on a TLS install fails with `self signed
+certificate in certificate chain`.
 
 ## Cheat sheet
 
@@ -192,7 +201,7 @@ To abandon a draft: `discard_draft`.
 
 **For workspace shape changes (agents, jobs, signals, validation):** always use the dedicated tools (`create_workspace`, `upsert_*`, `validate_workspace`, `publish_draft`, etc.). They are typed, return structured diffs and issues, and handle draft/live switching automatically. Never shell out to curl for these.
 
-**For daemon CRUD (list workspaces, get config, delete workspace):** use `run_code` bash + curl to `localhost:8080`. These are one-liners; the output is immediate and errors are obvious. Do not spawn `agent_claude-code` for a `DELETE` or a `GET`.
+**For daemon CRUD (list workspaces, get config, delete workspace):** use `run_code` bash + `friday_curl` against `$FRIDAYD_URL` (see the preamble below). These are one-liners; the output is immediate and errors are obvious. Do not spawn `agent_claude-code` for a `DELETE` or a `GET`.
 
 **For MCP server questions (install vs enable, credentials, catalog search):** load the `using-mcp-servers` skill. `workspace-api` does not cover MCP scope.
 

--- a/packages/system/skills/workspace-api/references/updating-workspaces.md
+++ b/packages/system/skills/workspace-api/references/updating-workspaces.md
@@ -18,6 +18,8 @@ another quietly loses it.
 > friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
 > ```
 
+
+**Rule: every daemon HTTP call below uses `friday_curl`, not `curl`.** Plain `curl` against `$FRIDAYD_URL` on a TLS install fails with `self signed certificate in certificate chain`.
 ## Contents
 
 - The three paths (preference order)

--- a/packages/system/skills/workspace-api/references/updating-workspaces.md
+++ b/packages/system/skills/workspace-api/references/updating-workspaces.md
@@ -6,20 +6,15 @@ restructuring. The path you pick matters — one path preserves runtime state,
 another quietly loses it.
 
 > **Preamble — source the daemon env once per shell.** Every curl example
-> below uses `$FRIDAYD_URL` and a `friday_curl` helper that adds `--cacert`
-> when TLS is on. Paste this once and the examples below work on both
-> plain-HTTP and TLS-enabled installs:
+> below uses `$FRIDAYD_URL`. Source the daemon `.env` once so the
+> variable is set. `curl -k` skips cert verification (safe for the
+> loopback-only daemon).
 >
 > ```bash
-> set -a
-> . "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
->   || . "$HOME/.atlas/.env" 2>/dev/null || true
-> set +a
-> friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
 > ```
 
 
-**Rule: every daemon HTTP call below uses `friday_curl`, not `curl`.** Plain `curl` against `$FRIDAYD_URL` on a TLS install fails with `self signed certificate in certificate chain`.
+**Rule: every daemon HTTP call below uses `curl -k`, not `curl`.** Plain `curl` against `$FRIDAYD_URL` on a TLS install fails with `self signed certificate in certificate chain`.
 ## Contents
 
 - The three paths (preference order)
@@ -49,13 +44,13 @@ Mount: `/api/workspaces/:id/config`. Every mutation here writes to
 
 ```bash
 # List
-friday_curl -s "$FRIDAYD_URL/api/workspaces/$WS/config/signals" | jq
+curl -k -s "$FRIDAYD_URL/api/workspaces/$WS/config/signals" | jq
 
 # Get one
-friday_curl -s "$FRIDAYD_URL/api/workspaces/$WS/config/signals/daily-summary" | jq
+curl -k -s "$FRIDAYD_URL/api/workspaces/$WS/config/signals/daily-summary" | jq
 
 # Create — 201 on success, 409 on dup id
-friday_curl -s -X POST "$FRIDAYD_URL/api/workspaces/$WS/config/signals" \
+curl -k -s -X POST "$FRIDAYD_URL/api/workspaces/$WS/config/signals" \
   -H 'Content-Type: application/json' \
   -d '{
     "signalId": "generate-report",
@@ -67,7 +62,7 @@ friday_curl -s -X POST "$FRIDAYD_URL/api/workspaces/$WS/config/signals" \
   }'
 
 # Full replace
-friday_curl -s -X PUT "$FRIDAYD_URL/api/workspaces/$WS/config/signals/daily-summary" \
+curl -k -s -X PUT "$FRIDAYD_URL/api/workspaces/$WS/config/signals/daily-summary" \
   -H 'Content-Type: application/json' \
   -d '{
     "provider": "schedule",
@@ -76,12 +71,12 @@ friday_curl -s -X PUT "$FRIDAYD_URL/api/workspaces/$WS/config/signals/daily-summ
   }'
 
 # Patch (loose — merged with existing)
-friday_curl -s -X PATCH "$FRIDAYD_URL/api/workspaces/$WS/config/signals/daily-summary" \
+curl -k -s -X PATCH "$FRIDAYD_URL/api/workspaces/$WS/config/signals/daily-summary" \
   -H 'Content-Type: application/json' \
   -d '{"config":{"schedule":"*/15 * * * *","timezone":"UTC"}}'
 
 # Delete — 409 if a job triggers on it; pass ?force=true to cascade
-friday_curl -s -X DELETE "$FRIDAYD_URL/api/workspaces/$WS/config/signals/daily-summary?force=true"
+curl -k -s -X DELETE "$FRIDAYD_URL/api/workspaces/$WS/config/signals/daily-summary?force=true"
 ```
 
 ### Agents — update only
@@ -91,7 +86,7 @@ prompt/model/tools but NOT add or delete via the API:
 
 ```bash
 # Update prompt + model + tools
-friday_curl -s -X PUT "$FRIDAYD_URL/api/workspaces/$WS/config/agents/summarizer" \
+curl -k -s -X PUT "$FRIDAYD_URL/api/workspaces/$WS/config/agents/summarizer" \
   -H 'Content-Type: application/json' \
   -d '{
     "prompt": "You produce a rigorous end-of-day summary.",
@@ -109,10 +104,10 @@ To add a new agent, use Path 2 (disk edit).
 
 ```bash
 # List refs — paths are "mcp:<server>:<ENV>" or "agent:<agent>:<ENV>"
-friday_curl -s "$FRIDAYD_URL/api/workspaces/$WS/config/credentials" | jq
+curl -k -s "$FRIDAYD_URL/api/workspaces/$WS/config/credentials" | jq
 
 # Swap — validates the new credential matches the provider; 400 on mismatch
-friday_curl -s -X PUT "$FRIDAYD_URL/api/workspaces/$WS/config/credentials/agent:gh-agent:GITHUB_TOKEN" \
+curl -k -s -X PUT "$FRIDAYD_URL/api/workspaces/$WS/config/credentials/agent:gh-agent:GITHUB_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"credentialId":"cred_abc123"}'
 ```
@@ -120,7 +115,7 @@ friday_curl -s -X PUT "$FRIDAYD_URL/api/workspaces/$WS/config/credentials/agent:
 ### Metadata (name, color)
 
 ```bash
-friday_curl -s -X PATCH "$FRIDAYD_URL/api/workspaces/$WS/metadata" \
+curl -k -s -X PATCH "$FRIDAYD_URL/api/workspaces/$WS/metadata" \
   -H 'Content-Type: application/json' \
   -d '{"name":"New Display Name","color":"#ff0066"}'
 ```
@@ -159,14 +154,14 @@ WS = "grilled_xylem"
 WS_PATH = "/path/to/.friday/local/workspaces/my-workspace/workspace.yml"
 
 # 1. Read current config (API gives parsed JSON — no YAML parsing needed).
-#    FRIDAYD_URL + FRIDAY_TLS_CA are exported by the daemon's launcher
-#    (installed Friday Studio) or `bash scripts/setup-tls.sh` (in-tree
-#    dev). Don't hardcode a default — installed Studio runs on :18080,
-#    dev on :8080, and FRIDAY_PORT_FRIDAY can override either. If the env
-#    var is missing, fail loud rather than silently misroute.
+#    FRIDAYD_URL is exported by the daemon's launcher (installed Friday
+#    Studio) or `bash scripts/setup-tls.sh` / `deno task atlas` (dev).
+#    Don't hardcode a default — installed Studio runs on :18080, dev on
+#    :8080, FRIDAY_PORT_FRIDAY can override either. KeyError on missing
+#    env beats silent misroute.
+#    `_unverified` context is fine here because the daemon binds loopback.
 daemon_url = os.environ["FRIDAYD_URL"]
-ca = os.environ.get("FRIDAY_TLS_CA")
-ctx = ssl.create_default_context(cafile=ca) if ca else None
+ctx = ssl._create_unverified_context()
 with urllib.request.urlopen(f"{daemon_url}/api/workspaces/{WS}/config", context=ctx) as resp:
     config = json.load(resp)["config"]
 
@@ -238,13 +233,13 @@ The `path` field in `GET /api/workspaces/:id` returns the workspace directory.
 Append `/workspace.yml`:
 
 ```bash
-WS_PATH=$(friday_curl -s "$FRIDAYD_URL/api/workspaces/$WS" | jq -r '.path')/workspace.yml
+WS_PATH=$(curl -k -s "$FRIDAYD_URL/api/workspaces/$WS" | jq -r '.path')/workspace.yml
 ```
 
 Or read `configPath` directly:
 
 ```bash
-friday_curl -s "$FRIDAYD_URL/api/workspaces/$WS" | jq -r '.configPath'
+curl -k -s "$FRIDAYD_URL/api/workspaces/$WS" | jq -r '.configPath'
 ```
 
 ### Verifying the reload
@@ -252,7 +247,7 @@ friday_curl -s "$FRIDAYD_URL/api/workspaces/$WS" | jq -r '.configPath'
 ```bash
 # After writing, wait ~1s for the debouncer, then confirm the new shape
 sleep 1
-friday_curl -s "$FRIDAYD_URL/api/workspaces/$WS/config" \
+curl -k -s "$FRIDAYD_URL/api/workspaces/$WS/config" \
   | jq '.config | {agents: (.agents // {} | keys), jobs: (.jobs // {} | keys)}'
 ```
 
@@ -281,13 +276,13 @@ corrupted beyond repair.
 
 ```bash
 # Capture the old runtime id so you know what's about to change
-OLD_WS=$(friday_curl -s "$FRIDAYD_URL/api/workspaces" | jq -r '.[]|select(.name=="my-workspace")|.id')
+OLD_WS=$(curl -k -s "$FRIDAYD_URL/api/workspaces" | jq -r '.[]|select(.name=="my-workspace")|.id')
 
 # Hard delete (directory + registration)
-friday_curl -s -X DELETE "$FRIDAYD_URL/api/workspaces/$OLD_WS"
+curl -k -s -X DELETE "$FRIDAYD_URL/api/workspaces/$OLD_WS"
 
 # Re-create
-friday_curl -s -X POST "$FRIDAYD_URL/api/workspaces/create" \
+curl -k -s -X POST "$FRIDAYD_URL/api/workspaces/create" \
   -H 'Content-Type: application/json' \
   -d "{\"config\":$(cat new-config.json),\"workspaceName\":\"my-workspace\"}"
 ```

--- a/packages/system/skills/workspace-api/references/updating-workspaces.md
+++ b/packages/system/skills/workspace-api/references/updating-workspaces.md
@@ -11,10 +11,14 @@ another quietly loses it.
 > loopback-only daemon).
 >
 > ```bash
+> set -a
+> . "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
+>   || . "$HOME/.atlas/.env" 2>/dev/null || true
+> set +a
 > ```
 
-
 **Rule: every daemon HTTP call below uses `curl -k`, not `curl`.** Plain `curl` against `$FRIDAYD_URL` on a TLS install fails with `self signed certificate in certificate chain`.
+
 ## Contents
 
 - The three paths (preference order)

--- a/packages/system/skills/workspace-api/references/updating-workspaces.md
+++ b/packages/system/skills/workspace-api/references/updating-workspaces.md
@@ -11,7 +11,10 @@ another quietly loses it.
 > plain-HTTP and TLS-enabled installs:
 >
 > ```bash
-> set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+> set -a
+> . "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
+>   || . "$HOME/.atlas/.env" 2>/dev/null || true
+> set +a
 > friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
 > ```
 

--- a/packages/system/skills/workspace-api/references/updating-workspaces.md
+++ b/packages/system/skills/workspace-api/references/updating-workspaces.md
@@ -5,6 +5,16 @@ exists: adding a signal, adding an agent, adding a job, editing an FSM, or
 restructuring. The path you pick matters — one path preserves runtime state,
 another quietly loses it.
 
+> **Preamble — source the daemon env once per shell.** Every curl example
+> below uses `$FRIDAYD_URL` and a `friday_curl` helper that adds `--cacert`
+> when TLS is on. Paste this once and the examples below work on both
+> plain-HTTP and TLS-enabled installs:
+>
+> ```bash
+> set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+> friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
+> ```
+
 ## Contents
 
 - The three paths (preference order)
@@ -34,13 +44,13 @@ Mount: `/api/workspaces/:id/config`. Every mutation here writes to
 
 ```bash
 # List
-curl -s http://localhost:8080/api/workspaces/$WS/config/signals | jq
+friday_curl -s "$FRIDAYD_URL/api/workspaces/$WS/config/signals" | jq
 
 # Get one
-curl -s http://localhost:8080/api/workspaces/$WS/config/signals/daily-summary | jq
+friday_curl -s "$FRIDAYD_URL/api/workspaces/$WS/config/signals/daily-summary" | jq
 
 # Create — 201 on success, 409 on dup id
-curl -s -X POST http://localhost:8080/api/workspaces/$WS/config/signals \
+friday_curl -s -X POST "$FRIDAYD_URL/api/workspaces/$WS/config/signals" \
   -H 'Content-Type: application/json' \
   -d '{
     "signalId": "generate-report",
@@ -52,7 +62,7 @@ curl -s -X POST http://localhost:8080/api/workspaces/$WS/config/signals \
   }'
 
 # Full replace
-curl -s -X PUT http://localhost:8080/api/workspaces/$WS/config/signals/daily-summary \
+friday_curl -s -X PUT "$FRIDAYD_URL/api/workspaces/$WS/config/signals/daily-summary" \
   -H 'Content-Type: application/json' \
   -d '{
     "provider": "schedule",
@@ -61,12 +71,12 @@ curl -s -X PUT http://localhost:8080/api/workspaces/$WS/config/signals/daily-sum
   }'
 
 # Patch (loose — merged with existing)
-curl -s -X PATCH http://localhost:8080/api/workspaces/$WS/config/signals/daily-summary \
+friday_curl -s -X PATCH "$FRIDAYD_URL/api/workspaces/$WS/config/signals/daily-summary" \
   -H 'Content-Type: application/json' \
   -d '{"config":{"schedule":"*/15 * * * *","timezone":"UTC"}}'
 
 # Delete — 409 if a job triggers on it; pass ?force=true to cascade
-curl -s -X DELETE "http://localhost:8080/api/workspaces/$WS/config/signals/daily-summary?force=true"
+friday_curl -s -X DELETE "$FRIDAYD_URL/api/workspaces/$WS/config/signals/daily-summary?force=true"
 ```
 
 ### Agents — update only
@@ -76,7 +86,7 @@ prompt/model/tools but NOT add or delete via the API:
 
 ```bash
 # Update prompt + model + tools
-curl -s -X PUT http://localhost:8080/api/workspaces/$WS/config/agents/summarizer \
+friday_curl -s -X PUT "$FRIDAYD_URL/api/workspaces/$WS/config/agents/summarizer" \
   -H 'Content-Type: application/json' \
   -d '{
     "prompt": "You produce a rigorous end-of-day summary.",
@@ -94,10 +104,10 @@ To add a new agent, use Path 2 (disk edit).
 
 ```bash
 # List refs — paths are "mcp:<server>:<ENV>" or "agent:<agent>:<ENV>"
-curl -s http://localhost:8080/api/workspaces/$WS/config/credentials | jq
+friday_curl -s "$FRIDAYD_URL/api/workspaces/$WS/config/credentials" | jq
 
 # Swap — validates the new credential matches the provider; 400 on mismatch
-curl -s -X PUT "http://localhost:8080/api/workspaces/$WS/config/credentials/agent:gh-agent:GITHUB_TOKEN" \
+friday_curl -s -X PUT "$FRIDAYD_URL/api/workspaces/$WS/config/credentials/agent:gh-agent:GITHUB_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"credentialId":"cred_abc123"}'
 ```
@@ -105,7 +115,7 @@ curl -s -X PUT "http://localhost:8080/api/workspaces/$WS/config/credentials/agen
 ### Metadata (name, color)
 
 ```bash
-curl -s -X PATCH "http://localhost:8080/api/workspaces/$WS/metadata" \
+friday_curl -s -X PATCH "$FRIDAYD_URL/api/workspaces/$WS/metadata" \
   -H 'Content-Type: application/json' \
   -d '{"name":"New Display Name","color":"#ff0066"}'
 ```
@@ -138,13 +148,18 @@ Runtime id, sessions, and memory are all preserved.
 
 ```python
 # run_code, language: python
-import json, urllib.request
+import json, os, ssl, urllib.request
 
 WS = "grilled_xylem"
 WS_PATH = "/path/to/.friday/local/workspaces/my-workspace/workspace.yml"
 
 # 1. Read current config (API gives parsed JSON — no YAML parsing needed)
-with urllib.request.urlopen(f"http://localhost:8080/api/workspaces/{WS}/config") as resp:
+#    FRIDAYD_URL + FRIDAY_TLS_CA are exported by the daemon's launcher,
+#    so this works whether the install is on plain HTTP or TLS.
+daemon_url = os.environ.get("FRIDAYD_URL", "http://localhost:8080")
+ca = os.environ.get("FRIDAY_TLS_CA")
+ctx = ssl.create_default_context(cafile=ca) if ca else None
+with urllib.request.urlopen(f"{daemon_url}/api/workspaces/{WS}/config", context=ctx) as resp:
     config = json.load(resp)["config"]
 
 # 2. Mutate the dict
@@ -215,13 +230,13 @@ The `path` field in `GET /api/workspaces/:id` returns the workspace directory.
 Append `/workspace.yml`:
 
 ```bash
-WS_PATH=$(curl -s http://localhost:8080/api/workspaces/$WS | jq -r '.path')/workspace.yml
+WS_PATH=$(friday_curl -s "$FRIDAYD_URL/api/workspaces/$WS" | jq -r '.path')/workspace.yml
 ```
 
 Or read `configPath` directly:
 
 ```bash
-curl -s http://localhost:8080/api/workspaces/$WS | jq -r '.configPath'
+friday_curl -s "$FRIDAYD_URL/api/workspaces/$WS" | jq -r '.configPath'
 ```
 
 ### Verifying the reload
@@ -229,7 +244,7 @@ curl -s http://localhost:8080/api/workspaces/$WS | jq -r '.configPath'
 ```bash
 # After writing, wait ~1s for the debouncer, then confirm the new shape
 sleep 1
-curl -s http://localhost:8080/api/workspaces/$WS/config \
+friday_curl -s "$FRIDAYD_URL/api/workspaces/$WS/config" \
   | jq '.config | {agents: (.agents // {} | keys), jobs: (.jobs // {} | keys)}'
 ```
 
@@ -258,13 +273,13 @@ corrupted beyond repair.
 
 ```bash
 # Capture the old runtime id so you know what's about to change
-OLD_WS=$(curl -s http://localhost:8080/api/workspaces | jq -r '.[]|select(.name=="my-workspace")|.id')
+OLD_WS=$(friday_curl -s "$FRIDAYD_URL/api/workspaces" | jq -r '.[]|select(.name=="my-workspace")|.id')
 
 # Hard delete (directory + registration)
-curl -s -X DELETE "http://localhost:8080/api/workspaces/$OLD_WS"
+friday_curl -s -X DELETE "$FRIDAYD_URL/api/workspaces/$OLD_WS"
 
 # Re-create
-curl -s -X POST http://localhost:8080/api/workspaces/create \
+friday_curl -s -X POST "$FRIDAYD_URL/api/workspaces/create" \
   -H 'Content-Type: application/json' \
   -d "{\"config\":$(cat new-config.json),\"workspaceName\":\"my-workspace\"}"
 ```

--- a/packages/system/skills/workspace-api/references/updating-workspaces.md
+++ b/packages/system/skills/workspace-api/references/updating-workspaces.md
@@ -158,10 +158,13 @@ import json, os, ssl, urllib.request
 WS = "grilled_xylem"
 WS_PATH = "/path/to/.friday/local/workspaces/my-workspace/workspace.yml"
 
-# 1. Read current config (API gives parsed JSON — no YAML parsing needed)
-#    FRIDAYD_URL + FRIDAY_TLS_CA are exported by the daemon's launcher,
-#    so this works whether the install is on plain HTTP or TLS.
-daemon_url = os.environ.get("FRIDAYD_URL", "http://localhost:8080")
+# 1. Read current config (API gives parsed JSON — no YAML parsing needed).
+#    FRIDAYD_URL + FRIDAY_TLS_CA are exported by the daemon's launcher
+#    (installed Friday Studio) or `bash scripts/setup-tls.sh` (in-tree
+#    dev). Don't hardcode a default — installed Studio runs on :18080,
+#    dev on :8080, and FRIDAY_PORT_FRIDAY can override either. If the env
+#    var is missing, fail loud rather than silently misroute.
+daemon_url = os.environ["FRIDAYD_URL"]
 ca = os.environ.get("FRIDAY_TLS_CA")
 ctx = ssl.create_default_context(cafile=ca) if ca else None
 with urllib.request.urlopen(f"{daemon_url}/api/workspaces/{WS}/config", context=ctx) as resp:

--- a/packages/system/skills/writing-friday-python-agents/SKILL.md
+++ b/packages/system/skills/writing-friday-python-agents/SKILL.md
@@ -369,25 +369,16 @@ the curl examples below work whether your install is on plain HTTP or
 HTTPS:
 
 ```bash
-set -a
-. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
-  || . "$HOME/.atlas/.env" 2>/dev/null || true
-set +a
-# Now $FRIDAYD_URL is set (https://… when TLS is on, http://… otherwise)
-# and $FRIDAY_TLS_CA points at the private-CA cert when TLS is on.
-# Wrapper that adds --cacert exactly when TLS is on — use this for every
-# daemon call below, never plain `curl` against $FRIDAYD_URL.
-friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
 ```
 
-**Rule: every daemon HTTP call below uses `friday_curl`, not `curl`.**
+**Rule: every daemon HTTP call below uses `curl -k`, not `curl`.**
 Plain `curl` against `$FRIDAYD_URL` on a TLS install fails with `self
 signed certificate in certificate chain`.
 
 Register your agent by POSTing the entrypoint's absolute path to the daemon:
 
 ```bash
-friday_curl -sf -X POST \
+curl -k -sf -X POST \
   "$FRIDAYD_URL/api/agents/register" \
   -H 'Content-Type: application/json' \
   -d '{"entrypoint": "/abs/path/to/your-agent/agent.py"}'
@@ -417,7 +408,7 @@ Execute an agent without going through the full FSM pipeline. Replace
 `my-agent` with your agent id (the `id=` value from the `@agent` decorator):
 
 ```bash
-friday_curl -sf -X POST \
+curl -k -sf -X POST \
   "$FRIDAYD_URL/api/agents/my-agent/run?workspaceId=user" \
   -H 'Content-Type: application/json' \
   -d '{"input": "test prompt"}'

--- a/packages/system/skills/writing-friday-python-agents/SKILL.md
+++ b/packages/system/skills/writing-friday-python-agents/SKILL.md
@@ -134,7 +134,7 @@ def execute(prompt: str, ctx: AgentContext):
 `{{env.VARIABLE}}` in MCP config references agent environment variables.
 Currently only `stdio` transport is supported.
 
-**Do not bypass `ctx.tools`.** Python agents must not call local MCP HTTP endpoints such as `http://localhost:8002/mcp`, hardcode bearer tokens, or guess provider-specific tool names. Use `ctx.tools.list()` to inspect the runtime tool surface and `ctx.tools.call(name, args)` to invoke it. Host-side tool calls are credentialed, audited, and recorded in session history; direct HTTP calls are invisible to Friday and commonly fail with unknown-tool or invalid-token errors.
+**Do not bypass `ctx.tools`.** Python agents must not call local MCP HTTP endpoints such as `http(s)://localhost:8002/mcp`, hardcode bearer tokens, or guess provider-specific tool names. Use `ctx.tools.list()` to inspect the runtime tool surface and `ctx.tools.call(name, args)` to invoke it. Host-side tool calls are credentialed, audited, and recorded in session history; direct HTTP calls are invisible to Friday and commonly fail with unknown-tool or invalid-token errors.
 
 If `ctx.tools.call` raises `ToolCallError("Unknown tool ...")`, list tools and fix the workspace/agent config rather than retrying a guessed name.
 
@@ -361,10 +361,21 @@ installed packages are fine.
 
 ### Register via the daemon HTTP API
 
+Friday's daemon URL and TLS settings live in `~/.atlas/.env` (set by
+`scripts/setup-tls.sh`). Source it once per shell so the curl examples
+below work whether your install is on plain HTTP or HTTPS:
+
+```bash
+set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+# Now $FRIDAYD_URL is set (https://… when TLS is on, http://… otherwise)
+# and $FRIDAY_TLS_CA points at the private-CA cert when TLS is on.
+```
+
 Register your agent by POSTing the entrypoint's absolute path to the daemon:
 
 ```bash
-curl -X POST http://localhost:8080/api/agents/register \
+curl -sf -X POST ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
+  "${FRIDAYD_URL:-http://localhost:8080}/api/agents/register" \
   -H 'Content-Type: application/json' \
   -d '{"entrypoint": "/abs/path/to/your-agent/agent.py"}'
 ```
@@ -382,7 +393,8 @@ source path of an existing agent, query `GET /api/agents/:id` and read
 
 The Friday daemon listens on `localhost:8080` by default (configurable via
 the `FRIDAY_PORT` env var or the `--port` flag if you started the daemon
-manually).
+manually). When `scripts/setup-tls.sh` has been run, the daemon binds TLS
+and `$FRIDAYD_URL` resolves to `https://…`.
 
 ### Test directly
 
@@ -390,15 +402,17 @@ Execute an agent without going through the full FSM pipeline. Replace
 `my-agent` with your agent id (the `id=` value from the `@agent` decorator):
 
 ```bash
-curl -s -X POST "http://localhost:8080/api/agents/my-agent/run?workspaceId=user" \
+curl -sf -X POST ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
+  "${FRIDAYD_URL:-http://localhost:8080}/api/agents/my-agent/run?workspaceId=user" \
   -H 'Content-Type: application/json' \
   -d '{"input": "test prompt"}'
 ```
 
-Or via the playground API on `localhost:5200`:
+Or via the playground API on `localhost:5200` (HTTPS when TLS is on —
+the playground always trusts mkcert's CA via the system trust store):
 
 ```bash
-curl -s -X POST http://localhost:5200/api/agents/my-agent/run \
+curl -sf "${PLAYGROUND_URL:-http://localhost:5200}/api/agents/my-agent/run" \
   -H 'Content-Type: application/json' \
   -d '{"input": "test prompt"}'
 ```

--- a/packages/system/skills/writing-friday-python-agents/SKILL.md
+++ b/packages/system/skills/writing-friday-python-agents/SKILL.md
@@ -363,9 +363,10 @@ installed packages are fine.
 
 Friday's daemon URL and TLS settings live in the daemon `.env` —
 `${FRIDAY_HOME:-~/.friday/local}/.env` on installed Friday Studio (written
-by the launcher) or `~/.atlas/.env` for in-tree dev (written by
-`scripts/setup-tls.sh`). Source whichever exists once per shell so the
-curl examples below work whether your install is on plain HTTP or HTTPS:
+by the launcher automatically) or `~/.atlas/.env` for in-tree dev (written
+by `bash scripts/setup-tls.sh`). Source whichever exists once per shell so
+the curl examples below work whether your install is on plain HTTP or
+HTTPS:
 
 ```bash
 set -a
@@ -403,10 +404,12 @@ The register response returns `agent.path` (the install dir). To look up the
 source path of an existing agent, query `GET /api/agents/:id` and read
 `sourceLocation` rather than constructing the path from a constant.
 
-The Friday daemon listens on `localhost:8080` by default (configurable via
-the `FRIDAY_PORT` env var or the `--port` flag if you started the daemon
-manually). When `scripts/setup-tls.sh` has been run, the daemon binds TLS
-and `$FRIDAYD_URL` resolves to `https://…`.
+The Friday daemon's bind address is whatever the launcher (installed
+Friday Studio: typically `:18080`) or `deno task atlas daemon start`
+(in-tree dev: typically `:8080`) wrote to the daemon `.env`. Don't
+hardcode the URL — use `$FRIDAYD_URL`. The scheme switches to `https://`
+when TLS is on (automatically configured by the launcher for installed
+Studio; opt-in via `bash scripts/setup-tls.sh` for in-tree dev).
 
 ### Test directly
 
@@ -415,7 +418,7 @@ Execute an agent without going through the full FSM pipeline. Replace
 
 ```bash
 friday_curl -sf -X POST \
-  "${FRIDAYD_URL:-http://localhost:8080}/api/agents/my-agent/run?workspaceId=user" \
+  "$FRIDAYD_URL/api/agents/my-agent/run?workspaceId=user" \
   -H 'Content-Type: application/json' \
   -d '{"input": "test prompt"}'
 ```

--- a/packages/system/skills/writing-friday-python-agents/SKILL.md
+++ b/packages/system/skills/writing-friday-python-agents/SKILL.md
@@ -369,6 +369,10 @@ the curl examples below work whether your install is on plain HTTP or
 HTTPS:
 
 ```bash
+set -a
+. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
+  || . "$HOME/.atlas/.env" 2>/dev/null || true
+set +a
 ```
 
 **Rule: every daemon HTTP call below uses `curl -k`, not `curl`.**

--- a/packages/system/skills/writing-friday-python-agents/SKILL.md
+++ b/packages/system/skills/writing-friday-python-agents/SKILL.md
@@ -361,12 +361,17 @@ installed packages are fine.
 
 ### Register via the daemon HTTP API
 
-Friday's daemon URL and TLS settings live in `~/.atlas/.env` (set by
-`scripts/setup-tls.sh`). Source it once per shell so the curl examples
-below work whether your install is on plain HTTP or HTTPS:
+Friday's daemon URL and TLS settings live in the daemon `.env` —
+`${FRIDAY_HOME:-~/.friday/local}/.env` on installed Friday Studio (written
+by the launcher) or `~/.atlas/.env` for in-tree dev (written by
+`scripts/setup-tls.sh`). Source whichever exists once per shell so the
+curl examples below work whether your install is on plain HTTP or HTTPS:
 
 ```bash
-set -a; [ -f ~/.atlas/.env ] && . ~/.atlas/.env; set +a
+set -a
+. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
+  || . "$HOME/.atlas/.env" 2>/dev/null || true
+set +a
 # Now $FRIDAYD_URL is set (https://… when TLS is on, http://… otherwise)
 # and $FRIDAY_TLS_CA points at the private-CA cert when TLS is on.
 ```

--- a/packages/system/skills/writing-friday-python-agents/SKILL.md
+++ b/packages/system/skills/writing-friday-python-agents/SKILL.md
@@ -374,13 +374,20 @@ set -a
 set +a
 # Now $FRIDAYD_URL is set (https://… when TLS is on, http://… otherwise)
 # and $FRIDAY_TLS_CA points at the private-CA cert when TLS is on.
+# Wrapper that adds --cacert exactly when TLS is on — use this for every
+# daemon call below, never plain `curl` against $FRIDAYD_URL.
+friday_curl() { curl ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} "$@"; }
 ```
+
+**Rule: every daemon HTTP call below uses `friday_curl`, not `curl`.**
+Plain `curl` against `$FRIDAYD_URL` on a TLS install fails with `self
+signed certificate in certificate chain`.
 
 Register your agent by POSTing the entrypoint's absolute path to the daemon:
 
 ```bash
-curl -sf -X POST ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
-  "${FRIDAYD_URL:-http://localhost:8080}/api/agents/register" \
+friday_curl -sf -X POST \
+  "$FRIDAYD_URL/api/agents/register" \
   -H 'Content-Type: application/json' \
   -d '{"entrypoint": "/abs/path/to/your-agent/agent.py"}'
 ```
@@ -407,7 +414,7 @@ Execute an agent without going through the full FSM pipeline. Replace
 `my-agent` with your agent id (the `id=` value from the `@agent` decorator):
 
 ```bash
-curl -sf -X POST ${FRIDAY_TLS_CA:+--cacert "$FRIDAY_TLS_CA"} \
+friday_curl -sf -X POST \
   "${FRIDAYD_URL:-http://localhost:8080}/api/agents/my-agent/run?workspaceId=user" \
   -H 'Content-Type: application/json' \
   -d '{"input": "test prompt"}'

--- a/packages/workspace/src/__tests__/variable-interpolation.test.ts
+++ b/packages/workspace/src/__tests__/variable-interpolation.test.ts
@@ -2,6 +2,7 @@ import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
+import { getAtlasDaemonUrl } from "@atlas/oapi-client";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   findRepoRoot,
@@ -136,15 +137,29 @@ describe("findRepoRoot", () => {
 
 describe("resolveWorkspaceVariables", () => {
   let tempDir: string;
+  // getAtlasDaemonUrl() reads FRIDAYD_URL, the legacy FRIDAY_DAEMON_URL alias,
+  // and auto-upgrades the scheme to https:// when FRIDAY_TLS_CERT + _KEY are
+  // both set. Snapshot all four keys per test so a developer who has run
+  // setup-tls.sh in their shell doesn't see flaky failures.
+  const ENV_KEYS = ["FRIDAYD_URL", "FRIDAY_DAEMON_URL", "FRIDAY_TLS_CERT", "FRIDAY_TLS_KEY"];
+  const envSnapshot: Record<string, string | undefined> = {};
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), "resolve-vars-"));
     mkdirSync(join(tempDir, ".git"));
     mkdirSync(join(tempDir, "workspaces", "test-ws"), { recursive: true });
+    for (const k of ENV_KEYS) {
+      envSnapshot[k] = process.env[k];
+      delete process.env[k];
+    }
   });
 
   afterEach(() => {
     rmSync(tempDir, { recursive: true, force: true });
+    for (const k of ENV_KEYS) {
+      if (envSnapshot[k] === undefined) delete process.env[k];
+      else process.env[k] = envSnapshot[k];
+    }
   });
 
   it("builds WorkspaceVariables from workspace path", async () => {
@@ -158,53 +173,58 @@ describe("resolveWorkspaceVariables", () => {
     expect(result?.platform_url).toBe("http://localhost:9090");
   });
 
-  it("defaults platform_url to getAtlasDaemonUrl() — honors FRIDAYD_URL", async () => {
-    const prev = process.env.FRIDAYD_URL;
-    process.env.FRIDAYD_URL = "http://localhost:8080";
-    try {
-      const wsPath = join(tempDir, "workspaces", "test-ws");
-      const result = await resolveWorkspaceVariables(wsPath, "test_ws");
+  it("default platform_url falls through to getAtlasDaemonUrl()'s no-env result", async () => {
+    // No env set (beforeEach cleared them) — proves the schema default ran
+    // and returned getAtlasDaemonUrl()'s no-env fallback rather than a
+    // hardcoded literal. If someone re-introduces `.default("http://...")`
+    // on the schema, this catches it because the literal would differ from
+    // what getAtlasDaemonUrl() returns.
+    const wsPath = join(tempDir, "workspaces", "test-ws");
+    const result = await resolveWorkspaceVariables(wsPath, "test_ws");
 
-      expect(result?.platform_url).toBe("http://localhost:8080");
-    } finally {
-      if (prev === undefined) delete process.env.FRIDAYD_URL;
-      else process.env.FRIDAYD_URL = prev;
-    }
+    expect(result?.platform_url).toBe(getAtlasDaemonUrl());
+    // Sanity: the value is a parseable URL with an HTTP(S) scheme.
+    expect(() => new URL(result!.platform_url)).not.toThrow();
+    expect(result?.platform_url).toMatch(/^https?:\/\//);
+  });
+
+  it("platform_url default honors FRIDAYD_URL env (non-tautological)", async () => {
+    // Use a URL nothing else in the test could plausibly produce — proves
+    // the env-honoring branch ran, not just that "what we set is what we
+    // got back via interpolation".
+    process.env.FRIDAYD_URL = "http://example.test:9999";
+    const wsPath = join(tempDir, "workspaces", "test-ws");
+    const result = await resolveWorkspaceVariables(wsPath, "test_ws");
+
+    expect(result?.platform_url).toBe("http://example.test:9999");
   });
 
   it("integration: interpolates a sample workspace config", async () => {
-    const prev = process.env.FRIDAYD_URL;
-    process.env.FRIDAYD_URL = "http://localhost:8080";
-    try {
-      const wsPath = join(tempDir, "workspaces", "test-ws");
-      const vars = await resolveWorkspaceVariables(wsPath, "test_ws");
-      expect(vars).not.toBeNull();
+    process.env.FRIDAYD_URL = "http://example.test:9999";
+    const wsPath = join(tempDir, "workspaces", "test-ws");
+    const vars = await resolveWorkspaceVariables(wsPath, "test_ws");
+    expect(vars).not.toBeNull();
 
-      const sampleConfig = {
-        agents: {
-          coder: {
-            prompt: "Monorepo at {{repo_root}}, workspace: {{workspace_id}}",
-            config: {
-              workDir: "{{repo_root}}",
-              apiUrl: "{{platform_url}}/api",
-              bootstrap: 'var root = "{{repo_root}}"; fetch("{{platform_url}}/signal");',
-            },
+    const sampleConfig = {
+      agents: {
+        coder: {
+          prompt: "Monorepo at {{repo_root}}, workspace: {{workspace_id}}",
+          config: {
+            workDir: "{{repo_root}}",
+            apiUrl: "{{platform_url}}/api",
+            bootstrap: 'var root = "{{repo_root}}"; fetch("{{platform_url}}/signal");',
           },
         },
-      };
+      },
+    };
 
-      // vars is non-null per assertion above
-      const result = interpolateConfig(sampleConfig, vars!);
-      expect(result.agents.coder.prompt).toBe(`Monorepo at ${tempDir}, workspace: test_ws`);
-      expect(result.agents.coder.config.workDir).toBe(tempDir);
-      expect(result.agents.coder.config.apiUrl).toBe("http://localhost:8080/api");
-      expect(result.agents.coder.config.bootstrap).toContain(`var root = "${tempDir}"`);
-      expect(result.agents.coder.config.bootstrap).toContain(
-        'fetch("http://localhost:8080/signal")',
-      );
-    } finally {
-      if (prev === undefined) delete process.env.FRIDAYD_URL;
-      else process.env.FRIDAYD_URL = prev;
-    }
+    const result = interpolateConfig(sampleConfig, vars!);
+    expect(result.agents.coder.prompt).toBe(`Monorepo at ${tempDir}, workspace: test_ws`);
+    expect(result.agents.coder.config.workDir).toBe(tempDir);
+    expect(result.agents.coder.config.apiUrl).toBe("http://example.test:9999/api");
+    expect(result.agents.coder.config.bootstrap).toContain(`var root = "${tempDir}"`);
+    expect(result.agents.coder.config.bootstrap).toContain(
+      'fetch("http://example.test:9999/signal")',
+    );
   });
 });

--- a/packages/workspace/src/__tests__/variable-interpolation.test.ts
+++ b/packages/workspace/src/__tests__/variable-interpolation.test.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import process from "node:process";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
   findRepoRoot,
@@ -157,37 +158,53 @@ describe("resolveWorkspaceVariables", () => {
     expect(result?.platform_url).toBe("http://localhost:9090");
   });
 
-  it("defaults platform_url to http://localhost:8080", async () => {
-    const wsPath = join(tempDir, "workspaces", "test-ws");
-    const result = await resolveWorkspaceVariables(wsPath, "test_ws");
+  it("defaults platform_url to getAtlasDaemonUrl() — honors FRIDAYD_URL", async () => {
+    const prev = process.env.FRIDAYD_URL;
+    process.env.FRIDAYD_URL = "http://localhost:8080";
+    try {
+      const wsPath = join(tempDir, "workspaces", "test-ws");
+      const result = await resolveWorkspaceVariables(wsPath, "test_ws");
 
-    expect(result?.platform_url).toBe("http://localhost:8080");
+      expect(result?.platform_url).toBe("http://localhost:8080");
+    } finally {
+      if (prev === undefined) delete process.env.FRIDAYD_URL;
+      else process.env.FRIDAYD_URL = prev;
+    }
   });
 
   it("integration: interpolates a sample workspace config", async () => {
-    const wsPath = join(tempDir, "workspaces", "test-ws");
-    const vars = await resolveWorkspaceVariables(wsPath, "test_ws");
-    expect(vars).not.toBeNull();
+    const prev = process.env.FRIDAYD_URL;
+    process.env.FRIDAYD_URL = "http://localhost:8080";
+    try {
+      const wsPath = join(tempDir, "workspaces", "test-ws");
+      const vars = await resolveWorkspaceVariables(wsPath, "test_ws");
+      expect(vars).not.toBeNull();
 
-    const sampleConfig = {
-      agents: {
-        coder: {
-          prompt: "Monorepo at {{repo_root}}, workspace: {{workspace_id}}",
-          config: {
-            workDir: "{{repo_root}}",
-            apiUrl: "{{platform_url}}/api",
-            bootstrap: 'var root = "{{repo_root}}"; fetch("{{platform_url}}/signal");',
+      const sampleConfig = {
+        agents: {
+          coder: {
+            prompt: "Monorepo at {{repo_root}}, workspace: {{workspace_id}}",
+            config: {
+              workDir: "{{repo_root}}",
+              apiUrl: "{{platform_url}}/api",
+              bootstrap: 'var root = "{{repo_root}}"; fetch("{{platform_url}}/signal");',
+            },
           },
         },
-      },
-    };
+      };
 
-    // vars is non-null per assertion above
-    const result = interpolateConfig(sampleConfig, vars!);
-    expect(result.agents.coder.prompt).toBe(`Monorepo at ${tempDir}, workspace: test_ws`);
-    expect(result.agents.coder.config.workDir).toBe(tempDir);
-    expect(result.agents.coder.config.apiUrl).toBe("http://localhost:8080/api");
-    expect(result.agents.coder.config.bootstrap).toContain(`var root = "${tempDir}"`);
-    expect(result.agents.coder.config.bootstrap).toContain('fetch("http://localhost:8080/signal")');
+      // vars is non-null per assertion above
+      const result = interpolateConfig(sampleConfig, vars!);
+      expect(result.agents.coder.prompt).toBe(`Monorepo at ${tempDir}, workspace: test_ws`);
+      expect(result.agents.coder.config.workDir).toBe(tempDir);
+      expect(result.agents.coder.config.apiUrl).toBe("http://localhost:8080/api");
+      expect(result.agents.coder.config.bootstrap).toContain(`var root = "${tempDir}"`);
+      expect(result.agents.coder.config.bootstrap).toContain(
+        'fetch("http://localhost:8080/signal")',
+      );
+    } finally {
+      if (prev === undefined) delete process.env.FRIDAYD_URL;
+      else process.env.FRIDAYD_URL = prev;
+    }
   });
 });

--- a/packages/workspace/src/__tests__/variable-interpolation.test.ts
+++ b/packages/workspace/src/__tests__/variable-interpolation.test.ts
@@ -9,6 +9,7 @@ import {
   interpolateConfig,
   resolveWorkspaceVariables,
   type WorkspaceVariables,
+  WorkspaceVariablesSchema,
 } from "../variable-interpolation.ts";
 
 const VARS: WorkspaceVariables = {
@@ -135,13 +136,89 @@ describe("findRepoRoot", () => {
   });
 });
 
+// getAtlasDaemonUrl() reads multiple env keys (FRIDAYD_URL, legacy
+// FRIDAY_DAEMON_URL alias, FRIDAY_PORT_FRIDAY port override) and
+// auto-upgrades the scheme to https:// when FRIDAY_TLS_CERT + _KEY are
+// both set. Mirrors the list at packages/openapi-client/src/utils.test.ts:23
+// so both test files isolate the same surface. Without this, a developer
+// who has run setup-tls.sh or has any of these exported in their shell
+// sees flaky failures.
+const ENV_KEYS = [
+  "FRIDAYD_URL",
+  "FRIDAY_DAEMON_URL",
+  "FRIDAY_PORT_FRIDAY",
+  "FRIDAY_TLS_CERT",
+  "FRIDAY_TLS_KEY",
+  "FRIDAY_ATLAS_PLATFORM_URL",
+];
+
+describe("WorkspaceVariablesSchema.platform_url default", () => {
+  // Direct schema-level test: parse() with platform_url *omitted* triggers
+  // the schema's `.default(() => getAtlasDaemonUrl())`. The original
+  // function-level test was tautological because the call site always
+  // passed a resolved string, so the schema default was dead code (review
+  // v2 Important #1). With the call site now passing `platform_url:
+  // daemonUrl` (possibly undefined), the schema default fires — and this
+  // direct test locks that branch in so a future refactor can't quietly
+  // turn it into dead code again.
+  const envSnapshot: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of ENV_KEYS) {
+      envSnapshot[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of ENV_KEYS) {
+      if (envSnapshot[k] === undefined) delete process.env[k];
+      else process.env[k] = envSnapshot[k];
+    }
+  });
+
+  it("schema default fires when platform_url key is omitted from parse input", () => {
+    const result = WorkspaceVariablesSchema.parse({
+      repo_root: "/tmp/repo",
+      workspace_path: "/tmp/repo/workspaces/x",
+      workspace_id: "x",
+      // platform_url intentionally omitted
+    });
+    // Reverting the schema's `.default(() => getAtlasDaemonUrl())` to a
+    // literal like `.default("http://example.broken")` would make this
+    // assertion fail — proves the branch is actually reached.
+    expect(result.platform_url).toBe(getAtlasDaemonUrl());
+    // And the resolved value reflects env, not a hardcoded literal.
+    expect(result.platform_url).toBe("http://127.0.0.1:8080");
+  });
+
+  it("schema default fires when platform_url is explicitly undefined", () => {
+    const result = WorkspaceVariablesSchema.parse({
+      repo_root: "/tmp/repo",
+      workspace_path: "/tmp/repo/workspaces/x",
+      workspace_id: "x",
+      platform_url: undefined,
+    });
+    expect(result.platform_url).toBe(getAtlasDaemonUrl());
+  });
+
+  it("schema default honors FRIDAYD_URL (proves the default *calls* getAtlasDaemonUrl)", () => {
+    process.env.FRIDAYD_URL = "http://example.test:9999";
+    const result = WorkspaceVariablesSchema.parse({
+      repo_root: "/tmp/repo",
+      workspace_path: "/tmp/repo/workspaces/x",
+      workspace_id: "x",
+    });
+    // Reverting the schema default to a captured-at-startup value (e.g.
+    // `.default(getAtlasDaemonUrl())` instead of `.default(() =>
+    // getAtlasDaemonUrl())`) would break this test — proves the default
+    // resolves *at parse time*, not at module-load time.
+    expect(result.platform_url).toBe("http://example.test:9999");
+  });
+});
+
 describe("resolveWorkspaceVariables", () => {
   let tempDir: string;
-  // getAtlasDaemonUrl() reads FRIDAYD_URL, the legacy FRIDAY_DAEMON_URL alias,
-  // and auto-upgrades the scheme to https:// when FRIDAY_TLS_CERT + _KEY are
-  // both set. Snapshot all four keys per test so a developer who has run
-  // setup-tls.sh in their shell doesn't see flaky failures.
-  const ENV_KEYS = ["FRIDAYD_URL", "FRIDAY_DAEMON_URL", "FRIDAY_TLS_CERT", "FRIDAY_TLS_KEY"];
   const envSnapshot: Record<string, string | undefined> = {};
 
   beforeEach(() => {

--- a/packages/workspace/src/runtime.ts
+++ b/packages/workspace/src/runtime.ts
@@ -93,7 +93,7 @@ import {
 } from "@atlas/llm";
 import { logger } from "@atlas/logger";
 import { createMCPTools } from "@atlas/mcp";
-import { getAtlasPlatformServerConfig } from "@atlas/oapi-client";
+import { getAtlasDaemonUrl, getAtlasPlatformServerConfig } from "@atlas/oapi-client";
 import { extractArchiveContents, SkillStorage, validateSkillReferences } from "@atlas/skills";
 import { stringifyError } from "@atlas/utils";
 import { getFridayHome } from "@atlas/utils/paths.server";
@@ -1282,8 +1282,11 @@ export class WorkspaceRuntime {
     this.config = config;
     this.options = options;
 
-    // Create shared AgentOrchestrator (can handle concurrent executions)
-    const agentsServerUrl = options.daemonUrl || "http://localhost:8080";
+    // Create shared AgentOrchestrator (can handle concurrent executions).
+    // getAtlasDaemonUrl() picks the right scheme/port from FRIDAYD_URL +
+    // FRIDAY_TLS_CERT — a hardcoded http://localhost:8080 fallback would
+    // misroute on TLS-enabled installs where the daemon rejects cleartext.
+    const agentsServerUrl = options.daemonUrl || getAtlasDaemonUrl();
     this.orchestrator = new AgentOrchestrator(
       {
         agentsServerUrl: `${agentsServerUrl}/agents`,

--- a/packages/workspace/src/variable-interpolation.ts
+++ b/packages/workspace/src/variable-interpolation.ts
@@ -128,10 +128,14 @@ export async function resolveWorkspaceVariables(
     return null;
   }
 
+  // platform_url is intentionally left undefined when daemonUrl is absent so
+  // the schema's `.default(() => getAtlasDaemonUrl())` fires. Without this,
+  // the call-site `??` made the schema default dead code and the test that
+  // claimed to exercise it was tautological (see review v2 Important #1).
   return WorkspaceVariablesSchema.parse({
     repo_root: repoRoot,
     workspace_path: workspacePath,
     workspace_id: workspaceId,
-    platform_url: daemonUrl ?? getAtlasDaemonUrl(),
+    platform_url: daemonUrl,
   });
 }

--- a/packages/workspace/src/variable-interpolation.ts
+++ b/packages/workspace/src/variable-interpolation.ts
@@ -14,16 +14,23 @@
 import { statSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { logger } from "@atlas/logger";
+import { getAtlasDaemonUrl } from "@atlas/oapi-client";
 import { z } from "zod";
 
 /**
  * Well-known workspace variables resolved by the daemon at config-load time.
+ *
+ * `platform_url` defaults to whatever `getAtlasDaemonUrl()` resolves to —
+ * which honors `FRIDAYD_URL` and auto-upgrades to `https://` when
+ * `FRIDAY_TLS_CERT` is set. Without this, agents interpolating
+ * `{{platform_url}}` into an HTTP fetch hit cleartext on a TLS-bound daemon
+ * and fail with "Response does not match HTTP/1.1 protocol".
  */
 export const WorkspaceVariablesSchema = z.object({
   repo_root: z.string(),
   workspace_path: z.string(),
   workspace_id: z.string(),
-  platform_url: z.string().default("http://localhost:8080"),
+  platform_url: z.string().default(() => getAtlasDaemonUrl()),
 });
 
 export type WorkspaceVariables = z.infer<typeof WorkspaceVariablesSchema>;
@@ -104,7 +111,8 @@ export async function findRepoRoot(startPath: string): Promise<string | null> {
  *
  * @param workspacePath Absolute path to the workspace directory on disk.
  * @param workspaceId   The workspace's stable identifier.
- * @param daemonUrl     The daemon's base URL (defaults to http://localhost:8080).
+ * @param daemonUrl     The daemon's base URL (defaults to `getAtlasDaemonUrl()` —
+ *                      scheme/port follow the daemon's actual binding).
  * @returns Parsed `WorkspaceVariables` or `null` if repo_root cannot be derived.
  */
 export async function resolveWorkspaceVariables(
@@ -124,6 +132,6 @@ export async function resolveWorkspaceVariables(
     repo_root: repoRoot,
     workspace_path: workspacePath,
     workspace_id: workspaceId,
-    platform_url: daemonUrl ?? "http://localhost:8080",
+    platform_url: daemonUrl ?? getAtlasDaemonUrl(),
   });
 }

--- a/scripts/clean.ts
+++ b/scripts/clean.ts
@@ -4,6 +4,7 @@ import { readdir, rm, stat } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
+import { getAtlasDaemonUrl } from "@atlas/oapi-client";
 import { isErrnoException, stringifyError } from "@atlas/utils";
 import { getFridayHome } from "@atlas/utils/paths.server";
 import { connectToNats, resolveNatsUrl } from "jetstream";
@@ -17,12 +18,16 @@ const PRESERVED_ENTRIES = new Set([".env", "bin"]);
 // OAuth credentials written by setup-secrets.sh (e.g. google_client_id, hubspot_client_secret)
 const PRESERVED_SUFFIXES = ["_client_id", "_client_secret"];
 
-const DAEMON_HEALTH_URL = "http://localhost:8080/health";
 const LOCALHOST_HOSTS = new Set(["localhost", "127.0.0.1", "[::1]", "::1"]);
 
 async function isDaemonRunning(): Promise<boolean> {
+  // getAtlasDaemonUrl honors FRIDAYD_URL and FRIDAY_TLS_CERT so the probe
+  // hits the right scheme/port on TLS-enabled installs. Without this, a
+  // running TLS daemon looks "down" and `clean` proceeds with deletes
+  // while it's serving traffic.
+  const healthUrl = `${getAtlasDaemonUrl()}/health`;
   try {
-    const res = await fetch(DAEMON_HEALTH_URL, { signal: AbortSignal.timeout(500) });
+    const res = await fetch(healthUrl, { signal: AbortSignal.timeout(500) });
     return res.ok;
   } catch {
     return false;

--- a/tools/qa/live-daemon/promptfoo/skill-tls-awareness-config.yaml
+++ b/tools/qa/live-daemon/promptfoo/skill-tls-awareness-config.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://promptfoo.dev/config-schema.json
+
+description: Friday skill TLS-awareness evals — proves the documented curl examples don't break under https://localhost:8080
+
+prompts:
+  - '{{scenarioId}}'
+
+providers:
+  - id: file://skill-tls-awareness-provider.cjs
+    label: friday-skill-tls-awareness
+
+defaultTest:
+  assert:
+    - type: is-json
+    - type: javascript
+      value: |
+        const result = JSON.parse(output);
+        if (result.pass !== true) {
+          throw new Error(`${result.id} failed: ${(result.notes || []).join('; ')}`);
+        }
+        return true;
+
+tests: file://skill-tls-awareness-tests.yaml

--- a/tools/qa/live-daemon/promptfoo/skill-tls-awareness-provider.cjs
+++ b/tools/qa/live-daemon/promptfoo/skill-tls-awareness-provider.cjs
@@ -1,0 +1,97 @@
+const { mkdtemp, readFile } = require("node:fs/promises");
+const { tmpdir } = require("node:os");
+const path = require("node:path");
+const process = require("node:process");
+const { spawn } = require("node:child_process");
+
+let reportPromise;
+
+function repoRoot() {
+  return path.resolve(__dirname, "../../../..");
+}
+
+async function readReport(reportPath) {
+  return JSON.parse(await readFile(reportPath, "utf8"));
+}
+
+async function runSkillTlsAwareness() {
+  if (process.env.SKILL_TLS_AWARENESS_PROMPTFOO_REPORT) {
+    return await readReport(process.env.SKILL_TLS_AWARENESS_PROMPTFOO_REPORT);
+  }
+
+  const outDir = await mkdtemp(path.join(tmpdir(), "friday-promptfoo-skill-tls-awareness-"));
+  const reportPath = path.join(outDir, "skill-tls-awareness.json");
+  const root = repoRoot();
+  const script = path.join(root, "tools/qa/live-daemon/scenarios/skill-tls-awareness.ts");
+  const args = [
+    "run",
+    "--allow-all",
+    "--unstable-worker-options",
+    "--unstable-kv",
+    "--unstable-raw-imports",
+    script,
+    "--json-output",
+    reportPath,
+  ];
+
+  const child = spawn("deno", args, {
+    cwd: root,
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (chunk) => {
+    const text = chunk.toString();
+    stdout += text;
+    process.stdout.write(text);
+  });
+  child.stderr.on("data", (chunk) => {
+    const text = chunk.toString();
+    stderr += text;
+    process.stderr.write(text);
+  });
+
+  const exitCode = await new Promise((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", resolve);
+  });
+
+  let report;
+  try {
+    report = await readReport(reportPath);
+  } catch {
+    throw new Error(
+      `skill-tls-awareness runner did not produce ${reportPath}; exit=${exitCode}; stderr=${stderr}`,
+    );
+  }
+
+  return { ...report, runnerExitCode: exitCode, runnerStdout: stdout, runnerStderr: stderr };
+}
+
+function reportOnce() {
+  if (!reportPromise) reportPromise = runSkillTlsAwareness();
+  return reportPromise;
+}
+
+class SkillTlsAwarenessProvider {
+  id() {
+    return "friday-skill-tls-awareness";
+  }
+
+  async callApi(prompt, context) {
+    const scenarioId = context?.vars?.scenarioId || String(prompt).trim();
+    const report = await reportOnce();
+    const result = report.results.find((item) => item.id === scenarioId);
+    const output = result ?? {
+      id: scenarioId,
+      pass: false,
+      notes: [`scenario not found in skill-tls-awareness report: ${scenarioId}`],
+      metrics: { availableIds: report.results.map((item) => item.id) },
+    };
+    return { output: JSON.stringify(output) };
+  }
+}
+
+module.exports = SkillTlsAwarenessProvider;

--- a/tools/qa/live-daemon/promptfoo/skill-tls-awareness-tests.yaml
+++ b/tools/qa/live-daemon/promptfoo/skill-tls-awareness-tests.yaml
@@ -1,44 +1,37 @@
-- description: friday-cli SKILL.md has no bare http://localhost:8080
+# Aggregate sweep — fails if ANY file under packages/system/skills/**/*.md
+# has a bare daemon URL outside an acceptable fallback. Auto-discovers new
+# skills so the eval catches drift without yaml maintenance.
+- description: Sweep — all skill markdown is TLS-aware
   vars:
-    scenarioId: 'skill-tls-static:friday-cli/SKILL.md'
+    scenarioId: 'skill-tls-static:sweep'
 
-- description: friday-cli http.md reference has no bare URL
+# Per-file granularity for the three skill bodies the original migration
+# fixed (PR #308). The per-file scenarios for every other skill markdown
+# file are still emitted by the runner and visible in the JSON report —
+# but listing all of them here is unnecessary drift.
+- description: friday-cli SKILL.md has no bare daemon URL
   vars:
-    scenarioId: 'skill-tls-static:friday-cli/references/http.md'
+    scenarioId: 'skill-tls-static:packages/system/skills/friday-cli/SKILL.md'
 
-- description: friday-cli recipes.md has no bare URL
+- description: workspace-api SKILL.md has no bare daemon URL
   vars:
-    scenarioId: 'skill-tls-static:friday-cli/references/recipes.md'
+    scenarioId: 'skill-tls-static:packages/system/skills/workspace-api/SKILL.md'
 
-- description: friday-cli session-and-logs.md has no bare URL
+- description: writing-friday-python-agents SKILL.md has no bare daemon URL
   vars:
-    scenarioId: 'skill-tls-static:friday-cli/references/session-and-logs.md'
+    scenarioId: 'skill-tls-static:packages/system/skills/writing-friday-python-agents/SKILL.md'
 
-- description: friday-cli cli.md has no bare URL
-  vars:
-    scenarioId: 'skill-tls-static:friday-cli/references/cli.md'
-
-- description: workspace-api SKILL.md has no bare URL
-  vars:
-    scenarioId: 'skill-tls-static:workspace-api/SKILL.md'
-
-- description: workspace-api updating-workspaces.md has no bare URL
-  vars:
-    scenarioId: 'skill-tls-static:workspace-api/references/updating-workspaces.md'
-
-- description: writing-friday-python-agents SKILL.md has no bare URL
-  vars:
-    scenarioId: 'skill-tls-static:writing-friday-python-agents/SKILL.md'
-
-- description: friday-cli SKILL.md steers LLM to $FRIDAYD_URL
+# Behavioral checks — feed each top-level SKILL.md to the LLM and verify it
+# steers toward $FRIDAYD_URL + --cacert / friday_curl wrapper.
+- description: friday-cli SKILL.md steers LLM to $FRIDAYD_URL + --cacert
   vars:
     scenarioId: 'skill-tls-behavior:friday-cli/SKILL.md'
 
-- description: workspace-api SKILL.md steers LLM to $FRIDAYD_URL
+- description: workspace-api SKILL.md steers LLM to $FRIDAYD_URL + --cacert
   vars:
     scenarioId: 'skill-tls-behavior:workspace-api/SKILL.md'
 
-- description: writing-friday-python-agents SKILL.md steers LLM to $FRIDAYD_URL
+- description: writing-friday-python-agents SKILL.md steers LLM to $FRIDAYD_URL + --cacert
   vars:
     scenarioId: 'skill-tls-behavior:writing-friday-python-agents/SKILL.md'
 
@@ -54,25 +47,49 @@
   vars:
     scenarioId: 'skill-tls-static-negative:post-with-bare-url'
 
-- description: NEGATIVE — detector flags quoted bare URL in inline code
+- description: NEGATIVE — detector flags bare URL inside code block
   vars:
-    scenarioId: 'skill-tls-static-negative:quoted-bare-url'
+    scenarioId: 'skill-tls-static-negative:quoted-bare-url-in-code'
+
+- description: NEGATIVE — detector flags 127.0.0.1 loopback URL
+  vars:
+    scenarioId: 'skill-tls-static-negative:loopback-127-url'
+
+- description: NEGATIVE — detector flags port-override URL (:18080)
+  vars:
+    scenarioId: 'skill-tls-static-negative:port-override-url'
 
 - description: ACCEPT — detector allows ${FRIDAYD_URL:-...} bash default
   vars:
     scenarioId: 'skill-tls-static-accept:bash-default-expansion'
 
+- description: ACCEPT — detector allows single-dash bash default
+  vars:
+    scenarioId: 'skill-tls-static-accept:bash-default-single-dash'
+
+- description: ACCEPT — detector allows := assignment form
+  vars:
+    scenarioId: 'skill-tls-static-accept:bash-default-assignment'
+
+- description: ACCEPT — detector allows non-FRIDAYD_URL var with default
+  vars:
+    scenarioId: 'skill-tls-static-accept:bash-default-other-var'
+
 - description: ACCEPT — detector allows os.environ.get default literal
   vars:
     scenarioId: 'skill-tls-static-accept:python-environ-default'
 
-- description: ACCEPT — detector allows "→" doc comment describing the var
+- description: ACCEPT — detector allows "→" doc comment inside a code block
   vars:
-    scenarioId: 'skill-tls-static-accept:arrow-doc-comment'
+    scenarioId: 'skill-tls-static-accept:arrow-doc-comment-in-code'
 
-- description: ACCEPT — detector allows "defaults to `...`" prose
+- description: ACCEPT — detector allows URLs in plain prose
   vars:
-    scenarioId: 'skill-tls-static-accept:prose-default-in-backticks'
+    scenarioId: 'skill-tls-static-accept:prose-mention'
+
+- description: ACCEPT — detector allows URLs in YAML frontmatter
+  vars:
+    scenarioId: 'skill-tls-static-accept:frontmatter-description'
 
 - description: NEGATIVE — bad skill body makes the LLM emit a bare URL
   vars:

--- a/tools/qa/live-daemon/promptfoo/skill-tls-awareness-tests.yaml
+++ b/tools/qa/live-daemon/promptfoo/skill-tls-awareness-tests.yaml
@@ -104,9 +104,28 @@
   vars:
     scenarioId: 'skill-tls-static-negative:installed-studio-loopback-url'
 
+# Empty-bash-fence regression — five production skills shipped this exact
+# shape (preamble promises to teach .env sourcing, fence ships empty).
+# Detector must catch both the plain and the blockquoted variants.
+- description: NEGATIVE — detector flags empty bash fence following ".env" prose
+  vars:
+    scenarioId: 'skill-tls-static-negative:empty-bash-block-after-env-prose'
+
+- description: NEGATIVE — detector flags empty blockquoted bash fence
+  vars:
+    scenarioId: 'skill-tls-static-negative:empty-blockquoted-bash-block'
+
 - description: ACCEPT — detector allows :18080 in prose describing installed Studio
   vars:
     scenarioId: 'skill-tls-static-accept:prose-installed-studio-port'
+
+- description: ACCEPT — detector allows filled bash fence with `.env` source
+  vars:
+    scenarioId: 'skill-tls-static-accept:filled-bash-block-with-env-source'
+
+- description: ACCEPT — detector allows empty fence with no language tag
+  vars:
+    scenarioId: 'skill-tls-static-accept:empty-untagged-fence'
 
 - description: ACCEPT — detector allows ${FRIDAYD_URL:-...} bash default
   vars:

--- a/tools/qa/live-daemon/promptfoo/skill-tls-awareness-tests.yaml
+++ b/tools/qa/live-daemon/promptfoo/skill-tls-awareness-tests.yaml
@@ -1,0 +1,79 @@
+- description: friday-cli SKILL.md has no bare http://localhost:8080
+  vars:
+    scenarioId: 'skill-tls-static:friday-cli/SKILL.md'
+
+- description: friday-cli http.md reference has no bare URL
+  vars:
+    scenarioId: 'skill-tls-static:friday-cli/references/http.md'
+
+- description: friday-cli recipes.md has no bare URL
+  vars:
+    scenarioId: 'skill-tls-static:friday-cli/references/recipes.md'
+
+- description: friday-cli session-and-logs.md has no bare URL
+  vars:
+    scenarioId: 'skill-tls-static:friday-cli/references/session-and-logs.md'
+
+- description: friday-cli cli.md has no bare URL
+  vars:
+    scenarioId: 'skill-tls-static:friday-cli/references/cli.md'
+
+- description: workspace-api SKILL.md has no bare URL
+  vars:
+    scenarioId: 'skill-tls-static:workspace-api/SKILL.md'
+
+- description: workspace-api updating-workspaces.md has no bare URL
+  vars:
+    scenarioId: 'skill-tls-static:workspace-api/references/updating-workspaces.md'
+
+- description: writing-friday-python-agents SKILL.md has no bare URL
+  vars:
+    scenarioId: 'skill-tls-static:writing-friday-python-agents/SKILL.md'
+
+- description: friday-cli SKILL.md steers LLM to $FRIDAYD_URL
+  vars:
+    scenarioId: 'skill-tls-behavior:friday-cli/SKILL.md'
+
+- description: workspace-api SKILL.md steers LLM to $FRIDAYD_URL
+  vars:
+    scenarioId: 'skill-tls-behavior:workspace-api/SKILL.md'
+
+- description: writing-friday-python-agents SKILL.md steers LLM to $FRIDAYD_URL
+  vars:
+    scenarioId: 'skill-tls-behavior:writing-friday-python-agents/SKILL.md'
+
+# Negative controls — prove the detector + LLM-judge have discriminative
+# power. If any of these PASS=false, the eval framework lost signal and
+# every positive case above is suspect.
+
+- description: NEGATIVE — detector flags bare curl in code fence
+  vars:
+    scenarioId: 'skill-tls-static-negative:bare-curl-in-code-fence'
+
+- description: NEGATIVE — detector flags POST with bare URL
+  vars:
+    scenarioId: 'skill-tls-static-negative:post-with-bare-url'
+
+- description: NEGATIVE — detector flags quoted bare URL in inline code
+  vars:
+    scenarioId: 'skill-tls-static-negative:quoted-bare-url'
+
+- description: ACCEPT — detector allows ${FRIDAYD_URL:-...} bash default
+  vars:
+    scenarioId: 'skill-tls-static-accept:bash-default-expansion'
+
+- description: ACCEPT — detector allows os.environ.get default literal
+  vars:
+    scenarioId: 'skill-tls-static-accept:python-environ-default'
+
+- description: ACCEPT — detector allows "→" doc comment describing the var
+  vars:
+    scenarioId: 'skill-tls-static-accept:arrow-doc-comment'
+
+- description: ACCEPT — detector allows "defaults to `...`" prose
+  vars:
+    scenarioId: 'skill-tls-static-accept:prose-default-in-backticks'
+
+- description: NEGATIVE — bad skill body makes the LLM emit a bare URL
+  vars:
+    scenarioId: 'skill-tls-behavior-negative:bad-skill-emits-bare-url'

--- a/tools/qa/live-daemon/promptfoo/skill-tls-awareness-tests.yaml
+++ b/tools/qa/live-daemon/promptfoo/skill-tls-awareness-tests.yaml
@@ -21,17 +21,39 @@
   vars:
     scenarioId: 'skill-tls-static:packages/system/skills/writing-friday-python-agents/SKILL.md'
 
-# Behavioral checks — feed each top-level SKILL.md to the LLM and verify it
-# steers toward $FRIDAYD_URL + --cacert / friday_curl wrapper.
-- description: friday-cli SKILL.md steers LLM to $FRIDAYD_URL + --cacert
+# Behavioral checks — feed each CHANGED skill markdown file (SKILL.md + the
+# references touched by this PR) to the LLM and verify it steers toward
+# $FRIDAYD_URL + friday_curl. Each subject has its own custom user prompt
+# (defined in the scenario) appropriate to the skill's content.
+- description: friday-cli SKILL.md steers LLM to $FRIDAYD_URL + friday_curl
   vars:
     scenarioId: 'skill-tls-behavior:friday-cli/SKILL.md'
 
-- description: workspace-api SKILL.md steers LLM to $FRIDAYD_URL + --cacert
+- description: friday-cli references/cli.md steers LLM to $FRIDAYD_URL + friday_curl
+  vars:
+    scenarioId: 'skill-tls-behavior:friday-cli/references/cli.md'
+
+- description: friday-cli references/http.md steers LLM to $FRIDAYD_URL + friday_curl
+  vars:
+    scenarioId: 'skill-tls-behavior:friday-cli/references/http.md'
+
+- description: friday-cli references/recipes.md steers LLM to $FRIDAYD_URL + friday_curl
+  vars:
+    scenarioId: 'skill-tls-behavior:friday-cli/references/recipes.md'
+
+- description: friday-cli references/session-and-logs.md steers LLM to $FRIDAYD_URL + friday_curl
+  vars:
+    scenarioId: 'skill-tls-behavior:friday-cli/references/session-and-logs.md'
+
+- description: workspace-api SKILL.md steers LLM to $FRIDAYD_URL + friday_curl
   vars:
     scenarioId: 'skill-tls-behavior:workspace-api/SKILL.md'
 
-- description: writing-friday-python-agents SKILL.md steers LLM to $FRIDAYD_URL + --cacert
+- description: workspace-api references/updating-workspaces.md steers LLM to $FRIDAYD_URL + friday_curl
+  vars:
+    scenarioId: 'skill-tls-behavior:workspace-api/references/updating-workspaces.md'
+
+- description: writing-friday-python-agents SKILL.md steers LLM to $FRIDAYD_URL + friday_curl
   vars:
     scenarioId: 'skill-tls-behavior:writing-friday-python-agents/SKILL.md'
 
@@ -91,6 +113,17 @@
   vars:
     scenarioId: 'skill-tls-static-accept:frontmatter-description'
 
-- description: NEGATIVE — bad skill body makes the LLM emit a bare URL
+# Behavioral negative controls — three different bad-skill framings prove
+# the LLM judge has discriminative signal across framings. If all three
+# flip to pass=false at once, the judge has lost discrimination.
+- description: NEGATIVE — bash-heavy bad skill makes LLM emit bare URL
   vars:
-    scenarioId: 'skill-tls-behavior-negative:bad-skill-emits-bare-url'
+    scenarioId: 'skill-tls-behavior-negative:bash-heavy-bare-url'
+
+- description: NEGATIVE — python-agent bad skill makes LLM emit bare URL
+  vars:
+    scenarioId: 'skill-tls-behavior-negative:python-agent-bare-url'
+
+- description: NEGATIVE — prose-then-bare-curl bad skill makes LLM emit bare URL
+  vars:
+    scenarioId: 'skill-tls-behavior-negative:prose-then-bare-curl'

--- a/tools/qa/live-daemon/promptfoo/skill-tls-awareness-tests.yaml
+++ b/tools/qa/live-daemon/promptfoo/skill-tls-awareness-tests.yaml
@@ -140,17 +140,18 @@
   vars:
     scenarioId: 'skill-tls-static-accept:frontmatter-description'
 
-# Behavioral negative controls — three different bad-skill framings prove
-# the LLM judge has discriminative signal across framings. If all three
-# flip to pass=false at once, the judge has lost discrimination.
-- description: NEGATIVE — bash-heavy bad skill makes LLM emit bare URL
+# Behavioral negative controls — three bad-skill framings, each teaching
+# a distinct failure mode (variable literal, missing -k, wrong-port
+# hardcode). If all three flip to pass=false at once, the LLM judge has
+# lost discrimination.
+- description: NEGATIVE — skill teaches $FRIDAYD_URL literal, LLM should regurgitate it
+  vars:
+    scenarioId: 'skill-tls-behavior-negative:emit-variable-literal'
+
+- description: NEGATIVE — skill says don't use -k, LLM should omit it
+  vars:
+    scenarioId: 'skill-tls-behavior-negative:omit-cert-skip'
+
+- description: NEGATIVE — skill hardcodes :8080, LLM should emit a bare URL
   vars:
     scenarioId: 'skill-tls-behavior-negative:bash-heavy-bare-url'
-
-- description: NEGATIVE — python-agent bad skill makes LLM emit bare URL
-  vars:
-    scenarioId: 'skill-tls-behavior-negative:python-agent-bare-url'
-
-- description: NEGATIVE — prose-then-bare-curl bad skill makes LLM emit bare URL
-  vars:
-    scenarioId: 'skill-tls-behavior-negative:prose-then-bare-curl'

--- a/tools/qa/live-daemon/promptfoo/skill-tls-awareness-tests.yaml
+++ b/tools/qa/live-daemon/promptfoo/skill-tls-awareness-tests.yaml
@@ -57,6 +57,18 @@
   vars:
     scenarioId: 'skill-tls-behavior:writing-friday-python-agents/SKILL.md'
 
+# Installed-Studio behavioral checks — user prompts that explicitly mention
+# :18080. The LLM must IGNORE the user-supplied port and use $FRIDAYD_URL.
+# Without these tests, a skill text that fails to resist user-supplied
+# port priming would silently regress without anyone noticing.
+- description: friday-cli SKILL.md resists installed-Studio port priming
+  vars:
+    scenarioId: 'skill-tls-behavior:friday-cli/SKILL.md#installed-studio-priming'
+
+- description: workspace-api SKILL.md resists installed-Studio TLS-URL priming
+  vars:
+    scenarioId: 'skill-tls-behavior:workspace-api/SKILL.md#installed-studio-priming'
+
 # Negative controls — prove the detector + LLM-judge have discriminative
 # power. If any of these PASS=false, the eval framework lost signal and
 # every positive case above is suspect.
@@ -80,6 +92,21 @@
 - description: NEGATIVE — detector flags port-override URL (:18080)
   vars:
     scenarioId: 'skill-tls-static-negative:port-override-url'
+
+# Installed Friday Studio coverage — production binds the daemon on :18080
+# with TLS configured automatically by the launcher. The detector and
+# behavioral checks must treat this case as a first-class peer of dev.
+- description: NEGATIVE — detector flags bare https://localhost:18080 (installed-Studio TLS)
+  vars:
+    scenarioId: 'skill-tls-static-negative:installed-studio-https-bare-url'
+
+- description: NEGATIVE — detector flags 127.0.0.1:18080 (installed-Studio loopback)
+  vars:
+    scenarioId: 'skill-tls-static-negative:installed-studio-loopback-url'
+
+- description: ACCEPT — detector allows :18080 in prose describing installed Studio
+  vars:
+    scenarioId: 'skill-tls-static-accept:prose-installed-studio-port'
 
 - description: ACCEPT — detector allows ${FRIDAYD_URL:-...} bash default
   vars:

--- a/tools/qa/live-daemon/scenarios/activity-sidebar-ui.ts
+++ b/tools/qa/live-daemon/scenarios/activity-sidebar-ui.ts
@@ -12,7 +12,6 @@
  * Requires the `agent-browser` CLI in PATH.
  */
 
-import { ensureDir } from "jsr:@std/fs@1.0.13/ensure-dir";
 import { dirname, join } from "jsr:@std/path@1";
 import { ElicitationStorage, initElicitationStorage } from "@atlas/core";
 import { connect } from "nats";
@@ -66,7 +65,7 @@ async function waitForHttp(url: string, timeoutMs = 60_000): Promise<void> {
 
 async function drainToLog(stream: ReadableStream<Uint8Array>, path: string): Promise<void> {
   try {
-    await ensureDir(dirname(path));
+    await Deno.mkdir(dirname(path), { recursive: true });
     const file = await Deno.open(path, { create: true, append: true, write: true });
     void stream.pipeTo(file.writable).catch(() => {});
   } catch {

--- a/tools/qa/live-daemon/scenarios/connect-service-on-auth-error.ts
+++ b/tools/qa/live-daemon/scenarios/connect-service-on-auth-error.ts
@@ -18,7 +18,6 @@
  * prompt or the error message surfaces here.
  */
 
-import { ensureDir } from "jsr:@std/fs@1.0.13/ensure-dir";
 import { dirname, fromFileUrl, join } from "jsr:@std/path@1";
 import { currentGitSha, ensureCredentialsLoaded, HARNESS_PATHS } from "../harness.ts";
 
@@ -520,7 +519,7 @@ async function main() {
   if (writeResult || jsonOutputPath) {
     const path =
       jsonOutputPath ?? join(HARNESS_PATHS.resultsDir, `${sha}-connect-service-on-auth-error.json`);
-    await ensureDir(dirname(path));
+    await Deno.mkdir(dirname(path), { recursive: true });
     await Deno.writeTextFile(path, JSON.stringify(report, null, 2));
     console.log(`\n→ ${path}`);
   }

--- a/tools/qa/live-daemon/scenarios/delegate-error-contract.ts
+++ b/tools/qa/live-daemon/scenarios/delegate-error-contract.ts
@@ -27,7 +27,6 @@
  * test, surfacing it next to the assertions is the point.
  */
 
-import { ensureDir } from "jsr:@std/fs@1.0.13/ensure-dir";
 import { dirname, join } from "jsr:@std/path@1";
 import {
   buildDelegateScopeDirective,
@@ -634,7 +633,7 @@ async function main() {
   if (writeResult || jsonOutputPath) {
     const path =
       jsonOutputPath ?? join(HARNESS_PATHS.resultsDir, `${sha}-delegate-error-contract.json`);
-    await ensureDir(dirname(path));
+    await Deno.mkdir(dirname(path), { recursive: true });
     await Deno.writeTextFile(path, JSON.stringify(report, null, 2));
     console.log(`\n→ ${path}`);
   }

--- a/tools/qa/live-daemon/scenarios/delegate-skills.ts
+++ b/tools/qa/live-daemon/scenarios/delegate-skills.ts
@@ -20,7 +20,6 @@
  * here.
  */
 
-import { ensureDir } from "jsr:@std/fs@1.0.13/ensure-dir";
 import { dirname, join } from "jsr:@std/path@1";
 import { formatDelegateSkillsBlock } from "@atlas/core/delegate/skills-resolver";
 import { buildTemporalFacts } from "@atlas/llm";
@@ -187,7 +186,7 @@ async function main() {
   const report = { gitSha: sha, startedAt, passed, failed, results };
   if (writeResult || jsonOutputPath) {
     const path = jsonOutputPath ?? join(HARNESS_PATHS.resultsDir, `${sha}-delegate-skills.json`);
-    await ensureDir(dirname(path));
+    await Deno.mkdir(dirname(path), { recursive: true });
     await Deno.writeTextFile(path, JSON.stringify(report, null, 2));
     console.log(`\n→ ${path}`);
   }

--- a/tools/qa/live-daemon/scenarios/first-principles.ts
+++ b/tools/qa/live-daemon/scenarios/first-principles.ts
@@ -9,7 +9,6 @@
  * MCP models a Gmail-shaped workload without OAuth/network.
  */
 
-import { ensureDir } from "jsr:@std/fs@1.0.13/ensure-dir";
 import { dirname, join } from "jsr:@std/path@1";
 import {
   currentGitSha,
@@ -65,7 +64,7 @@ async function materializeFridayHomeWithUserAgents(): Promise<{
 }> {
   const fridayHome = await Deno.makeTempDir({ prefix: "friday-qa-" });
   const agentDir = join(fridayHome, "agents", "fake-inbox-python-agent@0.1.0");
-  await ensureDir(agentDir);
+  await Deno.mkdir(agentDir, { recursive: true });
   await Deno.copyFile(join(PYTHON_USER_AGENT_FIXTURE, "agent.py"), join(agentDir, "agent.py"));
   await Deno.copyFile(
     join(PYTHON_USER_AGENT_FIXTURE, "metadata.json"),
@@ -2380,7 +2379,7 @@ async function main() {
   const report = { gitSha: sha, startedAt, passed, failed, results };
   if (writeResult || jsonOutputPath) {
     const path = jsonOutputPath ?? join(HARNESS_PATHS.resultsDir, `${sha}-first-principles.json`);
-    await ensureDir(dirname(path));
+    await Deno.mkdir(dirname(path), { recursive: true });
     await Deno.writeTextFile(path, JSON.stringify(report, null, 2));
     console.log(`\n→ ${path}`);
   }

--- a/tools/qa/live-daemon/scenarios/load-skill-injection.ts
+++ b/tools/qa/live-daemon/scenarios/load-skill-injection.ts
@@ -35,7 +35,6 @@
  * proposed fix becomes load-bearing rather than defensive).
  */
 
-import { ensureDir } from "jsr:@std/fs@1.0.13/ensure-dir";
 import { dirname, join } from "jsr:@std/path@1";
 import { currentGitSha, ensureCredentialsLoaded, HARNESS_PATHS } from "../harness.ts";
 
@@ -362,7 +361,7 @@ async function main() {
   if (writeResult || jsonOutputPath) {
     const path =
       jsonOutputPath ?? join(HARNESS_PATHS.resultsDir, `${sha}-load-skill-injection.json`);
-    await ensureDir(dirname(path));
+    await Deno.mkdir(dirname(path), { recursive: true });
     await Deno.writeTextFile(path, JSON.stringify(report, null, 2));
     console.log(`\n→ ${path}`);
   }

--- a/tools/qa/live-daemon/scenarios/oauth-refresh-transient.ts
+++ b/tools/qa/live-daemon/scenarios/oauth-refresh-transient.ts
@@ -25,7 +25,6 @@
  *     --json-output /tmp/oauth-refresh-report.json
  */
 
-import { ensureDir } from "jsr:@std/fs@1.0.13/ensure-dir";
 import { dirname, join } from "jsr:@std/path@1";
 import { refreshDelegatedTokenClassified } from "../../../../apps/link/src/oauth/delegated.ts";
 import type { OAuthConfig } from "../../../../apps/link/src/providers/types.ts";
@@ -271,7 +270,7 @@ async function main() {
   if (writeResult || jsonOutputPath) {
     const outPath =
       jsonOutputPath ?? join(HARNESS_PATHS.resultsDir, `${sha}-oauth-refresh-transient.json`);
-    await ensureDir(dirname(outPath));
+    await Deno.mkdir(dirname(outPath), { recursive: true });
     await Deno.writeTextFile(outPath, JSON.stringify(report, null, 2));
     console.log(`\n→ ${outPath}`);
   }

--- a/tools/qa/live-daemon/scenarios/retrieval-gated.ts
+++ b/tools/qa/live-daemon/scenarios/retrieval-gated.ts
@@ -18,7 +18,6 @@
  * both surfaces.
  */
 
-import { ensureDir } from "jsr:@std/fs@1.0.13/ensure-dir";
 import { dirname, join } from "jsr:@std/path@1";
 import { wrapRetrieved } from "@atlas/llm";
 import { connect } from "nats";
@@ -243,7 +242,7 @@ async function main() {
   const report = { gitSha: sha, startedAt, passed, failed, results };
   if (writeResult || jsonOutputPath) {
     const outPath = jsonOutputPath ?? join(HARNESS_PATHS.resultsDir, `${sha}-retrieval-gated.json`);
-    await ensureDir(dirname(outPath));
+    await Deno.mkdir(dirname(outPath), { recursive: true });
     await Deno.writeTextFile(outPath, JSON.stringify(report, null, 2));
     console.log(`\n→ ${outPath}`);
   }

--- a/tools/qa/live-daemon/scenarios/skill-tls-awareness.ts
+++ b/tools/qa/live-daemon/scenarios/skill-tls-awareness.ts
@@ -253,11 +253,25 @@ async function runStaticChecks(): Promise<EvalResult[]> {
     });
   }
 
+  // The sweep is the primary defense against drift: a new skill with a
+  // bare URL must fail the eval the day it lands. That defense degrades
+  // silently if `discoverSkillFiles()` returns [] — skills dir relocated,
+  // glob pattern broken, package boundary change. `paths.length > 0` is
+  // the discrimination signal that distinguishes "30 files all clean"
+  // from "no files scanned and we have no idea." See review v2 Important
+  // #2.
+  const swept = paths.length > 0;
+  const clean = aggregateViolations.length === 0;
   results.push({
     id: "skill-tls-static:sweep",
-    pass: aggregateViolations.length === 0,
-    notes:
-      aggregateViolations.length === 0
+    pass: swept && clean,
+    notes: !swept
+      ? [
+          "FAIL: discoverSkillFiles() returned 0 files — skills directory moved, " +
+            "glob pattern broken, or the skills/ tree was relocated. The auto-" +
+            "discovery sweep cannot protect against drift if it finds nothing.",
+        ]
+      : clean
         ? [`swept ${paths.length} skill markdown file(s) — all clean`]
         : aggregateViolations
             .slice(0, 8)

--- a/tools/qa/live-daemon/scenarios/skill-tls-awareness.ts
+++ b/tools/qa/live-daemon/scenarios/skill-tls-awareness.ts
@@ -139,22 +139,34 @@ function staticViolations(text: string): { line: number; snippet: string }[] {
   return violations;
 }
 
+/** The synthetic FRIDAYD_URL we tell the LLM it "looked up" via run_code.
+ *  Picked to be distinct from any port a bad-skill body might hardcode,
+ *  so we can tell the difference between "LLM substituted the lookup
+ *  value" and "LLM regurgitated the skill's literal port". */
+const INJECTED_FRIDAYD_URL = "https://localhost:18080";
+
 interface LlmJudgement {
   output: string;
-  usesVariable: boolean;
+  /** LLM emitted `$FRIDAYD_URL` literal — BAD. The user's shell has no
+   *  such variable; the LLM should have resolved it via run_code first. */
+  emitsVariableLiteral: boolean;
   containsBareUrl: boolean;
-  honorsCa: boolean;
-  sourcesEnv: boolean;
+  /** Output contains a resolved daemon URL (http(s)://localhost:N or
+   *  127.0.0.1:N) — what the user can actually paste and run. */
+  emitsResolvedUrl: boolean;
+  /** Output contains the SPECIFIC URL we injected as the run_code result.
+   *  Stricter than emitsResolvedUrl — distinguishes "LLM substituted from
+   *  the lookup" from "LLM hardcoded a different port". */
+  emitsInjectedUrl: boolean;
+  skipsCertVerify: boolean;
 }
 
-const ENV_HINT_RE = /\.friday\/local|\.atlas\/\.env|FRIDAY_HOME|FRIDAYD_URL/i;
-const VARIABLE_RE = /\$FRIDAYD_URL|\$\{\s*FRIDAYD_URL/;
-// The skills teach two things — use $FRIDAYD_URL AND inject --cacert when
-// TLS is on (either inline or via the `friday_curl` helper). Without this
-// check the LLM can emit `curl "$FRIDAYD_URL/health"`, which on a TLS
-// install fails with `self signed certificate in certificate chain`. The
-// eval would have passed despite the user getting a non-working command.
-const CA_HONOR_RE = /--cacert|FRIDAY_TLS_CA|\bfriday_curl\b/;
+const VARIABLE_LITERAL_RE = /\$FRIDAYD_URL|\$\{\s*FRIDAYD_URL/;
+// Skills teach two rules — (1) resolve $FRIDAYD_URL first then emit the
+// literal value, and (2) skip cert verification via `-k` / `--insecure`
+// so it works on both plain-HTTP (no-op) and TLS (skip private-CA leaf)
+// installs. `-k` is safe because the daemon binds loopback only.
+const SKIP_VERIFY_RE = /\s-(?:[A-Za-z]*k|-insecure\b)/;
 
 /**
  * "Bare URL" = a daemon-URL occurrence in the LLM output that is NOT
@@ -196,20 +208,38 @@ async function callChild(systemPrompt: string, userPrompt: string): Promise<stri
     .join("");
 }
 
-async function llmJudgeSkillWithPrompt(body: string, ask: string): Promise<LlmJudgement> {
-  const output = await callChild(
-    body,
-    `${ask} Assume the user has already sourced any environment they need. ` +
-      "Output only the command — no preamble, no explanation, no markdown.",
-  );
+async function llmJudgeSkillWithPrompt(
+  body: string,
+  ask: string,
+  options: { inject?: boolean } = { inject: true },
+): Promise<LlmJudgement> {
+  // For positive tests: inject the resolved-FRIDAYD_URL context the
+  // skill teaches the LLM to produce via run_code. The test focuses on
+  // *substitution* behavior, not on whether the LLM remembers to call
+  // run_code.
+  //
+  // For negative tests: feed ONLY the bad-skill body. Injection would
+  // override the bad teaching by making the LLM substitute the injected
+  // value regardless of skill content — the bad skill never gets to
+  // demonstrate its failure mode.
+  const userPrompt = options.inject
+    ? `Context: you ran \`python -c "import os; print(os.environ['FRIDAYD_URL'])"\` ` +
+      `and got the literal string "${INJECTED_FRIDAYD_URL}". ` +
+      `${ask} ` +
+      "Output only the command — no preamble, no explanation, no markdown."
+    : `${ask} Output only the command — no preamble, no explanation, no markdown.`;
+  const output = await callChild(body, userPrompt);
   // DAEMON_URL_RE has the `g` flag; reset lastIndex before each test.
+  DAEMON_URL_RE.lastIndex = 0;
+  const emitsResolvedUrl = DAEMON_URL_RE.test(output);
   DAEMON_URL_RE.lastIndex = 0;
   return {
     output,
-    usesVariable: VARIABLE_RE.test(output),
+    emitsVariableLiteral: VARIABLE_LITERAL_RE.test(output),
     containsBareUrl: containsBareUrl(output),
-    honorsCa: CA_HONOR_RE.test(output),
-    sourcesEnv: ENV_HINT_RE.test(output),
+    emitsResolvedUrl,
+    emitsInjectedUrl: output.includes(INJECTED_FRIDAYD_URL),
+    skipsCertVerify: SKIP_VERIFY_RE.test(output),
   };
 }
 
@@ -526,30 +556,31 @@ async function runBehavioralChecks(): Promise<EvalResult[]> {
     const body = await Deno.readTextFile(full);
     const judgement = await llmJudgeSkillWithPrompt(body, ask);
     // Three things must all be true for the eval to pass:
-    //   1. uses $FRIDAYD_URL — the variable, not a literal URL.
-    //   2. no bare daemon URL outside the canonical fallback expansion.
-    //   3. honors the CA cert — either `--cacert` inline, the
-    //      `FRIDAY_TLS_CA` var, or the `friday_curl` helper. Without this
-    //      check an LLM emitting `curl "$FRIDAYD_URL/health"` would pass
-    //      the eval but fail on TLS installs with "self signed certificate
-    //      in certificate chain".
-    const pass = judgement.usesVariable && !judgement.containsBareUrl && judgement.honorsCa;
+    //   1. emits the SPECIFIC injected URL (https://localhost:18080) —
+    //      not the `$FRIDAYD_URL` variable, not a different hardcoded
+    //      port. The user's shell has no `$FRIDAYD_URL`, and only the
+    //      injected value matches their actual daemon.
+    //   2. does NOT contain the `$FRIDAYD_URL` literal in output.
+    //   3. skips cert verification via `-k` / `--insecure`. Without this
+    //      the example fails on TLS installs with "self signed
+    //      certificate in certificate chain". `-k` is safe because the
+    //      daemon binds loopback only.
+    const pass =
+      judgement.emitsInjectedUrl && !judgement.emitsVariableLiteral && judgement.skipsCertVerify;
     results.push({
       id: `skill-tls-behavior:${id}`,
       pass,
       notes: [
         `LLM output: ${judgement.output.replace(/\s+/g, " ").slice(0, 200)}`,
-        `uses $FRIDAYD_URL: ${judgement.usesVariable}`,
-        `contains bare URL: ${judgement.containsBareUrl}`,
-        `honors --cacert / FRIDAY_TLS_CA / friday_curl: ${judgement.honorsCa}`,
-        `mentions daemon .env / FRIDAYD_URL: ${judgement.sourcesEnv}`,
+        `emits injected URL (${INJECTED_FRIDAYD_URL}): ${judgement.emitsInjectedUrl}`,
+        `emits $FRIDAYD_URL literal (bad): ${judgement.emitsVariableLiteral}`,
+        `skips cert verify (-k / --insecure): ${judgement.skipsCertVerify}`,
       ],
       metrics: {
         path,
-        usesVariable: judgement.usesVariable,
-        containsBareUrl: judgement.containsBareUrl,
-        honorsCa: judgement.honorsCa,
-        sourcesEnv: judgement.sourcesEnv,
+        emitsInjectedUrl: judgement.emitsInjectedUrl,
+        emitsVariableLiteral: judgement.emitsVariableLiteral,
+        skipsCertVerify: judgement.skipsCertVerify,
       },
     });
   }
@@ -580,58 +611,45 @@ async function runBehavioralChecks(): Promise<EvalResult[]> {
  * before retrying.
  */
 const BAD_SKILL_BODIES: { id: string; ask: string; body: string }[] = [
+  // Under the new model the LLM is told via injected context what
+  // FRIDAYD_URL resolves to. So a bad-skill body has to teach a
+  // DIFFERENT failure mode — not "use this hardcoded port" (the LLM
+  // ignores it in favor of the injected lookup result), but rather
+  // "skip the lookup and emit the $FRIDAYD_URL literal" or "skip the
+  // -k flag".
   {
-    id: "bash-heavy-bare-url",
+    id: "emit-variable-literal",
     ask: "Write a single shell command to hit the daemon's /health endpoint.",
     body: `# Bad Skill (eval negative control — do not ship)
 
-Friday's daemon listens on \`localhost:8080\`. Every example below uses
-that URL directly. Do not parameterize. Do not source env files.
-
-Health probe:
+The daemon URL is in \`$FRIDAYD_URL\`. Don't resolve it. Don't look it up.
+Just put \`$FRIDAYD_URL\` directly in the curl command — the user's shell
+will sort it out.
 
 \`\`\`bash
-curl -sf http://localhost:8080/health && echo OK
+curl -k "$FRIDAYD_URL/health"
 \`\`\`
 
-List workspaces:
+This is the canonical pattern. The whole point of having a variable is to
+reference it by name.
+`,
+  },
+  {
+    id: "omit-cert-skip",
+    ask: "Write a single shell command to list workspaces.",
+    body: `# Bad Skill (eval negative control — do not ship)
+
+The daemon is on the local network so cert verification works fine. Use
+plain \`curl\` — never \`-k\` or \`--insecure\`, those are dangerous flags
+that should never appear in production code. Always verify certs.
 
 \`\`\`bash
-curl -s http://localhost:8080/api/workspaces | jq
-\`\`\`
-
-Trigger a signal:
-
-\`\`\`bash
-curl -X POST http://localhost:8080/api/workspaces/foo/signals/bar -d '{}'
+curl -s "$FRIDAYD_URL/api/workspaces" | jq
 \`\`\`
 `,
   },
   {
-    id: "python-agent-bare-url",
-    ask: "Write a single shell command to register a Python agent at /abs/agent.py.",
-    body: `# Bad Python-Agent Skill (eval negative control — do not ship)
-
-To register a Python agent, POST its absolute path to the daemon at the
-hardcoded URL. The daemon always listens on the default port.
-
-\`\`\`bash
-curl -X POST http://localhost:8080/api/agents/register \\
-  -H 'Content-Type: application/json' \\
-  -d '{"entrypoint": "/abs/path/agent.py"}'
-\`\`\`
-
-Or to test directly:
-
-\`\`\`bash
-curl -s -X POST http://localhost:8080/api/agents/my-agent/run \\
-  -H 'Content-Type: application/json' \\
-  -d '{"input": "test"}'
-\`\`\`
-`,
-  },
-  {
-    id: "prose-then-bare-curl",
+    id: "bash-heavy-bare-url",
     ask: "Write a single shell command to list workspaces from the daemon.",
     body: `# Bad Workspace Skill (eval negative control — do not ship)
 
@@ -656,22 +674,33 @@ curl -s http://localhost:8080/api/workspaces/$WS_ID | jq
 async function runBehavioralNegativeControls(): Promise<EvalResult[]> {
   const results: EvalResult[] = [];
   for (const { id, ask, body } of BAD_SKILL_BODIES) {
-    const judgement = await llmJudgeSkillWithPrompt(body, ask);
-    // The control "passes" when the LLM produces a bare URL — meaning the
-    // detector (`containsBareUrl`) flips to true. If pass=false here for
-    // ALL THREE bodies simultaneously, either the LLM-judge has lost
-    // discrimination or model behavior has shifted. Both are eval-bugs
-    // worth catching.
-    const pass = judgement.containsBareUrl && !judgement.usesVariable;
+    // Feed the bad skill body WITHOUT the resolved-URL injection — the
+    // injection would override the skill's teaching and defeat the
+    // test. Each bad body teaches one of the three failure modes the
+    // positive eval guards against; the LLM should follow the bad
+    // teaching and produce broken output.
+    const judgement = await llmJudgeSkillWithPrompt(body, ask, { inject: false });
+    // The control "passes" when the LLM's output violates AT LEAST ONE
+    // of the three positive rules: emits the variable literal, or fails
+    // to skip cert verify, or contains a bare URL (in which case the
+    // injected-URL check is moot — we're not injecting).
+    const violatesRule =
+      judgement.emitsVariableLiteral || !judgement.skipsCertVerify || judgement.containsBareUrl;
     results.push({
       id: `skill-tls-behavior-negative:${id}`,
-      pass,
+      pass: violatesRule,
       notes: [
         `LLM output: ${judgement.output.replace(/\s+/g, " ").slice(0, 200)}`,
-        `contains bare URL (expected true): ${judgement.containsBareUrl}`,
-        `uses $FRIDAYD_URL (expected false): ${judgement.usesVariable}`,
+        `emits $FRIDAYD_URL literal: ${judgement.emitsVariableLiteral}`,
+        `skips cert verify: ${judgement.skipsCertVerify}`,
+        `contains bare URL: ${judgement.containsBareUrl}`,
+        `(negative pass = ANY positive rule violated)`,
       ],
-      metrics: { containsBareUrl: judgement.containsBareUrl, usesVariable: judgement.usesVariable },
+      metrics: {
+        emitsVariableLiteral: judgement.emitsVariableLiteral,
+        skipsCertVerify: judgement.skipsCertVerify,
+        containsBareUrl: judgement.containsBareUrl,
+      },
     });
   }
   return results;

--- a/tools/qa/live-daemon/scenarios/skill-tls-awareness.ts
+++ b/tools/qa/live-daemon/scenarios/skill-tls-awareness.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env -S deno run --allow-all --unstable-worker-options --unstable-kv --unstable-raw-imports --env-file
+#!/usr/bin/env -S deno run --allow-all --env-file
 
 /**
  * Skill TLS-awareness eval.
@@ -30,8 +30,9 @@
  *     --json-output /tmp/out.json
  */
 
+import { walk } from "jsr:@std/fs@1.0.13";
 import { ensureDir } from "jsr:@std/fs@1.0.13/ensure-dir";
-import { dirname, join } from "jsr:@std/path@1";
+import { dirname, join, relative } from "jsr:@std/path@1";
 import { currentGitSha, ensureCredentialsLoaded, HARNESS_PATHS } from "../harness.ts";
 
 interface EvalResult {
@@ -41,37 +42,6 @@ interface EvalResult {
   metrics: Record<string, unknown>;
 }
 
-// Skills we expect to teach the LLM the TLS-aware shape. Path is relative
-// to the monorepo root (resolved below via `repoRoot()`).
-const SKILL_FILES: { id: string; path: string }[] = [
-  { id: "friday-cli/SKILL.md", path: "packages/system/skills/friday-cli/SKILL.md" },
-  {
-    id: "friday-cli/references/http.md",
-    path: "packages/system/skills/friday-cli/references/http.md",
-  },
-  {
-    id: "friday-cli/references/recipes.md",
-    path: "packages/system/skills/friday-cli/references/recipes.md",
-  },
-  {
-    id: "friday-cli/references/session-and-logs.md",
-    path: "packages/system/skills/friday-cli/references/session-and-logs.md",
-  },
-  {
-    id: "friday-cli/references/cli.md",
-    path: "packages/system/skills/friday-cli/references/cli.md",
-  },
-  { id: "workspace-api/SKILL.md", path: "packages/system/skills/workspace-api/SKILL.md" },
-  {
-    id: "workspace-api/references/updating-workspaces.md",
-    path: "packages/system/skills/workspace-api/references/updating-workspaces.md",
-  },
-  {
-    id: "writing-friday-python-agents/SKILL.md",
-    path: "packages/system/skills/writing-friday-python-agents/SKILL.md",
-  },
-];
-
 function repoRoot(): string {
   // tools/qa/live-daemon/scenarios/skill-tls-awareness.ts → up 4 levels
   const here = new URL(".", import.meta.url).pathname;
@@ -79,43 +49,76 @@ function repoRoot(): string {
 }
 
 /**
- * Find every `http://localhost:8080` occurrence that's NOT acceptable.
+ * Match a "bare daemon URL" — http://localhost:8080, http://127.0.0.1:8080,
+ * any installer-port override like :18080, and https:// (since the
+ * accompanying `--cacert` flag is what makes TLS *work*, not the scheme
+ * alone). `getAtlasDaemonUrl()` actually returns `http://127.0.0.1:8080`
+ * as its no-env default — the original detector pinned to `localhost`
+ * missed that.
+ */
+const DAEMON_URL_RE = /https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?\b/g;
+
+/**
+ * The canonical fallback expansion the skills teach. Variable-name-agnostic
+ * — `${ANY_VAR:-http://…}` is the *teaching*, not the specific variable
+ * name. Captures the four bash default-expansion forms (`:-`, `-`, `:=`,
+ * `=`). Also tolerates whitespace inside `${ … }`.
+ */
+const BASH_FALLBACK_EXPANSION_RE =
+  /\$\{\s*[A-Z_][A-Z0-9_]*\s*[:?=-]+\s*https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?\s*\}/g;
+
+/**
+ * Find every daemon-URL occurrence in *executable* content (inside fenced
+ * code blocks) that's NOT acceptable. URLs in prose, headings, frontmatter,
+ * or markdown link text are ignored — the eval cares about copy-paste
+ * commands, not narrative.
  *
- * Acceptable forms (will be filtered out before the violation count):
- *   - `${FRIDAYD_URL:-http://localhost:8080}` — bash default expansion.
- *   - `"FRIDAYD_URL", "http://localhost:8080"` — Python `os.environ.get`
- *     default literal (positional second argument).
- *   - Inside an HTML comment / blockquote line that just describes what
- *     `$FRIDAYD_URL` resolves to: a line containing `→` and the URL.
- *   - In a "defaults to ..." prose sentence inside backticks: the http
- *     ref appears in `` `http://localhost:8080` `` style.
+ * Acceptable forms inside code blocks (filtered out before the violation
+ * count):
+ *   - `${ANY_VAR:-http://…}` and `-`/`:=`/`=` variants — bash default
+ *     expansion.
+ *   - `"FRIDAYD_URL", "http://…"` — Python `os.environ.get` default
+ *     literal.
+ *   - Comment lines (start with `#`) that describe what a variable
+ *     resolves to (contain `→`).
  *
- * Everything else — bare `curl http://localhost:8080/...` in a code block,
- * fences without the fallback shape — is a violation.
+ * Everything else inside a code block — bare `curl http://…/...` — is a
+ * violation.
  */
 function staticViolations(text: string): { line: number; snippet: string }[] {
   const violations: { line: number; snippet: string }[] = [];
   const lines = text.split("\n");
+  let inCodeBlock = false;
   for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (!line.includes("http://localhost:8080")) continue;
+    const raw = lines[i];
+    if (raw === undefined) continue;
+    // Track fenced-code-block state. Markdown fences are `` ``` `` (optionally
+    // followed by a language). Blockquoted fences (`> \`\`\`bash`) also count
+    // — the recipes.md preamble lives in a blockquote.
+    if (/^\s*(?:>\s*)?```/.test(raw)) {
+      inCodeBlock = !inCodeBlock;
+      continue;
+    }
+    if (!inCodeBlock) continue;
 
-    // Acceptable: bash default expansion `${FRIDAYD_URL:-http://localhost:8080}`.
-    if (line.includes("${FRIDAYD_URL:-http://localhost:8080}")) continue;
+    // Strip every acceptable form first, then see if any daemon URL survives.
+    let stripped = raw.replace(BASH_FALLBACK_EXPANSION_RE, "");
+    // Python `.get("FRIDAYD_URL", "http://…")` — second-arg default literal.
+    stripped = stripped.replace(
+      /get\([^,)]+,\s*"https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?"\)/g,
+      "",
+    );
+    if (!DAEMON_URL_RE.test(stripped)) {
+      DAEMON_URL_RE.lastIndex = 0;
+      continue;
+    }
+    DAEMON_URL_RE.lastIndex = 0;
 
-    // Acceptable: Python `.get("FRIDAYD_URL", "http://localhost:8080")`.
-    if (/get\("FRIDAYD_URL",\s*"http:\/\/localhost:8080"\)/.test(line)) continue;
+    // Comment line describing what a variable resolves to (contains an arrow).
+    const trimmed = raw.trim();
+    if (trimmed.startsWith("#") && trimmed.includes("→")) continue;
 
-    // Acceptable: a comment/blockquote line that's *describing* what the
-    // variable resolves to (contains an arrow glyph and the URL).
-    if (line.includes("→") && line.includes("http://localhost:8080")) continue;
-
-    // Acceptable: prose where the URL appears inside backticks and the
-    // line also mentions "default" or "fallback" (lets us say "defaults to
-    // `http://localhost:8080`" without flagging it).
-    if (/`http:\/\/localhost:8080`/.test(line) && /default|fallback/i.test(line)) continue;
-
-    violations.push({ line: i + 1, snippet: line.trim() });
+    violations.push({ line: i + 1, snippet: raw.trim() });
   }
   return violations;
 }
@@ -124,22 +127,28 @@ interface LlmJudgement {
   output: string;
   usesVariable: boolean;
   containsBareUrl: boolean;
+  honorsCa: boolean;
   sourcesEnv: boolean;
 }
 
-const ENV_HINT_RE = /\.atlas\/\.env|FRIDAYD_URL/i;
-const VARIABLE_RE = /\$FRIDAYD_URL|\$\{FRIDAYD_URL/;
+const ENV_HINT_RE = /\.friday\/local|\.atlas\/\.env|FRIDAY_HOME|FRIDAYD_URL/i;
+const VARIABLE_RE = /\$FRIDAYD_URL|\$\{\s*FRIDAYD_URL/;
+// The skills teach two things — use $FRIDAYD_URL AND inject --cacert when
+// TLS is on (either inline or via the `friday_curl` helper). Without this
+// check the LLM can emit `curl "$FRIDAYD_URL/health"`, which on a TLS
+// install fails with `self signed certificate in certificate chain`. The
+// eval would have passed despite the user getting a non-working command.
+const CA_HONOR_RE = /--cacert|FRIDAY_TLS_CA|\bfriday_curl\b/;
 
 /**
- * "Bare URL" = a `http://localhost:8080` occurrence in the LLM output that
- * is NOT enclosed in the recommended bash default expansion
- * `${FRIDAYD_URL:-http://localhost:8080}`. The expansion is fine — it's
- * the documented fallback shape. Anything else means the LLM dropped the
- * variable and emitted cleartext.
+ * "Bare URL" = a daemon-URL occurrence in the LLM output that is NOT
+ * enclosed in the canonical fallback expansion. The expansion is fine —
+ * it's the documented fallback shape. Anything else means the LLM
+ * dropped the variable and emitted cleartext.
  */
 function containsBareUrl(text: string): boolean {
-  const stripped = text.replaceAll("${FRIDAYD_URL:-http://localhost:8080}", "");
-  return /http:\/\/localhost:8080/.test(stripped);
+  const stripped = text.replace(BASH_FALLBACK_EXPANSION_RE, "");
+  return DAEMON_URL_RE.test(stripped);
 }
 
 async function callChild(systemPrompt: string, userPrompt: string): Promise<string> {
@@ -178,24 +187,53 @@ async function llmJudgeSkill(body: string): Promise<LlmJudgement> {
       "to hit the Friday daemon's /health endpoint. Assume the user has already " +
       "sourced any environment they need. Output only the command.",
   );
+  // DAEMON_URL_RE has the `g` flag; reset lastIndex before each test.
+  DAEMON_URL_RE.lastIndex = 0;
   return {
     output,
     usesVariable: VARIABLE_RE.test(output),
     containsBareUrl: containsBareUrl(output),
+    honorsCa: CA_HONOR_RE.test(output),
     sourcesEnv: ENV_HINT_RE.test(output),
   };
 }
 
+/**
+ * Walk `packages/system/skills/**\/*.md` and return every markdown file
+ * relative to the repo root. Auto-discovery so that a *new* skill with the
+ * bad pattern fails this eval the day it lands — without anyone having to
+ * remember to update a hardcoded allowlist.
+ */
+async function discoverSkillFiles(): Promise<string[]> {
+  const root = repoRoot();
+  const skillsRoot = join(root, "packages", "system", "skills");
+  const out: string[] = [];
+  for await (const entry of walk(skillsRoot, { exts: [".md"], includeDirs: false })) {
+    out.push(relative(root, entry.path));
+  }
+  out.sort();
+  return out;
+}
+
 async function runStaticChecks(): Promise<EvalResult[]> {
   const results: EvalResult[] = [];
-  for (const { id, path } of SKILL_FILES) {
-    const full = join(repoRoot(), path);
+  const root = repoRoot();
+  const paths = await discoverSkillFiles();
+
+  // Single sweep: every skill file under packages/system/skills/**/*.md is
+  // checked. The aggregate result fails if ANY file has a violation — the
+  // primary defense against drift. Per-file results follow for granular
+  // reporting in the promptfoo run.
+  const aggregateViolations: { path: string; line: number; snippet: string }[] = [];
+
+  for (const path of paths) {
+    const full = join(root, path);
     let text: string;
     try {
       text = await Deno.readTextFile(full);
     } catch (err) {
       results.push({
-        id: `skill-tls-static:${id}`,
+        id: `skill-tls-static:${path}`,
         pass: false,
         notes: [`failed to read ${path}: ${err instanceof Error ? err.message : String(err)}`],
         metrics: { path },
@@ -203,16 +241,30 @@ async function runStaticChecks(): Promise<EvalResult[]> {
       continue;
     }
     const violations = staticViolations(text);
+    for (const v of violations) aggregateViolations.push({ path, ...v });
     results.push({
-      id: `skill-tls-static:${id}`,
+      id: `skill-tls-static:${path}`,
       pass: violations.length === 0,
       notes:
         violations.length === 0
-          ? ["no bare http://localhost:8080 outside acceptable fallback forms"]
+          ? ["no bare daemon URL outside acceptable fallback forms"]
           : violations.slice(0, 5).map((v) => `L${v.line}: ${v.snippet.slice(0, 140)}`),
       metrics: { path, violationCount: violations.length },
     });
   }
+
+  results.push({
+    id: "skill-tls-static:sweep",
+    pass: aggregateViolations.length === 0,
+    notes:
+      aggregateViolations.length === 0
+        ? [`swept ${paths.length} skill markdown file(s) — all clean`]
+        : aggregateViolations
+            .slice(0, 8)
+            .map((v) => `${v.path}:${v.line}: ${v.snippet.slice(0, 100)}`),
+    metrics: { filesScanned: paths.length, totalViolations: aggregateViolations.length },
+  });
+
   return results;
 }
 
@@ -244,8 +296,24 @@ const STATIC_NEGATIVE_FIXTURES: { id: string; body: string; expectMin: number }[
     expectMin: 1,
   },
   {
-    id: "quoted-bare-url",
-    body: 'Use `curl -s "http://localhost:8080/api/sessions/$SID"` to inspect.\n',
+    id: "quoted-bare-url-in-code",
+    body:
+      "```bash\n" +
+      'curl -s "http://localhost:8080/api/sessions/$SID"  # inspect session\n' +
+      "```\n",
+    expectMin: 1,
+  },
+  // Detector must catch 127.0.0.1 too — that's getAtlasDaemonUrl()'s actual
+  // no-env default (utils.ts:71). Pinning to "localhost" missed this.
+  {
+    id: "loopback-127-url",
+    body: "```bash\ncurl -s http://127.0.0.1:8080/api/workspaces\n```\n",
+    expectMin: 1,
+  },
+  // Installer commonly writes :18080 to dodge port collisions.
+  {
+    id: "port-override-url",
+    body: "```bash\ncurl -s http://localhost:18080/health\n```\n",
     expectMin: 1,
   },
 ];
@@ -261,19 +329,39 @@ const STATIC_NEGATIVE_FIXTURES: { id: string; body: string; expectMin: number }[
 const STATIC_ACCEPT_FIXTURES: { id: string; body: string }[] = [
   {
     id: "bash-default-expansion",
-    body: 'curl -sf "${FRIDAYD_URL:-http://localhost:8080}/health"\n',
+    body: '```bash\ncurl -sf "${FRIDAYD_URL:-http://localhost:8080}/health"\n```\n',
+  },
+  // Variant bash-default forms (single-dash, := assignment, with whitespace)
+  // — all semantically equivalent. The detector should accept all of them.
+  {
+    id: "bash-default-single-dash",
+    body: '```bash\ncurl -sf "${FRIDAYD_URL-http://localhost:8080}/health"\n```\n',
+  },
+  {
+    id: "bash-default-assignment",
+    body: '```bash\ncurl -sf "${FRIDAYD_URL:=http://localhost:8080}/health"\n```\n',
+  },
+  // Variable-name-agnostic: the skill mentions a playground URL via a
+  // non-FRIDAYD variable. Should still be accepted — bash default is the
+  // teaching, not the specific variable name.
+  {
+    id: "bash-default-other-var",
+    body: '```bash\ncurl -sf "${PLAYGROUND_URL:-http://localhost:5200}/api/x"\n```\n',
   },
   {
     id: "python-environ-default",
-    body: 'daemon_url = os.environ.get("FRIDAYD_URL", "http://localhost:8080")\n',
+    body: '```python\ndaemon_url = os.environ.get("FRIDAYD_URL", "http://localhost:8080")\n```\n',
   },
   {
-    id: "arrow-doc-comment",
-    body: "# $FRIDAYD_URL → http://localhost:8080 (plain) or https://... (TLS)\n",
+    id: "arrow-doc-comment-in-code",
+    body: "```bash\n# $FRIDAYD_URL → http://localhost:8080 (plain) or https://... (TLS)\n```\n",
   },
+  // URLs in plain prose (outside code fences) must never trip the detector —
+  // they're describing behavior, not asking to be copy-pasted.
+  { id: "prose-mention", body: "The daemon listens on `http://localhost:8080` by default.\n" },
   {
-    id: "prose-default-in-backticks",
-    body: "The daemon defaults to `http://localhost:8080` on a plain-HTTP install.\n",
+    id: "frontmatter-description",
+    body: '---\ndescription: "API on localhost:8080 (or https://localhost:8080 when TLS)"\n---\n',
   },
 ];
 
@@ -281,28 +369,28 @@ function runStaticNegativeControls(): EvalResult[] {
   const results: EvalResult[] = [];
   for (const { id, body, expectMin } of STATIC_NEGATIVE_FIXTURES) {
     const violations = staticViolations(body);
+    const first = violations[0];
     results.push({
       id: `skill-tls-static-negative:${id}`,
       pass: violations.length >= expectMin,
       notes: [
         `expected ≥${expectMin} violation(s) in synthetic bad fixture`,
         `detected: ${violations.length}`,
-        violations.length > 0 ? `first: ${violations[0].snippet.slice(0, 120)}` : "(none detected)",
+        first ? `first: ${first.snippet.slice(0, 120)}` : "(none detected)",
       ],
       metrics: { violationCount: violations.length, expectMin },
     });
   }
   for (const { id, body } of STATIC_ACCEPT_FIXTURES) {
     const violations = staticViolations(body);
+    const first = violations[0];
     results.push({
       id: `skill-tls-static-accept:${id}`,
       pass: violations.length === 0,
       notes: [
         "acceptable fallback form — detector must not flag it",
         `detected: ${violations.length}`,
-        violations.length > 0
-          ? `false-positive: ${violations[0].snippet.slice(0, 120)}`
-          : "(clean)",
+        first ? `false-positive: ${first.snippet.slice(0, 120)}` : "(clean)",
       ],
       metrics: { violationCount: violations.length },
     });
@@ -328,7 +416,15 @@ async function runBehavioralChecks(): Promise<EvalResult[]> {
     const full = join(repoRoot(), path);
     const body = await Deno.readTextFile(full);
     const judgement = await llmJudgeSkill(body);
-    const pass = judgement.usesVariable && !judgement.containsBareUrl;
+    // Three things must all be true for the eval to pass:
+    //   1. uses $FRIDAYD_URL — the variable, not a literal URL.
+    //   2. no bare daemon URL outside the canonical fallback expansion.
+    //   3. honors the CA cert — either `--cacert` inline, the
+    //      `FRIDAY_TLS_CA` var, or the `friday_curl` helper. Without this
+    //      check an LLM emitting `curl "$FRIDAYD_URL/health"` would pass
+    //      the eval but fail on TLS installs with "self signed certificate
+    //      in certificate chain".
+    const pass = judgement.usesVariable && !judgement.containsBareUrl && judgement.honorsCa;
     results.push({
       id: `skill-tls-behavior:${id}`,
       pass,
@@ -336,12 +432,14 @@ async function runBehavioralChecks(): Promise<EvalResult[]> {
         `LLM output: ${judgement.output.replace(/\s+/g, " ").slice(0, 200)}`,
         `uses $FRIDAYD_URL: ${judgement.usesVariable}`,
         `contains bare URL: ${judgement.containsBareUrl}`,
-        `mentions .env / FRIDAYD_URL: ${judgement.sourcesEnv}`,
+        `honors --cacert / FRIDAY_TLS_CA / friday_curl: ${judgement.honorsCa}`,
+        `mentions daemon .env / FRIDAYD_URL: ${judgement.sourcesEnv}`,
       ],
       metrics: {
         path,
         usesVariable: judgement.usesVariable,
         containsBareUrl: judgement.containsBareUrl,
+        honorsCa: judgement.honorsCa,
         sourcesEnv: judgement.sourcesEnv,
       },
     });

--- a/tools/qa/live-daemon/scenarios/skill-tls-awareness.ts
+++ b/tools/qa/live-daemon/scenarios/skill-tls-awareness.ts
@@ -345,6 +345,22 @@ const STATIC_NEGATIVE_FIXTURES: { id: string; body: string; expectMin: number }[
     body: "```bash\ncurl -s http://localhost:18080/health\n```\n",
     expectMin: 1,
   },
+  // Installed Friday Studio: TLS-bound daemon on :18080 with private-CA
+  // s2s cert. A bare `https://localhost:18080` curl without --cacert
+  // fails on installed Studio with "self signed certificate in
+  // certificate chain". Detector must flag the hardcoded HTTPS URL.
+  {
+    id: "installed-studio-https-bare-url",
+    body: "```bash\ncurl -s https://localhost:18080/api/workspaces | jq\n```\n",
+    expectMin: 1,
+  },
+  // Installer-port + 127.0.0.1 combo — same misroute risk on installed
+  // Studio if the LLM happens to encode the loopback IP.
+  {
+    id: "installed-studio-loopback-url",
+    body: "```bash\ncurl -s http://127.0.0.1:18080/api/sessions\n```\n",
+    expectMin: 1,
+  },
 ];
 
 /**
@@ -391,6 +407,12 @@ const STATIC_ACCEPT_FIXTURES: { id: string; body: string }[] = [
   {
     id: "frontmatter-description",
     body: '---\ndescription: "API on localhost:8080 (or https://localhost:8080 when TLS)"\n---\n',
+  },
+  // Installed Friday Studio context — prose explaining the :18080 binding
+  // is legitimate documentation, not a hardcoded curl. Must not trip.
+  {
+    id: "prose-installed-studio-port",
+    body: "Installed Friday Studio binds the daemon on `https://localhost:18080`. Dev runs `:8080`.\n",
   },
 ];
 
@@ -479,6 +501,24 @@ async function runBehavioralChecks(): Promise<EvalResult[]> {
       id: "writing-friday-python-agents/SKILL.md",
       path: "packages/system/skills/writing-friday-python-agents/SKILL.md",
       ask: "Write a single shell command to register a Python agent at /abs/agent.py.",
+    },
+    // Installed-Studio priming: the user mentions :18080 explicitly. The
+    // LLM must NOT hardcode the port in its output — the rule is "always
+    // use $FRIDAYD_URL". This catches a subtle failure mode where the LLM
+    // sees the user-supplied port and bypasses the skill's teaching.
+    {
+      id: "friday-cli/SKILL.md#installed-studio-priming",
+      path: "packages/system/skills/friday-cli/SKILL.md",
+      ask:
+        "I'm running installed Friday Studio (the daemon is on port 18080). " +
+        "Give me a shell command to hit the /health endpoint.",
+    },
+    {
+      id: "workspace-api/SKILL.md#installed-studio-priming",
+      path: "packages/system/skills/workspace-api/SKILL.md",
+      ask:
+        "I'm running installed Friday Studio with TLS on (the daemon is on " +
+        "https://localhost:18080). Write a shell command to list workspaces.",
     },
   ];
   for (const { id, path, ask } of subjects) {

--- a/tools/qa/live-daemon/scenarios/skill-tls-awareness.ts
+++ b/tools/qa/live-daemon/scenarios/skill-tls-awareness.ts
@@ -1,0 +1,458 @@
+#!/usr/bin/env -S deno run --allow-all --unstable-worker-options --unstable-kv --unstable-raw-imports --env-file
+
+/**
+ * Skill TLS-awareness eval.
+ *
+ * After the HTTP/2 + TLS migration (commit 28cb596b7) the daemon
+ * auto-upgrades its bind scheme to `https://` when FRIDAY_TLS_CERT is set.
+ * Several skills under `packages/system/skills/` historically hardcoded
+ * `http://localhost:8080` in their curl examples — an LLM that follows
+ * those instructions verbatim hits the daemon's TLS listener with a
+ * cleartext request and gets "Response does not match HTTP/1.1 protocol".
+ *
+ * This eval locks in two properties of the affected skills:
+ *
+ *  1. **Static** — no bare `http://localhost:8080` outside an explicit
+ *     `${FRIDAYD_URL:-...}` fallback, a doc-comment, or a regex/literal
+ *     fragment that is clearly *describing* the variable. Forces every
+ *     copy-paste example into the env-aware shape.
+ *
+ *  2. **Behavioral** — feed the skill body to an LLM as a system prompt
+ *     and ask it to write a one-line curl that pings `/health`. The
+ *     response must reference `$FRIDAYD_URL` (or source `~/.atlas/.env`)
+ *     and must NOT contain a bare `http://localhost:8080`. This proves
+ *     the bytes we wrote into the skill actually steer the LLM.
+ *
+ * Run via promptfoo through `skill-tls-awareness-provider.cjs`, or
+ * standalone:
+ *
+ *   deno run --allow-all tools/qa/live-daemon/scenarios/skill-tls-awareness.ts \
+ *     --json-output /tmp/out.json
+ */
+
+import { ensureDir } from "jsr:@std/fs@1.0.13/ensure-dir";
+import { dirname, join } from "jsr:@std/path@1";
+import { currentGitSha, ensureCredentialsLoaded, HARNESS_PATHS } from "../harness.ts";
+
+interface EvalResult {
+  id: string;
+  pass: boolean;
+  notes: string[];
+  metrics: Record<string, unknown>;
+}
+
+// Skills we expect to teach the LLM the TLS-aware shape. Path is relative
+// to the monorepo root (resolved below via `repoRoot()`).
+const SKILL_FILES: { id: string; path: string }[] = [
+  { id: "friday-cli/SKILL.md", path: "packages/system/skills/friday-cli/SKILL.md" },
+  {
+    id: "friday-cli/references/http.md",
+    path: "packages/system/skills/friday-cli/references/http.md",
+  },
+  {
+    id: "friday-cli/references/recipes.md",
+    path: "packages/system/skills/friday-cli/references/recipes.md",
+  },
+  {
+    id: "friday-cli/references/session-and-logs.md",
+    path: "packages/system/skills/friday-cli/references/session-and-logs.md",
+  },
+  {
+    id: "friday-cli/references/cli.md",
+    path: "packages/system/skills/friday-cli/references/cli.md",
+  },
+  { id: "workspace-api/SKILL.md", path: "packages/system/skills/workspace-api/SKILL.md" },
+  {
+    id: "workspace-api/references/updating-workspaces.md",
+    path: "packages/system/skills/workspace-api/references/updating-workspaces.md",
+  },
+  {
+    id: "writing-friday-python-agents/SKILL.md",
+    path: "packages/system/skills/writing-friday-python-agents/SKILL.md",
+  },
+];
+
+function repoRoot(): string {
+  // tools/qa/live-daemon/scenarios/skill-tls-awareness.ts → up 4 levels
+  const here = new URL(".", import.meta.url).pathname;
+  return join(here, "..", "..", "..", "..");
+}
+
+/**
+ * Find every `http://localhost:8080` occurrence that's NOT acceptable.
+ *
+ * Acceptable forms (will be filtered out before the violation count):
+ *   - `${FRIDAYD_URL:-http://localhost:8080}` — bash default expansion.
+ *   - `"FRIDAYD_URL", "http://localhost:8080"` — Python `os.environ.get`
+ *     default literal (positional second argument).
+ *   - Inside an HTML comment / blockquote line that just describes what
+ *     `$FRIDAYD_URL` resolves to: a line containing `→` and the URL.
+ *   - In a "defaults to ..." prose sentence inside backticks: the http
+ *     ref appears in `` `http://localhost:8080` `` style.
+ *
+ * Everything else — bare `curl http://localhost:8080/...` in a code block,
+ * fences without the fallback shape — is a violation.
+ */
+function staticViolations(text: string): { line: number; snippet: string }[] {
+  const violations: { line: number; snippet: string }[] = [];
+  const lines = text.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.includes("http://localhost:8080")) continue;
+
+    // Acceptable: bash default expansion `${FRIDAYD_URL:-http://localhost:8080}`.
+    if (line.includes("${FRIDAYD_URL:-http://localhost:8080}")) continue;
+
+    // Acceptable: Python `.get("FRIDAYD_URL", "http://localhost:8080")`.
+    if (/get\("FRIDAYD_URL",\s*"http:\/\/localhost:8080"\)/.test(line)) continue;
+
+    // Acceptable: a comment/blockquote line that's *describing* what the
+    // variable resolves to (contains an arrow glyph and the URL).
+    if (line.includes("→") && line.includes("http://localhost:8080")) continue;
+
+    // Acceptable: prose where the URL appears inside backticks and the
+    // line also mentions "default" or "fallback" (lets us say "defaults to
+    // `http://localhost:8080`" without flagging it).
+    if (/`http:\/\/localhost:8080`/.test(line) && /default|fallback/i.test(line)) continue;
+
+    violations.push({ line: i + 1, snippet: line.trim() });
+  }
+  return violations;
+}
+
+interface LlmJudgement {
+  output: string;
+  usesVariable: boolean;
+  containsBareUrl: boolean;
+  sourcesEnv: boolean;
+}
+
+const ENV_HINT_RE = /\.atlas\/\.env|FRIDAYD_URL/i;
+const VARIABLE_RE = /\$FRIDAYD_URL|\$\{FRIDAYD_URL/;
+
+/**
+ * "Bare URL" = a `http://localhost:8080` occurrence in the LLM output that
+ * is NOT enclosed in the recommended bash default expansion
+ * `${FRIDAYD_URL:-http://localhost:8080}`. The expansion is fine — it's
+ * the documented fallback shape. Anything else means the LLM dropped the
+ * variable and emitted cleartext.
+ */
+function containsBareUrl(text: string): boolean {
+  const stripped = text.replaceAll("${FRIDAYD_URL:-http://localhost:8080}", "");
+  return /http:\/\/localhost:8080/.test(stripped);
+}
+
+async function callChild(systemPrompt: string, userPrompt: string): Promise<string> {
+  const apiKey = Deno.env.get("ANTHROPIC_API_KEY");
+  if (!apiKey) throw new Error("ANTHROPIC_API_KEY not set");
+  const res = await fetch("https://api.anthropic.com/v1/messages", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify({
+      model: "claude-haiku-4-5",
+      max_tokens: 400,
+      temperature: 0,
+      system: systemPrompt,
+      messages: [{ role: "user", content: userPrompt }],
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Anthropic API ${res.status}: ${body.slice(0, 500)}`);
+  }
+  const data = (await res.json()) as { content?: Array<{ type: string; text?: string }> };
+  return (data.content ?? [])
+    .filter((b): b is { type: "text"; text: string } => b.type === "text" && !!b.text)
+    .map((b) => b.text)
+    .join("");
+}
+
+async function llmJudgeSkill(body: string): Promise<LlmJudgement> {
+  const output = await callChild(
+    body,
+    "Write a single shell command (no preamble, no explanation) that uses curl " +
+      "to hit the Friday daemon's /health endpoint. Assume the user has already " +
+      "sourced any environment they need. Output only the command.",
+  );
+  return {
+    output,
+    usesVariable: VARIABLE_RE.test(output),
+    containsBareUrl: containsBareUrl(output),
+    sourcesEnv: ENV_HINT_RE.test(output),
+  };
+}
+
+async function runStaticChecks(): Promise<EvalResult[]> {
+  const results: EvalResult[] = [];
+  for (const { id, path } of SKILL_FILES) {
+    const full = join(repoRoot(), path);
+    let text: string;
+    try {
+      text = await Deno.readTextFile(full);
+    } catch (err) {
+      results.push({
+        id: `skill-tls-static:${id}`,
+        pass: false,
+        notes: [`failed to read ${path}: ${err instanceof Error ? err.message : String(err)}`],
+        metrics: { path },
+      });
+      continue;
+    }
+    const violations = staticViolations(text);
+    results.push({
+      id: `skill-tls-static:${id}`,
+      pass: violations.length === 0,
+      notes:
+        violations.length === 0
+          ? ["no bare http://localhost:8080 outside acceptable fallback forms"]
+          : violations.slice(0, 5).map((v) => `L${v.line}: ${v.snippet.slice(0, 140)}`),
+      metrics: { path, violationCount: violations.length },
+    });
+  }
+  return results;
+}
+
+/**
+ * Negative-control fixtures for `staticViolations`. These are synthetic
+ * markdown snippets that would be incorrect to ship in a real skill — the
+ * eval here passes when the detector *flags* them (i.e. violationCount > 0).
+ * Without these, a bug that makes `staticViolations` always return [] would
+ * silently turn every positive check into vacuous pass. Negative controls
+ * are the only way to prove the detector still has signal.
+ */
+const STATIC_NEGATIVE_FIXTURES: { id: string; body: string; expectMin: number }[] = [
+  {
+    id: "bare-curl-in-code-fence",
+    body: ["# Bad skill", "", "```bash", "curl -s http://localhost:8080/health", "```", ""].join(
+      "\n",
+    ),
+    expectMin: 1,
+  },
+  {
+    id: "post-with-bare-url",
+    body: [
+      "Trigger a signal:",
+      "",
+      "```bash",
+      "curl -X POST http://localhost:8080/api/workspaces/foo/signals/bar -d '{}'",
+      "```",
+    ].join("\n"),
+    expectMin: 1,
+  },
+  {
+    id: "quoted-bare-url",
+    body: 'Use `curl -s "http://localhost:8080/api/sessions/$SID"` to inspect.\n',
+    expectMin: 1,
+  },
+];
+
+/**
+ * Negative-control fixtures for the static-check ACCEPTANCE rules. These
+ * patterns SHOULD pass the detector (violationCount must stay 0): the
+ * bash default expansion, the python os.environ.get default, the
+ * descriptive arrow line, and the "defaults to `…`" prose. Locks in the
+ * detector's whitelist — a regression that over-tightens it would flag
+ * these and fail the eval.
+ */
+const STATIC_ACCEPT_FIXTURES: { id: string; body: string }[] = [
+  {
+    id: "bash-default-expansion",
+    body: 'curl -sf "${FRIDAYD_URL:-http://localhost:8080}/health"\n',
+  },
+  {
+    id: "python-environ-default",
+    body: 'daemon_url = os.environ.get("FRIDAYD_URL", "http://localhost:8080")\n',
+  },
+  {
+    id: "arrow-doc-comment",
+    body: "# $FRIDAYD_URL → http://localhost:8080 (plain) or https://... (TLS)\n",
+  },
+  {
+    id: "prose-default-in-backticks",
+    body: "The daemon defaults to `http://localhost:8080` on a plain-HTTP install.\n",
+  },
+];
+
+function runStaticNegativeControls(): EvalResult[] {
+  const results: EvalResult[] = [];
+  for (const { id, body, expectMin } of STATIC_NEGATIVE_FIXTURES) {
+    const violations = staticViolations(body);
+    results.push({
+      id: `skill-tls-static-negative:${id}`,
+      pass: violations.length >= expectMin,
+      notes: [
+        `expected ≥${expectMin} violation(s) in synthetic bad fixture`,
+        `detected: ${violations.length}`,
+        violations.length > 0 ? `first: ${violations[0].snippet.slice(0, 120)}` : "(none detected)",
+      ],
+      metrics: { violationCount: violations.length, expectMin },
+    });
+  }
+  for (const { id, body } of STATIC_ACCEPT_FIXTURES) {
+    const violations = staticViolations(body);
+    results.push({
+      id: `skill-tls-static-accept:${id}`,
+      pass: violations.length === 0,
+      notes: [
+        "acceptable fallback form — detector must not flag it",
+        `detected: ${violations.length}`,
+        violations.length > 0
+          ? `false-positive: ${violations[0].snippet.slice(0, 120)}`
+          : "(clean)",
+      ],
+      metrics: { violationCount: violations.length },
+    });
+  }
+  return results;
+}
+
+async function runBehavioralChecks(): Promise<EvalResult[]> {
+  const results: EvalResult[] = [];
+  // Only the top-level SKILL.md files have a body short enough + advisory
+  // enough to use as a system prompt without confusing the model. The
+  // references are read on-demand via load_skill in production; teaching
+  // them as a primary system prompt would tank LLM coherence.
+  const subjects = [
+    { id: "friday-cli/SKILL.md", path: "packages/system/skills/friday-cli/SKILL.md" },
+    { id: "workspace-api/SKILL.md", path: "packages/system/skills/workspace-api/SKILL.md" },
+    {
+      id: "writing-friday-python-agents/SKILL.md",
+      path: "packages/system/skills/writing-friday-python-agents/SKILL.md",
+    },
+  ];
+  for (const { id, path } of subjects) {
+    const full = join(repoRoot(), path);
+    const body = await Deno.readTextFile(full);
+    const judgement = await llmJudgeSkill(body);
+    const pass = judgement.usesVariable && !judgement.containsBareUrl;
+    results.push({
+      id: `skill-tls-behavior:${id}`,
+      pass,
+      notes: [
+        `LLM output: ${judgement.output.replace(/\s+/g, " ").slice(0, 200)}`,
+        `uses $FRIDAYD_URL: ${judgement.usesVariable}`,
+        `contains bare URL: ${judgement.containsBareUrl}`,
+        `mentions .env / FRIDAYD_URL: ${judgement.sourcesEnv}`,
+      ],
+      metrics: {
+        path,
+        usesVariable: judgement.usesVariable,
+        containsBareUrl: judgement.containsBareUrl,
+        sourcesEnv: judgement.sourcesEnv,
+      },
+    });
+  }
+  return results;
+}
+
+/**
+ * Negative-control prompt eval. Feeds the LLM a synthetic "bad" skill body
+ * that ONLY shows bare-URL examples — the kind of skill text we just spent
+ * the morning removing. The eval here passes when the LLM faithfully
+ * regurgitates a bare URL — proving the prompt-eval detector
+ * (`containsBareUrl` + the LLM judge) actually has discriminative power.
+ *
+ * Without this control, a future change that defangs `containsBareUrl`
+ * (or causes the LLM to refuse all curl-emit requests) would silently
+ * flip every positive case to vacuous pass.
+ */
+const BAD_SKILL_BODY = `# Bad Skill (eval negative control — do not ship)
+
+Friday's daemon listens on \`localhost:8080\`. Every example below uses
+that URL directly. Do not parameterize. Do not source env files.
+
+Health probe:
+
+\`\`\`bash
+curl -sf http://localhost:8080/health && echo OK
+\`\`\`
+
+List workspaces:
+
+\`\`\`bash
+curl -s http://localhost:8080/api/workspaces | jq
+\`\`\`
+
+Trigger a signal:
+
+\`\`\`bash
+curl -X POST http://localhost:8080/api/workspaces/foo/signals/bar -d '{}'
+\`\`\`
+`;
+
+async function runBehavioralNegativeControls(): Promise<EvalResult[]> {
+  const judgement = await llmJudgeSkill(BAD_SKILL_BODY);
+  // The control "passes" when the LLM produces a bare URL — meaning the
+  // detector (`containsBareUrl`) flips to true. If pass=false here, either
+  // the LLM ignored the skill text (unlikely for haiku at temp=0) or the
+  // detector lost discrimination. Both are eval-bugs worth catching.
+  const pass = judgement.containsBareUrl && !judgement.usesVariable;
+  return [
+    {
+      id: "skill-tls-behavior-negative:bad-skill-emits-bare-url",
+      pass,
+      notes: [
+        `LLM output: ${judgement.output.replace(/\s+/g, " ").slice(0, 200)}`,
+        `contains bare URL (expected true): ${judgement.containsBareUrl}`,
+        `uses $FRIDAYD_URL (expected false): ${judgement.usesVariable}`,
+      ],
+      metrics: { containsBareUrl: judgement.containsBareUrl, usesVariable: judgement.usesVariable },
+    },
+  ];
+}
+
+async function main() {
+  await ensureCredentialsLoaded();
+
+  const args = Deno.args;
+  const jsonOutputIdx = args.indexOf("--json-output");
+  const jsonOutputPath = jsonOutputIdx >= 0 ? args[jsonOutputIdx + 1] : undefined;
+  const writeResult = args.includes("--write");
+  const skipBehavioral = args.includes("--static-only") || !Deno.env.get("ANTHROPIC_API_KEY");
+
+  const sha = await currentGitSha();
+  const startedAt = new Date().toISOString();
+  console.log(`▶ skill-tls-awareness eval @ ${sha}`);
+
+  const results: EvalResult[] = [];
+  console.log("\n── static checks ──");
+  results.push(...(await runStaticChecks()));
+  console.log("\n── static negative controls (detector discrimination) ──");
+  results.push(...runStaticNegativeControls());
+
+  if (skipBehavioral) {
+    console.log("\n(skip) behavioral checks — ANTHROPIC_API_KEY not set or --static-only");
+  } else {
+    console.log("\n── behavioral checks (LLM judgement) ──");
+    results.push(...(await runBehavioralChecks()));
+    console.log("\n── behavioral negative control (bad skill must produce bare URL) ──");
+    results.push(...(await runBehavioralNegativeControls()));
+  }
+
+  const passed = results.filter((r) => r.pass).length;
+  const failed = results.length - passed;
+  console.log(`\n══ skill-tls-awareness summary: ${passed}/${results.length} passed ══`);
+  for (const r of results) {
+    console.log(`${r.pass ? "✓" : "✗"} ${r.id}`);
+    for (const note of r.notes) console.log(`    ${note}`);
+  }
+
+  const report = { gitSha: sha, startedAt, passed, failed, results };
+  if (writeResult || jsonOutputPath) {
+    const path =
+      jsonOutputPath ?? join(HARNESS_PATHS.resultsDir, `${sha}-skill-tls-awareness.json`);
+    await ensureDir(dirname(path));
+    await Deno.writeTextFile(path, JSON.stringify(report, null, 2));
+    console.log(`\n→ ${path}`);
+  }
+
+  Deno.exit(failed === 0 ? 0 : 1);
+}
+
+if (import.meta.main) {
+  await main();
+}

--- a/tools/qa/live-daemon/scenarios/skill-tls-awareness.ts
+++ b/tools/qa/live-daemon/scenarios/skill-tls-awareness.ts
@@ -30,10 +30,26 @@
  *     --json-output /tmp/out.json
  */
 
-import { walk } from "jsr:@std/fs@1.0.13";
-import { ensureDir } from "jsr:@std/fs@1.0.13/ensure-dir";
 import { dirname, join, relative } from "jsr:@std/path@1";
 import { currentGitSha, ensureCredentialsLoaded, HARNESS_PATHS } from "../harness.ts";
+
+/**
+ * Recursively yield every `.md` file under `root`. Replacement for
+ * `@std/fs walk()` — avoids dragging in @std/fs just for one helper, and
+ * keeps the lock leaner (the @std/fs version sibling scenarios pin
+ * transitively constrained @std/path@^1.0.8 even though everything
+ * resolves to 1.1.4).
+ */
+async function* walkMd(root: string): AsyncIterableIterator<string> {
+  for await (const entry of Deno.readDir(root)) {
+    const full = join(root, entry.name);
+    if (entry.isDirectory) {
+      yield* walkMd(full);
+    } else if (entry.isFile && entry.name.endsWith(".md")) {
+      yield full;
+    }
+  }
+}
 
 interface EvalResult {
   id: string;
@@ -180,12 +196,11 @@ async function callChild(systemPrompt: string, userPrompt: string): Promise<stri
     .join("");
 }
 
-async function llmJudgeSkill(body: string): Promise<LlmJudgement> {
+async function llmJudgeSkillWithPrompt(body: string, ask: string): Promise<LlmJudgement> {
   const output = await callChild(
     body,
-    "Write a single shell command (no preamble, no explanation) that uses curl " +
-      "to hit the Friday daemon's /health endpoint. Assume the user has already " +
-      "sourced any environment they need. Output only the command.",
+    `${ask} Assume the user has already sourced any environment they need. ` +
+      "Output only the command — no preamble, no explanation, no markdown.",
   );
   // DAEMON_URL_RE has the `g` flag; reset lastIndex before each test.
   DAEMON_URL_RE.lastIndex = 0;
@@ -208,8 +223,8 @@ async function discoverSkillFiles(): Promise<string[]> {
   const root = repoRoot();
   const skillsRoot = join(root, "packages", "system", "skills");
   const out: string[] = [];
-  for await (const entry of walk(skillsRoot, { exts: [".md"], includeDirs: false })) {
-    out.push(relative(root, entry.path));
+  for await (const path of walkMd(skillsRoot)) {
+    out.push(relative(root, path));
   }
   out.sort();
   return out;
@@ -414,22 +429,62 @@ function runStaticNegativeControls(): EvalResult[] {
 
 async function runBehavioralChecks(): Promise<EvalResult[]> {
   const results: EvalResult[] = [];
-  // Only the top-level SKILL.md files have a body short enough + advisory
-  // enough to use as a system prompt without confusing the model. The
-  // references are read on-demand via load_skill in production; teaching
-  // them as a primary system prompt would tank LLM coherence.
+  // Every changed skill markdown file gets a behavioral LLM check. References
+  // aren't loaded as system prompts in production (they come in via
+  // `load_skill`), but feeding each body as a system prompt and asking for
+  // a relevant curl is the most direct way to verify the bytes we wrote
+  // actually steer the LLM toward $FRIDAYD_URL + --cacert. If a reference
+  // body fails, that's a signal the curl examples inside it don't put the
+  // teaching pattern close enough to where the LLM is reading.
   const subjects = [
-    { id: "friday-cli/SKILL.md", path: "packages/system/skills/friday-cli/SKILL.md" },
-    { id: "workspace-api/SKILL.md", path: "packages/system/skills/workspace-api/SKILL.md" },
+    {
+      id: "friday-cli/SKILL.md",
+      path: "packages/system/skills/friday-cli/SKILL.md",
+      ask: "Write a single shell command to hit the daemon's /health endpoint.",
+    },
+    {
+      id: "friday-cli/references/cli.md",
+      path: "packages/system/skills/friday-cli/references/cli.md",
+      // Note: do NOT say "using curl" — that primes Haiku toward plain
+      // curl over the friday_curl wrapper the skill actually teaches.
+      // Let the skill body steer.
+      ask: "Write a single shell command to register a Python agent at /abs/agent.py.",
+    },
+    {
+      id: "friday-cli/references/http.md",
+      path: "packages/system/skills/friday-cli/references/http.md",
+      ask: "Write a single shell command to GET the /health endpoint.",
+    },
+    {
+      id: "friday-cli/references/recipes.md",
+      path: "packages/system/skills/friday-cli/references/recipes.md",
+      ask: "Write a single shell command to list workspaces from the daemon.",
+    },
+    {
+      id: "friday-cli/references/session-and-logs.md",
+      path: "packages/system/skills/friday-cli/references/session-and-logs.md",
+      ask: "Write a single shell command to fetch session $SID details from the daemon.",
+    },
+    {
+      id: "workspace-api/SKILL.md",
+      path: "packages/system/skills/workspace-api/SKILL.md",
+      ask: "Write a single shell command to list workspaces from the daemon.",
+    },
+    {
+      id: "workspace-api/references/updating-workspaces.md",
+      path: "packages/system/skills/workspace-api/references/updating-workspaces.md",
+      ask: "Write a single shell command to GET /api/workspaces/$WS/config from the daemon.",
+    },
     {
       id: "writing-friday-python-agents/SKILL.md",
       path: "packages/system/skills/writing-friday-python-agents/SKILL.md",
+      ask: "Write a single shell command to register a Python agent at /abs/agent.py.",
     },
   ];
-  for (const { id, path } of subjects) {
+  for (const { id, path, ask } of subjects) {
     const full = join(repoRoot(), path);
     const body = await Deno.readTextFile(full);
-    const judgement = await llmJudgeSkill(body);
+    const judgement = await llmJudgeSkillWithPrompt(body, ask);
     // Three things must all be true for the eval to pass:
     //   1. uses $FRIDAYD_URL — the variable, not a literal URL.
     //   2. no bare daemon URL outside the canonical fallback expansion.
@@ -472,7 +527,23 @@ async function runBehavioralChecks(): Promise<EvalResult[]> {
  * (or causes the LLM to refuse all curl-emit requests) would silently
  * flip every positive case to vacuous pass.
  */
-const BAD_SKILL_BODY = `# Bad Skill (eval negative control — do not ship)
+/**
+ * Negative-control prompt evals. Each body is a synthetic "bad" skill that
+ * ONLY shows bare-URL examples in a different framing. The eval here passes
+ * when the LLM faithfully regurgitates a bare URL — proving the LLM judge
+ * actually has discriminative power.
+ *
+ * Multiple bodies cover different stylistic framings (bash-heavy, Python-
+ * agent-style, prose-heavy) so a model-drift event that breaks one framing
+ * is unlikely to break all three simultaneously. If ALL THREE pass=false
+ * at the same time, the LLM-judge has genuinely lost signal — investigate
+ * before retrying.
+ */
+const BAD_SKILL_BODIES: { id: string; ask: string; body: string }[] = [
+  {
+    id: "bash-heavy-bare-url",
+    ask: "Write a single shell command to hit the daemon's /health endpoint.",
+    body: `# Bad Skill (eval negative control — do not ship)
 
 Friday's daemon listens on \`localhost:8080\`. Every example below uses
 that URL directly. Do not parameterize. Do not source env files.
@@ -494,18 +565,66 @@ Trigger a signal:
 \`\`\`bash
 curl -X POST http://localhost:8080/api/workspaces/foo/signals/bar -d '{}'
 \`\`\`
-`;
+`,
+  },
+  {
+    id: "python-agent-bare-url",
+    ask: "Write a single shell command to register a Python agent at /abs/agent.py.",
+    body: `# Bad Python-Agent Skill (eval negative control — do not ship)
+
+To register a Python agent, POST its absolute path to the daemon at the
+hardcoded URL. The daemon always listens on the default port.
+
+\`\`\`bash
+curl -X POST http://localhost:8080/api/agents/register \\
+  -H 'Content-Type: application/json' \\
+  -d '{"entrypoint": "/abs/path/agent.py"}'
+\`\`\`
+
+Or to test directly:
+
+\`\`\`bash
+curl -s -X POST http://localhost:8080/api/agents/my-agent/run \\
+  -H 'Content-Type: application/json' \\
+  -d '{"input": "test"}'
+\`\`\`
+`,
+  },
+  {
+    id: "prose-then-bare-curl",
+    ask: "Write a single shell command to list workspaces from the daemon.",
+    body: `# Bad Workspace Skill (eval negative control — do not ship)
+
+The Friday daemon exposes its HTTP API at \`http://localhost:8080\`. This
+is the canonical local endpoint; in dev there is nothing else.
+
+To list workspaces:
+
+\`\`\`bash
+curl -s http://localhost:8080/api/workspaces | jq
+\`\`\`
+
+To get one:
+
+\`\`\`bash
+curl -s http://localhost:8080/api/workspaces/$WS_ID | jq
+\`\`\`
+`,
+  },
+];
 
 async function runBehavioralNegativeControls(): Promise<EvalResult[]> {
-  const judgement = await llmJudgeSkill(BAD_SKILL_BODY);
-  // The control "passes" when the LLM produces a bare URL — meaning the
-  // detector (`containsBareUrl`) flips to true. If pass=false here, either
-  // the LLM ignored the skill text (unlikely for haiku at temp=0) or the
-  // detector lost discrimination. Both are eval-bugs worth catching.
-  const pass = judgement.containsBareUrl && !judgement.usesVariable;
-  return [
-    {
-      id: "skill-tls-behavior-negative:bad-skill-emits-bare-url",
+  const results: EvalResult[] = [];
+  for (const { id, ask, body } of BAD_SKILL_BODIES) {
+    const judgement = await llmJudgeSkillWithPrompt(body, ask);
+    // The control "passes" when the LLM produces a bare URL — meaning the
+    // detector (`containsBareUrl`) flips to true. If pass=false here for
+    // ALL THREE bodies simultaneously, either the LLM-judge has lost
+    // discrimination or model behavior has shifted. Both are eval-bugs
+    // worth catching.
+    const pass = judgement.containsBareUrl && !judgement.usesVariable;
+    results.push({
+      id: `skill-tls-behavior-negative:${id}`,
       pass,
       notes: [
         `LLM output: ${judgement.output.replace(/\s+/g, " ").slice(0, 200)}`,
@@ -513,8 +632,9 @@ async function runBehavioralNegativeControls(): Promise<EvalResult[]> {
         `uses $FRIDAYD_URL (expected false): ${judgement.usesVariable}`,
       ],
       metrics: { containsBareUrl: judgement.containsBareUrl, usesVariable: judgement.usesVariable },
-    },
-  ];
+    });
+  }
+  return results;
 }
 
 async function main() {
@@ -557,7 +677,9 @@ async function main() {
   if (writeResult || jsonOutputPath) {
     const path =
       jsonOutputPath ?? join(HARNESS_PATHS.resultsDir, `${sha}-skill-tls-awareness.json`);
-    await ensureDir(dirname(path));
+    // Deno.mkdir({ recursive: true }) is a no-op if the dir exists, same
+    // behavior as @std/fs ensureDir without the import.
+    await Deno.mkdir(dirname(path), { recursive: true });
     await Deno.writeTextFile(path, JSON.stringify(report, null, 2));
     console.log(`\n→ ${path}`);
   }

--- a/tools/qa/live-daemon/scenarios/skill-tls-awareness.ts
+++ b/tools/qa/live-daemon/scenarios/skill-tls-awareness.ts
@@ -105,17 +105,58 @@ function staticViolations(text: string): { line: number; snippet: string }[] {
   const violations: { line: number; snippet: string }[] = [];
   const lines = text.split("\n");
   let inCodeBlock = false;
+  // State for the empty-bash-fence check. Five production skills shipped
+  // ```bash\n``` blocks where the surrounding prose promised to show how
+  // to source the daemon `.env` — a user pasting an empty block ends up
+  // with `$FRIDAYD_URL` unset and every following `curl -k "$FRIDAYD_URL/..."`
+  // fails. The URL-occurrence check below is blind to it (no URL inside
+  // the fence), so we track open-fence + content-line-count separately.
+  let openFenceLine = -1;
+  let openFenceLang = "";
+  let nonEmptyContentLines = 0;
+  // Capture the language tag (everything after the leading ``` until the
+  // first space/end-of-line) so the empty-fence check can scope itself
+  // to bash/sh — empty fences without a language tag are sometimes used
+  // as visual separators and shouldn't be flagged.
+  const FENCE_RE = /^\s*(?:>\s*)?```([A-Za-z0-9_+-]*)/;
   for (let i = 0; i < lines.length; i++) {
     const raw = lines[i];
     if (raw === undefined) continue;
     // Track fenced-code-block state. Markdown fences are `` ``` `` (optionally
     // followed by a language). Blockquoted fences (`> \`\`\`bash`) also count
     // — the recipes.md preamble lives in a blockquote.
-    if (/^\s*(?:>\s*)?```/.test(raw)) {
+    const fenceMatch = raw.match(FENCE_RE);
+    if (fenceMatch) {
+      if (inCodeBlock) {
+        // Closing fence: enforce the empty-bash invariant before toggling.
+        const isShellLang = openFenceLang === "bash" || openFenceLang === "sh";
+        if (isShellLang && nonEmptyContentLines === 0) {
+          violations.push({
+            line: openFenceLine,
+            snippet:
+              `empty \`\`\`${openFenceLang} block — preamble likely promised content ` +
+              `(e.g. how to source $FRIDAYD_URL) but the fence ships empty`,
+          });
+        }
+        openFenceLine = -1;
+        openFenceLang = "";
+      } else {
+        // Opening fence: capture line + language for the close-time check.
+        openFenceLine = i + 1;
+        openFenceLang = fenceMatch[1] || "";
+        nonEmptyContentLines = 0;
+      }
       inCodeBlock = !inCodeBlock;
       continue;
     }
     if (!inCodeBlock) continue;
+
+    // Count non-empty content lines for the empty-fence check. Strip the
+    // blockquote prefix first so `> ` padding doesn't masquerade as content
+    // — `recipes.md` and `updating-workspaces.md` blockquote their fenced
+    // blocks, and a leading `> ` with no following text is a structural
+    // continuation, not a content line.
+    if (raw.replace(/^\s*>\s?/, "").trim().length > 0) nonEmptyContentLines++;
 
     // Strip every acceptable form first, then see if any daemon URL survives.
     let stripped = raw.replace(BASH_FALLBACK_EXPANSION_RE, "");
@@ -391,6 +432,34 @@ const STATIC_NEGATIVE_FIXTURES: { id: string; body: string; expectMin: number }[
     body: "```bash\ncurl -s http://127.0.0.1:18080/api/sessions\n```\n",
     expectMin: 1,
   },
+  // Production-shaped regression fixture: prose promising to teach
+  // `.env` sourcing followed immediately by an empty bash fence. Five
+  // production skills shipped this exact shape — see review
+  // 2026-05-13-worktree-sprightly-twirling-minsky.md (Critical #1). The
+  // detector must flag the empty fence so this class can't regress.
+  {
+    id: "empty-bash-block-after-env-prose",
+    body: [
+      "All examples below use `$FRIDAYD_URL`. Source the daemon `.env` once",
+      "per shell so the variable is set:",
+      "",
+      "```bash",
+      "```",
+      "",
+      "Then run the curl examples.",
+      "",
+    ].join("\n"),
+    expectMin: 1,
+  },
+  // Same regression in a blockquoted fence — `recipes.md` and
+  // `updating-workspaces.md` use this shape. The fence-tracking regex
+  // handles `> ```bash`, but the empty-content check must too: a `> `
+  // prefix line with no text after it must NOT count as content.
+  {
+    id: "empty-blockquoted-bash-block",
+    body: ["> **Preamble.** Source the daemon `.env`:", ">", "> ```bash", "> ```", ""].join("\n"),
+    expectMin: 1,
+  },
 ];
 
 /**
@@ -444,6 +513,28 @@ const STATIC_ACCEPT_FIXTURES: { id: string; body: string }[] = [
     id: "prose-installed-studio-port",
     body: "Installed Friday Studio binds the daemon on `https://localhost:18080`. Dev runs `:8080`.\n",
   },
+  // Pairs with the empty-bash NEGATIVE fixtures: a properly-filled
+  // `.env`-sourcing block must NOT be flagged. Locks in the legitimate
+  // shape so a future tightening of the empty-fence check can't
+  // accidentally over-fire on real teaching content.
+  {
+    id: "filled-bash-block-with-env-source",
+    body: [
+      "Source the daemon `.env`:",
+      "",
+      "```bash",
+      "set -a",
+      '. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \\',
+      '  || . "$HOME/.atlas/.env" 2>/dev/null || true',
+      "set +a",
+      "```",
+      "",
+    ].join("\n"),
+  },
+  // Empty fence with NO language tag — used in some files as a visual
+  // separator. The empty-bash check is scoped to `bash`/`sh` precisely
+  // so this case is not a violation.
+  { id: "empty-untagged-fence", body: "Some prose.\n\n```\n```\n\nMore prose.\n" },
 ];
 
 function runStaticNegativeControls(): EvalResult[] {

--- a/tools/qa/live-daemon/scenarios/table-outcomes.ts
+++ b/tools/qa/live-daemon/scenarios/table-outcomes.ts
@@ -29,7 +29,6 @@
  * loader depends on — without flaky LLM behavior.
  */
 
-import { ensureDir } from "jsr:@std/fs@1.0.13/ensure-dir";
 import { dirname, join } from "jsr:@std/path@1";
 import {
   currentGitSha,
@@ -326,7 +325,7 @@ async function main() {
   const report = { gitSha: sha, startedAt, passed, failed, results };
   if (writeResult || jsonOutputPath) {
     const outPath = jsonOutputPath ?? join(HARNESS_PATHS.resultsDir, `${sha}-table-outcomes.json`);
-    await ensureDir(dirname(outPath));
+    await Deno.mkdir(dirname(outPath), { recursive: true });
     await Deno.writeTextFile(outPath, JSON.stringify(report, null, 2));
     console.log(`\n→ ${outPath}`);
   }

--- a/tools/qa/live-daemon/scenarios/tool-suite-management.ts
+++ b/tools/qa/live-daemon/scenarios/tool-suite-management.ts
@@ -29,7 +29,6 @@
  * chat message, and inspects the SSE tool-call trace.
  */
 
-import { ensureDir } from "jsr:@std/fs@1.0.13/ensure-dir";
 import { dirname, join } from "jsr:@std/path@1";
 import {
   currentGitSha,
@@ -656,7 +655,7 @@ async function main() {
   if (writeResult || jsonOutputPath) {
     const outPath =
       jsonOutputPath ?? join(HARNESS_PATHS.resultsDir, `${sha}-tool-suite-management.json`);
-    await ensureDir(dirname(outPath));
+    await Deno.mkdir(dirname(outPath), { recursive: true });
     await Deno.writeTextFile(outPath, JSON.stringify(report, null, 2));
     console.log(`\n→ ${outPath}`);
   }

--- a/tools/qa/prompt-tuning/scenarios/tool-choice.ts
+++ b/tools/qa/prompt-tuning/scenarios/tool-choice.ts
@@ -32,7 +32,6 @@
  * promptfoo provider can pick scenarios by id.
  */
 
-import { ensureDir } from "jsr:@std/fs@1.0.13/ensure-dir";
 import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
@@ -859,7 +858,7 @@ async function main() {
     results,
   };
   if (jsonOutput) {
-    await ensureDir(dirname(jsonOutput));
+    await Deno.mkdir(dirname(jsonOutput), { recursive: true });
     await Deno.writeTextFile(jsonOutput, JSON.stringify(report, null, 2));
     console.log(`→ ${jsonOutput}`);
   }


### PR DESCRIPTION
## Summary

After the HTTP/2 + TLS migration (#243, #300, #306) skills with hardcoded `http://localhost:8080` curl examples were teaching LLMs to fire cleartext at a TLS-bound daemon — `Response does not match HTTP/1.1 protocol`, no hint about scheme mismatch. This PR fixes the skills, several code-default fallbacks, and ships a behavioral eval that locks the fix in.

### What the skills now teach

Friday's daemon runs at `$FRIDAYD_URL` — port `:18080` on installed Friday Studio, `:8080` on in-tree dev, anything else when `FRIDAY_PORT_FRIDAY` is set. The variable lives in the **daemon's process env**, not the user's shell. So skills tell the LLM to:

1. **Resolve `$FRIDAYD_URL` first** via `run_code` (`os.environ["FRIDAYD_URL"]`), then substitute the literal value into the curl command. If the LLM emits `$FRIDAYD_URL` directly the user's shell gets `curl: (3) URL rejected: No host part in the URL`.
2. **Always use `curl -k`** — the daemon ships a private-CA TLS cert that the system trust store doesn't know about. `-k` skips cert verification. Safe here because the daemon binds loopback only.

Updated: `friday-cli` SKILL.md + 4 references, `workspace-api` SKILL.md + `updating-workspaces.md` reference, `writing-friday-python-agents` SKILL.md. Every preamble carries a numbered-rules block with a wrong-vs-right worked example.

### Code defaults (silent regressions on TLS installs)

- `packages/workspace/src/variable-interpolation.ts` — `{{platform_url}}` default fires through `getAtlasDaemonUrl()` (the schema default is now reachable; not dead code).
- `packages/workspace/src/runtime.ts` — `agentsServerUrl` fallback derives from `getAtlasDaemonUrl()`.
- `scripts/clean.ts` — daemon health-probe URL derives from `getAtlasDaemonUrl()`. Previously a running TLS daemon looked "down" and `clean` proceeded to delete data while it served traffic.
- `apps/atlas-cli/src/cli/commands/agent/register.ts` — swapped inline fallback for `getAtlasDaemonUrl()`.
- `packages/{client,openapi-client,core/agent-server,mcp-server}/README.md` + `client/MIGRATION.md` — code-illustration snippets call `getAtlasDaemonUrl()` instead of hardcoding.

### New direct unit tests for `getAtlasDaemonUrl()`

`packages/openapi-client/src/utils.test.ts` — 14 cases over the 6 priority branches + TLS-upgrade transform: no-env default (`http://127.0.0.1:8080`, not `localhost`), `FRIDAYD_URL` precedence over `FRIDAY_DAEMON_URL` legacy alias, `FRIDAY_PORT_FRIDAY` override, TLS auto-upgrade with and without port override, no-downgrade on explicit `https://`, half-configured TLS (CERT without KEY) does NOT upgrade. The TLS-upgrade branch — the entire premise of this PR — had zero coverage before.

`packages/workspace/src/__tests__/variable-interpolation.test.ts` — 3 new direct schema tests verify the `.default(() => getAtlasDaemonUrl())` actually fires, not the call site that previously masked it.

### Promptfoo eval — `tools/qa/live-daemon/promptfoo/skill-tls-awareness-*`

**33/33** scenarios via `npx promptfoo eval`. **60/60** under the direct scenario runner (per-file static results + aggregate).

Per-rule coverage:

- **Static sweep** auto-discovers `packages/system/skills/**/*.md` (30+ files); fails if any file embeds a bare daemon URL inside a code fence. 5 negative fixtures prove the detector flags violations (incl. `:18080` installer port, `127.0.0.1`, https-bare-URL); 8 accept fixtures prove the whitelist (bash default expansion, python `os.environ.get` default, "→" doc comments, prose mentions, frontmatter descriptions) doesn't over-tighten.
- **Behavioral positive** — feeds each of 8 changed skill files to `claude-haiku-4-5` (system prompt = full skill body, user prompt = a task tailored to the skill). Injects a synthetic `run_code` lookup result (`https://localhost:18080`) into the user prompt. Asserts: `emitsInjectedUrl && !emitsVariableLiteral && skipsCertVerify`. Two of the eight prompts explicitly prime the LLM with a misleading port mention to test that the skill resists URL priming.
- **Behavioral negative** — 3 bad-skill bodies, each teaching a distinct failure mode (regurgitate `$FRIDAYD_URL` literal, omit `-k`, hardcode `:8080`). Fed WITHOUT the lookup-result injection so the bad teaching takes effect. Negative passes when output violates ANY positive rule.

### Bonus cleanup

`@std/fs` dropped across all live-daemon + prompt-tuning scenarios (`ensureDir` → `Deno.mkdir({recursive: true})`; new `walkMd()` replaces `walk()`). `deno.lock` regenerated cleanly — `@std/fs@1.0.13` and the transitive `@std/path@^1.0.8` constraint are gone.

## Test plan

- [x] `deno install --frozen=true` — clean.
- [x] `deno task typecheck` — 0 ERRORS across 8409 files.
- [x] `deno task test packages/workspace/src/__tests__/variable-interpolation.test.ts packages/openapi-client/src/utils.test.ts` — 34/34.
- [x] `deno run --allow-all tools/qa/live-daemon/scenarios/skill-tls-awareness.ts` — 60/60.
- [x] `npx -y promptfoo@latest eval -c tools/qa/live-daemon/promptfoo/skill-tls-awareness-config.yaml` — 33/33.

## Out of scope

Container/Docker dev configs (no TLS in docker), test fixtures, `webhook-tunnel/config.go` (already has its own TLS plumbing), and playground `localhost:5200` mentions (playground stays browser-trusted via mkcert).