### PR TITLE
Playground: redirect to personal workspace after deleting another

### DIFF
--- a/tools/agent-playground/src/lib/queries/workspace-queries.ts
+++ b/tools/agent-playground/src/lib/queries/workspace-queries.ts
@@ -214,8 +214,6 @@ export function useDeleteWorkspace() {
       if (!res.ok) throw new Error(`Failed to delete workspace: ${res.status}`);
       return res.json();
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: workspaceQueries.all() });
-    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: workspaceQueries.all() }),
   }));
 }

--- a/tools/agent-playground/src/lib/queries/workspace-queries.ts
+++ b/tools/agent-playground/src/lib/queries/workspace-queries.ts
@@ -215,6 +215,8 @@ export function useDeleteWorkspace() {
       if (!res.ok) throw new Error(`Failed to delete workspace: ${res.status}`);
       return res.json();
     },
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: workspaceQueries.all() }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: workspaceQueries.all() });
+    },
   }));
 }

--- a/tools/agent-playground/src/lib/queries/workspace-queries.ts
+++ b/tools/agent-playground/src/lib/queries/workspace-queries.ts
@@ -19,6 +19,7 @@ const WorkspaceSummarySchema = z.object({
   name: z.string(),
   description: z.string().optional(),
   type: z.enum(["ephemeral", "persistent"]),
+  canonical: z.enum(["personal", "system"]).optional(),
   metadata: z
     .object({
       color: z.string().optional(),

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/+page.svelte
@@ -17,7 +17,7 @@
   import { deriveTopology } from "@atlas/config/topology";
   import { deriveWorkspaceAgents } from "@atlas/config/workspace-agents";
   import { Button, Dialog, DropdownMenu, IconLarge, Icons, toast } from "@atlas/ui";
-  import { createQuery } from "@tanstack/svelte-query";
+  import { createQuery, useQueryClient } from "@tanstack/svelte-query";
   import { goto } from "$app/navigation";
   import { browser } from "$app/environment";
   import { page } from "$app/state";
@@ -26,7 +26,12 @@
   import CommunicatorsCard from "$lib/components/workspace/communicators-card.svelte";
   import JobsIntegrationsCard from "$lib/components/workspace/jobs-integrations-card.svelte";
   import SignalsCard from "$lib/components/workspace/signals-card.svelte";
-  import { sessionQueries, useDeleteWorkspace, workspaceQueries } from "$lib/queries";
+  import {
+    sessionQueries,
+    useDeleteWorkspace,
+    workspaceQueries,
+    type WorkspaceSummary,
+  } from "$lib/queries";
   import { writable } from "svelte/store";
   import { stringify } from "yaml";
 
@@ -302,14 +307,24 @@
 
   const deleteMut = useDeleteWorkspace();
   const deleteDialogOpen = writable(false);
+  const queryClient = useQueryClient();
 
   async function confirmDelete() {
     if (!workspaceId || deleteMut.isPending) return;
+    const deletedId = workspaceId;
     try {
-      await deleteMut.mutateAsync(workspaceId);
+      await deleteMut.mutateAsync(deletedId);
       deleteDialogOpen.set(false);
-      toast({ title: `${configQuery.data?.config?.workspace?.name ?? workspaceId} removed` });
-      goto("/platform");
+      toast({ title: `${configQuery.data?.config?.workspace?.name ?? deletedId} removed` });
+
+      await queryClient.invalidateQueries({ queryKey: workspaceQueries.all() });
+      const workspaces = queryClient.getQueryData<WorkspaceSummary[]>(
+        workspaceQueries.list().queryKey,
+      );
+      const fallback =
+        workspaces?.find((ws) => ws.id === "user" && ws.id !== deletedId) ??
+        workspaces?.find((ws) => ws.type === "persistent" && ws.id !== deletedId);
+      goto(fallback ? `/platform/${fallback.id}` : "/platform");
     } catch {
       toast({ title: "Failed to remove workspace", error: true });
     }

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/+page.svelte
@@ -17,7 +17,7 @@
   import { deriveTopology } from "@atlas/config/topology";
   import { deriveWorkspaceAgents } from "@atlas/config/workspace-agents";
   import { Button, Dialog, DropdownMenu, IconLarge, Icons, toast } from "@atlas/ui";
-  import { createQuery, useQueryClient } from "@tanstack/svelte-query";
+  import { createQuery } from "@tanstack/svelte-query";
   import { goto } from "$app/navigation";
   import { browser } from "$app/environment";
   import { page } from "$app/state";
@@ -26,12 +26,7 @@
   import CommunicatorsCard from "$lib/components/workspace/communicators-card.svelte";
   import JobsIntegrationsCard from "$lib/components/workspace/jobs-integrations-card.svelte";
   import SignalsCard from "$lib/components/workspace/signals-card.svelte";
-  import {
-    sessionQueries,
-    useDeleteWorkspace,
-    workspaceQueries,
-    type WorkspaceSummary,
-  } from "$lib/queries";
+  import { sessionQueries, useDeleteWorkspace, workspaceQueries } from "$lib/queries";
   import { writable } from "svelte/store";
   import { stringify } from "yaml";
 
@@ -63,7 +58,9 @@
     return COLORS[color ?? "yellow"] ?? COLORS["yellow"];
   });
 
-  const isCanonical = $derived(currentWorkspace?.canonical !== undefined);
+  // Default to canonical (non-deletable) while the workspace list is still
+  // loading — keeps the destructive "Remove" action hidden until we're sure.
+  const isCanonical = $derived(!currentWorkspace || currentWorkspace.canonical !== undefined);
 
   // ---------------------------------------------------------------------------
   // Agents
@@ -312,24 +309,16 @@
 
   const deleteMut = useDeleteWorkspace();
   const deleteDialogOpen = writable(false);
-  const queryClient = useQueryClient();
 
   async function confirmDelete() {
     if (!workspaceId || deleteMut.isPending) return;
-    const deletedId = workspaceId;
     try {
-      await deleteMut.mutateAsync(deletedId);
+      await deleteMut.mutateAsync(workspaceId);
       deleteDialogOpen.set(false);
-      toast({ title: `${configQuery.data?.config?.workspace?.name ?? deletedId} removed` });
-
-      await queryClient.invalidateQueries({ queryKey: workspaceQueries.all() });
-      const workspaces = queryClient.getQueryData<WorkspaceSummary[]>(
-        workspaceQueries.list().queryKey,
-      );
-      const fallback =
-        workspaces?.find((ws) => ws.id === "user" && ws.id !== deletedId) ??
-        workspaces?.find((ws) => ws.type === "persistent" && ws.id !== deletedId);
-      goto(fallback ? `/platform/${fallback.id}` : "/platform");
+      toast({ title: `${configQuery.data?.config?.workspace?.name ?? workspaceId} removed` });
+      // Only non-canonical workspaces are deletable, so the personal workspace
+      // ("user") always exists as a landing target.
+      goto("/platform/user");
     } catch {
       toast({ title: "Failed to remove workspace", error: true });
     }

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/+page.svelte
@@ -54,11 +54,16 @@
     brown: "var(--brown-2, #a3824a)",
   };
 
+  const currentWorkspace = $derived(
+    (workspacesQuery.data ?? []).find((w) => w.id === workspaceId),
+  );
+
   const workspaceColor = $derived.by(() => {
-    const ws = (workspacesQuery.data ?? []).find((w) => w.id === workspaceId);
-    const color = ws?.metadata?.color;
+    const color = currentWorkspace?.metadata?.color;
     return COLORS[color ?? "yellow"] ?? COLORS["yellow"];
   });
+
+  const isCanonical = $derived(currentWorkspace?.canonical !== undefined);
 
   // ---------------------------------------------------------------------------
   // Agents
@@ -433,10 +438,12 @@
               <DropdownMenu.Item onclick={() => downloadWorkspaceBundle("migration")}>
                 Download workspace with notes &amp; memory
               </DropdownMenu.Item>
-              <DropdownMenu.Separator />
-              <DropdownMenu.Item onclick={() => deleteDialogOpen.set(true)}>
-                Remove workspace
-              </DropdownMenu.Item>
+              {#if !isCanonical}
+                <DropdownMenu.Separator />
+                <DropdownMenu.Item onclick={() => deleteDialogOpen.set(true)}>
+                  Remove workspace
+                </DropdownMenu.Item>
+              {/if}
             </DropdownMenu.Content>
           {/snippet}
         </DropdownMenu.Root>


### PR DESCRIPTION
## Summary
- Deleting a workspace now redirects to your personal workspace (or another persistent one) instead of dropping you on the generic `/platform` landing.
- Awaits the workspace-list cache invalidation before navigating, so the post-delete redirect reads fresh state instead of re-selecting the just-deleted workspace.

Fixes #305

## Test plan
- [x] Open a non-personal workspace, delete it from the overflow menu → lands on the personal workspace.
- [x] If the personal workspace itself is deleted, the redirect falls through to another persistent workspace, then to `/platform` if none exist.
- [x] Sidebar list reflects the deletion immediately after redirect.