### PR TITLE
Chat: stop losing context after a failed tool call

### DIFF
--- a/packages/agent-sdk/src/messages.test.ts
+++ b/packages/agent-sdk/src/messages.test.ts
@@ -448,4 +448,89 @@ describe("validateAtlasUIMessages", () => {
       expect(dataPart.data.integrations[0]?.kind).toEqual("credential_temporarily_unavailable");
     }
   });
+
+  it("repairs static tool parts with rawInput-only output-error shape", async () => {
+    const messages = [
+      {
+        id: "1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-echo-job",
+            toolCallId: "toolu_1",
+            state: "output-error",
+            rawInput: { foo: "bar" },
+            errorText: "Model tried to call unavailable tool 'echo-job'.",
+          },
+        ],
+        metadata: {},
+      },
+    ];
+
+    const validated = await validateAtlasUIMessages(messages);
+    expect(validated.length).toEqual(1);
+    expect(validated[0]?.parts[0]).toMatchObject({
+      type: "tool-echo-job",
+      state: "output-error",
+      input: { foo: "bar" },
+      errorText: "Model tried to call unavailable tool 'echo-job'.",
+    });
+  });
+
+  it("repairs dynamic-tool parts with rawInput-only output-error shape", async () => {
+    const messages = [
+      {
+        id: "1",
+        role: "assistant",
+        parts: [
+          {
+            type: "dynamic-tool",
+            toolName: "ghost_tool",
+            toolCallId: "toolu_3",
+            state: "output-error",
+            rawInput: { x: 1 },
+            errorText: "tool not found",
+          },
+        ],
+        metadata: {},
+      },
+    ];
+
+    const validated = await validateAtlasUIMessages(messages);
+    expect(validated.length).toEqual(1);
+    expect(validated[0]?.parts[0]).toMatchObject({
+      type: "dynamic-tool",
+      toolName: "ghost_tool",
+      state: "output-error",
+      input: { x: 1 },
+      errorText: "tool not found",
+    });
+  });
+
+  it("does not touch tool parts that already have input", async () => {
+    const messages = [
+      {
+        id: "1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-search",
+            toolCallId: "toolu_2",
+            state: "output-available",
+            input: { query: "hello" },
+            output: { results: 3 },
+          },
+        ],
+        metadata: {},
+      },
+    ];
+
+    const validated = await validateAtlasUIMessages(messages);
+    expect(validated[0]?.parts[0]).toMatchObject({
+      type: "tool-search",
+      state: "output-available",
+      input: { query: "hello" },
+      output: { results: 3 },
+    });
+  });
 });

--- a/packages/agent-sdk/src/messages.test.ts
+++ b/packages/agent-sdk/src/messages.test.ts
@@ -473,6 +473,7 @@ describe("validateAtlasUIMessages", () => {
       type: "tool-echo-job",
       state: "output-error",
       input: { foo: "bar" },
+      rawInput: { foo: "bar" },
       errorText: "Model tried to call unavailable tool 'echo-job'.",
     });
   });
@@ -503,7 +504,59 @@ describe("validateAtlasUIMessages", () => {
       toolName: "ghost_tool",
       state: "output-error",
       input: { x: 1 },
+      rawInput: { x: 1 },
       errorText: "tool not found",
+    });
+  });
+
+  it("skips parts whose state is not output-error", async () => {
+    const messages = [
+      {
+        id: "1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-search",
+            toolCallId: "toolu_4",
+            state: "input-streaming",
+            rawInput: { partial: "q" },
+          },
+        ],
+        metadata: {},
+      },
+    ];
+
+    const validated = await validateAtlasUIMessages(messages);
+    const part = validated[0]?.parts[0] as Record<string, unknown> | undefined;
+    expect(part?.state).toEqual("input-streaming");
+    expect(part?.input).toBeUndefined();
+  });
+
+  it("skips output-error parts that already have valid input", async () => {
+    const messages = [
+      {
+        id: "1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-echo-job",
+            toolCallId: "toolu_5",
+            state: "output-error",
+            input: { real: "args" },
+            rawInput: { stale: "rawArgs" },
+            errorText: "downstream tool execute threw",
+          },
+        ],
+        metadata: {},
+      },
+    ];
+
+    const validated = await validateAtlasUIMessages(messages);
+    expect(validated[0]?.parts[0]).toMatchObject({
+      type: "tool-echo-job",
+      state: "output-error",
+      input: { real: "args" },
+      rawInput: { stale: "rawArgs" },
     });
   });
 

