### PR TITLE
Chat-UI: export preview survives chats containing artifact cards

### DIFF
--- a/tools/agent-playground/src/lib/components/chat/__test-stubs__/artifact-card-export-parent.svelte
+++ b/tools/agent-playground/src/lib/components/chat/__test-stubs__/artifact-card-export-parent.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
   import { setExportContext, type ExportContext } from "../export-context.ts";
   import ArtifactCard from "../artifact-card.svelte";
 
@@ -11,13 +10,6 @@
   const props: Props = $props();
   // svelte-ignore state_referenced_locally
   setExportContext(props.ctx);
-
-  // QueryClient is required by `createQuery`, even though the artifact
-  // card's queries are disabled (via skipToken) in export mode — the
-  // hook call still needs the context. No fetches fire.
-  const queryClient = new QueryClient();
 </script>
 
-<QueryClientProvider client={queryClient}>
-  <ArtifactCard artifactId={props.artifactId} />
-</QueryClientProvider>
+<ArtifactCard artifactId={props.artifactId} />

--- a/tools/agent-playground/src/lib/components/chat/artifact-card.svelte
+++ b/tools/agent-playground/src/lib/components/chat/artifact-card.svelte
@@ -25,37 +25,40 @@
   // TanStack Query for the live UI path. Same artifactId across N
   // cards shares one in-flight request and a process-wide cache, which
   // is what makes the chat tree survive a heavy delegation that
-  // produces 30+ artifacts. In export mode the query is disabled
-  // (null id → skipToken) and the prefetched map drives the render.
-  const liveQuery = createQuery(() =>
-    artifactQueries.byId(exportCtx === undefined ? artifactId : null),
-  );
+  // produces 30+ artifacts. In export mode the query is skipped
+  // entirely — the export-preview layout is chromeless and does not
+  // mount a QueryClientProvider, so calling createQuery() there would
+  // throw "No QueryClient was found in Svelte context" during SSR.
+  const liveQuery =
+    exportCtx === undefined
+      ? createQuery(() => artifactQueries.byId(artifactId))
+      : undefined;
 
   const resolvedTitle = $derived(
     exportCtx !== undefined
       ? prefetched?.title || "Artifact"
-      : liveQuery.data?.artifact.title || "Artifact",
+      : liveQuery?.data?.artifact.title || "Artifact",
   );
   const resolvedSummary = $derived(
-    exportCtx !== undefined ? prefetched?.summary : liveQuery.data?.artifact.summary,
+    exportCtx !== undefined ? prefetched?.summary : liveQuery?.data?.artifact.summary,
   );
   const mimeType = $derived(
-    exportCtx !== undefined ? prefetched?.mimeType : liveQuery.data?.artifact.data.mimeType,
+    exportCtx !== undefined ? prefetched?.mimeType : liveQuery?.data?.artifact.data.mimeType,
   );
   const originalName = $derived(
-    exportCtx !== undefined ? prefetched?.originalName : liveQuery.data?.artifact.data.originalName,
+    exportCtx !== undefined ? prefetched?.originalName : liveQuery?.data?.artifact.data.originalName,
   );
   const sizeBytes = $derived(
-    exportCtx !== undefined ? prefetched?.size : liveQuery.data?.artifact.data.size,
+    exportCtx !== undefined ? prefetched?.size : liveQuery?.data?.artifact.data.size,
   );
   const contents = $derived(
-    exportCtx !== undefined ? undefined : liveQuery.data?.contents,
+    exportCtx !== undefined ? undefined : liveQuery?.data?.contents,
   );
-  const loading = $derived(exportCtx === undefined && liveQuery.isPending);
+  const loading = $derived(exportCtx === undefined && (liveQuery?.isPending ?? false));
   const fetchError = $derived(
     exportMissing
       ? `Artifact ${artifactId} missing from export context`
-      : exportCtx === undefined && liveQuery.error
+      : exportCtx === undefined && liveQuery?.error
         ? liveQuery.error.message
         : null,
   );
@@ -173,17 +176,20 @@
 
   // Raw text for tabular artifacts that didn't ship inline with the
   // metadata response. Disabled (skipToken) when the mime isn't
