### PR TITLE
studio-installer CI: fix macos-intel cargo shim shadowing rust toolchain

### DIFF
--- a/.github/workflows/studio-installer-build.yml
+++ b/.github/workflows/studio-installer-build.yml
@@ -115,6 +115,19 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Pin PATH to fresh Rust toolchain (macos-latest-large)
+        # The macos-latest-large image ships a pre-installed /usr/local/bin/cargo
+        # that is actually rustup-init and dies on `cargo metadata` with
+        # "unexpected argument 'metadata' found". The dtolnay step above
+        # installs a working toolchain at ~/.cargo/bin but its PATH entry gets
+        # shadowed by the runner image shim. Force it to the front of PATH.
+        if: matrix.platform == 'macos-intel'
+        shell: bash
+        run: |
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+          "$HOME/.cargo/bin/cargo" --version
+          "$HOME/.cargo/bin/rustc" --version
+
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
         with:


### PR DESCRIPTION
## Summary
- `macos-latest-large` ships a `/usr/local/bin/cargo` that's really `rustup-init`, so Tauri's `cargo metadata` call dies with `unexpected argument 'metadata' found` before the build even starts ([failing run](https://github.com/friday-platform/friday-studio/actions/runs/25882925406/job/76067253790))
- `dtolnay/rust-toolchain` installs a working toolchain at `~/.cargo/bin` but its `GITHUB_PATH` entry gets shadowed by the runner image shim
- Prepend `$HOME/.cargo/bin` to `GITHUB_PATH` after the toolchain install on `macos-intel` only (the arm runner `macos-latest-xlarge` is unaffected); print `cargo --version` / `rustc --version` so a future regression is obvious in the logs

## Test plan
- [ ] Re-run `studio-installer-build` workflow_dispatch on this branch and confirm the macos-intel job reaches the cache/build steps instead of failing in <1s
- [ ] Confirm macos-arm + windows builds still pass (step is gated on `matrix.platform == 'macos-intel'`)