--- a/packages/agent-sdk/src/messages.ts
+++ b/packages/agent-sdk/src/messages.ts
@@ -283,6 +283,26 @@ export type AtlasDataEvents = {
   usage: z.infer<(typeof AtlasDataEventSchemas)["usage"]>;
 };
 
+function repairToolPartInput(message: unknown): unknown {
+  if (typeof message !== "object" || message === null) return message;
+  const msg = message as Record<string, unknown>;
+  if (!Array.isArray(msg.parts)) return message;
+  let changed = false;
+  const repairedParts = msg.parts.map((part) => {
+    if (typeof part !== "object" || part === null) return part;
+    const p = part as Record<string, unknown>;
+    const type = typeof p.type === "string" ? p.type : "";
+    const isToolPart = type.startsWith("tool-") || type === "dynamic-tool";
+    if (!isToolPart) return part;
+    if (p.state !== "output-error") return part;
+    if (p.input !== undefined) return part;
+    if (!("rawInput" in p)) return part;
+    changed = true;
+    return { ...p, input: p.rawInput };
+  });
+  return changed ? { ...msg, parts: repairedParts } : message;
+}
+
 /**
  * Validates Atlas UI messages.
  * Checks message structure, metadata, and data parts.
@@ -323,8 +343,25 @@ export async function validateAtlasUIMessages(messages: unknown[]): Promise<Atla
     return { ...m, id: crypto.randomUUID() };
   });
 
+  // Backfill `input` from `rawInput` on tool parts with state
+  // `output-error` before validation.
+  //
+  // Why: the AI SDK's tool-input-error chunk handler emits non-dynamic
+  // tool parts as `{ state: "output-error", input: undefined, rawInput:
+  // chunk.input }` (process-ui-message-stream.ts:656-668), which fires
+  // for NoSuchToolError, InvalidToolInputError, and ToolCallRepairError.
+  // But the SDK's own UIMessage schema for `output-error` requires
+  // `input: z.unknown()` as a non-optional field, so the persisted part
+  // fails to round-trip — every subsequent history load throws
+  // AI_TypeValidationError, the route returns 500, and downstream
+  // callers (e.g. workspace-chat agent) silently fall back to empty
+  // history. The SDK's own model-message conversion does this same
+  // fallback at read time, gated to `output-error`
+  // (convert-to-model-messages.ts:183-187); we mirror the gate here.
+  const repaired = withIds.map(repairToolPartInput);
+
   const validated = await validateUIMessages<AtlasUIMessage>({
-    messages: withIds,
+    messages: repaired,
     metadataSchema: MessageMetadataSchema.optional(),
     dataSchemas: AtlasDataEventSchemas,
   });

--- a/packages/core/src/chat/jetstream-backend.ts
+++ b/packages/core/src/chat/jetstream-backend.ts
@@ -450,12 +450,20 @@ export function createJetStreamChatBackend(
   ): Promise<Result<void, string>> {
     try {
       await enqueue(`${workspaceId}/${chatId}`, async () => {
-        await validateAtlasUIMessages([message]);
+        // Persist the validator's repaired output, not the raw input. The
+        // AI SDK emits `tool-*` parts with `state: "output-error"` and
+        // `input: undefined / rawInput: …` for unbound-tool errors;
+        // `validateAtlasUIMessages` backfills `input` so the persisted
+        // bytes round-trip through the SDK schema. Writing the raw
+        // message would leave the broken shape in JetStream and force
+        // the read-side repair to carry the load forever.
+        const [validated] = await validateAtlasUIMessages([message]);
+        const repaired = validated ?? message;
         const jsm = await nc.jetstreamManager();
         const layout = await ensureChatStream(jsm, workspaceId, chatId, limits);
 
         const c = js();
-        const envelope = { message, ts: new Date().toISOString() };
+        const envelope = { message: repaired, ts: new Date().toISOString() };
         const h = natsHeaders();
         h.set("Friday-Schema-Version", SCHEMA_VERSION);
         h.set("Friday-Message-Id", message.id);

--- a/packages/core/src/chat/storage.test.ts
+++ b/packages/core/src/chat/storage.test.ts
@@ -62,6 +62,37 @@ describe("ChatStorage (JetStream-backed)", () => {
     }
   });
 
+  it("persists tool-part input from rawInput on appendMessage", async () => {
+    const chatId = crypto.randomUUID();
+    await createTestChat(chatId);
+
+    const msg = {
+      id: crypto.randomUUID(),
+      role: "assistant",
+      parts: [
+        {
+          type: "tool-echo-job",
+          toolCallId: "toolu_persist_1",
+          state: "output-error",
+          rawInput: { hello: "world" },
+          errorText: "Model tried to call unavailable tool 'echo-job'.",
+        },
+      ],
+    } as unknown as AtlasUIMessage;
+
+    const append = await ChatStorage.appendMessage(chatId, msg);
+    expect(append.ok).toBe(true);
+
+    const get = await ChatStorage.getChat(chatId);
+    expect(get.ok && get.data?.messages.length).toBe(1);
+    if (get.ok && get.data) {
+      const part = get.data.messages[0]?.parts[0] as Record<string, unknown> | undefined;
+      expect(part?.type).toBe("tool-echo-job");
+      expect(part?.state).toBe("output-error");
+      expect(part?.input).toEqual({ hello: "world" });
+    }
+  });
+
   it("isolates messages between different chats", async () => {
     const a = crypto.randomUUID();
     const b = crypto.randomUUID();


### PR DESCRIPTION
## Summary

- A failed tool call (model emits a call to an unbound tool) used to wipe the rest of the conversation. Every turn after the failure came back with the default "Hey, what can I help you with?" — the assistant looked amnesiac to the user.
- The poisoned shape lived in the persisted chat history forever, so once a thread tripped over it, the only recovery was abandoning the chat.
- Fixed at the validator boundary, so existing broken chats also recover the next time history loads.

## Why

The AI SDK persists a failed tool call as a `tool-*` part with `state: "output-error"` and the model's args parked in `rawInput` instead of `input`. The SDK's own UIMessage schema for that state requires `input`, so every history round-trip throws `AI_TypeValidationError`. The route returned 500, the workspace chat agent's history fetch fell back to an empty array, and the model answered with no context.

`validateAtlasUIMessages` now backfills `input` from `rawInput` on `output-error` tool parts before validation — same fallback the SDK does on its own read-side conversion (`convert-to-model-messages.ts`). `appendMessage` persists the validator output, so new writes converge to a clean shape; legacy chats are repaired on read.

## Test plan

- [ ] Open a chat, ask the assistant to call a tool that isn't bound in the session, then send a follow-up. The follow-up should respond to the conversation, not greet you cold.
- [ ] Reload an existing chat that already has a stuck `tool-*` part — it should load normally instead of 500ing.

## Known failures

The promptfoo eval suite has 4 pre-existing infra failures (`promptfooconfig`, `retrieval-gated`, `table-outcomes`, `tool-suite-management`) — all "Daemon did not become healthy within 90s" timeouts when the QA harness spins up its ephemeral daemon in parallel with a live local daemon. Unrelated to this change; failure mode is in the harness bootstrap, not the validator path. The other 5 suites pass clean.