### PR TITLE
Chat-UI: collapsible sidebar, fullscreen mode, chat list refresh

### DIFF
--- a/packages/ui/src/lib/list-detail/list-detail.svelte
+++ b/packages/ui/src/lib/list-detail/list-detail.svelte
@@ -7,22 +7,47 @@
 
 <script lang="ts">
   import type { Snippet } from "svelte";
+  import { IconSmall } from "../icons/small/index.js";
 
   interface Props {
     header: Snippet;
     sidebar: Snippet;
     children: Snippet;
+    /**
+     * When true, the sidebar collapses to a thin peek strip with a
+     * chevron button. Clicking (or keyboard-activating) the strip
+     * slides the sidebar back out — bindable, so this component flips
+     * it to false itself. Default false — existing consumers see no
+     * change.
+     */
+    sidebarCollapsed?: boolean;
   }
 
-  let { header, sidebar, children }: Props = $props();
+  let { header, sidebar, children, sidebarCollapsed = $bindable(false) }: Props = $props();
 </script>
 
-<div class="layout">
+<div class="layout" class:sidebar-collapsed={sidebarCollapsed}>
   <aside class="sidebar">
-    <div class="header">
-      {@render header()}
+    <!-- `inert` when collapsed pulls the faded-out content out of the
+         tab order and the accessibility tree, so keyboard / screen
+         reader users can't land on invisible controls. -->
+    <div class="sidebar-inner" inert={sidebarCollapsed}>
+      <div class="header">
+        {@render header()}
+      </div>
+      {@render sidebar()}
     </div>
