### PR TITLE
Workspace chat now reflects its own config changes mid-session

### DIFF
--- a/apps/atlasd/routes/workspaces/index.test.ts
+++ b/apps/atlasd/routes/workspaces/index.test.ts
@@ -175,6 +175,24 @@ describe("POST /workspaces/:workspaceId/signals/:signalId envelope guard", () =>
     expect(triggerWorkspaceSignal).not.toHaveBeenCalled();
   });
 
+  test("rejects a bare payload on the SSE handler too (Accept: text/event-stream)", async () => {
+    // The SSE handler is a separate `.post` registration dispatched by the
+    // accept header — it reads rawBody directly, so its guard branch needs
+    // its own coverage.
+    const { app, triggerWorkspaceSignal } = createTestApp();
+    const res = await post(
+      app,
+      "/workspaces/ws-1/signals/sig-1",
+      { input: "hello" },
+      { Accept: "text/event-stream" },
+    );
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('{"payload"');
+    expect(triggerWorkspaceSignal).not.toHaveBeenCalled();
+  });
+
   test("allows a properly enveloped body through the guard", async () => {
     const previous = process.env[INTERNAL_SIGNAL_BYPASS_TOKEN_ENV];
     process.env[INTERNAL_SIGNAL_BYPASS_TOKEN_ENV] = "test-token";

--- a/apps/atlasd/routes/workspaces/index.test.ts
+++ b/apps/atlasd/routes/workspaces/index.test.ts
@@ -152,6 +152,70 @@ describe("POST /workspaces/:workspaceId/signals/:signalId bypass guard", () => {
   });
 });
 
