### PR TITLE
Link+TLS: route OAuth callbacks through the browser-trusted playground origin

### DIFF
--- a/apps/atlasd/routes/link.test.ts
+++ b/apps/atlasd/routes/link.test.ts
@@ -1,0 +1,57 @@
+import process from "node:process";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+describe("daemon /api/link proxy: X-Forwarded-* forwarding", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+    process.env.FRIDAY_ENV = "dev";
+    process.env.LINK_SERVICE_URL = "http://link.local:3100";
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    delete process.env.LINK_SERVICE_URL;
+  });
+
+  it("preserves incoming X-Forwarded-Host/Proto and appends /api/link to the prefix", async () => {
+    // Fresh import so the LINK_SERVICE_URL env we set in beforeEach is picked
+    // up (the route resolves it at module load).
+    const { linkRoutes } = await import("./link.ts?fresh-forwarded-headers");
+    const res = await linkRoutes.request(
+      "http://127.0.0.1:8080/api/link/v1/oauth/authorize/google-calendar",
+      {
+        method: "GET",
+        headers: {
+          "X-Forwarded-Host": "localhost:5200",
+          "X-Forwarded-Proto": "https",
+          "X-Forwarded-Prefix": "/api/daemon",
+        },
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalled();
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.headers.get("x-forwarded-host")).toBe("localhost:5200");
+    expect(forwarded.headers.get("x-forwarded-proto")).toBe("https");
+    // Concatenated: playground prefix + this proxy's own prefix.
+    expect(forwarded.headers.get("x-forwarded-prefix")).toBe("/api/daemon/api/link");
+  });
+
+  it("falls back to the daemon's own host when no forwarded headers are present", async () => {
+    const { linkRoutes } = await import("./link.ts?fresh-no-forwarded");
+    const res = await linkRoutes.request(
+      "https://127.0.0.1:8080/api/link/v1/oauth/authorize/google-calendar",
+      { method: "GET" },
+    );
+    expect(res.status).toBe(200);
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(forwarded.headers.get("x-forwarded-host")).toBe("127.0.0.1:8080");
+    expect(forwarded.headers.get("x-forwarded-proto")).toBe("https");
+    expect(forwarded.headers.get("x-forwarded-prefix")).toBe("/api/link");
+  });
+});

