### PR TITLE
Runs: fix dark-mode dark rectangle behind step icons

### DIFF
--- a/tools/agent-playground/src/lib/components/session/agent-block-card.svelte
+++ b/tools/agent-playground/src/lib/components/session/agent-block-card.svelte
@@ -276,7 +276,7 @@
 
   .icon {
     align-items: center;
-    background-color: var(--color-surface-1);
+    background-color: var(--surface);
     block-size: var(--size-8);
     color: color-mix(in srgb, var(--color-text), transparent 70%);
     display: flex;

--- a/tools/agent-playground/src/lib/components/session/agent-block-card.svelte
+++ b/tools/agent-playground/src/lib/components/session/agent-block-card.svelte
@@ -286,7 +286,7 @@
     margin-inline-start: calc(-1 * calc(var(--size-2) + 0.5px));
 
     &.running {
-      animation: spin 2s linear infinite;
+      animation: spin 4s linear infinite;
     }
   }
 

--- a/tools/agent-playground/src/lib/components/session/agent-block-card.svelte
+++ b/tools/agent-playground/src/lib/components/session/agent-block-card.svelte
@@ -371,6 +371,12 @@
     }
   }
 
+  @keyframes spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
   .ephemeral-label {
     font-size: var(--font-size-2);
     opacity: 0.5;

--- a/tools/agent-playground/src/lib/components/session/step-block/header.svelte
+++ b/tools/agent-playground/src/lib/components/session/step-block/header.svelte
@@ -45,7 +45,7 @@
 
   .icon {
     align-items: center;
-    background-color: var(--color-surface-1);
+    background-color: var(--surface);
     block-size: var(--size-8);
     color: color-mix(in srgb, var(--color-text), transparent 70%);
     display: flex;


### PR DESCRIPTION
## Summary
- The `.icon` strip on each agent block in the Runs page is a mask that hides the timeline border line behind the step icon.
- It was filled with `--color-surface-1` (`hsl(228 2% 7%)`), but the page itself uses `--surface` (`rgb(27 28 29)` ≈ `hsl(216 4% 11%)`). In dark mode the mask is ~4% darker than the background, so it shows up as a black box behind the spinner / status dot for every step, in every state (running, completed, failed, pending).
- Fix: use `--surface` for the mask so it blends with the surrounding `.app-content` background.

Before:
<img width="544" height="118" alt="CleanShot 2026-05-13 at 19 48 28@2x" src="https://github.com/user-attachments/assets/16507067-530c-45ee-ba51-2f26bfc2d299" />

After:
<img width="516" height="112" alt="CleanShot 2026-05-13 at 19 52 04@2x" src="https://github.com/user-attachments/assets/9560c106-1b4f-49c7-a9ff-3f16f45d0e26" />

## Test plan
- [ ] Open a workspace → Runs → in-progress run; the running step spinner should not have a darker rectangle behind it in dark mode.
- [ ] Open a completed run; the filled dots / open dots on each step should sit flat on the page background.
- [ ] Light mode still looks correct (no regression).