+describe("POST /workspaces/:workspaceId/signals/:signalId envelope guard", () => {
+  test("rejects a bare (un-enveloped) payload with a clear envelope error", async () => {
+    const { app, triggerWorkspaceSignal } = createTestApp();
+    const res = await post(app, "/workspaces/ws-1/signals/sig-1", { input: "hello" });
+
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain('{"payload"');
+    expect(body.error).toContain("input");
+    expect(triggerWorkspaceSignal).not.toHaveBeenCalled();
+  });
+
+  test("rejects stray keys even when a valid envelope key is also present", async () => {
+    const { app, triggerWorkspaceSignal } = createTestApp();
+    const res = await post(app, "/workspaces/ws-1/signals/sig-1", {
+      streamId: "stream-1",
+      input: "hello",
+    });
+
+    expect(res.status).toBe(400);
+    expect(triggerWorkspaceSignal).not.toHaveBeenCalled();
+  });
+
+  test("allows a properly enveloped body through the guard", async () => {
+    const previous = process.env[INTERNAL_SIGNAL_BYPASS_TOKEN_ENV];
+    process.env[INTERNAL_SIGNAL_BYPASS_TOKEN_ENV] = "test-token";
+    try {
+      const { app, triggerWorkspaceSignal } = createTestApp();
+      const res = await post(
+        app,
+        "/workspaces/ws-1/signals/sig-1",
+        { payload: { input: "hello" }, bypassConcurrency: true },
+        { [INTERNAL_SIGNAL_BYPASS_HEADER]: "test-token" },
+      );
+
+      expect(res.status).toBe(200);
+      expect(triggerWorkspaceSignal).toHaveBeenCalledOnce();
+    } finally {
+      if (previous === undefined) delete process.env[INTERNAL_SIGNAL_BYPASS_TOKEN_ENV];
+      else process.env[INTERNAL_SIGNAL_BYPASS_TOKEN_ENV] = previous;
+    }
+  });
+
+  test("allows an empty body — no-payload signal triggers stay valid", async () => {
+    const previous = process.env[INTERNAL_SIGNAL_BYPASS_TOKEN_ENV];
+    process.env[INTERNAL_SIGNAL_BYPASS_TOKEN_ENV] = "test-token";
+    try {
+      const { app, triggerWorkspaceSignal } = createTestApp();
+      const res = await post(
+        app,
+        "/workspaces/ws-1/signals/sig-1",
+        { bypassConcurrency: true },
+        { [INTERNAL_SIGNAL_BYPASS_HEADER]: "test-token" },
+      );
+
+      expect(res.status).toBe(200);
+      expect(triggerWorkspaceSignal).toHaveBeenCalledOnce();
+    } finally {
+      if (previous === undefined) delete process.env[INTERNAL_SIGNAL_BYPASS_TOKEN_ENV];
+      else process.env[INTERNAL_SIGNAL_BYPASS_TOKEN_ENV] = previous;
+    }
+  });
+});
+
 describe("POST /workspaces/add validation", () => {
   test("rejects missing path", async () => {
     const { app } = createTestApp();

--- a/apps/atlasd/routes/workspaces/index.ts
+++ b/apps/atlasd/routes/workspaces/index.ts
@@ -236,6 +236,50 @@ function rejectUnauthorizedSignalBypass() {
   return { error: "bypassConcurrency is internal to workspace-chat job tools" };
 }
 
+/**
+ * Envelope keys recognized on a signal-trigger request body. Anything else at
+ * the top level is almost certainly a bare (un-enveloped) payload — see
+ * {@link detectUnwrappedSignalBody}.
+ */
+const SIGNAL_ENVELOPE_KEYS = new Set([
+  "payload",
+  "streamId",
+  "skipStates",
+  "bypassConcurrency",
+  "parentSessionId",
+]);
+
+/**
+ * Catch the most common signal-trigger mistake: POSTing the bare payload
+ * (`{"input": "hi"}`) instead of the required envelope
+ * (`{"payload": {"input": "hi"}}`).
+ *
+ * Without this guard the bare body still parses cleanly — every field of
+ * {@link signalBodySchema} is optional — leaving `payload` undefined. That
+ * `undefined` then surfaces downstream as a misleading "expected <type>,
+ * received undefined → at <field>" error that points at the signal's own
+ * schema rather than the missing envelope, sending callers hunting for a
+ * payload bug that doesn't exist.
+ *
+ * Returns a caller-facing error message when the body looks un-enveloped, or
+ * null when it's a valid envelope or a legitimately empty body (no-payload
+ * signal triggers stay valid).
+ */
+function detectUnwrappedSignalBody(rawBody: unknown): string | null {
+  if (rawBody === null || typeof rawBody !== "object" || Array.isArray(rawBody)) {
+    return null;
+  }
+  const body = rawBody as Record<string, unknown>;
+  if (body.payload !== undefined) return null;
+  const strayKeys = Object.keys(body).filter((k) => !SIGNAL_ENVELOPE_KEYS.has(k));
+  if (strayKeys.length === 0) return null;
+  return (
+    `Signal body must wrap the payload: {"payload": {...}}. ` +
+    `Received un-enveloped top-level key(s): ${strayKeys.join(", ")} — ` +
+    `wrap them as {"payload": {${strayKeys.map((k) => `"${k}": ...`).join(", ")}}}.`
+  );
+}
+
 const signalBodySchema = z.object({
   payload: z.record(z.string(), z.unknown()).optional(),
   streamId: z.string().optional(),
@@ -1666,6 +1710,10 @@ const workspacesRoutes = daemonFactory
       return c.json({ error: bodyResult.error.message }, 400);
     }
     const body = bodyResult.data;
+    if (body.payload === undefined) {
+      const envelopeError = detectUnwrappedSignalBody(rawBody);
+      if (envelopeError) return c.json({ error: envelopeError }, 400);
+    }
     const ctx = c.get("app");
 
     // Pre-stream validation: return HTTP error before committing to SSE stream
@@ -2017,6 +2065,12 @@ const workspacesRoutes = daemonFactory
         parentSessionId,
         bypassConcurrency,
       } = c.req.valid("json");
+      if (payload === undefined) {
+        // Hono caches the parsed body — re-reading here is the same object
+        // zValidator already consumed, just with unknown keys still visible.
+        const envelopeError = detectUnwrappedSignalBody(await c.req.json());
+        if (envelopeError) return c.json({ error: envelopeError }, 400);
+      }
       const ctx = c.get("app");
 
       if (bypassConcurrency) {

--- a/packages/core/src/artifacts/scrubber.test.ts
+++ b/packages/core/src/artifacts/scrubber.test.ts
@@ -456,6 +456,38 @@ describe("scrubAssistantMessage (pre-persist)", () => {
     const out = (parts[0] as { output: { instructions: string } }).output;
     expect(out.instructions).toContain(blob);
   });
+
+  it("exempts load_skill results inside delegate-chunk envelopes", async () => {
+    // A sub-agent's tool-output chunk carries no toolName — the exemption
+    // resolves it through the earlier tool-input chunk's toolCallId.
+    const blob = bigBase64(SIZE_THRESHOLD_CHARS + 500);
+    const parts: Array<Record<string, unknown>> = [
+      {
+        type: "data-delegate-chunk",
+        data: {
+          delegateToolCallId: "del1",
+          chunk: { type: "tool-input-start", toolCallId: "skill-call", toolName: "load_skill" },
+        },
+      },
+      {
+        type: "data-delegate-chunk",
+        data: {
+          delegateToolCallId: "del1",
+          chunk: {
+            type: "tool-output-available",
+            toolCallId: "skill-call",
+            output: { instructions: `# Skill\n\n${blob}` },
+          },
+        },
+      },
+    ];
+    const r = await scrubAssistantMessage(parts, { workspaceId: "ws", chatId: "ch", logger });
+    expect(r.rewritten).toBe(0);
+    expect(mockFetch).not.toHaveBeenCalled();
+    const outChunk = (parts[1] as { data: { chunk: { output: { instructions: string } } } }).data
+      .chunk;
+    expect(outChunk.output.instructions).toContain(blob);
+  });
 });
 
 describe("liftAnswerForModel (pre-model answer lift)", () => {

--- a/packages/core/src/artifacts/scrubber.test.ts
+++ b/packages/core/src/artifacts/scrubber.test.ts
@@ -488,6 +488,64 @@ describe("scrubAssistantMessage (pre-persist)", () => {
       .chunk;
     expect(outChunk.output.instructions).toContain(blob);
   });
+
+  it("resolves the exemption per-delegate when sibling delegates share a toolCallId", async () => {
+    // Two sibling delegates, same inner toolCallId. The map is namespaced by
+    // delegateToolCallId, so delA's load_skill output stays inline while
+    // delB's non-exempt output is still lifted.
+    mockArtifactCreate("art_sibling", 24_000, "application/pdf");
+    const blob = bigBase64(SIZE_THRESHOLD_CHARS + 500);
+    const parts: Array<Record<string, unknown>> = [
+      {
+        type: "data-delegate-chunk",
+        data: {
+          delegateToolCallId: "delA",
+          chunk: { type: "tool-input-start", toolCallId: "tc-shared", toolName: "load_skill" },
+        },
+      },
+      {
+        type: "data-delegate-chunk",
+        data: {
+          delegateToolCallId: "delB",
+          chunk: { type: "tool-input-start", toolCallId: "tc-shared", toolName: "fetch_url" },
+        },
+      },
+      {
+        type: "data-delegate-chunk",
+        data: {
+          delegateToolCallId: "delA",
+          chunk: {
+            type: "tool-output-available",
+            toolCallId: "tc-shared",
+            output: { instructions: `# Skill\n\n${blob}` },
+          },
+        },
+      },
+      {
+        type: "data-delegate-chunk",
+        data: {
+          delegateToolCallId: "delB",
+          chunk: {
+            type: "tool-output-available",
+            toolCallId: "tc-shared",
+            output: { content: [{ type: "text", text: `prefix ${blob} suffix` }] },
+          },
+        },
+      },
+    ];
+    await scrubAssistantMessage(parts, { workspaceId: "ws", chatId: "ch", logger });
+
+    // delA (load_skill) — body untouched.
+    const skillChunk = (parts[2] as { data: { chunk: { output: { instructions: string } } } }).data
+      .chunk;
+    expect(skillChunk.output.instructions).toContain(blob);
+    // delB (fetch_url, not exempt) — blob lifted to an artifact marker.
+    const fetchChunk = (
+      parts[3] as { data: { chunk: { output: { content: Array<{ text: string }> } } } }
+    ).data.chunk;
+    expect(fetchChunk.output.content[0]?.text).toMatch(/artifact art_sibling/);
+    expect(fetchChunk.output.content[0]?.text).not.toContain(blob);
+  });
 });
 
 describe("liftAnswerForModel (pre-model answer lift)", () => {

--- a/packages/core/src/artifacts/scrubber.test.ts
+++ b/packages/core/src/artifacts/scrubber.test.ts
@@ -197,6 +197,17 @@ describe("post-stream lift (liftToolResultsForPersist)", () => {
     expect(result).toEqual({ content: [{ type: "text", text }] });
     expect(mockFetch).not.toHaveBeenCalled();
   });
+
+  it("exempts load_skill results — the skill body is the point, never lift it", async () => {
+    // A skill body well over threshold that would otherwise be lifted.
+    const skillResult = {
+      instructions: `# Skill\n\n${bigBase64(SIZE_THRESHOLD_CHARS + 500)}`,
+      frontmatter: { name: "writing-workspace-jobs" },
+    };
+    const result = await lift(skillResult, { serverId: "skill", toolName: "load_skill" });
+    expect(result).toEqual(skillResult);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
 });
 
 describe("createScrubber — text/JSON lifting", () => {
@@ -426,6 +437,24 @@ describe("scrubAssistantMessage (pre-persist)", () => {
     const r = await scrubAssistantMessage(parts, { workspaceId: "ws", chatId: "ch", logger });
     expect(r.rewritten).toBe(0);
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("exempts tool-load_skill parts — the skill body stays inline", async () => {
+    const blob = bigBase64(SIZE_THRESHOLD_CHARS + 500);
+    const parts: Array<Record<string, unknown>> = [
+      {
+        type: "tool-load_skill",
+        toolCallId: "t-skill",
+        state: "output-available",
+        input: { name: "@friday/writing-workspace-jobs" },
+        output: { instructions: `# Skill\n\n${blob}`, frontmatter: { name: "x" } },
+      },
+    ];
+    const r = await scrubAssistantMessage(parts, { workspaceId: "ws", chatId: "ch", logger });
+    expect(r.rewritten).toBe(0);
+    expect(mockFetch).not.toHaveBeenCalled();
+    const out = (parts[0] as { output: { instructions: string } }).output;
+    expect(out.instructions).toContain(blob);
   });
 });
 

--- a/packages/core/src/artifacts/scrubber.ts
+++ b/packages/core/src/artifacts/scrubber.ts
@@ -52,6 +52,18 @@ const SIZE_THRESHOLD_CHARS = 4 * 1024;
 const TEXT_THRESHOLD_CHARS = 8 * 1024;
 
 /**
+ * Tool results that must never be lifted to artifacts, keyed by tool name.
+ *
+ * `load_skill`'s entire purpose is to inline a skill's body (instructions +
+ * reference files) into the prompt. Lifting that body to an artifact defeats
+ * the tool: the agent "loads" a skill and gets back a `[lifted to artifact]`
+ * marker instead of the guidance it asked for, then proceeds without it.
+ * Skill bodies are authored markdown, not the base64 / 50-email-JSON dumps
+ * the scrubber exists to keep out of the prompt — so they're exempt.
+ */
+const SCRUB_EXEMPT_TOOLS = new Set(["load_skill"]);
+
+/**
  * Literal prefix produced by {@link refMarker}. A scrubbed string that
  * already starts with this prefix is the output of a previous scrub pass
  * (e.g. MCP-boundary scrub re-walked by pre-persist scrub) — lifting it
@@ -496,7 +508,9 @@ export async function liftToolResultsForPersist(
     // `== null` covers both `undefined` (not set) and `null` (explicit
     // "no result"). Either way there's nothing to
     // scrub. Matches the rest of the codebase's nullish-check style.
-    if (call.result == null) {
+    // Exempt tools (e.g. load_skill) keep their full inline result —
+    // their payload is the point, not noise to lift out.
+    if (call.result == null || SCRUB_EXEMPT_TOOLS.has(call.toolName)) {
       out.push(call);
       continue;
     }
@@ -572,15 +586,19 @@ export async function scrubAssistantMessage(
     // string literal in `run_code`'s source argument). Without input scrub,
     // those bytes survive into chat history and into the next turn's prompt.
     if (type.startsWith("tool-")) {
-      if ("output" in part) {
-        await scrubField(part.output, "pre-persist", type, (next) => {
-          part.output = next;
-        });
-      }
-      if ("input" in part) {
-        await scrubField(part.input, "pre-persist", `${type}.input`, (next) => {
-          part.input = next;
-        });
+      // `type` is `tool-<name>` — strip the prefix to match the exempt set.
+      const toolName = type.slice("tool-".length);
+      if (!SCRUB_EXEMPT_TOOLS.has(toolName)) {
+        if ("output" in part) {
+          await scrubField(part.output, "pre-persist", type, (next) => {
+            part.output = next;
+          });
+        }
+        if ("input" in part) {
+          await scrubField(part.input, "pre-persist", `${type}.input`, (next) => {
+            part.input = next;
+          });
+        }
       }
     }
     // Sub-agent stream envelopes — chunk may carry an embedded tool

--- a/packages/core/src/artifacts/scrubber.ts
+++ b/packages/core/src/artifacts/scrubber.ts
@@ -577,6 +577,25 @@ export async function scrubAssistantMessage(
     }
   };
 
+  // Pre-pass: map toolCallId -> toolName across `data-delegate-chunk`
+  // envelopes. A sub-agent's `tool-output-available` chunk carries the
+  // result but not the tool name, so an exempt tool's output (e.g. a
+  // `load_skill` skill body streamed from a delegate child) can only be
+  // recognized by correlating it with the earlier `tool-input-*` chunk
+  // that did carry the name.
+  const delegateToolNames = new Map<string, string>();
+  for (const part of parts) {
+    if (part.type !== "data-delegate-chunk") continue;
+    const data = part.data;
+    if (!data || typeof data !== "object") continue;
+    const chunk = (data as Record<string, unknown>).chunk;
+    if (!chunk || typeof chunk !== "object") continue;
+    const c = chunk as Record<string, unknown>;
+    if (typeof c.toolCallId === "string" && typeof c.toolName === "string") {
+      delegateToolNames.set(c.toolCallId, c.toolName);
+    }
+  }
+
   for (const part of parts) {
     const type = typeof part.type === "string" ? part.type : "";
     // Tool calls from the parent's own tool-use steps. Both `input` and
@@ -607,9 +626,22 @@ export async function scrubAssistantMessage(
     if (type === "data-delegate-chunk" && part.data && typeof part.data === "object") {
       const data = part.data as Record<string, unknown>;
       if ("chunk" in data) {
-        await scrubField(data.chunk, "pre-persist", "delegate-chunk", (next) => {
-          data.chunk = next;
-        });
+        // Skip exempt tools (e.g. load_skill) here too — the chunk's own
+        // toolName is absent on output chunks, so resolve it through the
+        // toolCallId -> toolName map built above.
+        const chunk = data.chunk;
+        const chunkToolCallId =
+          chunk &&
+          typeof chunk === "object" &&
+          typeof (chunk as Record<string, unknown>).toolCallId === "string"
+            ? ((chunk as Record<string, unknown>).toolCallId as string)
+            : undefined;
+        const chunkToolName = chunkToolCallId ? delegateToolNames.get(chunkToolCallId) : undefined;
+        if (!chunkToolName || !SCRUB_EXEMPT_TOOLS.has(chunkToolName)) {
+          await scrubField(data.chunk, "pre-persist", "delegate-chunk", (next) => {
+            data.chunk = next;
+          });
+        }
       }
     }
   }

--- a/packages/core/src/artifacts/scrubber.ts
+++ b/packages/core/src/artifacts/scrubber.ts
@@ -583,16 +583,25 @@ export async function scrubAssistantMessage(
   // `load_skill` skill body streamed from a delegate child) can only be
   // recognized by correlating it with the earlier `tool-input-*` chunk
   // that did carry the name.
+  //
+  // Keyed by `<delegateToolCallId>:<toolCallId>` — inner toolCallIds are
+  // only guaranteed unique within a single delegate's stream, so two
+  // sibling delegates could otherwise collide on the bare id.
   const delegateToolNames = new Map<string, string>();
   for (const part of parts) {
     if (part.type !== "data-delegate-chunk") continue;
     const data = part.data;
     if (!data || typeof data !== "object") continue;
-    const chunk = (data as Record<string, unknown>).chunk;
+    const d = data as Record<string, unknown>;
+    const chunk = d.chunk;
     if (!chunk || typeof chunk !== "object") continue;
     const c = chunk as Record<string, unknown>;
-    if (typeof c.toolCallId === "string" && typeof c.toolName === "string") {
-      delegateToolNames.set(c.toolCallId, c.toolName);
+    if (
+      typeof d.delegateToolCallId === "string" &&
+      typeof c.toolCallId === "string" &&
+      typeof c.toolName === "string"
+    ) {
+      delegateToolNames.set(`${d.delegateToolCallId}:${c.toolCallId}`, c.toolName);
     }
   }
 
@@ -628,7 +637,7 @@ export async function scrubAssistantMessage(
       if ("chunk" in data) {
         // Skip exempt tools (e.g. load_skill) here too — the chunk's own
         // toolName is absent on output chunks, so resolve it through the
-        // toolCallId -> toolName map built above.
+        // <delegateToolCallId>:<toolCallId> map built above.
         const chunk = data.chunk;
         const chunkToolCallId =
           chunk &&
@@ -636,7 +645,12 @@ export async function scrubAssistantMessage(
           typeof (chunk as Record<string, unknown>).toolCallId === "string"
             ? ((chunk as Record<string, unknown>).toolCallId as string)
             : undefined;
-        const chunkToolName = chunkToolCallId ? delegateToolNames.get(chunkToolCallId) : undefined;
+        const delegateToolCallId =
+          typeof data.delegateToolCallId === "string" ? data.delegateToolCallId : undefined;
+        const chunkToolName =
+          chunkToolCallId && delegateToolCallId
+            ? delegateToolNames.get(`${delegateToolCallId}:${chunkToolCallId}`)
+            : undefined;
         if (!chunkToolName || !SCRUB_EXEMPT_TOOLS.has(chunkToolName)) {
           await scrubField(data.chunk, "pre-persist", "delegate-chunk", (next) => {
             data.chunk = next;

--- a/packages/system/agents/workspace-chat/block2-cache.ts
+++ b/packages/system/agents/workspace-chat/block2-cache.ts
@@ -120,10 +120,12 @@ export async function getBlock2Inputs(workspaceId: string, logger: Logger): Prom
 }
 
 /**
- * Drop the cached entry for a workspace. Called when the workspace
- * structure is known to have changed (publish_draft, upsert_*,
- * skill assignment events). Caller is responsible for triggering;
- * the cache otherwise relies on the 5-minute TTL.
+ * Drop the cached entry for a workspace. Called when workspace state
+ * cached in this entry is known to have changed — `publish_draft`,
+ * `upsert_*`, and MCP server enable/disable. Skills and user identity
+ * are fetched fresh every turn rather than cached here, so their
+ * mutation tools deliberately do not call this. Caller is responsible
+ * for triggering; the cache otherwise relies on the 5-minute TTL.
  */
 export function invalidateBlock2(workspaceId: string): void {
   cache.delete(workspaceId);

--- a/packages/system/agents/workspace-chat/prompt.txt
+++ b/packages/system/agents/workspace-chat/prompt.txt
@@ -85,7 +85,7 @@ Always inside specific workspace. `<workspace>` section = authoritative source.
 
 "how do I run this?" / "why fail?" / "where is data?" → read `<workspace>` first. Match to signals (trigger), jobs (what runs), agents (pipeline), MCP servers (tool access).
 
-Each workspace job is bound as a callable tool with the same name — run job → call its tool directly. To list/inspect jobs without running them, use `list_jobs` / `describe_job`.
+Each job that existed when this chat started is bound as a callable tool with the same name — run job → call its tool directly. A job you just created this session (via `upsert_job`) is NOT bound yet — run it with `trigger_signal({ signalId, payload })` using its trigger signal. Don't tell the user to send another message; `trigger_signal` runs it now. To list/inspect jobs without running them, use `list_jobs` / `describe_job`.
 
 Job tool returns error → read the message. Input wrong → fix and retry. Job/agent itself broken (parser, schema, runtime exception) → surface the failure to the user before substituting. The workspace was authored deliberately; silently routing the immediate ask through `agent_*`/direct tools leaves a broken job in place that the user doesn't know about. Offer two paths: fix the job (preferred — keeps the workspace working), or one-shot with tools and flag the regression. Default to fix unless the user says do-it-now.
 

--- a/packages/system/agents/workspace-chat/skills-section.test.ts
+++ b/packages/system/agents/workspace-chat/skills-section.test.ts
@@ -2,6 +2,7 @@ import type { SkillSummary } from "@atlas/skills";
 import { describe, expect, it } from "vitest";
 import {
   buildSkillsSection,
+  flattenSystemBlocks,
   getSystemBlocks,
   summarizeSkillDescription,
 } from "./workspace-chat.agent.ts";
@@ -148,16 +149,33 @@ describe("getSystemBlocks block-4 (volatile workspace inventory)", () => {
     expect(blocks.block2).toContain("@svelte/core");
   });
 
-  it("prepends the cache salt to block 4, not block 2", () => {
+  it("prepends the cache salt to block 2 so a force-fresh bump cascades", () => {
     const cacheSaltTag = '<cache_salt workspace="ws-1" version="7"/>';
     const blocks = getSystemBlocks(workspaceSection, { cacheSaltTag });
-    expect(blocks.block4).toContain(cacheSaltTag);
-    expect(blocks.block2).not.toContain(cacheSaltTag);
+    // The salt leads block 2 — changing block 2's prefix invalidates
+    // block 3 and block 4 behind it, so "force fresh" busts everything.
+    expect(blocks.block2).toContain(cacheSaltTag);
+    expect(blocks.block4).not.toContain(cacheSaltTag);
   });
 
-  it("block 2 is empty when the workspace has no skills and no user identity", () => {
+  it("block 2 is empty when the workspace has no skills, identity, or salt", () => {
     const blocks = getSystemBlocks(workspaceSection);
     expect(blocks.block2).toBe("");
     expect(blocks.block4).toContain(workspaceSection);
+  });
+});
+
+describe("flattenSystemBlocks", () => {
+  it("omits an empty block 2 and still includes block 4", () => {
+    const workspaceSection = '<workspace id="ws-1" name="Personal"></workspace>';
+    // No skills / identity / salt -> block 2 is empty.
+    const blocks = getSystemBlocks(workspaceSection);
+    expect(blocks.block2).toBe("");
+
+    const flat = flattenSystemBlocks(blocks);
+    expect(flat).toContain(blocks.block1);
+    expect(flat).toContain(workspaceSection);
+    // An empty block 2 must not introduce a stray blank section.
+    expect(flat).not.toContain("\n\n\n\n");
   });
 });

--- a/packages/system/agents/workspace-chat/skills-section.test.ts
+++ b/packages/system/agents/workspace-chat/skills-section.test.ts
@@ -135,3 +135,29 @@ describe("getSystemBlocks block-2 byte-stability", () => {
     expect(after).not.toContain("@friday/qa");
   });
 });
+
+describe("getSystemBlocks block-4 (volatile workspace inventory)", () => {
+  const workspaceSection = '<workspace id="ws-1" name="Personal"></workspace>';
+
+  it("routes the workspace section into block 4, not block 2", () => {
+    const blocks = getSystemBlocks(workspaceSection, {
+      skills: buildSkillsSection([skill("svelte", "core", "Patterns for Svelte 5.")]),
+    });
+    expect(blocks.block4).toContain(workspaceSection);
+    expect(blocks.block2).not.toContain(workspaceSection);
+    expect(blocks.block2).toContain("@svelte/core");
+  });
+
+  it("prepends the cache salt to block 4, not block 2", () => {
+    const cacheSaltTag = '<cache_salt workspace="ws-1" version="7"/>';
+    const blocks = getSystemBlocks(workspaceSection, { cacheSaltTag });
+    expect(blocks.block4).toContain(cacheSaltTag);
+    expect(blocks.block2).not.toContain(cacheSaltTag);
+  });
+
+  it("block 2 is empty when the workspace has no skills and no user identity", () => {
+    const blocks = getSystemBlocks(workspaceSection);
+    expect(blocks.block2).toBe("");
+    expect(blocks.block4).toContain(workspaceSection);
+  });
+});

--- a/packages/system/agents/workspace-chat/skills-section.test.ts
+++ b/packages/system/agents/workspace-chat/skills-section.test.ts
@@ -1,6 +1,8 @@
 import type { SkillSummary } from "@atlas/skills";
+import type { ModelMessage } from "ai";
 import { describe, expect, it } from "vitest";
 import {
+  buildAnthropicSystemMessages,
   buildSkillsSection,
   flattenSystemBlocks,
   getSystemBlocks,
@@ -177,5 +179,53 @@ describe("flattenSystemBlocks", () => {
     expect(flat).toContain(workspaceSection);
     // An empty block 2 must not introduce a stray blank section.
     expect(flat).not.toContain("\n\n\n\n");
+  });
+});
+
+describe("buildAnthropicSystemMessages", () => {
+  const longTtl = { type: "ephemeral", ttl: "1h" };
+  const shortTtl = { type: "ephemeral" };
+
+  function ttlOf(msg: ModelMessage): unknown {
+    return (msg.providerOptions as { anthropic?: { cacheControl?: unknown } } | undefined)
+      ?.anthropic?.cacheControl;
+  }
+
+  it("emits one breakpoint per non-empty block, ordered, with the expected TTLs", () => {
+    const msgs = buildAnthropicSystemMessages({
+      block1: "B1",
+      block2: "B2",
+      block3: "B3",
+      block4: "B4",
+    });
+    expect(msgs.map((m) => m.content)).toEqual(["B1", "B2", "B3", "B4"]);
+    expect(msgs.map(ttlOf)).toEqual([longTtl, longTtl, shortTtl, shortTtl]);
+  });
+
+  it("skips empty block 2 / block 3 but always keeps block 1 and block 4", () => {
+    const msgs = buildAnthropicSystemMessages({
+      block1: "B1",
+      block2: "",
+      block3: "",
+      block4: "B4",
+    });
+    expect(msgs.map((m) => m.content)).toEqual(["B1", "B4"]);
+    expect(msgs.map(ttlOf)).toEqual([longTtl, shortTtl]);
+  });
+
+  it("keeps the TTL sequence non-increasing (Anthropic rejects 1h after 5m)", () => {
+    // 1h -> ordinal 1, 5m -> ordinal 0; the sequence must never rise.
+    const ordinal = (ttl: unknown) => ((ttl as { ttl?: string })?.ttl === "1h" ? 1 : 0);
+    for (const blocks of [
+      { block1: "B1", block2: "B2", block3: "B3", block4: "B4" },
+      { block1: "B1", block2: "", block3: "B3", block4: "B4" },
+      { block1: "B1", block2: "B2", block3: "", block4: "B4" },
+      { block1: "B1", block2: "", block3: "", block4: "B4" },
+    ]) {
+      const seq = buildAnthropicSystemMessages(blocks).map((m) => ordinal(ttlOf(m)));
+      for (let i = 1; i < seq.length; i++) {
+        expect(seq[i]).toBeLessThanOrEqual(seq[i - 1] as number);
+      }
+    }
   });
 });

--- a/packages/system/agents/workspace-chat/tools/disable-mcp-server.test.ts
+++ b/packages/system/agents/workspace-chat/tools/disable-mcp-server.test.ts
@@ -8,8 +8,10 @@ import { createDisableMcpServerTool } from "./disable-mcp-server.ts";
 
 const mockDelete = vi.hoisted(() => vi.fn());
 const mockWorkspaceMcp = vi.hoisted(() => vi.fn());
+const mockInvalidateBlock2 = vi.hoisted(() => vi.fn<(workspaceId: string) => void>());
 
 vi.mock("@atlas/client/v2", () => ({ client: { workspaceMcp: mockWorkspaceMcp } }));
+vi.mock("../block2-cache.ts", () => ({ invalidateBlock2: mockInvalidateBlock2 }));
 
 function setupMock(_workspaceId: string) {
   mockWorkspaceMcp.mockReturnValue({ ":serverId": { $delete: mockDelete } });
@@ -47,6 +49,7 @@ describe("createDisableMcpServerTool", () => {
   beforeEach(() => {
     mockDelete.mockReset();
     mockWorkspaceMcp.mockReset();
+    mockInvalidateBlock2.mockReset();
   });
 
   it("returns object with disable_mcp_server key", () => {
@@ -218,5 +221,37 @@ describe("createDisableMcpServerTool", () => {
     expect(mockDelete).toHaveBeenCalledWith(
       expect.objectContaining({ param: { serverId: "github" } }),
     );
+  });
+
+  // Disabling a server mutates the workspace's MCP list — the chat's
+  // Block 2 cache must be dropped or the `<workspace>` section stays
+  // stale for up to the cache TTL.
+  it("invalidates the workspace cache on success, scoped to the target workspace", async () => {
+    setupMock("ws-other");
+    mockDelete.mockResolvedValueOnce({
+      status: 200,
+      json: () => Promise.resolve({ removed: "github" }),
+    });
+
+    const tools = createDisableMcpServerTool("ws-1", logger);
+    await tools.disable_mcp_server!.execute!(
+      { serverId: "github", workspaceId: "ws-other" },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(mockInvalidateBlock2).toHaveBeenCalledWith("ws-other");
+  });
+
+  it("does not invalidate the cache on a 409 conflict", async () => {
+    setupMock("ws-1");
+    mockDelete.mockResolvedValueOnce({
+      status: 409,
+      json: () => Promise.resolve({ message: "Server is referenced by workspace entities." }),
+    });
+
+    const tools = createDisableMcpServerTool("ws-1", logger);
+    await tools.disable_mcp_server!.execute!({ serverId: "github" }, TOOL_CALL_OPTS);
+
+    expect(mockInvalidateBlock2).not.toHaveBeenCalled();
   });
 });

--- a/packages/system/agents/workspace-chat/tools/disable-mcp-server.test.ts
+++ b/packages/system/agents/workspace-chat/tools/disable-mcp-server.test.ts
@@ -89,6 +89,9 @@ describe("createDisableMcpServerTool", () => {
     expect(mockDelete).toHaveBeenCalledWith(
       expect.objectContaining({ param: { serverId: "github" }, query: { force: "true" } }),
     );
+    // The force path cascades reference-stripping across agents/jobs —
+    // the cache must drop on this branch too, not just non-force disable.
+    expect(mockInvalidateBlock2).toHaveBeenCalledWith("ws-1");
   });
 
   it("passes force=false without query param", async () => {

--- a/packages/system/agents/workspace-chat/tools/disable-mcp-server.ts
+++ b/packages/system/agents/workspace-chat/tools/disable-mcp-server.ts
@@ -3,6 +3,7 @@ import { client } from "@atlas/client/v2";
 import type { Logger } from "@atlas/logger";
 import { tool } from "ai";
 import { z } from "zod";
+import { invalidateBlock2 } from "../block2-cache.ts";
 
 const DisableInputSchema = z.object({
   serverId: z
@@ -84,6 +85,10 @@ export function createDisableMcpServerTool(workspaceId: string, logger: Logger):
               serverId,
               force,
             });
+            // The workspace's MCP server list just changed — drop the
+            // Block 2 cache so the chat's `<workspace>` section reflects
+            // it on the next turn instead of a stale snapshot.
+            invalidateBlock2(effectiveWorkspaceId);
             return {
               success: true,
               removed: serverId,

--- a/packages/system/agents/workspace-chat/tools/draft-tools.test.ts
+++ b/packages/system/agents/workspace-chat/tools/draft-tools.test.ts
@@ -11,6 +11,7 @@ const mockDraftPublishPost = vi.hoisted(() => vi.fn<() => Promise<unknown>>());
 const mockDraftValidatePost = vi.hoisted(() => vi.fn<() => Promise<unknown>>());
 const mockDraftDelete = vi.hoisted(() => vi.fn<() => Promise<unknown>>());
 const mockLintPost = vi.hoisted(() => vi.fn<() => Promise<unknown>>());
+const mockInvalidateBlock2 = vi.hoisted(() => vi.fn<(workspaceId: string) => void>());
 
 function mockResponse(ok: boolean, status: number, body: unknown): unknown {
   return { ok, status, json: () => Promise.resolve(body) };
@@ -31,6 +32,8 @@ vi.mock("@atlas/client/v2", () => ({
     },
   },
 }));
+
+vi.mock("../block2-cache.ts", () => ({ invalidateBlock2: mockInvalidateBlock2 }));
 
 function makeLogger(): Logger {
   return {
@@ -101,6 +104,7 @@ describe("createBoundDraftTools", () => {
     mockDraftValidatePost.mockReset();
     mockDraftDelete.mockReset();
     mockLintPost.mockReset();
+    mockInvalidateBlock2.mockReset();
   });
 
   it("includes begin_draft tool in bound tool set", () => {
@@ -190,6 +194,30 @@ describe("createBoundDraftTools", () => {
     const result = await tools.publish_draft!.execute!({}, TOOL_CALL_OPTS);
 
     expect(result).toEqual({ success: false, error: "No draft to publish" });
+  });
+
+  // Publishing swaps the live workspace.yml — the chat's Block 2 cache must
+  // be dropped so the next turn rebuilds from the newly-published config.
+  it("publish_draft invalidates the workspace cache on success", async () => {
+    mockDraftPublishPost.mockResolvedValueOnce(
+      mockResponse(true, 200, { success: true, livePath: "/tmp/ws-1/workspace.yml" }),
+    );
+
+    const tools = createBoundDraftTools(logger, "ws-1");
+    await tools.publish_draft!.execute!({}, TOOL_CALL_OPTS);
+
+    expect(mockInvalidateBlock2).toHaveBeenCalledWith("ws-1");
+  });
+
+  it("publish_draft does not invalidate the cache when publish fails", async () => {
+    mockDraftPublishPost.mockResolvedValueOnce(
+      mockResponse(false, 409, { success: false, error: "No draft to publish" }),
+    );
+
+    const tools = createBoundDraftTools(logger, "ws-1");
+    await tools.publish_draft!.execute!({}, TOOL_CALL_OPTS);
+
+    expect(mockInvalidateBlock2).not.toHaveBeenCalled();
   });
 
   it("validate_workspace returns draft report when draft exists", async () => {

--- a/packages/system/agents/workspace-chat/tools/draft-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/draft-tools.ts
@@ -12,6 +12,7 @@ import { client } from "@atlas/client/v2";
 import type { Logger } from "@atlas/logger";
 import { tool } from "ai";
 import { z } from "zod";
+import { invalidateBlock2 } from "../block2-cache.ts";
 
 const ErrorBodySchema = z.object({ error: z.string().optional(), report: z.unknown().optional() });
 
@@ -152,6 +153,10 @@ export function createBoundDraftTools(logger: Logger, workspaceId: string): Atla
 
         const data = await res.json();
         logger.info("publish_draft succeeded", { workspaceId: targetId });
+        // Publishing swaps the live workspace.yml — drop the Block 2 cache so
+        // the chat's `<workspace>` section and job-as-tools rebuild from the
+        // newly-published config on the next turn.
+        invalidateBlock2(targetId);
         return { success: true, livePath: data.livePath };
       },
     }),

--- a/packages/system/agents/workspace-chat/tools/enable-mcp-server.test.ts
+++ b/packages/system/agents/workspace-chat/tools/enable-mcp-server.test.ts
@@ -8,8 +8,10 @@ import { createEnableMcpServerTool } from "./enable-mcp-server.ts";
 
 const mockPut = vi.hoisted(() => vi.fn());
 const mockWorkspaceMcp = vi.hoisted(() => vi.fn());
+const mockInvalidateBlock2 = vi.hoisted(() => vi.fn<(workspaceId: string) => void>());
 
 vi.mock("@atlas/client/v2", () => ({ client: { workspaceMcp: mockWorkspaceMcp } }));
+vi.mock("../block2-cache.ts", () => ({ invalidateBlock2: mockInvalidateBlock2 }));
 
 function setupMock(_workspaceId: string) {
   mockWorkspaceMcp.mockReturnValue({ ":serverId": { $put: mockPut } });
@@ -47,6 +49,7 @@ describe("createEnableMcpServerTool", () => {
   beforeEach(() => {
     mockPut.mockReset();
     mockWorkspaceMcp.mockReset();
+    mockInvalidateBlock2.mockReset();
   });
 
   it("returns object with enable_mcp_server key", () => {
@@ -171,5 +174,37 @@ describe("createEnableMcpServerTool", () => {
     });
     expect(mockWorkspaceMcp).toHaveBeenCalledWith("ws-other");
     expect(mockPut).toHaveBeenCalledWith({ param: { serverId: "github" } });
+  });
+
+  // Enabling a server mutates the workspace's MCP list — the chat's
+  // Block 2 cache must be dropped or the `<workspace>` section stays
+  // stale for up to the cache TTL.
+  it("invalidates the workspace cache on success, scoped to the target workspace", async () => {
+    setupMock("ws-other");
+    mockPut.mockResolvedValueOnce({
+      status: 200,
+      json: () => Promise.resolve({ server: { id: "github", name: "GitHub" } }),
+    });
+
+    const tools = createEnableMcpServerTool("ws-1", logger);
+    await tools.enable_mcp_server!.execute!(
+      { serverId: "github", workspaceId: "ws-other" },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(mockInvalidateBlock2).toHaveBeenCalledWith("ws-other");
+  });
+
+  it("does not invalidate the cache when enable fails", async () => {
+    setupMock("ws-1");
+    mockPut.mockResolvedValueOnce({
+      status: 404,
+      json: () => Promise.resolve({ message: 'Server "github" not found in catalog.' }),
+    });
+
+    const tools = createEnableMcpServerTool("ws-1", logger);
+    await tools.enable_mcp_server!.execute!({ serverId: "github" }, TOOL_CALL_OPTS);
+
+    expect(mockInvalidateBlock2).not.toHaveBeenCalled();
   });
 });

--- a/packages/system/agents/workspace-chat/tools/enable-mcp-server.ts
+++ b/packages/system/agents/workspace-chat/tools/enable-mcp-server.ts
@@ -3,6 +3,7 @@ import { client } from "@atlas/client/v2";
 import type { Logger } from "@atlas/logger";
 import { tool } from "ai";
 import { z } from "zod";
+import { invalidateBlock2 } from "../block2-cache.ts";
 
 const EnableInputSchema = z.object({
   serverId: z
@@ -66,6 +67,10 @@ export function createEnableMcpServerTool(workspaceId: string, logger: Logger): 
               serverId,
               name,
             });
+            // The workspace's MCP server list just changed — drop the
+            // Block 2 cache so the chat's `<workspace>` section reflects
+            // it on the next turn instead of a stale snapshot.
+            invalidateBlock2(effectiveWorkspaceId);
             return {
               success: true,
               server: { id: serverId, name },

--- a/packages/system/agents/workspace-chat/tools/inventory-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/inventory-tools.ts
@@ -222,9 +222,11 @@ export function createListJobsTool(defaultWorkspaceId: string, logger: Logger): 
     list_jobs: tool({
       description:
         "List jobs configured on the current chat's workspace. Returns id + name + description " +
-        "per job. Each workspace job is also bound as a callable tool with the same name — this " +
-        "tool gives a flat overview of which jobs exist and what they do, separate from invoking " +
-        "them. Use describe_job(name) to pull the full FSM definition.",
+        "per job. Each job that existed when this chat session started is also bound as a " +
+        "callable tool with the same name. A job you create mid-session (via upsert_job) is " +
+        "NOT bound until the next session — invoke it via `trigger_signal` with its trigger " +
+        "signal id instead. This tool gives a flat overview of which jobs exist and what they " +
+        "do, separate from invoking them. Use describe_job(name) to pull the full FSM definition.",
       inputSchema: z.object({ scope: WorkspaceScope }),
       execute: async () => {
         const result = await daemonGet<JobEntry[]>(

--- a/packages/system/agents/workspace-chat/tools/job-tools.test.ts
+++ b/packages/system/agents/workspace-chat/tools/job-tools.test.ts
@@ -922,6 +922,11 @@ describe("createJobTools trigger_signal (SSE streaming)", () => {
 
   beforeEach(() => {
     originalFetch = globalThis.fetch;
+    // Reset the client mocks for parity with the sibling JSON describe
+    // block — the SSE path doesn't touch them today, but a future
+    // JSON-path test added here would otherwise inherit stale state.
+    mockSignalPost.mockReset();
+    mockParseResult.mockReset();
   });
 
   afterEach(() => {

--- a/packages/system/agents/workspace-chat/tools/job-tools.test.ts
+++ b/packages/system/agents/workspace-chat/tools/job-tools.test.ts
@@ -826,3 +826,143 @@ describe("createJobTools execute (SSE streaming)", () => {
     expect(result).not.toHaveProperty("summary");
   });
 });
+
+// ---------------------------------------------------------------------------
+// trigger_signal — the generic same-session signal-trigger escape hatch
+// ---------------------------------------------------------------------------
+
+describe("createJobTools trigger_signal", () => {
+  const noSignals: Record<string, WorkspaceSignalConfig> = {};
+
+  beforeEach(() => {
+    mockSignalPost.mockReset();
+    mockParseResult.mockReset();
+  });
+
+  it("is registered even when the workspace has no jobs", () => {
+    const tools = createJobTools("ws-test", {}, noSignals, makeLogger());
+    expect(tools).toHaveProperty("trigger_signal");
+    expect(tools.trigger_signal?.description).toContain("Fire a workspace signal");
+  });
+
+  it("fires the named signal with the given payload (JSON mode)", async () => {
+    mockParseResult.mockResolvedValueOnce({
+      ok: true,
+      data: { sessionId: "sess-ts-1", status: "completed" },
+    });
+
+    const tools = createJobTools("ws-test", {}, noSignals, makeLogger());
+    const execute = tools.trigger_signal?.execute;
+    if (!execute) throw new Error("trigger_signal has no execute");
+
+    const result = await execute(
+      { signalId: "echo-run", payload: { name: "Ken" } },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(mockSignalPost).toHaveBeenCalledWith({
+      param: { workspaceId: "ws-test", signalId: "echo-run" },
+      json: { payload: { name: "Ken" }, bypassConcurrency: true },
+    });
+    expect(result).toEqual({
+      success: true,
+      sessionId: "sess-ts-1",
+      status: "completed",
+      output: [],
+    });
+  });
+
+  it("defaults payload to {} when omitted — no-input signals stay callable", async () => {
+    mockParseResult.mockResolvedValueOnce({
+      ok: true,
+      data: { sessionId: "sess-ts-2", status: "completed" },
+    });
+
+    const tools = createJobTools("ws-test", {}, noSignals, makeLogger());
+    const execute = tools.trigger_signal?.execute;
+    if (!execute) throw new Error("trigger_signal has no execute");
+
+    await execute({ signalId: "tick" }, TOOL_CALL_OPTS);
+
+    expect(mockSignalPost).toHaveBeenCalledWith({
+      param: { workspaceId: "ws-test", signalId: "tick" },
+      json: { payload: {}, bypassConcurrency: true },
+    });
+  });
+
+  it("passes through a structured signal failure", async () => {
+    mockParseResult.mockResolvedValueOnce({ ok: false, error: "workspace not found" });
+
+    const tools = createJobTools("ws-test", {}, noSignals, makeLogger());
+    const execute = tools.trigger_signal?.execute;
+    if (!execute) throw new Error("trigger_signal has no execute");
+
+    const result = await execute({ signalId: "echo-run" }, TOOL_CALL_OPTS);
+
+    expect(result).toEqual({ success: false, statusCode: undefined, error: "workspace not found" });
+  });
+
+  it("skips a job named trigger_signal so the generic tool keeps the name", () => {
+    const logger = makeLogger();
+    const tools = createJobTools(
+      "ws-test",
+      { trigger_signal: makeJob({ triggers: [{ signal: "ts-signal" }] }) },
+      noSignals,
+      logger,
+    );
+
+    // The generic escape hatch, not the workspace job, owns the name.
+    expect(tools.trigger_signal?.description).toContain("Fire a workspace signal");
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});
+
+describe("createJobTools trigger_signal (SSE streaming)", () => {
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("routes through the SSE path when a writer is present", async () => {
+    globalThis.fetch = vi.fn(() =>
+      makeMockFetchResponse([
+        `data: ${JSON.stringify({
+          type: "job-complete",
+          data: { success: true, sessionId: "sess-ts-sse", status: "completed", output: [] },
+        })}
+\n\n`,
+        "data: [DONE]\n\n",
+      ]),
+    ) as unknown as typeof fetch;
+
+    const writer: UIMessageStreamWriter<AtlasUIMessage> = {
+      write: vi.fn(),
+      merge: vi.fn(),
+      onError: vi.fn(),
+    };
+    const tools = createJobTools("ws-test", {}, {}, makeLogger(), undefined, writer);
+    const execute = tools.trigger_signal?.execute;
+    if (!execute) throw new Error("trigger_signal has no execute");
+
+    const result = await execute({ signalId: "echo-run", payload: { x: 1 } }, TOOL_CALL_OPTS);
+
+    expect(result).toEqual({
+      success: true,
+      sessionId: "sess-ts-sse",
+      status: "completed",
+      output: [],
+    });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      "http://localhost:3000/api/workspaces/ws-test/signals/echo-run",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ payload: { x: 1 }, bypassConcurrency: true }),
+      }),
+    );
+  });
+});

--- a/packages/system/agents/workspace-chat/tools/job-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/job-tools.ts
@@ -160,6 +160,66 @@ export function createJobTools(
     });
   }
 
+  // Generic signal-trigger escape hatch. The per-job tools above are built
+  // from a config snapshot taken when this chat session started — a job
+  // created mid-session (via upsert_job) has no bound tool until the next
+  // session. `trigger_signal` closes that gap: it fires any signal by id
+  // with an arbitrary payload, so the agent can create a job and run it in
+  // the same turn instead of telling the user to "send another message."
+  tools.trigger_signal = tool({
+    description:
+      "Fire a workspace signal by id with an arbitrary payload, and block until the " +
+      "spawned job completes. Use this to run a job you created earlier in THIS chat " +
+      "session — a newly-created job is not bound as its own callable tool until the " +
+      "next session, so `trigger_signal` is the in-session path to invoke it. For jobs " +
+      "that already existed when this chat started, prefer their dedicated bound tool " +
+      "(named after the job). `payload` is sent as the signal's input — its fields are " +
+      "reachable as `{{inputs.<field>}}` in the job's FSM action prompts.",
+    inputSchema: z.object({
+      signalId: z
+        .string()
+        .min(1)
+        .describe("The signal id to fire, as returned by upsert_signal or list_signals."),
+      payload: z
+        .record(z.string(), z.unknown())
+        .optional()
+        .describe("Structured input for the signal. Omit for signals that take no input."),
+    }),
+    execute: ({ signalId, payload }, { toolCallId }) => {
+      const input = payload ?? {};
+      logger.info("trigger_signal executing", {
+        workspaceId,
+        signalId,
+        mode: writer ? "sse" : "json",
+      });
+
+      if (writer) {
+        return executeJobViaSSE({
+          workspaceId,
+          signalId,
+          input,
+          streamId: parentStreamId,
+          toolCallId,
+          writer,
+          abortSignal,
+          logger,
+          jobName: signalId,
+          parentSessionId,
+        });
+      }
+
+      return executeJobViaJSON({
+        workspaceId,
+        signalId,
+        input,
+        streamId: parentStreamId,
+        logger,
+        jobName: signalId,
+        parentSessionId,
+      });
+    },
+  });
+
   return tools;
 }
 

--- a/packages/system/agents/workspace-chat/tools/job-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/job-tools.ts
@@ -103,6 +103,20 @@ export function createJobTools(
     // Skip handle-chat — that's the workspace-chat agent itself
     if (jobName === "handle-chat") continue;
 
+    // Skip a job named `trigger_signal` — the generic escape-hatch tool
+    // (registered after this loop) owns that name. Binding the job here
+    // would be silently overwritten; skipping keeps the generic tool
+    // predictable, and the job is still runnable via `trigger_signal`
+    // with its own trigger signal id.
+    if (jobName === "trigger_signal") {
+      logger.warn(
+        "Job named 'trigger_signal' shadows the generic signal-trigger tool — " +
+          "skipping its dedicated tool; invoke it via trigger_signal instead",
+        { workspaceId },
+      );
+      continue;
+    }
+
     // Find the trigger signal for this job
     const triggerSignal = jobSpec.triggers?.[0]?.signal;
     if (!triggerSignal) {

--- a/packages/system/agents/workspace-chat/tools/upsert-tools.test.ts
+++ b/packages/system/agents/workspace-chat/tools/upsert-tools.test.ts
@@ -13,6 +13,7 @@ const mockDirectItemsPost = vi.hoisted(() => vi.fn<() => Promise<Response>>());
 const mockParseResult = vi.hoisted(() =>
   vi.fn<(promise: Promise<unknown>) => Promise<Result<unknown, unknown>>>(),
 );
+const mockInvalidateBlock2 = vi.hoisted(() => vi.fn<(workspaceId: string) => void>());
 
 vi.mock("@atlas/client/v2", () => ({
   client: {
@@ -25,6 +26,8 @@ vi.mock("@atlas/client/v2", () => ({
   },
   parseResult: mockParseResult,
 }));
+
+vi.mock("../block2-cache.ts", () => ({ invalidateBlock2: mockInvalidateBlock2 }));
 
 function makeLogger(): Logger {
   return {
@@ -66,6 +69,7 @@ describe("createBoundUpsertTools", () => {
     mockDraftItemsPost.mockReset();
     mockDirectItemsPost.mockReset();
     mockParseResult.mockReset();
+    mockInvalidateBlock2.mockReset();
   });
 
   it("includes all three upsert tools in bound set", () => {
@@ -264,6 +268,45 @@ describe("createBoundUpsertTools", () => {
       structural_issues: null,
       error: "Draft agent upsert failed",
     });
+  });
+
+  // The chat agent's Block 2 cache must be dropped on every successful
+  // config mutation, or a freshly-upserted job/signal stays invisible to
+  // the chat for up to the cache TTL.
+  it("invalidates the workspace cache after a successful draft upsert", async () => {
+    mockDraftItemsPost.mockResolvedValueOnce(
+      makeResponse({ ok: true, diff: {}, structuralIssues: null }),
+    );
+
+    const tools = createBoundUpsertTools(logger, "ws-1");
+    await tools.upsert_job!.execute!({ id: "j", config: {} }, TOOL_CALL_OPTS);
+
+    expect(mockInvalidateBlock2).toHaveBeenCalledWith("ws-1");
+  });
+
+  it("invalidates the workspace cache after a successful direct upsert", async () => {
+    mockDraftItemsPost.mockResolvedValueOnce(
+      makeResponse({ error: "No draft exists" }, 409, false),
+    );
+    mockDirectItemsPost.mockResolvedValueOnce(
+      makeResponse({ ok: true, diff: {}, structuralIssues: null }),
+    );
+
+    const tools = createBoundUpsertTools(logger, "ws-1");
+    await tools.upsert_signal!.execute!({ id: "s", config: {} }, TOOL_CALL_OPTS);
+
+    expect(mockInvalidateBlock2).toHaveBeenCalledWith("ws-1");
+  });
+
+  it("does not invalidate the cache when the upsert fails", async () => {
+    mockDraftItemsPost.mockResolvedValueOnce(
+      makeResponse({ error: "Invalid agent config" }, 400, false),
+    );
+
+    const tools = createBoundUpsertTools(logger, "ws-1");
+    await tools.upsert_agent!.execute!({ id: "bad", config: {} }, TOOL_CALL_OPTS);
+
+    expect(mockInvalidateBlock2).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/system/agents/workspace-chat/tools/upsert-tools.ts
+++ b/packages/system/agents/workspace-chat/tools/upsert-tools.ts
@@ -14,6 +14,7 @@ import { client } from "@atlas/client/v2";
 import type { Logger } from "@atlas/logger";
 import { jsonSchema, tool } from "ai";
 import { z } from "zod";
+import { invalidateBlock2 } from "../block2-cache.ts";
 
 const StructuralIssueSchema = z.object({ code: z.string(), path: z.string(), message: z.string() });
 
@@ -162,6 +163,10 @@ export function createBoundUpsertTools(logger: Logger, workspaceId: string): Atl
 
       const body = await directRes.json();
       logger.info(`Direct ${kind} upsert succeeded`, { workspaceId: targetWorkspaceId, id });
+      // The workspace structure just changed — drop the Block 2 cache so the
+      // next turn rebuilds the `<workspace>` section and job-as-tools from
+      // fresh config instead of a stale (up to 5 min) snapshot.
+      invalidateBlock2(targetWorkspaceId);
       return {
         ok: body.ok,
         diff: body.diff ?? {},
@@ -191,6 +196,9 @@ export function createBoundUpsertTools(logger: Logger, workspaceId: string): Atl
 
     const body = await draftRes.json();
     logger.info(`Draft ${kind} upsert succeeded`, { workspaceId: targetWorkspaceId, id });
+    // Invalidate even on draft writes — cheap, and keeps the cache honest if
+    // the config endpoint ever starts surfacing draft state.
+    invalidateBlock2(targetWorkspaceId);
     return {
       ok: body.ok,
       diff: body.diff ?? {},

--- a/packages/system/agents/workspace-chat/workspace-chat.agent.ts
+++ b/packages/system/agents/workspace-chat/workspace-chat.agent.ts
@@ -395,25 +395,33 @@ ${entries.join("\n")}
 /**
  * Build workspace-chat system prompt blocks.
  *
- * Returns three logical tiers matching the prompt-cache layout:
+ * Returns four logical tiers matching the prompt-cache layout:
  *   - block1: weeks-stable static instructions (prompt.txt)
- *   - block2: workspace-stable inventory + identity (workspace XML,
- *     skills, integrations, user identity)
+ *   - block2: workspace-stable identity (skills index, user identity)
  *   - block3: session-stable turn-context (onboarding clause, user profile)
+ *   - block4: volatile workspace inventory — the `<workspace>` XML
+ *     (agents, signals, jobs, MCP servers). Pulled out of block2 because
+ *     it changes on every `upsert_*` / `publish_draft`; co-locating it
+ *     with the 1h-TTL identity tier burned a full-rate cache write on
+ *     every workspace mutation. Carries the cache salt for the same
+ *     reason — "force fresh" should bust the breakpoint that actually
+ *     holds mutable structure.
  *
- * Block 4 (memory + temporal facts) is NOT in the system prompt — it
- * rides as a synthetic user-message preface so the system stays
+ * The turn preface (memory + temporal facts) is NOT in the system prompt
+ * — it rides as a synthetic user-message preface so the system stays
  * byte-stable across turns and the Anthropic prompt cache hits the
- * prefix.
+ * prefix. It is not a cache breakpoint.
  *
- * Anthropic supports up to 4 cache breakpoints per request. We wire
- * one each at block1/block2/block3 boundaries (see
- * `buildSystemMessages`), leaving headroom for a turn-level marker.
+ * Anthropic supports up to 4 cache breakpoints per request. We wire one
+ * each at the block1/block2/block3/block4 boundaries (see the Anthropic
+ * branch of the streamText setup). TTLs are non-increasing across the
+ * sequence (1h, 1h, 5m, 5m) as Anthropic requires.
  */
 export interface SystemBlocks {
   block1: string;
   block2: string;
   block3: string;
+  block4: string;
 }
 
 export function getSystemBlocks(
@@ -424,20 +432,18 @@ export function getSystemBlocks(
     onboarding?: string;
     userProfile?: string;
     /**
-     * Optional cache-salt tag prepended to block 2. The /debug page
+     * Optional cache-salt tag prepended to block 4. The /debug page
      * "force fresh next turn" button bumps a workspace-scoped salt;
      * the chat handler reads it and threads the rendered tag here so
-     * a one-byte change at block 2's prefix invalidates the cached
-     * breakpoint for every chat in the workspace. Empty string when
-     * the workspace has never bumped — no behavior change in that
-     * case.
+     * a one-byte change at block 4's prefix invalidates the volatile-
+     * inventory breakpoint for every chat in the workspace. Empty
+     * string when the workspace has never bumped — no behavior change
+     * in that case.
      */
     cacheSaltTag?: string;
   },
 ): SystemBlocks {
   const block2Parts: string[] = [];
-  if (options?.cacheSaltTag) block2Parts.push(options.cacheSaltTag.trimEnd());
-  block2Parts.push(workspaceSection);
   if (options?.skills) block2Parts.push(options.skills);
   if (options?.userIdentity) block2Parts.push(options.userIdentity);
 
@@ -445,10 +451,18 @@ export function getSystemBlocks(
   if (options?.onboarding) block3Parts.push(options.onboarding);
   if (options?.userProfile) block3Parts.push(options.userProfile);
 
+  // Block 4 — volatile workspace inventory. The cache salt rides here
+  // (not block 2) so "force fresh" busts the breakpoint that actually
+  // carries mutable workspace structure.
+  const block4Parts: string[] = [];
+  if (options?.cacheSaltTag) block4Parts.push(options.cacheSaltTag.trimEnd());
+  block4Parts.push(workspaceSection);
+
   return {
     block1: SYSTEM_PROMPT,
     block2: block2Parts.join("\n\n"),
     block3: block3Parts.join("\n\n"),
+    block4: block4Parts.join("\n\n"),
   };
 }
 
@@ -458,8 +472,10 @@ export function getSystemBlocks(
  * providers see the full prompt as one string.
  */
 export function flattenSystemBlocks(blocks: SystemBlocks): string {
-  const parts = [blocks.block1, blocks.block2];
+  const parts = [blocks.block1];
+  if (blocks.block2) parts.push(blocks.block2);
   if (blocks.block3) parts.push(blocks.block3);
+  if (blocks.block4) parts.push(blocks.block4);
   return parts.join("\n\n");
 }
 
@@ -1050,11 +1066,13 @@ export const workspaceChatAgent = createAgent<string, WorkspaceChatResult>({
         const allTools = composeTools(primaryTools, foregroundToolSets);
         allToolsRef = allTools;
 
-        // Block 4 (turn-local): memory + artifacts + temporal facts injected
-        // as a synthetic user-message preface, NOT in the system prompt.
-        // Keeps the system prompt byte-stable across turns so the Anthropic
-        // prompt cache hits on the prefix; per-turn variation rides
-        // alongside the user's actual message.
+        // Turn preface (turn-local): memory + artifacts + temporal facts
+        // injected as a synthetic user-message preface, NOT in the system
+        // prompt. Keeps the system prompt byte-stable across turns so the
+        // Anthropic prompt cache hits on the prefix; per-turn variation rides
+        // alongside the user's actual message. Distinct from system block 4
+        // (the volatile workspace inventory) — the preface is not a cache
+        // breakpoint, it's a turn-local user message.
         //
         // Each section wraps in `<retrieved_content>` with a provenance
         // attribute so the model applies the `<retrieved_content_hygiene>`
@@ -1065,31 +1083,31 @@ export const workspaceChatAgent = createAgent<string, WorkspaceChatResult>({
           logger,
         );
         const datetimeMessage = buildTemporalFacts(session.datetime);
-        const block4FetchedAt = new Date().toISOString();
-        const block4Entries: PrefaceEntry[] = [];
+        const prefaceFetchedAt = new Date().toISOString();
+        const prefaceEntries: PrefaceEntry[] = [];
         if (memoryBlocks.length > 0) {
-          block4Entries.push({
+          prefaceEntries.push({
             source: "user-authored",
             origin: "memory:workspace-stores",
             body: memoryBlocks.join("\n\n"),
-            fetched_at: block4FetchedAt,
+            fetched_at: prefaceFetchedAt,
           });
         }
         if (artifactBlocks.length > 0) {
-          block4Entries.push({
+          prefaceEntries.push({
             source: "user-authored",
             origin: "artifacts:session",
             body: artifactBlocks.join("\n\n"),
-            fetched_at: block4FetchedAt,
+            fetched_at: prefaceFetchedAt,
           });
         }
-        block4Entries.push({
+        prefaceEntries.push({
           source: "system-config",
           origin: "temporal",
           body: datetimeMessage,
-          fetched_at: block4FetchedAt,
+          fetched_at: prefaceFetchedAt,
         });
-        const block4Preface = composePreface(block4Entries);
+        const turnPreface = composePreface(prefaceEntries);
 
         const onboardingClause = buildOnboardingClause(profileState);
         const userProfileClause = buildUserProfileClause(profileState);
@@ -1136,15 +1154,17 @@ export const workspaceChatAgent = createAgent<string, WorkspaceChatResult>({
         if (session.streamId) {
           // Capture each cache block separately so the chat-inspector can
           // render the breakpoint layout the model actually saw — block 1
-          // (weeks-stable), block 2 (workspace-stable), block 3 (session-
-          // stable, optional), and block 4 (volatile preface). The
-          // operator can spot prefix drift by comparing block-by-block
-          // across turns instead of squinting at a single 26K-char blob.
-          const capturedSystemMessages: string[] = [systemBlocks.block1, systemBlocks.block2];
-          if (systemBlocks.block3) {
-            capturedSystemMessages.push(systemBlocks.block3);
-          }
-          capturedSystemMessages.push(block4Preface);
+          // (weeks-stable), block 2 (workspace-stable identity, optional),
+          // block 3 (session-stable, optional), block 4 (volatile workspace
+          // inventory), then the turn preface (memory + temporal, not a
+          // breakpoint). The operator can spot prefix drift by comparing
+          // block-by-block across turns instead of squinting at a single
+          // 26K-char blob.
+          const capturedSystemMessages: string[] = [systemBlocks.block1];
+          if (systemBlocks.block2) capturedSystemMessages.push(systemBlocks.block2);
+          if (systemBlocks.block3) capturedSystemMessages.push(systemBlocks.block3);
+          capturedSystemMessages.push(systemBlocks.block4);
+          capturedSystemMessages.push(turnPreface);
           ChatStorage.setSystemPromptContext(
             session.streamId,
             { systemMessages: capturedSystemMessages },
@@ -1196,24 +1216,24 @@ export const workspaceChatAgent = createAgent<string, WorkspaceChatResult>({
           return !hasReasoning;
         });
 
-        // Block 4 preface (memory + datetime) injected as a synthetic
+        // Turn preface (memory + datetime) injected as a synthetic
         // user-message at position 0 — NOT inside `system`. This keeps
         // `system` byte-stable across turns so the Anthropic prompt
         // cache hits the prefix; turn-local variation lives in the
         // messages array where it doesn't poison the cacheable prefix.
         // The synthetic message is ephemeral — it isn't appended to
         // ChatStorage so it doesn't accumulate in the conversation.
-        const messagesWithBlock4Preface: AtlasUIMessage[] = block4Preface
+        const messagesWithTurnPreface: AtlasUIMessage[] = turnPreface
           ? [
               {
                 id: crypto.randomUUID(),
                 role: "user",
-                parts: [{ type: "text", text: block4Preface }],
+                parts: [{ type: "text", text: turnPreface }],
               },
               ...sanitizedMessages,
             ]
           : sanitizedMessages;
-        const modelMessages = await convertToModelMessages(messagesWithBlock4Preface, {
+        const modelMessages = await convertToModelMessages(messagesWithTurnPreface, {
           convertDataPart: (part) => {
             if (part.type === "data-credential-linked") {
               const data = (
@@ -1261,12 +1281,17 @@ export const workspaceChatAgent = createAgent<string, WorkspaceChatResult>({
                   content: systemBlocks.block1,
                   providerOptions: { anthropic: { cacheControl: longTtl } },
                 },
-                {
+              ];
+              // block2 — workspace-stable identity. May be empty (a
+              // workspace with no skills and no stored user identity);
+              // skip rather than emit an empty system message.
+              if (systemBlocks.block2) {
+                msgs.push({
                   role: "system",
                   content: systemBlocks.block2,
                   providerOptions: { anthropic: { cacheControl: longTtl } },
-                },
-              ];
+                });
+              }
               if (systemBlocks.block3) {
                 msgs.push({
                   role: "system",
@@ -1274,6 +1299,15 @@ export const workspaceChatAgent = createAgent<string, WorkspaceChatResult>({
                   providerOptions: { anthropic: { cacheControl: shortTtl } },
                 });
               }
+              // block4 — volatile workspace inventory. 5m TTL: it changes
+              // on every upsert_*/publish_draft, so a full-rate (1h) write
+              // would be wasted. Sits last so the non-increasing-TTL rule
+              // holds across the sequence: 1h, 1h, 5m, 5m.
+              msgs.push({
+                role: "system",
+                content: systemBlocks.block4,
+                providerOptions: { anthropic: { cacheControl: shortTtl } },
+              });
               return msgs;
             })()
           : [];

--- a/packages/system/agents/workspace-chat/workspace-chat.agent.ts
+++ b/packages/system/agents/workspace-chat/workspace-chat.agent.ts
@@ -481,6 +481,53 @@ export function flattenSystemBlocks(blocks: SystemBlocks): string {
 }
 
 /**
+ * Build the Anthropic system-message array — one `role: "system"` message
+ * per non-empty block, each carrying its own `cache_control` breakpoint.
+ *
+ * Anthropic enforces non-increasing TTL across the tools → system →
+ * messages sequence (a 1h breakpoint cannot follow a 5m one). Block 1 and
+ * block 2 are weeks-/workspace-stable so they take the 1h TTL; block 3
+ * (session-stable) and block 4 (volatile workspace inventory, rewritten on
+ * every `upsert_*`/`publish_draft`) take the cheaper 5m TTL. The emitted
+ * order is 1h, 1h, 5m, 5m — non-increasing, so the rule holds.
+ *
+ * block2 may be empty (a workspace with no skills and no stored user
+ * identity); it's skipped rather than emitted as an empty system message.
+ * block3 is likewise conditional. block1 and block4 are always present.
+ */
+export function buildAnthropicSystemMessages(blocks: SystemBlocks): ModelMessage[] {
+  const longTtl = { type: "ephemeral", ttl: "1h" } as const;
+  const shortTtl = { type: "ephemeral" } as const;
+  const msgs: ModelMessage[] = [
+    {
+      role: "system",
+      content: blocks.block1,
+      providerOptions: { anthropic: { cacheControl: longTtl } },
+    },
+  ];
+  if (blocks.block2) {
+    msgs.push({
+      role: "system",
+      content: blocks.block2,
+      providerOptions: { anthropic: { cacheControl: longTtl } },
+    });
+  }
+  if (blocks.block3) {
+    msgs.push({
+      role: "system",
+      content: blocks.block3,
+      providerOptions: { anthropic: { cacheControl: shortTtl } },
+    });
+  }
+  msgs.push({
+    role: "system",
+    content: blocks.block4,
+    providerOptions: { anthropic: { cacheControl: shortTtl } },
+  });
+  return msgs;
+}
+
+/**
  * Generates a concise 2-3 word title for a conversation based on its messages.
  */
 export async function generateChatTitle(
@@ -1266,51 +1313,7 @@ export const workspaceChatAgent = createAgent<string, WorkspaceChatResult>({
         // every prefix wrote fresh.
         const isAnthropic = conversationalModel.provider.startsWith("anthropic");
         const systemModelMessages: ModelMessage[] = isAnthropic
-          ? (() => {
-              // Anthropic enforces non-increasing TTL across the
-              // tools → system → messages block sequence — a 1h
-              // cache_control cannot come after a 5m one — but the
-              // reverse (1h, 1h, 5m, ...) is valid. Block 1 and 2 are
-              // weeks-stable / workspace-stable; block 3 is session-
-              // stable so it gets the cheaper 5m TTL (~0.6× write cost
-              // vs 1h).
-              const longTtl = { type: "ephemeral", ttl: "1h" } as const;
-              const shortTtl = { type: "ephemeral" } as const;
-              const msgs: ModelMessage[] = [
-                {
-                  role: "system",
-                  content: systemBlocks.block1,
-                  providerOptions: { anthropic: { cacheControl: longTtl } },
-                },
-              ];
-              // block2 — workspace-stable identity. May be empty (a
-              // workspace with no skills and no stored user identity);
-              // skip rather than emit an empty system message.
-              if (systemBlocks.block2) {
-                msgs.push({
-                  role: "system",
-                  content: systemBlocks.block2,
-                  providerOptions: { anthropic: { cacheControl: longTtl } },
-                });
-              }
-              if (systemBlocks.block3) {
-                msgs.push({
-                  role: "system",
-                  content: systemBlocks.block3,
-                  providerOptions: { anthropic: { cacheControl: shortTtl } },
-                });
-              }
-              // block4 — volatile workspace inventory. 5m TTL: it changes
-              // on every upsert_*/publish_draft, so a full-rate (1h) write
-              // would be wasted. Sits last so the non-increasing-TTL rule
-              // holds across the sequence: 1h, 1h, 5m, 5m.
-              msgs.push({
-                role: "system",
-                content: systemBlocks.block4,
-                providerOptions: { anthropic: { cacheControl: shortTtl } },
-              });
-              return msgs;
-            })()
+          ? buildAnthropicSystemMessages(systemBlocks)
           : [];
 
         try {

--- a/packages/system/agents/workspace-chat/workspace-chat.agent.ts
+++ b/packages/system/agents/workspace-chat/workspace-chat.agent.ts
@@ -403,9 +403,12 @@ ${entries.join("\n")}
  *     (agents, signals, jobs, MCP servers). Pulled out of block2 because
  *     it changes on every `upsert_*` / `publish_draft`; co-locating it
  *     with the 1h-TTL identity tier burned a full-rate cache write on
- *     every workspace mutation. Carries the cache salt for the same
- *     reason — "force fresh" should bust the breakpoint that actually
- *     holds mutable structure.
+ *     every workspace mutation.
+ *
+ * The cache salt rides on block2 (not block4): a "force fresh" bump must
+ * bust *everything*, and a change at block2's prefix cascades through
+ * block3 and block4 too. Salting only block4 would leave the skills /
+ * identity breakpoint cached.
  *
  * The turn preface (memory + temporal facts) is NOT in the system prompt
  * — it rides as a synthetic user-message preface so the system stays
@@ -432,18 +435,21 @@ export function getSystemBlocks(
     onboarding?: string;
     userProfile?: string;
     /**
-     * Optional cache-salt tag prepended to block 4. The /debug page
+     * Optional cache-salt tag prepended to block 2. The /debug page
      * "force fresh next turn" button bumps a workspace-scoped salt;
      * the chat handler reads it and threads the rendered tag here so
-     * a one-byte change at block 4's prefix invalidates the volatile-
-     * inventory breakpoint for every chat in the workspace. Empty
-     * string when the workspace has never bumped — no behavior change
-     * in that case.
+     * a one-byte change at block 2's prefix invalidates that breakpoint
+     * — and, because block 3 and block 4 sit behind it, the whole
+     * cached prefix — for every chat in the workspace. Empty string
+     * when the workspace has never bumped — no behavior change then.
      */
     cacheSaltTag?: string;
   },
 ): SystemBlocks {
+  // The salt leads block 2 so a "force fresh" bump cascades: changing
+  // block 2's prefix invalidates block 3 and block 4 along with it.
   const block2Parts: string[] = [];
+  if (options?.cacheSaltTag) block2Parts.push(options.cacheSaltTag.trimEnd());
   if (options?.skills) block2Parts.push(options.skills);
   if (options?.userIdentity) block2Parts.push(options.userIdentity);
 
@@ -451,12 +457,7 @@ export function getSystemBlocks(
   if (options?.onboarding) block3Parts.push(options.onboarding);
   if (options?.userProfile) block3Parts.push(options.userProfile);
 
-  // Block 4 — volatile workspace inventory. The cache salt rides here
-  // (not block 2) so "force fresh" busts the breakpoint that actually
-  // carries mutable workspace structure.
-  const block4Parts: string[] = [];
-  if (options?.cacheSaltTag) block4Parts.push(options.cacheSaltTag.trimEnd());
-  block4Parts.push(workspaceSection);
+  const block4Parts: string[] = [workspaceSection];
 
   return {
     block1: SYSTEM_PROMPT,

--- a/packages/system/skills/debugging-broken-jobs/SKILL.md
+++ b/packages/system/skills/debugging-broken-jobs/SKILL.md
@@ -31,6 +31,15 @@ known issue" until you have:
 If you skipped any of those, you don't know enough to claim a bug.
 Run the steps first.
 
+**Run a control before blaming your own change.** When something you just
+created or edited fails, fire an equivalent request at something you have
+*not* touched this session. If the untouched thing fails the same way, your
+edit is not the cause — you're looking at a shared layer (request envelope,
+auth, a stale cache, the runtime), so stop re-editing your change. If only
+your edited thing fails, then it *is* your edit. Either branch halves the
+search space in one call; the expensive mistake is looping on your change on
+the assumption it must be the culprit.
+
 ## Symptom triage table
 
 Match the job tool's return shape OR the session's status, then load
@@ -48,6 +57,7 @@ the matching sibling skill.
 | Session `status: failed`, error contains `Invalid job config` or `Invalid signal config` (Zod rejection) | `debugging-runtime-errors` |
 | Job tool returned `output-error` with no meaningful error text (typically called with bare `{}`) | `debugging-job-invocation` |
 | Job tool returned `output-error` mentioning "tool isn't bound" — this is wrong; you forgot a `prompt` arg | `debugging-job-invocation` |
+| `Model tried to call unavailable tool '<name>'` — you created the job this session; it has no bound tool yet | `debugging-job-invocation` |
 | External MCP tool returned 422 / 401 / 403 with provider-side error | check the workspace's MCP server credentials; not a platform bug |
 
 If no row matches, gather more evidence — don't escalate.

--- a/packages/system/skills/debugging-job-invocation/SKILL.md
+++ b/packages/system/skills/debugging-job-invocation/SKILL.md
@@ -77,15 +77,28 @@ with `path: /stale`) and reference it in both `triggers` and
 
 ## When the job tool genuinely isn't bound
 
-The "tool isn't bound" hypothesis is real for:
-- Jobs that exist in `workspace.yml` but the runtime hasn't
-  picked them up yet (workspace was just edited).
-- Jobs whose `triggers` list is empty.
+Distinct from the bare-`{}` case above: here the tool name does not
+exist in your tool set at all — calling it returns
+`Model tried to call unavailable tool '<name>'`.
+
+The usual cause: **you created the job this session.** Job tools are
+bound from a config snapshot taken when the chat session started, so a
+job you just made via `upsert_job` has no dedicated tool until the next
+session. This is expected, not a bug — and you do NOT need to tell the
+user to send another message.
+
+**Fix: run it with `trigger_signal`.** Call
+`trigger_signal({ signalId, payload })` with the job's trigger signal
+id. That fires the job through the signal endpoint and blocks until it
+completes — the in-session equivalent of the bound tool.
+
+Other real causes (rare):
+- Jobs whose `triggers` list is empty — no signal, nothing to fire.
 - Jobs whose signal is unknown to the runtime.
 
-Diagnose by calling `list_jobs(workspaceId)`. If the job appears in
-the list and has triggers, it IS bound. If not, fix the workspace
-config.
+Diagnose by calling `list_jobs(workspaceId)`. If the job appears with a
+trigger signal, invoke it via `trigger_signal` with that signal id. If
+it has no trigger, fix the workspace config.
 
 ## Cross-references
 


### PR DESCRIPTION
## Summary

- A workspace job or signal you create or edit in chat now shows up on the next message instead of being stale for up to 5 minutes — the chat's workspace cache is dropped on every `upsert_*` / `publish_draft`.
- New `trigger_signal` tool: run a job you just created in the *same* chat turn. Before this, a freshly-created job had no callable tool until the next session, so the agent would tell you to send another message.
- Triggering a signal over HTTP with the wrong body shape now returns a clear 400 naming the `{"payload": {...}}` envelope, instead of a misleading "expected X, received undefined" error that pointed at the signal's own schema.
- `load_skill` results are no longer lifted out to artifacts. Skill bodies over the scrubber's size threshold were being replaced with a "[lifted to artifact]" marker, so a "loaded" skill was silently never actually read — the agent proceeded without it. Covers delegate sub-agent calls too.
- The volatile workspace inventory moved to its own prompt-cache breakpoint, so editing a workspace no longer burns a full-rate cache write on the otherwise-stable identity/skills tier. The "force fresh" cache salt stays on the earlier breakpoint so it still busts everything.
- Two debugging skills updated: a "run a control before blaming your own change" triage rule, and corrected guidance for invoking a job created in the current session.

## Test plan

- [ ] In a chat: `upsert_job`, then run it the same turn via `trigger_signal` — no "send another message"
- [ ] In a chat: `upsert_signal`, confirm the change is visible without starting a new chat
- [ ] `curl` a signal endpoint with a bare body -> clear envelope error; with `{"payload": {...}}` -> works
- [ ] `load_skill` on a large skill -> the body lands in the prompt, not a marker
- [ ] typecheck + knip + full test suite (green locally)

## Not yet run

The promptfoo eval suite hasn't been run on this branch yet — opening for review with typecheck / knip / unit tests green. Evals to follow.