-  // tabular, the metadata already supplied contents, or we're in
-  // export mode. Same TanStack cache as the metadata query — multiple
-  // cards for the same tabular artifact share one network request,
-  // which is what stops `ERR_INSUFFICIENT_RESOURCES` on heavy-
-  // delegation chats that surface 30+ artifact ids.
-  const tabularContentQuery = createQuery(() =>
-    artifactQueries.content(
-      exportCtx === undefined && isTabularMime && !contents ? artifactId : null,
-    ),
-  );
-  const tabularText = $derived(contents ?? tabularContentQuery.data);
+  // tabular or the metadata already supplied contents. Skipped
+  // entirely in export mode — same reason as `liveQuery` above: no
+  // QueryClientProvider in the chromeless preview layout. Same
+  // TanStack cache as the metadata query — multiple cards for the
+  // same tabular artifact share one network request, which is what
+  // stops `ERR_INSUFFICIENT_RESOURCES` on heavy-delegation chats that
+  // surface 30+ artifact ids.
+  const tabularContentQuery =
+    exportCtx === undefined
+      ? createQuery(() =>
+          artifactQueries.content(isTabularMime && !contents ? artifactId : null),
+        )
+      : undefined;
+  const tabularText = $derived(contents ?? tabularContentQuery?.data);
 
   // text/markdown routes through the bare `/artifacts/<id>` dispatcher
   // (one redirect hop) so the same disambiguation lives in one place:

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/chat/[chatId]/export/preview/preview.test.ts
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/chat/[chatId]/export/preview/preview.test.ts
@@ -286,6 +286,38 @@ describe("export-preview +page.svelte render", () => {
     const { body } = render(Page, { props: { data: makePageData() } });
     expect(body).toContain("Tracer Bullet Chat");
   });
+
+  // Regression: ArtifactCard previously called `createQuery()`
+  // unconditionally. The export-preview layout is chromeless and never
+  // mounts a QueryClientProvider, so a chat that surfaced even one
+  // display_artifact tool call blew up SSR with "No QueryClient was
+  // found in Svelte context". The card now skips both createQuery
+  // hooks when export context is set and hydrates from the prefetched
+  // map instead.
+  it("renders ArtifactCard from a display_artifact tool call without a QueryClient", () => {
+    const data = makePageData();
+    data.messages = [
+      ...data.messages,
+      {
+        id: "m3",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-display_artifact",
+            toolCallId: "call-1",
+            state: "output-available",
+            input: { artifactId: "art-1" },
+            output: {},
+          },
+        ],
+        metadata: { timestamp: "2026-05-04T12:00:03.000Z" },
+      },
+    ] as unknown as AtlasUIMessage[]; // test fixture exempt from no-`as` rule
+
+    const { body } = render(Page, { props: { data } });
+    expect(body).toContain("Diagram");
+    expect(body).toContain("assets/artifacts/art-1/diagram.png");
+  });
 });
 
 describe("artifactZipPath helper (resolveUrl contract)", () => {


### PR DESCRIPTION
## Summary
- Exporting a chat that contains any artifact card (`display_artifact` tool calls or lifted-artifact previews) no longer crashes the preview SSR — the page renders end-to-end from the prefetched artifact map.
- Live chat UI is byte-identical: same query keys, same fetches, same caching behavior. No new DOM mutations for `chat-message-list`'s virtualizer to re-measure.

## Why it broke
ArtifactCard called `createQuery()` unconditionally and relied on a null query id (→ `skipToken`) to "disable" the query in export mode. But the export-preview layout is intentionally chromeless and never mounts a `QueryClientProvider` — so the hook threw at `useQueryClient()` even when the query itself was skipped. `skipToken` disables the *query*, not the *hook*.

## Known limitation
Chats containing a `request_human_input` tool call still crash export-preview SSR with the same root cause in `human-input-tool-card.svelte` (`createQuery` + two mutation hooks). The proper fix renders a static view from the recorded answer in `call.output` instead of from live elicitation state — shape-different enough to track separately rather than bundle here.

## Test plan
- [ ] Open `/platform/<ws>/chat/<id>/export/preview` for a chat that contains at least one displayed artifact (image / PDF / tabular / generic). Confirm the artifact title, mime badge, asset URL, and any inline preview render — no spinner, no "Loading…" placeholder, no 500.
- [ ] Open the same chat in the live UI. Artifact cards still fetch from the daemon, table previews still render, download / open buttons still work.
- [ ] `deno task typecheck` clean and the agent-playground vitest suite is green (494/494 locally; new regression test pins the bug).