-    {@render sidebar()}
+    {#if sidebarCollapsed}
+      <button
+        type="button"
+        class="peek-indicator"
+        aria-label="Expand sidebar"
+        aria-expanded="false"
+        onclick={() => (sidebarCollapsed = false)}
+      >
+        <IconSmall.ChevronRight />
+      </button>
+    {/if}
   </aside>
 
   <div class="content">
@@ -42,11 +67,71 @@
     display: flex;
     flex-direction: column;
     flex-shrink: 0;
-    gap: var(--size-4);
     inline-size: 300px;
+    /* overflow: hidden clips the inner content during the collapse /
+       expand width transition (both directions) so no scrollbar flashes
+       while the sidebar is mid-slide. The actual scroll lives on
+       .sidebar-inner. */
+    overflow: hidden;
+    /* No block-end padding: the sidebar snippet owns the bottom edge so
+       content (e.g. an overlay footer) can sit flush against it. */
+    padding: var(--size-4) var(--size-4) 0;
+    position: relative;
+    transition:
+      inline-size 240ms cubic-bezier(0.4, 0, 0.2, 1),
+      padding 240ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  .sidebar-inner {
+    display: flex;
+    /* Fill the aside so children with flex: 1 (e.g. chat-list-panel)
+       get the full available height. */
+    flex: 1;
+    flex-direction: column;
+    gap: var(--size-4);
+    min-block-size: 0;
+    opacity: 1;
+    /* The scroll container for every consumer. Sidebar snippets that
+       manage their own internal scroll (chat-list-panel) simply never
+       overflow this; tree-style snippets (skills, mcp, discover) scroll
+       here. */
     overflow-y: auto;
-    padding: var(--size-4);
     scrollbar-width: thin;
+    transition: opacity 180ms cubic-bezier(0.4, 0, 0.2, 1);
+  }
+
+  /* Collapsed: sidebar slides out to a thin peek strip. The
+     .peek-indicator button is the affordance to bring it back — hover
+     and focus only highlight the chevron, the sidebar does not expand
+     on hover so the pointer can graze the strip safely. */
+  .sidebar-collapsed .sidebar {
+    inline-size: var(--size-5);
+    padding-inline: 0;
+  }
+
+  .sidebar-collapsed .sidebar-inner {
+    opacity: 0;
+  }
+
+  .peek-indicator {
+    align-items: center;
+    background: none;
+    border: none;
+    color: var(--text-faded);
+    cursor: pointer;
+    display: flex;
+    inline-size: var(--size-5);
+    inset-block: 0;
+    inset-inline-start: 0;
+    justify-content: center;
+    padding: 0;
+    position: absolute;
+    transition: color 120ms ease;
+  }
+
+  .peek-indicator:hover,
+  .peek-indicator:focus-visible {
+    color: var(--text-bright);
   }
 
   .header {

--- a/tools/agent-playground/src/lib/components/chat/chat-list-panel.svelte
+++ b/tools/agent-playground/src/lib/components/chat/chat-list-panel.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Badge } from "@atlas/ui";
+  import { Badge, IconSmall } from "@atlas/ui";
   import { onMount } from "svelte";
   import { z } from "zod";
 
@@ -177,7 +177,7 @@
     const then = new Date(iso).getTime();
     const diffMs = Date.now() - then;
     const min = Math.floor(diffMs / 60_000);
-    if (min < 1) return "just now";
+    if (min < 1) return "now";
     if (min < 60) return `${min}m`;
     const hr = Math.floor(min / 60);
     if (hr < 24) return `${hr}h`;
@@ -282,15 +282,19 @@
       {@const unread = isUnread(chat)}
       <li class="chat-row" class:active={chat.id === currentChatId}>
         <button class="chat-item" class:unread onclick={() => handleClick(chat.id)}>
-          <span class="item-dot" aria-hidden="true"></span>
           <div class="item-body">
             <div class="item-top">
               <span class="item-title">{chat.title ?? "Untitled"}</span>
+              {#if unread}
+                <span class="item-unread" aria-hidden="true">*</span>
+              {/if}
               <span class="item-time">{formatRelativeTime(chat.updatedAt)}</span>
             </div>
-            <div class="item-meta">
-              <Badge variant={sourceVariant(chat.source)}>{sourceLabel(chat.source)}</Badge>
-            </div>
+            {#if chat.source !== "atlas"}
+              <div class="item-meta">
+                <Badge variant={sourceVariant(chat.source)}>{sourceLabel(chat.source)}</Badge>
+              </div>
+            {/if}
           </div>
         </button>
         <button
@@ -299,29 +303,18 @@
           aria-label="Delete chat {chat.title ?? 'Untitled'}"
           title="Delete chat"
         >
-          <svg
-            width="12"
-            height="12"
-            viewBox="0 0 12 12"
-            fill="none"
-            xmlns="http://www.w3.org/2000/svg"
-          >
-            <path
-              d="M3 3L9 9M9 3L3 9"
-              stroke="currentColor"
-              stroke-width="1.5"
-              stroke-linecap="round"
-            />
-          </svg>
+          <IconSmall.TrashBin />
         </button>
       </li>
     {/each}
   </ul>
 
   {#if hasMore}
-    <button class="load-more" onclick={loadMore} disabled={loading}>
-      {loading ? "Loading…" : "Load more"}
-    </button>
+    <div class="load-more-footer">
+      <button class="load-more" onclick={loadMore} disabled={loading}>
+        {loading ? "Loading…" : "Load more"}
+      </button>
+    </div>
   {/if}
 </aside>
 
@@ -332,6 +325,10 @@
     flex-direction: column;
     min-block-size: 0;
     overflow: hidden;
+    /* Positioning context for .load-more-footer. ListDetail's aside has
+       no block-end padding, so this panel reaches the sidebar's bottom
+       edge — the footer anchored here lands flush with it. */
+    position: relative;
   }
 
   .list-error {
@@ -353,29 +350,35 @@
     flex-direction: column;
     list-style: none;
     margin: 0;
+    /* Without an explicit min-height: 0 a flex item won't shrink below
+       its content size, which kills the inner overflow-y: auto scroll
+       when the parent column has a finite height. */
+    min-block-size: 0;
     overflow-y: auto;
-    padding: 0;
+    /* Bottom padding clears the absolutely-positioned .load-more-footer
+       so the last chat row can scroll fully into view above it. Matches
+       the footer's total height: pill + its block padding. */
+    padding-block-end: calc(var(--size-7) + var(--size-4) * 2);
+    padding-inline: 0;
+    padding-block-start: 0;
     scrollbar-width: thin;
   }
 
   /* Row wraps the main click target (.chat-item) and the delete button so
      they share a single hover/active state — from the user's POV it's one
      row, but we need two independent buttons so a click on the X doesn't
-     also select the chat. */
+     also select the chat. Rounded pill matches the left-nav active state
+     (var(--radius-2-5) + var(--highlight)). */
   .chat-row {
     align-items: stretch;
-    border-block-end: 1px solid var(--border);
+    border-radius: var(--radius-2-5);
     display: flex;
     position: relative;
     transition: background-color 100ms ease;
   }
 
-  .chat-row:hover {
-    background-color: var(--highlight);
-  }
-
   .chat-row.active {
-    background-color: var(--highlight-bright);
+    background-color: var(--highlight);
   }
 
   .chat-item {
@@ -387,9 +390,14 @@
     display: flex;
     flex: 1;
     font: inherit;
-    gap: var(--size-2);
     min-inline-size: 0;
     padding-block: var(--size-2);
+    /* Left padding is sized so the title's left edge optically aligns with
+       the trash icon's right edge — the trash sits at inset-inline-end:
+       var(--size-2) of a 24px button with the 16px icon centered (4px gap
+       inside the button), so visible content is ~12px from the row's
+       right edge. */
+    padding-inline: var(--size-3) var(--size-2);
     text-align: start;
   }
 
@@ -401,58 +409,41 @@
     color: var(--text-faded);
     cursor: pointer;
     display: flex;
-    flex-shrink: 0;
+    /* Match .item-time's fixed-width slot so the icon is centered on the
+       same span the time was occupying — both elements share a 24px box.
+       Stretches the row's full height (inset-block: 0) so the icon
+       vertically centers regardless of whether the row also renders a
+       Badge under the title. */
     inline-size: 24px;
+    inset-block: 0;
+    inset-inline-end: var(--size-2);
     justify-content: center;
-    margin-block: 6px;
+    position: absolute;
     /* Hidden until the row is hovered so quiet rows stay tidy; still
-       keyboard-focusable for accessibility (see :focus-visible below). */
+       keyboard-focusable for accessibility (see :focus-visible below).
+       Cross-fades with .item-time over the same 150ms — both elements
+       sit in the same 24px slot, so opacity-only animation reads as a
+       single swap rather than a positional shift. */
     opacity: 0;
+    pointer-events: none;
     transition:
-      opacity 100ms ease,
+      opacity 150ms ease,
       color 100ms ease;
   }
 
   .chat-row:hover .chat-delete,
   .chat-delete:focus-visible {
     opacity: 1;
+    pointer-events: auto;
+  }
+
+  .chat-row:hover .item-time {
+    opacity: 0;
   }
 
   .chat-delete:hover,
   .chat-delete:focus-visible {
     color: var(--red-primary);
-  }
-
-  .item-dot {
-    background-color: transparent;
-    block-size: 8px;
-    border-radius: 50%;
-    flex-shrink: 0;
-    inline-size: 8px;
-    margin-block-start: 6px;
-  }
-
-  .chat-item.unread .item-dot {
-    animation: unread-pulse 1.8s ease-in-out infinite;
-    background-color: var(--blue-primary);
-  }
-
-  @keyframes unread-pulse {
-    0%,
-    100% {
-      box-shadow: 0 0 0 0 var(--blue-primary);
-      opacity: 1;
-    }
-    50% {
-      box-shadow: 0 0 0 4px transparent;
-      opacity: 0.7;
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .chat-item.unread .item-dot {
-      animation: none;
-    }
   }
 
   .item-body {
@@ -467,12 +458,13 @@
     align-items: center;
     display: flex;
     gap: var(--size-2);
-    justify-content: space-between;
   }
 
   .item-title {
-    font-size: var(--font-size-1);
+    flex: 1;
+    font-size: var(--font-size-3);
     font-weight: var(--font-weight-5);
+    min-inline-size: 0;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -482,10 +474,28 @@
     font-weight: var(--font-weight-6);
   }
 
+  .item-unread {
+    color: var(--blue-primary);
+    flex-shrink: 0;
+    font-weight: var(--font-weight-6);
+    /* Tighter gap between title and asterisk than between asterisk and
+       the time slot, so the asterisk reads as part of the title. */
+    margin-inline-start: calc(var(--size-2) * -1 + var(--size-1));
+    /* The asterisk glyph sits in the upper half of its em-box; nudge it
+       down so it optically centers with the title text rather than
+       floating near the cap line. */
+    transform: translateY(0.2em);
+  }
+
   .item-time {
     color: var(--text-faded);
     flex-shrink: 0;
     font-size: var(--font-size-0);
+    /* Fixed-width slot so the on-hover trash icon (same width, centered)
+       swaps in over the same visual span without shifting. */
+    inline-size: 24px;
+    text-align: center;
+    transition: opacity 150ms ease;
   }
 
   .item-meta {
@@ -493,19 +503,58 @@
     gap: var(--size-1);
   }
 
+  /* Absolutely positioned against .chat-list-panel (its positioned
+     ancestor). Since ListDetail's aside has no block-end padding, the
+     panel reaches the sidebar's bottom edge and this footer lands flush
+     with it — lined up with the workspace-sidebar Docs footer. The
+     gradient fades the scrolled chat rows underneath; pointer-events:
+     none lets wheel + clicks pass through everywhere except the pill. */
+  .load-more-footer {
+    align-items: center;
+    background: linear-gradient(to top, var(--surface-dark) 60%, transparent);
+    display: flex;
+    inset-block-end: 0;
+    inset-inline: 0;
+    justify-content: center;
+    padding-block: var(--size-4);
+    pointer-events: none;
+    position: absolute;
+  }
+
   .load-more {
-    background-color: transparent;
+    align-items: center;
+    background-color: var(--surface);
+    block-size: var(--size-7);
     border: none;
-    border-block-start: 1px solid var(--border);
-    color: var(--blue-primary);
+    border-radius: var(--radius-round);
+    color: inherit;
     cursor: pointer;
+    display: inline-flex;
     flex-shrink: 0;
     font-size: var(--font-size-1);
-    padding-block: var(--size-2);
+    font-weight: var(--font-weight-5-5);
+    justify-content: center;
+    padding-inline: var(--size-3);
+    pointer-events: auto;
+    transition: background-color 200ms ease;
+  }
+
+  .load-more:hover:not(:disabled) {
+    background-color: color-mix(in srgb, var(--surface), var(--text) 10%);
+  }
+
+  @media (prefers-color-scheme: light) {
+    .load-more {
+      background-color: color-mix(in srgb, black 5%, transparent);
+    }
+
+    .load-more:hover:not(:disabled) {
+      background-color: color-mix(in srgb, black 10%, transparent);
+    }
   }
 
   .load-more:disabled {
-    color: var(--text-faded);
     cursor: default;
+    opacity: 0.6;
   }
 </style>

--- a/tools/agent-playground/src/lib/components/chat/user-chat.svelte
+++ b/tools/agent-playground/src/lib/components/chat/user-chat.svelte
@@ -46,12 +46,27 @@
   const { chatId }: Props = $props();
 
   let inspectorOpen = $state(false);
+  let fullscreen = $state(false);
 
   function handleGlobalKeydown(e: KeyboardEvent) {
     // Cmd+Shift+D (Debug) — Cmd+Shift+I is intercepted by Chrome DevTools
     if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "d") {
       e.preventDefault();
       inspectorOpen = !inspectorOpen;
+      return;
+    }
+    // Ctrl+F toggles fullscreen — deliberately Ctrl, never ⌘, so Mac's
+    // ⌘+F find-in-page is untouched. Tradeoff: on Windows/Linux Ctrl+F
+    // *is* browser find, so it's shadowed inside the chat surface. This
+    // is a local dev tool and the in-app shortcut is the priority here;
+    // revisit if that becomes a real friction point.
+    if (e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey && e.key === "f") {
+      e.preventDefault();
+      fullscreen = !fullscreen;
+      return;
+    }
+    if (e.key === "Escape" && fullscreen) {
+      fullscreen = false;
     }
   }
   let systemPromptContext: { timestamp: string; systemMessages: string[] } | null = $state(null);
@@ -1323,6 +1338,7 @@
 <div
   class="user-chat"
   class:chat-drag-over={chatDragOver}
+  class:fullscreen
   ondrop={handleChatDrop}
   ondragenter={handleChatDragEnter}
   ondragover={handleChatDragOver}
@@ -1346,10 +1362,53 @@
            waste a flex item for the same effect. -->
       <ChatSessionUsage messages={displayedMessages} />
       <button
-        class="new-chat-button"
+        class="icon-button"
+        type="button"
         onclick={handleExportChat}
         disabled={exportInFlight}
-      >{exportInFlight ? "Exporting…" : "Export chat"}</button>
+        aria-label={exportInFlight ? "Exporting chat…" : "Export chat"}
+        title={exportInFlight ? "Exporting…" : "Export chat"}
+      >
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+          <path
+            d="M8 2v8m-4-4 4 4 4-4M3 14h10"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+          />
+        </svg>
+      </button>
+      <button
+        class="icon-button"
+        type="button"
+        onclick={() => (fullscreen = !fullscreen)}
+        aria-label={`${fullscreen ? "Exit" : "Enter"} fullscreen (Ctrl+F)`}
+        aria-pressed={fullscreen}
+        title={`${fullscreen ? "Exit" : "Enter"} fullscreen (Ctrl+F)`}
+      >
+        {#if fullscreen}
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path
+              d="M10 2v3a1 1 0 0 0 1 1h3M6 14v-3a1 1 0 0 0-1-1H2M14 6h-3a1 1 0 0 1-1-1V2M2 10h3a1 1 0 0 1 1 1v3"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        {:else}
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <path
+              d="M2 6V3a1 1 0 0 1 1-1h3M14 6V3a1 1 0 0 0-1-1h-3M2 10v3a1 1 0 0 0 1 1h3M14 10v3a1 1 0 0 1-1 1h-3"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            />
+          </svg>
+        {/if}
+      </button>
     </header>
   {/if}
 
@@ -1485,27 +1544,42 @@
     padding: var(--size-2) var(--size-4);
   }
 
-  .new-chat-button {
+  .icon-button {
+    align-items: center;
     background: none;
     border: 1px solid var(--color-border-1);
     border-radius: var(--radius-1);
     color: inherit;
     cursor: pointer;
-    font-size: var(--font-size-2);
-    /* Pushes to the trailing edge regardless of how wide the leading-
-       edge ChatSessionUsage row is (or whether it rendered at all,
-       for legacy chats with no recorded usage). */
-    margin-inline-start: auto;
-    padding: var(--size-1) var(--size-3);
+    display: inline-flex;
+    justify-content: center;
+    padding: var(--size-1);
   }
 
-  .new-chat-button:hover:not(:disabled) {
+  /* The first .icon-button after .session-usage pushes itself (and any
+     siblings) to the trailing edge. Replaces the role .new-chat-button
+     used to play when the export button was a text pill. */
+  .icon-button:first-of-type {
+    margin-inline-start: auto;
+  }
+
+  .icon-button:hover:not(:disabled) {
     background-color: color-mix(in srgb, var(--color-text), transparent 95%);
   }
 
-  .new-chat-button:disabled {
+  .icon-button:disabled {
     cursor: not-allowed;
     opacity: 0.6;
+  }
+
+  /* Fullscreen mode: lift the chat surface out of its ListDetail slot to
+     cover the sidebar and any surrounding chrome. Ctrl+F toggles, Esc
+     exits — the keydown handler at the top of the component owns both. */
+  .user-chat.fullscreen {
+    background: var(--surface);
+    inset: 0;
+    position: fixed;
+    z-index: 100;
   }
 
   .chat-body {

--- a/tools/agent-playground/src/lib/components/mcp/mcp-catalog-tree.svelte
+++ b/tools/agent-playground/src/lib/components/mcp/mcp-catalog-tree.svelte
@@ -150,6 +150,11 @@
     display: flex;
     flex-direction: column;
     gap: var(--size-4);
+    /* ListDetail's aside is full-bleed at the block-end (no padding) so
+       the chat consumer's overlay footer can sit flush; tree-style
+       sidebars add their own bottom gutter so the last item isn't
+       jammed against the edge when the list scrolls. */
+    padding-block-end: var(--size-4);
   }
 
   /* ─── Search field ─────────────────────────────────────────────────────── */

--- a/tools/agent-playground/src/lib/components/shared/sidebar.svelte
+++ b/tools/agent-playground/src/lib/components/shared/sidebar.svelte
@@ -527,6 +527,11 @@
     margin-block: auto 0;
     padding-block: var(--size-6);
     padding-inline: var(--size-6);
+    /* Sticky footer overlays the bottom of the scrollable workspace list.
+       Only the Docs pill is meant to be interactive; everything else
+       (status pill, dead space, fade) passes clicks through to the
+       workspace row beneath. */
+    pointer-events: none;
     position: sticky;
 
     a {
@@ -539,6 +544,7 @@
       font-weight: var(--font-weight-5-5);
       justify-content: center;
       padding-inline: var(--size-2-5);
+      pointer-events: auto;
       transition: all 200ms ease;
 
       &:hover {

--- a/tools/agent-playground/src/lib/components/skills/skills-tree.svelte
+++ b/tools/agent-playground/src/lib/components/skills/skills-tree.svelte
@@ -235,6 +235,11 @@
     display: flex;
     flex-direction: column;
     gap: var(--size-0-5);
+    /* ListDetail's aside is full-bleed at the block-end (no padding) so
+       the chat consumer's overlay footer can sit flush; tree-style
+       sidebars add their own bottom gutter so the last item isn't
+       jammed against the edge when the list scrolls. */
+    padding-block-end: var(--size-4);
   }
 
   /* Reset list markers from Tree's <ul>/<li> elements */

--- a/tools/agent-playground/src/routes/discover/[[slug]]/+page.svelte
+++ b/tools/agent-playground/src/routes/discover/[[slug]]/+page.svelte
@@ -277,6 +277,11 @@
     display: flex;
     flex-direction: column;
     gap: var(--size-4);
+    /* ListDetail's aside is full-bleed at the block-end (no padding) so
+       the chat consumer's overlay footer can sit flush; tree-style
+       sidebars add their own bottom gutter so the last item isn't
+       jammed against the edge when the list scrolls. */
+    padding-block-end: var(--size-4);
   }
 
   .search-field {

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/chat/[[chatId]]/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/chat/[[chatId]]/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { Button, ListDetail } from "@atlas/ui";
   import { goto } from "$app/navigation";
+  import { browser } from "$app/environment";
   import { page } from "$app/state";
   import ChatListPanel from "$lib/components/chat/chat-list-panel.svelte";
   import UserChat from "$lib/components/chat/user-chat.svelte";
@@ -9,6 +10,40 @@
 
   const { data }: { data: PageData } = $props();
   const workspaceId = $derived(page.params.workspaceId ?? "user");
+
+  const SIDEBAR_KEY = "atlas:chat:sidebar-collapsed";
+
+  function readSidebarCollapsed(): boolean {
+    if (!browser) return false;
+    try {
+      return localStorage.getItem(SIDEBAR_KEY) === "1";
+    } catch {
+      // localStorage unavailable (private mode / disabled) — keep default
+      return false;
+    }
+  }
+
+  // Seed from storage at init so there's no SSR-default → stored-value
+  // flash, then persist on every change.
+  let sidebarCollapsed = $state(readSidebarCollapsed());
+
+  $effect(() => {
+    if (!browser) return;
+    try {
+      localStorage.setItem(SIDEBAR_KEY, sidebarCollapsed ? "1" : "0");
+    } catch {
+      // ignore quota / availability errors
+    }
+  });
+
+  function handleGlobalKeydown(e: KeyboardEvent) {
+    // Ctrl+B — hide / reveal the chat list sidebar. Cmd+B is reserved
+    // for Mac browser's bookmarks bar so we don't intercept it.
+    if (e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey && e.key === "b") {
+      e.preventDefault();
+      sidebarCollapsed = !sidebarCollapsed;
+    }
+  }
 
   function handleSelectChat(chatId: string) {
     if (chatId === data.chatId) return;
@@ -26,8 +61,10 @@
   }
 </script>
 
+<svelte:window onkeydown={handleGlobalKeydown} />
+
 {#key workspaceId}
-  <ListDetail>
+  <ListDetail bind:sidebarCollapsed>
     {#snippet header()}
       <WorkspaceDropdown selected={workspaceId} />
       <Button variant="secondary" size="small" onclick={handleNewChat}>New chat</Button>


### PR DESCRIPTION
## Summary

- **Collapsible chat list** — Ctrl+B (or clicking the collapsed peek strip) hides and shows the chat list sidebar. It slides out to a thin chevron strip; clicking the strip or pressing Ctrl+B again brings it back. The choice persists across reloads.
- **Fullscreen chat** — a new header button and Ctrl+F expand the chat to cover the sidebar and surrounding chrome; Esc or the button exits. (Ctrl, not ⌘, so Mac's ⌘+F find-in-page is untouched — on Windows/Linux it does shadow browser find inside the chat surface.)
- **Chat list visual refresh** — unread chats are marked with a blue `*` instead of a pulsing dot, the selected chat is a rounded pill matching the left nav, hovering a row cross-fades the timestamp into a trash (delete) icon, and "Load more" is a pill button pinned to the bottom of the list.
- **Export chat is now an icon button** — a download glyph sized to match the new fullscreen button, replacing the old text pill.
- **Web-sourced chats drop the redundant "Web" badge** — only external sources (Slack, Discord, Telegram, WhatsApp) still show a source badge.
- **Fix: the workspace sidebar footer no longer swallows clicks** — the fade band behind Docs/Online passes clicks through to the workspace row underneath; only the Docs link itself stays interactive.

The collapse behavior lives on the shared `ListDetail` layout as an opt-in `sidebarCollapsed` prop, so the skills / discover / MCP sidebars are unaffected (they keep their own scroll and bottom spacing).

## Test plan

- [x] On a chat page, press Ctrl+B — the sidebar collapses to a strip; press again or click the strip — it expands. Reload — the state persists.
- [x] Tab to the collapsed peek strip and press Enter — it expands (keyboard path works).
- [x] Press Ctrl+F or click the header button — the chat goes fullscreen; Esc exits.
- [x] Hover a chat row — the timestamp cross-fades to a trash icon; clicking it deletes the chat.
- [x] Scroll a long chat list — it scrolls and "Load more" stays pinned at the bottom, aligned with the workspace-sidebar footer.
- [x] Visit /skills, /discover, /mcp — those sidebars still scroll and keep a bottom gutter on the last item.
- [x] Click a workspace row near the Docs/Online footer in the left nav — the click lands on the row.