--- a/apps/atlasd/routes/link.test.ts
+++ b/apps/atlasd/routes/link.test.ts
@@ -1,12 +1,15 @@
 import process from "node:process";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { linkRoutes } from "./link.ts";
 
 describe("daemon /api/link proxy: X-Forwarded-* forwarding", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
   let originalFetch: typeof globalThis.fetch;
+  let originalFridayEnv: string | undefined;
 
   beforeEach(() => {
     originalFetch = globalThis.fetch;
+    originalFridayEnv = process.env.FRIDAY_ENV;
     fetchMock = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
     globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
     process.env.FRIDAY_ENV = "dev";
@@ -15,13 +18,15 @@ describe("daemon /api/link proxy: X-Forwarded-* forwarding", () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    if (originalFridayEnv === undefined) {
+      delete process.env.FRIDAY_ENV;
+    } else {
+      process.env.FRIDAY_ENV = originalFridayEnv;
+    }
     delete process.env.LINK_SERVICE_URL;
   });
 
   it("preserves incoming X-Forwarded-Host/Proto and appends /api/link to the prefix", async () => {
-    // Fresh import so the LINK_SERVICE_URL env we set in beforeEach is picked
-    // up (the route resolves it at module load).
-    const { linkRoutes } = await import("./link.ts?fresh-forwarded-headers");
     const res = await linkRoutes.request(
       "http://127.0.0.1:8080/api/link/v1/oauth/authorize/google-calendar",
       {
@@ -34,8 +39,8 @@ describe("daemon /api/link proxy: X-Forwarded-* forwarding", () => {
       },
     );
     expect(res.status).toBe(200);
-    expect(fetchMock).toHaveBeenCalled();
-    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const forwarded = fetchMock.mock.calls[0][0] as Request;
     expect(forwarded.headers.get("x-forwarded-host")).toBe("localhost:5200");
     expect(forwarded.headers.get("x-forwarded-proto")).toBe("https");
     // Concatenated: playground prefix + this proxy's own prefix.
@@ -43,13 +48,13 @@ describe("daemon /api/link proxy: X-Forwarded-* forwarding", () => {
   });
 
   it("falls back to the daemon's own host when no forwarded headers are present", async () => {
-    const { linkRoutes } = await import("./link.ts?fresh-no-forwarded");
     const res = await linkRoutes.request(
       "https://127.0.0.1:8080/api/link/v1/oauth/authorize/google-calendar",
       { method: "GET" },
     );
     expect(res.status).toBe(200);
-    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const forwarded = fetchMock.mock.calls[0][0] as Request;
     expect(forwarded.headers.get("x-forwarded-host")).toBe("127.0.0.1:8080");
     expect(forwarded.headers.get("x-forwarded-proto")).toBe("https");
     expect(forwarded.headers.get("x-forwarded-prefix")).toBe("/api/link");

--- a/apps/atlasd/routes/link.test.ts
+++ b/apps/atlasd/routes/link.test.ts
@@ -38,7 +38,7 @@ describe("daemon /api/link proxy: X-Forwarded-* forwarding", () => {
     );
     expect(res.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledOnce();
-    const forwarded = fetchMock.mock.calls[0][0] as Request;
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
     expect(forwarded.headers.get("x-forwarded-host")).toBe("localhost:5200");
     expect(forwarded.headers.get("x-forwarded-proto")).toBe("https");
     // Concatenated: playground prefix + this proxy's own prefix.
@@ -59,7 +59,7 @@ describe("daemon /api/link proxy: X-Forwarded-* forwarding", () => {
     );
     expect(res.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledOnce();
-    const forwarded = fetchMock.mock.calls[0][0] as Request;
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
     // Without normalization this would be "/api/daemon//api/link".
     expect(forwarded.headers.get("x-forwarded-prefix")).toBe("/api/daemon/api/link");
   });
@@ -71,7 +71,7 @@ describe("daemon /api/link proxy: X-Forwarded-* forwarding", () => {
     );
     expect(res.status).toBe(200);
     expect(fetchMock).toHaveBeenCalledOnce();
-    const forwarded = fetchMock.mock.calls[0][0] as Request;
+    const forwarded = fetchMock.mock.calls[0]?.[0] as Request;
     expect(forwarded.headers.get("x-forwarded-host")).toBe("127.0.0.1:8080");
     expect(forwarded.headers.get("x-forwarded-proto")).toBe("https");
     expect(forwarded.headers.get("x-forwarded-prefix")).toBe("/api/link");

--- a/apps/atlasd/routes/link.test.ts
+++ b/apps/atlasd/routes/link.test.ts
@@ -13,7 +13,6 @@ describe("daemon /api/link proxy: X-Forwarded-* forwarding", () => {
     fetchMock = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
     globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
     process.env.FRIDAY_ENV = "dev";
-    process.env.LINK_SERVICE_URL = "http://link.local:3100";
   });
 
   afterEach(() => {
@@ -23,7 +22,6 @@ describe("daemon /api/link proxy: X-Forwarded-* forwarding", () => {
     } else {
       process.env.FRIDAY_ENV = originalFridayEnv;
     }
-    delete process.env.LINK_SERVICE_URL;
   });
 
   it("preserves incoming X-Forwarded-Host/Proto and appends /api/link to the prefix", async () => {
@@ -44,6 +42,25 @@ describe("daemon /api/link proxy: X-Forwarded-* forwarding", () => {
     expect(forwarded.headers.get("x-forwarded-host")).toBe("localhost:5200");
     expect(forwarded.headers.get("x-forwarded-proto")).toBe("https");
     // Concatenated: playground prefix + this proxy's own prefix.
+    expect(forwarded.headers.get("x-forwarded-prefix")).toBe("/api/daemon/api/link");
+  });
+
+  it("strips a trailing slash from incoming X-Forwarded-Prefix before concatenation", async () => {
+    const res = await linkRoutes.request(
+      "http://127.0.0.1:8080/api/link/v1/oauth/authorize/google-calendar",
+      {
+        method: "GET",
+        headers: {
+          "X-Forwarded-Host": "localhost:5200",
+          "X-Forwarded-Proto": "https",
+          "X-Forwarded-Prefix": "/api/daemon/",
+        },
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const forwarded = fetchMock.mock.calls[0][0] as Request;
+    // Without normalization this would be "/api/daemon//api/link".
     expect(forwarded.headers.get("x-forwarded-prefix")).toBe("/api/daemon/api/link");
   });
 

--- a/apps/atlasd/routes/link.ts
+++ b/apps/atlasd/routes/link.ts
@@ -69,7 +69,11 @@ linkRoutes.all("/*", (c) => {
   // The prefix is concatenated so Link sees the full external path.
   const incomingHost = c.req.header("X-Forwarded-Host");
   const incomingProto = c.req.header("X-Forwarded-Proto");
-  const incomingPrefix = c.req.header("X-Forwarded-Prefix") ?? "";
+  // Strip a trailing slash so concatenation with PROXY_PREFIX (which starts
+  // with "/") doesn't produce a doubled separator. Today the only known
+  // upstream emitter (the playground proxy) never sends one, but the daemon
+  // is also reachable from tunnels / future deployments we don't control.
+  const incomingPrefix = (c.req.header("X-Forwarded-Prefix") ?? "").replace(/\/$/, "");
 
   // Use a Headers instance so the case-insensitive `.set()` semantics
   // unambiguously override incoming X-Forwarded-* values. A plain-object

--- a/apps/atlasd/routes/link.ts
+++ b/apps/atlasd/routes/link.ts
@@ -71,18 +71,20 @@ linkRoutes.all("/*", (c) => {
   const incomingProto = c.req.header("X-Forwarded-Proto");
   const incomingPrefix = c.req.header("X-Forwarded-Prefix") ?? "";
 
-  const headers: Record<string, string> = {
-    ...Object.fromEntries(c.req.raw.headers),
-    // Forwarded headers so Link can generate correct external URLs
-    "X-Forwarded-Host": incomingHost ?? originalUrl.host,
-    "X-Forwarded-Proto": incomingProto ?? originalUrl.protocol.replace(":", ""),
-    "X-Forwarded-Prefix": `${incomingPrefix}${PROXY_PREFIX}`,
-  };
+  // Use a Headers instance so the case-insensitive `.set()` semantics
+  // unambiguously override incoming X-Forwarded-* values. A plain-object
+  // spread keeps both the lowercase key (from `Object.fromEntries`) and
+  // the PascalCase override side-by-side and relies on Hono's internal
+  // iteration order in `preprocessRequestInit` to pick the right one.
+  const headers = new Headers(c.req.raw.headers);
+  headers.set("X-Forwarded-Host", incomingHost ?? originalUrl.host);
+  headers.set("X-Forwarded-Proto", incomingProto ?? originalUrl.protocol.replace(":", ""));
+  headers.set("X-Forwarded-Prefix", `${incomingPrefix}${PROXY_PREFIX}`);
 
   // Authenticate with Link using service FRIDAY_KEY (read at request time, not module load)
   const atlasKey = process.env.FRIDAY_KEY;
   if (atlasKey) {
-    headers.Authorization = `Bearer ${atlasKey}`;
+    headers.set("Authorization", `Bearer ${atlasKey}`);
   }
 
   return proxy(targetUrl, {

--- a/apps/atlasd/routes/link.ts
+++ b/apps/atlasd/routes/link.ts
@@ -61,12 +61,22 @@ linkRoutes.all("/*", (c) => {
 
   const originalUrl = new URL(c.req.url);
 
+  // Preserve forwarded headers from an upstream proxy (e.g. the
+  // playground dev server at https://localhost:5200/api/daemon/*). Without
+  // this, Link emits callback URLs pointing at the daemon's s2s TLS
+  // listener (https://localhost:8080), which uses a non-browser-trusted
+  // cert — the OAuth provider redirect lands on ERR_CERT_AUTHORITY_INVALID.
+  // The prefix is concatenated so Link sees the full external path.
+  const incomingHost = c.req.header("X-Forwarded-Host");
+  const incomingProto = c.req.header("X-Forwarded-Proto");
+  const incomingPrefix = c.req.header("X-Forwarded-Prefix") ?? "";
+
   const headers: Record<string, string> = {
     ...Object.fromEntries(c.req.raw.headers),
     // Forwarded headers so Link can generate correct external URLs
-    "X-Forwarded-Host": originalUrl.host,
-    "X-Forwarded-Proto": originalUrl.protocol.replace(":", ""),
-    "X-Forwarded-Prefix": PROXY_PREFIX,
+    "X-Forwarded-Host": incomingHost ?? originalUrl.host,
+    "X-Forwarded-Proto": incomingProto ?? originalUrl.protocol.replace(":", ""),
+    "X-Forwarded-Prefix": `${incomingPrefix}${PROXY_PREFIX}`,
   };
 
   // Authenticate with Link using service FRIDAY_KEY (read at request time, not module load)

--- a/apps/atlasd/routes/me/index.ts
+++ b/apps/atlasd/routes/me/index.ts
@@ -6,7 +6,15 @@ import { daemonFactory } from "../../src/factory.ts";
 import { getCurrentUser, updateCurrentUser } from "./adapter.ts";
 import { deletePhoto, getPhoto, savePhoto, validatePhoto } from "./photo-storage.ts";
 
-/** Derive the external-facing origin, respecting reverse-proxy headers. */
+/** Derive the external-facing origin, respecting reverse-proxy headers.
+ *
+ * Header source in dev: tools/agent-playground/src/lib/server/proxy.ts
+ * stamps `x-forwarded-host` = playground origin (localhost:5200) so the
+ * persisted profile-photo URL is browser-reachable through the
+ * browser-trusted cert, not the daemon's s2s listener. Trust on this
+ * endpoint is enforced by session-cookie auth — the X-Forwarded-* values
+ * are not authenticated, so they MUST NOT be used for authorization
+ * decisions, only for synthesizing reply URLs. */
 function getExternalOrigin(c: Context): string {
   const proto = c.req.header("x-forwarded-proto") ?? new URL(c.req.url).protocol.replace(":", "");
   const host = c.req.header("x-forwarded-host") ?? new URL(c.req.url).host;

--- a/packages/jetstream/src/connect.test.ts
+++ b/packages/jetstream/src/connect.test.ts
@@ -98,7 +98,12 @@ describe("connectOrSpawn — URL-file rendezvous (source: url-file)", () => {
     }
   });
 
-  it("falls through to spawn when the URL file points at a dead broker", async () => {
+  // Timeout: two nats-server spawns + a stop with up to 3s SIGTERM grace
+  // can exceed vitest's 5s default on cold CI runners. Sequence:
+  // spawn (~2s) → stop (~3s) → tcpProbe (500ms) → fresh spawn (~2s).
+  it("falls through to spawn when the URL file points at a dead broker", {
+    timeout: 20_000,
+  }, async () => {
     // Spawn + stop a broker, then write its now-dead URL to the file.
     // connectOrSpawn must detect the stale URL (TCP probe fails) and
     // spawn a fresh broker. spawnFallback defaults to true.

--- a/tools/agent-playground/src/lib/server/proxy.hono.test.ts
+++ b/tools/agent-playground/src/lib/server/proxy.hono.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Wrapper-specific tests for `buildHonoProxy` — the variant used by the
+ * compiled `playground` binary (`static-server.ts`). Full header / redirect
+ * / SSE coverage lives in `proxy.test.ts` (both wrappers share
+ * `executeProxyFetch`). These tests pin only what the Hono wrapper adds:
+ * prefix-stripping path construction and that OAuth-critical semantics
+ * reach the upstream when invoked through this wrapper.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { buildHonoProxy } from "./proxy.ts";
+
+describe("buildHonoProxy (compiled binary wrapper)", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchMock = vi.fn().mockResolvedValue(new Response("ok", { status: 200 }));
+    globalThis.fetch = fetchMock as unknown as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function call(prefix: string, upstream: string, label: string, url: string) {
+    const handler = buildHonoProxy(prefix, upstream, label);
+    const request = new Request(url, { method: "GET" });
+    return handler({ req: { url: request.url, raw: request } });
+  }
+
+  it("strips the prefix from the path and forwards to the upstream", async () => {
+    await call(
+      "/api/daemon",
+      "https://daemon.local:8080",
+      "daemon",
+      "https://localhost:5200/api/daemon/api/workspaces/x?foo=1",
+    );
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const target = fetchMock.mock.calls[0][0] as URL;
+    expect(target.toString()).toBe("https://daemon.local:8080/api/workspaces/x?foo=1");
+  });
+
+  it("delegates OAuth-critical semantics (X-Forwarded-* + redirect:manual) to executeProxyFetch", async () => {
+    await call(
+      "/api/daemon",
+      "https://daemon.local:8080",
+      "daemon",
+      "https://localhost:5200/api/daemon/api/link/v1/oauth/authorize/google-calendar",
+    );
+    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    expect(init.redirect).toBe("manual");
+    const headers = init.headers as Headers;
+    expect(headers.get("x-forwarded-host")).toBe("localhost:5200");
+    expect(headers.get("x-forwarded-proto")).toBe("https");
+    expect(headers.get("x-forwarded-prefix")).toBe("/api/daemon");
+  });
+});

--- a/tools/agent-playground/src/lib/server/proxy.hono.test.ts
+++ b/tools/agent-playground/src/lib/server/proxy.hono.test.ts
@@ -37,7 +37,7 @@ describe("buildHonoProxy (compiled binary wrapper)", () => {
       "https://localhost:5200/api/daemon/api/workspaces/x?foo=1",
     );
     expect(fetchMock).toHaveBeenCalledOnce();
-    const target = fetchMock.mock.calls[0][0] as URL;
+    const target = fetchMock.mock.calls[0]?.[0] as URL;
     expect(target.toString()).toBe("https://daemon.local:8080/api/workspaces/x?foo=1");
   });
 
@@ -48,7 +48,7 @@ describe("buildHonoProxy (compiled binary wrapper)", () => {
       "daemon",
       "https://localhost:5200/api/daemon/api/link/v1/oauth/authorize/google-calendar",
     );
-    const init = fetchMock.mock.calls[0][1] as RequestInit;
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
     expect(init.redirect).toBe("manual");
     const headers = init.headers as Headers;
     expect(headers.get("x-forwarded-host")).toBe("localhost:5200");

--- a/tools/agent-playground/src/lib/server/proxy.test.ts
+++ b/tools/agent-playground/src/lib/server/proxy.test.ts
@@ -109,6 +109,43 @@ describe("buildProxyHandler", () => {
     expect(await res.text()).toBe("data: hello\n\n");
   });
 
+  it("sets X-Forwarded-* so upstream services emit browser-reachable URLs", async () => {
+    // Regression: Link generates OAuth callback URLs from X-Forwarded-Host.
+    // Without these headers it defaults to the daemon's s2s host
+    // (localhost:8080), whose cert is not browser-trusted, breaking the
+    // OAuth-provider → browser callback step.
+    fetchMock.mockResolvedValueOnce(new Response("ok", { status: 200 }));
+    const handler = buildProxyHandler({ upstream: "https://daemon.local:8080", label: "daemon" });
+    await handler(
+      event({
+        path: "api/link/v1/oauth/authorize/google-calendar",
+        url: "https://localhost:5200/api/daemon/api/link/v1/oauth/authorize/google-calendar",
+      }),
+    );
+    const forwardedHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
+    expect(forwardedHeaders.get("x-forwarded-host")).toBe("localhost:5200");
+    expect(forwardedHeaders.get("x-forwarded-proto")).toBe("https");
+    expect(forwardedHeaders.get("x-forwarded-prefix")).toBe("/api/daemon");
+  });
+
+  it("forwards 3xx redirects to the client instead of following them upstream", async () => {
+    // Regression: OAuth flows (e.g. Link → Google authorize) depend on the
+    // browser navigating the popup to accounts.google.com itself. If the SSR
+    // proxy follows the Location header, the browser stays on localhost:5200
+    // and renders Google's HTML under the wrong origin (CSP / CORS dies).
+    fetchMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: "https://accounts.google.com/o/oauth2/v2/auth?x=1" },
+      }),
+    );
+    const handler = buildProxyHandler({ upstream: "https://daemon.local:8080", label: "daemon" });
+    const res = await handler(event({ path: "api/link/v1/oauth/authorize/google-calendar" }));
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("https://accounts.google.com/o/oauth2/v2/auth?x=1");
+    expect(fetchMock.mock.calls[0]?.[1]?.redirect).toBe("manual");
+  });
+
   it("aborts the upstream fetch when the client aborts", async () => {
     let abortedSignal: AbortSignal | undefined;
     fetchMock.mockImplementation((_url, init) => {

--- a/tools/agent-playground/src/lib/server/proxy.ts
+++ b/tools/agent-playground/src/lib/server/proxy.ts
@@ -79,8 +79,98 @@ export function proxyAbortableBody(
 export interface BuildProxyOptions {
   /** Absolute URL of the upstream service (daemon or tunnel). */
   upstream: string;
-  /** Short label used in 502 error bodies — "daemon" or "tunnel". */
+  /** Short label used in 502 error bodies and X-Forwarded-Prefix —
+   * "daemon" or "tunnel". */
   label: string;
+}
+
+/** Core reverse-proxy execution: forwards `request` to `target`, sets
+ * X-Forwarded-* + `redirect: "manual"`, strips hop-by-hop headers, and
+ * preserves SSE / abort semantics. Shared by `buildProxyHandler`
+ * (SvelteKit dev hook) and `static-server.ts:buildProxy` (the compiled
+ * playground binary) so both paths can't drift again on header / redirect
+ * semantics — see `static-server.ts:buildProxy` for the binary wrapper.
+ *
+ * Defense-in-depth: this is an unauthenticated pass-through. Any caller
+ * who reaches the playground origin can inject X-Forwarded-Host. Trust
+ * is enforced individually by each downstream consumer, e.g.:
+ *   - `apps/atlasd/routes/link.ts` — dev-only middleware
+ *   - `apps/atlasd/routes/me/index.ts:10-12` — session-cookie auth on
+ *     reads, but persists the resolved URL to user records, so the host
+ *     becomes sticky
+ * Keep this function dumb — new daemon endpoints consuming these headers
+ * must enforce trust on their own boundary, not here.
+ */
+export async function executeProxyFetch(
+  target: URL,
+  request: Request,
+  label: string,
+): Promise<Response> {
+  const headers = new Headers(request.headers);
+  headers.delete("host");
+  headers.delete("content-length");
+
+  // Tell the upstream where the browser actually lives. Required for
+  // services like Link that synthesize external callback URLs from
+  // X-Forwarded-* — otherwise they emit URLs pointing at the upstream's
+  // own s2s listener (cert not browser-trusted → ERR_CERT_AUTHORITY_INVALID
+  // when the OAuth provider redirects the browser back).
+  const incoming = new URL(request.url);
+  headers.set("x-forwarded-host", incoming.host);
+  headers.set("x-forwarded-proto", incoming.protocol.replace(":", ""));
+  headers.set("x-forwarded-prefix", `/api/${label}`);
+
+  const upstreamController = new AbortController();
+  const abortUpstream = () => upstreamController.abort();
+  request.signal.addEventListener("abort", abortUpstream, { once: true });
+
+  // Buffer the request body for methods that carry one. Streaming with
+  // `duplex: "half"` races the response: when the upstream short-
+  // circuits (e.g. 401 before consuming the body) the in-flight body
+  // sender can error with `TypeError: fetch failed`, swallowing the
+  // upstream's real status code.
+  let body: BodyInit | null = null;
+  if (request.method !== "GET" && request.method !== "HEAD") {
+    body = new Uint8Array(await request.arrayBuffer());
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(target, {
+      method: request.method,
+      headers,
+      body,
+      signal: upstreamController.signal,
+      // Forward 3xx as-is. Node's fetch defaults to redirect: "follow",
+      // which silently walks Location headers on the SSR side — fatal
+      // for OAuth, where the browser must navigate to accounts.google.com
+      // itself, not receive Google's HTML rendered under localhost:5200.
+      redirect: "manual",
+    });
+  } catch (err) {
+    request.signal.removeEventListener("abort", abortUpstream);
+    const message = err instanceof Error ? err.message : String(err);
+    return new Response(
+      JSON.stringify({ error: `${label} proxy fetch failed: ${message}` }),
+      { status: 502, headers: { "content-type": "application/json" } },
+    );
+  }
+
+  const responseHeaders = new Headers(res.headers);
+  for (const h of HOP_BY_HOP_HEADERS) responseHeaders.delete(h);
+
+  if (res.headers.get("content-type")?.includes("text/event-stream")) {
+    if (!res.body) {
+      request.signal.removeEventListener("abort", abortUpstream);
+      return new Response(null, { status: res.status, headers: responseHeaders });
+    }
+    request.signal.removeEventListener("abort", abortUpstream);
+    const stream = proxyAbortableBody(res.body, request.signal, abortUpstream);
+    return new Response(stream, { status: res.status, headers: responseHeaders });
+  }
+
+  request.signal.removeEventListener("abort", abortUpstream);
+  return new Response(res.body, { status: res.status, headers: responseHeaders });
 }
 
 /** Build a SvelteKit `RequestHandler` that reverse-proxies the path
@@ -92,78 +182,22 @@ export function buildProxyHandler({ upstream, label }: BuildProxyOptions): Reque
     const path = params.path ?? "";
     const target = new URL(`/${path}`, upstream);
     target.search = new URL(request.url).search;
+    return executeProxyFetch(target, request, label);
+  };
+}
 
-    const headers = new Headers(request.headers);
-    headers.delete("host");
-    headers.delete("content-length");
-
-    // Tell the upstream where the browser actually lives. Required for
-    // services like Link that synthesize external callback URLs from
-    // X-Forwarded-* — otherwise they emit URLs pointing at the upstream's
-    // own s2s listener (cert not browser-trusted → ERR_CERT_AUTHORITY_INVALID
-    // when the OAuth provider redirects the browser back).
-    //
-    // Defense-in-depth: this is an unauthenticated pass-through. Any caller
-    // who reaches the playground origin can inject X-Forwarded-Host. Trust
-    // is gated downstream at apps/atlasd/src/dev-only.ts (Link proxy is
-    // dev-mode-only). Keep this handler dumb — do NOT add validation that
-    // would let new daemon endpoints start trusting these headers
-    // unconditionally.
-    const incoming = new URL(request.url);
-    headers.set("x-forwarded-host", incoming.host);
-    headers.set("x-forwarded-proto", incoming.protocol.replace(":", ""));
-    headers.set("x-forwarded-prefix", `/api/${label}`);
-
-    const upstreamController = new AbortController();
-    const abortUpstream = () => upstreamController.abort();
-    request.signal.addEventListener("abort", abortUpstream, { once: true });
-
-    // Buffer the request body for methods that carry one. Streaming with
-    // `duplex: "half"` races the response: when the upstream short-
-    // circuits (e.g. 401 before consuming the body) the in-flight body
-    // sender can error with `TypeError: fetch failed`, swallowing the
-    // upstream's real status code.
-    let body: BodyInit | null = null;
-    if (request.method !== "GET" && request.method !== "HEAD") {
-      body = new Uint8Array(await request.arrayBuffer());
-    }
-
-    let res: Response;
-    try {
-      res = await fetch(target, {
-        method: request.method,
-        headers,
-        body,
-        signal: upstreamController.signal,
-        // Forward 3xx as-is. Node's fetch defaults to redirect: "follow",
-        // which silently walks Location headers on the SSR side — fatal
-        // for OAuth, where the browser must navigate to accounts.google.com
-        // itself, not receive Google's HTML rendered under localhost:5200.
-        redirect: "manual",
-      });
-    } catch (err) {
-      request.signal.removeEventListener("abort", abortUpstream);
-      const message = err instanceof Error ? err.message : String(err);
-      return new Response(
-        JSON.stringify({ error: `${label} proxy fetch failed: ${message}` }),
-        { status: 502, headers: { "content-type": "application/json" } },
-      );
-    }
-
-    const responseHeaders = new Headers(res.headers);
-    for (const h of HOP_BY_HOP_HEADERS) responseHeaders.delete(h);
-
-    if (res.headers.get("content-type")?.includes("text/event-stream")) {
-      if (!res.body) {
-        request.signal.removeEventListener("abort", abortUpstream);
-        return new Response(null, { status: res.status, headers: responseHeaders });
-      }
-      request.signal.removeEventListener("abort", abortUpstream);
-      const stream = proxyAbortableBody(res.body, request.signal, abortUpstream);
-      return new Response(stream, { status: res.status, headers: responseHeaders });
-    }
-
-    request.signal.removeEventListener("abort", abortUpstream);
-    return new Response(res.body, { status: res.status, headers: responseHeaders });
+/** Build a Hono handler that reverse-proxies requests matching `prefix` to
+ * the upstream service. Used by the compiled `playground` binary
+ * (`static-server.ts`) where the SvelteKit dev server is unavailable and
+ * Hono mounts the `/api/{daemon,tunnel}/*` routes directly. Lives here
+ * (next to `buildProxyHandler` + `executeProxyFetch`) so both runtimes
+ * share the same OAuth-critical semantics and can be exercised by a
+ * single Node-compatible test suite. */
+export function buildHonoProxy(prefix: string, upstream: string, label: string) {
+  return (c: { req: { url: string; raw: Request } }) => {
+    const url = new URL(c.req.url);
+    const path = url.pathname.replace(new RegExp(`^${prefix}`), "");
+    const target = new URL(path + url.search, upstream);
+    return executeProxyFetch(target, c.req.raw, label);
   };
 }

--- a/tools/agent-playground/src/lib/server/proxy.ts
+++ b/tools/agent-playground/src/lib/server/proxy.ts
@@ -178,7 +178,7 @@ export async function executeProxyFetch(
  * route) to the upstream service. Used by both `/api/daemon/*` and
  * `/api/tunnel/*` so they stay behaviorally identical. */
 export function buildProxyHandler({ upstream, label }: BuildProxyOptions): RequestHandler {
-  return async ({ params, request }) => {
+  return ({ params, request }) => {
     const path = params.path ?? "";
     const target = new URL(`/${path}`, upstream);
     target.search = new URL(request.url).search;

--- a/tools/agent-playground/src/lib/server/proxy.ts
+++ b/tools/agent-playground/src/lib/server/proxy.ts
@@ -97,6 +97,16 @@ export function buildProxyHandler({ upstream, label }: BuildProxyOptions): Reque
     headers.delete("host");
     headers.delete("content-length");
 
+    // Tell the upstream where the browser actually lives. Required for
+    // services like Link that synthesize external callback URLs from
+    // X-Forwarded-* — otherwise they emit URLs pointing at the upstream's
+    // own s2s listener (cert not browser-trusted → ERR_CERT_AUTHORITY_INVALID
+    // when the OAuth provider redirects the browser back).
+    const incoming = new URL(request.url);
+    headers.set("x-forwarded-host", incoming.host);
+    headers.set("x-forwarded-proto", incoming.protocol.replace(":", ""));
+    headers.set("x-forwarded-prefix", `/api/${label}`);
+
     const upstreamController = new AbortController();
     const abortUpstream = () => upstreamController.abort();
     request.signal.addEventListener("abort", abortUpstream, { once: true });
@@ -118,6 +128,11 @@ export function buildProxyHandler({ upstream, label }: BuildProxyOptions): Reque
         headers,
         body,
         signal: upstreamController.signal,
+        // Forward 3xx as-is. Node's fetch defaults to redirect: "follow",
+        // which silently walks Location headers on the SSR side — fatal
+        // for OAuth, where the browser must navigate to accounts.google.com
+        // itself, not receive Google's HTML rendered under localhost:5200.
+        redirect: "manual",
       });
     } catch (err) {
       request.signal.removeEventListener("abort", abortUpstream);

--- a/tools/agent-playground/src/lib/server/proxy.ts
+++ b/tools/agent-playground/src/lib/server/proxy.ts
@@ -102,6 +102,13 @@ export function buildProxyHandler({ upstream, label }: BuildProxyOptions): Reque
     // X-Forwarded-* — otherwise they emit URLs pointing at the upstream's
     // own s2s listener (cert not browser-trusted → ERR_CERT_AUTHORITY_INVALID
     // when the OAuth provider redirects the browser back).
+    //
+    // Defense-in-depth: this is an unauthenticated pass-through. Any caller
+    // who reaches the playground origin can inject X-Forwarded-Host. Trust
+    // is gated downstream at apps/atlasd/src/dev-only.ts (Link proxy is
+    // dev-mode-only). Keep this handler dumb — do NOT add validation that
+    // would let new daemon endpoints start trusting these headers
+    // unconditionally.
     const incoming = new URL(request.url);
     headers.set("x-forwarded-host", incoming.host);
     headers.set("x-forwarded-proto", incoming.protocol.replace(":", ""));

--- a/tools/agent-playground/static-server.ts
+++ b/tools/agent-playground/static-server.ts
@@ -12,6 +12,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { Hono } from "hono";
 import { serveStatic } from "hono/deno";
+import { buildHonoProxy } from "./src/lib/server/proxy.ts";
 import { api } from "./src/lib/server/router.ts";
 import { resolveBrowserTlsPaths } from "./tls-paths.ts";
 
@@ -43,56 +44,6 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const BUILD_ROOT = join(HERE, "build");
 const INDEX_HTML = join(BUILD_ROOT, "index.html");
 
-function proxyAbortableBody(
-  body: ReadableStream<Uint8Array>,
-  requestSignal: AbortSignal,
-  abortUpstream: () => void,
-): ReadableStream<Uint8Array> {
-  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
-  let cancelled = false;
-
-  const cancelUpstream = () => {
-    if (cancelled) return;
-    cancelled = true;
-    abortUpstream();
-    void reader?.cancel().catch(() => {
-      // The upstream may already be gone.
-    });
-  };
-
-  return new ReadableStream<Uint8Array>({
-    start(controller) {
-      reader = body.getReader();
-      requestSignal.addEventListener("abort", cancelUpstream, { once: true });
-      if (requestSignal.aborted) cancelUpstream();
-
-      void (async () => {
-        try {
-          while (!cancelled) {
-            const { done, value } = await reader!.read();
-            if (done) break;
-            controller.enqueue(value);
-          }
-          if (!cancelled) controller.close();
-        } catch (err) {
-          if (!cancelled) controller.error(err);
-        } finally {
-          requestSignal.removeEventListener("abort", cancelUpstream);
-          try {
-            reader?.releaseLock();
-          } catch {
-            // Reader may already be released after cancellation.
-          }
-          abortUpstream();
-        }
-      })();
-    },
-    cancel() {
-      cancelUpstream();
-    },
-  });
-}
-
 // Reverse proxy for browser → local service. The SvelteKit dev server has
 // per-route versions of this under src/routes/api/{daemon,tunnel}/[...path]/,
 // but adapter-static strips all server routes — the production binary has
@@ -100,91 +51,13 @@ function proxyAbortableBody(
 // /api/daemon/api/workspaces/X falls through to the SPA fallback returning
 // index.html, surfacing as "Unexpected token '<', '<!doctype' is not valid
 // JSON" on every page that loads workspace config.
-function buildProxy(prefix: string, upstream: string, label: string) {
-  return async (c: { req: { url: string; method: string; raw: Request } }) => {
-    const url = new URL(c.req.url);
-    const path = url.pathname.replace(new RegExp(`^${prefix}`), "");
-    const target = new URL(path + url.search, upstream);
-
-    const headers = new Headers(c.req.raw.headers);
-    headers.delete("host");
-    headers.delete("content-length");
-
-    // Buffer the request body for methods that carry one. Streaming with
-    // `duplex: "half"` races the response: when the upstream short-circuits
-    // (e.g. 401 before consuming the body) the in-flight body sender can
-    // error with `TypeError: fetch failed`, swallowing the real status code.
-    let body: BodyInit | null = null;
-    if (c.req.method !== "GET" && c.req.method !== "HEAD") {
-      body = new Uint8Array(await c.req.raw.arrayBuffer());
-    }
-
-    const upstreamController = new AbortController();
-    const abortUpstream = () => upstreamController.abort();
-    c.req.raw.signal.addEventListener("abort", abortUpstream, { once: true });
-
-    let res: Response;
-    try {
-      res = await fetch(target, {
-        method: c.req.method,
-        headers,
-        body,
-        signal: upstreamController.signal,
-      });
-    } catch (err) {
-      c.req.raw.signal.removeEventListener("abort", abortUpstream);
-      const message = err instanceof Error ? err.message : String(err);
-      return new Response(JSON.stringify({ error: `${label} proxy fetch failed: ${message}` }), {
-        status: 502,
-        headers: { "content-type": "application/json" },
-      });
-    }
-
-    // Strip headers that don't survive the proxy / HTTP/2 boundary:
-    //  - content-encoding: fetch() already decompressed; forwarding makes
-    //    the browser double-decompress.
-    //  - content-length: chunked re-encoding may invalidate it.
-    //  - HTTP/1.1 connection-specific headers: when this binary serves TLS
-    //    (https://) the Deno HTTP server negotiates h2 with the browser;
-    //    h2 forbids `transfer-encoding`, `connection`, etc. The upstream
-    //    is h1.1, so its responses carry these — drop them.
-    const responseHeaders = new Headers(res.headers);
-    for (const h of [
-      "content-encoding",
-      "content-length",
-      "transfer-encoding",
-      "connection",
-      "keep-alive",
-      "upgrade",
-      "proxy-connection",
-      "te",
-      "trailer",
-    ]) {
-      responseHeaders.delete(h);
-    }
-
-    // SSE: pass the body stream through unbuffered so live event streams
-    // don't get held up at our proxy boundary. Wrap the body so browser
-    // disconnects cancel the upstream fetch instead of leaving
-    // subscriptions and file descriptors open behind the proxy.
-    if (res.headers.get("content-type")?.includes("text/event-stream")) {
-      if (!res.body) {
-        c.req.raw.signal.removeEventListener("abort", abortUpstream);
-        return new Response(null, { status: res.status, headers: responseHeaders });
-      }
-      c.req.raw.signal.removeEventListener("abort", abortUpstream);
-      const stream = proxyAbortableBody(res.body, c.req.raw.signal, abortUpstream);
-      return new Response(stream, { status: res.status, headers: responseHeaders });
-    }
-
-    c.req.raw.signal.removeEventListener("abort", abortUpstream);
-    return new Response(res.body, { status: res.status, headers: responseHeaders });
-  };
-}
-
+//
+// All header rewriting, X-Forwarded-* injection, redirect: "manual",
+// SSE + abort handling lives in `src/lib/server/proxy.ts` so the dev hook
+// and this binary share a single implementation (and a single test suite).
 const proxies = new Hono()
-  .all("/api/daemon/*", buildProxy("/api/daemon", DAEMON_URL, "daemon"))
-  .all("/api/tunnel/*", buildProxy("/api/tunnel", TUNNEL_URL, "tunnel"));
+  .all("/api/daemon/*", buildHonoProxy("/api/daemon", DAEMON_URL, "daemon"))
+  .all("/api/tunnel/*", buildHonoProxy("/api/tunnel", TUNNEL_URL, "tunnel"));
 
 let CACHED_HTML: string | null = null;
 async function indexHtml(): Promise<string> {


### PR DESCRIPTION
## Summary

OAuth (Google Calendar, Gmail, etc.) was broken end-to-end after the s2s/browser TLS split (#243, #300, #306). The daemon's listener cert is intentionally not browser-trusted — browser traffic to the daemon must flow through the playground proxy at `https://localhost:5200/api/daemon/*`. Two latent bugs in that proxy chain killed the flow at two different stages:

**Stage 1 — Vite proxy followed Link's 302 itself.** `tools/agent-playground/src/lib/server/proxy.ts` called `fetch()` with the default `redirect: \"follow\"`, so when Link returned `302 Location: https://accounts.google.com/...` the SSR proxy walked the redirect, downloaded Google's sign-in HTML, and returned it under `localhost:5200`. The browser stayed on the playground origin while rendering Google's page — CSP `base-uri 'self'` blocked the `<base>` tag, gstatic.com scripts failed CORS, and the \"Next\" button never came alive.

**Stage 2 — daemon's Link proxy clobbered `X-Forwarded-*`.** `apps/atlasd/routes/link.ts` unconditionally overwrote any incoming forwarded headers with the daemon's own host, and the playground proxy never set them. Link computed `externalBaseUrl = https://localhost:8080/api/link` and registered the OAuth callback there. After Google completed auth, the Cloud Function redirected the browser straight at the daemon's s2s cert → `NET::ERR_CERT_AUTHORITY_INVALID`.

## Fixes

- **`tools/agent-playground/src/lib/server/proxy.ts`**: pass `redirect: \"manual\"` to upstream `fetch`, and set `X-Forwarded-Host` / `Proto` / `Prefix` (with `Prefix = /api/${label}`) so daemon + tunnel proxies both work.
- **`apps/atlasd/routes/link.ts`**: preserve incoming `X-Forwarded-Host` / `Proto` if present, and **concatenate** the incoming prefix with this proxy's own (`/api/daemon` + `/api/link` → `/api/daemon/api/link`). Falls back to the daemon's own host when no upstream proxy is involved (preserves direct daemon-internal callers).

Net effect: Link now emits `https://localhost:5200/api/daemon/api/link/v1/callback/<provider>`, which uses the mkcert browser-trusted cert and routes back through the playground proxy to Link.

## Test plan

- [x] `deno task test src/lib/server/proxy.test.ts` — new regression tests assert `redirect: \"manual\"` and that `X-Forwarded-*` are set
- [x] `deno task test apps/atlasd/routes/link.test.ts` — new tests for prefix concatenation and direct-call fallback
- [x] `deno task test apps/atlasd/routes/ tools/agent-playground/src/lib/server/` — 41 files, 790 tests pass
- [ ] Manual: `deno task dev:playground` → open Settings → connect Google Calendar → OAuth completes back to localhost:5200 without cert warning