### PR TITLE
fix(webhook-tunnel): verify https origin via --origin-ca-pool

### DIFF
--- a/tools/webhook-tunnel/config.go
+++ b/tools/webhook-tunnel/config.go
@@ -24,11 +24,14 @@ type Config struct {
 	// local origin URL follows the same scheme. Empty in plain-HTTP mode.
 	TLSCert string
 	TLSKey  string
-	// FRIDAY_TLS_CA — private CA file used to verify atlasd's s2s cert
-	// on outbound forwarder calls. The system trust store has no entry
-	// for it, so without this the forwarder x509-errors on every POST
-	// once atlasd is on s2s TLS. Empty when atlasd is on plain HTTP.
-	AtlasdCA string
+	// FRIDAY_TLS_CA — path to the private s2s CA bundle. Used in two
+	// places: (1) the forwarder loads it to verify atlasd's s2s leaf on
+	// outbound POSTs, and (2) cloudflared receives it via
+	// --origin-ca-pool to verify the webhook-tunnel listener's own leaf
+	// on the loopback hop. Both leaves chain to the same CA — the system
+	// trust store has no entry for it, so without this both paths
+	// x509-error. Empty when the mesh is on plain HTTP.
+	FridayCA string
 }
 
 func loadConfig() (*Config, error) {
@@ -44,14 +47,14 @@ func loadConfig() (*Config, error) {
 	if atlasdURL == "" {
 		atlasdURL = "http://localhost:8080"
 	}
-	atlasdCA := os.Getenv("FRIDAY_TLS_CA")
+	fridayCA := os.Getenv("FRIDAY_TLS_CA")
 	// Auto-upgrade scheme when the local s2s CA is configured: atlasd
 	// will be on HTTPS and a stale http:// FRIDAYD_URL (e.g. left over
 	// from a prior non-TLS run) would otherwise hit a TLS listener
 	// with cleartext bytes and fail. Mirrors getAtlasDaemonUrl()'s
 	// upgrade in packages/openapi-client/src/utils.ts. We don't
 	// downgrade https→http for the same reason as the TS path.
-	if atlasdCA != "" && strings.HasPrefix(atlasdURL, "http://") {
+	if fridayCA != "" && strings.HasPrefix(atlasdURL, "http://") {
 		atlasdURL = "https://" + strings.TrimPrefix(atlasdURL, "http://")
 	}
 	secret := os.Getenv("WEBHOOK_SECRET")
@@ -66,6 +69,6 @@ func loadConfig() (*Config, error) {
 		NoTunnel:      os.Getenv("NO_TUNNEL") == "true",
 		TLSCert:       os.Getenv("FRIDAY_TLS_CERT"),
 		TLSKey:        os.Getenv("FRIDAY_TLS_KEY"),
-		AtlasdCA:      atlasdCA,
+		FridayCA:      fridayCA,
 	}, nil
 }

--- a/tools/webhook-tunnel/main.go
+++ b/tools/webhook-tunnel/main.go
@@ -77,7 +77,7 @@ func main() {
 	if err := provider.Init(); err != nil {
 		log.Fatal("provider init", "error", err)
 	}
-	f, err := forwarder.New(cfg.AtlasdURL, cfg.AtlasdCA)
+	f, err := forwarder.New(cfg.AtlasdURL, cfg.FridayCA)
 	if err != nil {
 		log.Fatal("forwarder init", "error", err)
 	}
@@ -150,6 +150,15 @@ func main() {
 func startTunnel(tlsOn bool) {
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
+	// Surface the misconfig that would otherwise look like a 502 from
+	// Cloudflare's edge: HTTPS origin without a CA bundle means
+	// cloudflared falls back to its system trust store, which has no
+	// entry for our private s2s CA, so every webhook x509-errors on the
+	// loopback hop. Logging here saves the next debugger from chasing
+	// the 502 back through cloudflared and the public edge.
+	if tlsOn && cfg.FridayCA == "" {
+		log.Warn("TLS origin without FRIDAY_TLS_CA — cloudflared will likely 502 on inbound webhooks (no --origin-ca-pool)")
+	}
 	bin, err := cloudflared.Resolve(ctx)
 	if err != nil {
 		log.Error("cloudflared resolve failed; tunnel disabled", "error", err)
@@ -161,7 +170,7 @@ func startTunnel(tlsOn bool) {
 		TunnelToken:    cfg.TunnelToken,
 		CloudflaredBin: bin,
 		TLS:            tlsOn,
-		OriginCA:       cfg.AtlasdCA,
+		OriginCA:       cfg.FridayCA,
 		Logger:         log.Child("subcomponent", "tunnel"),
 	})
 	if err := tunMgr.Start(ctx); err != nil {

--- a/tools/webhook-tunnel/main.go
+++ b/tools/webhook-tunnel/main.go
@@ -161,6 +161,7 @@ func startTunnel(tlsOn bool) {
 		TunnelToken:    cfg.TunnelToken,
 		CloudflaredBin: bin,
 		TLS:            tlsOn,
+		OriginCA:       cfg.AtlasdCA,
 		Logger:         log.Child("subcomponent", "tunnel"),
 	})
 	if err := tunMgr.Start(ctx); err != nil {

--- a/tools/webhook-tunnel/tunnel/manager.go
+++ b/tools/webhook-tunnel/tunnel/manager.go
@@ -31,7 +31,12 @@ type Options struct {
 	TunnelToken    string // empty = quick tunnel
 	CloudflaredBin string // resolved binary path (caller does discovery)
 	TLS            bool   // origin speaks https — cloudflared connects via https://localhost:<port>
-	Logger         *logger.Logger
+	// OriginCA is the path to the s2s CA bundle used to verify the local
+	// origin's cert (the webhook-tunnel listener). Required when TLS is true:
+	// cloudflared's system trust store has no entry for the private s2s CA,
+	// so without this it x509-errors and the public edge returns 502.
+	OriginCA string
+	Logger   *logger.Logger
 }
 
 // Status is the value-snapshot returned to callers asking about
@@ -207,15 +212,26 @@ func (m *Manager) buildArgs() []string {
 		scheme = "https"
 	}
 	url := fmt.Sprintf("%s://localhost:%d", scheme, m.opts.Port)
+	// When the local origin is HTTPS with the private s2s cert, cloudflared's
+	// system trust store has no entry for our CA. Point it at the s2s CA
+	// bundle via --origin-ca-pool so the loopback hop is still authenticated
+	// (preserves the rest of the mesh's mutual-auth posture). Without this,
+	// cloudflared x509-errors and the public edge returns 502 to GitHub.
+	args := []string{}
 	if m.opts.TunnelToken != "" {
 		// Named tunnel via token. cloudflared accepts the token via
 		// `tunnel run --token <t>` (the npm wrapper uses the same
 		// invocation). --url is ignored when the token's config defines
 		// ingress, but doesn't error if present.
-		return []string{"tunnel", "run", "--token", m.opts.TunnelToken, "--url", url}
+		args = append(args, "tunnel", "run", "--token", m.opts.TunnelToken, "--url", url)
+	} else {
+		// Quick tunnel: trycloudflare.com URL.
+		args = append(args, "tunnel", "--url", url, "--no-autoupdate")
 	}
-	// Quick tunnel: trycloudflare.com URL.
-	return []string{"tunnel", "--url", url, "--no-autoupdate"}
+	if m.opts.TLS && m.opts.OriginCA != "" {
+		args = append(args, "--origin-ca-pool", m.opts.OriginCA)
+	}
+	return args
 }
 
 // scan reads cloudflared lines from r and fans Event values into the

--- a/tools/webhook-tunnel/tunnel/manager_test.go
+++ b/tools/webhook-tunnel/tunnel/manager_test.go
@@ -1,0 +1,59 @@
+package tunnel
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestBuildArgs locks in the cloudflared command line for each
+// (TunnelToken, TLS, OriginCA) shape. The original 502-on-every-webhook
+// bug was a missing --origin-ca-pool branch in this function, so it's
+// worth pinning the contract here in isolation.
+func TestBuildArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		opts Options
+		want []string
+	}{
+		{
+			name: "quick tunnel http",
+			opts: Options{Port: 9090},
+			want: []string{"tunnel", "--url", "http://localhost:9090", "--no-autoupdate"},
+		},
+		{
+			name: "quick tunnel https without ca — no flag (matches buggy pre-fix behavior for ergonomics; the main process logs a warn)",
+			opts: Options{Port: 9090, TLS: true},
+			want: []string{"tunnel", "--url", "https://localhost:9090", "--no-autoupdate"},
+		},
+		{
+			name: "quick tunnel https with ca",
+			opts: Options{Port: 9090, TLS: true, OriginCA: "/etc/friday/s2s-ca.crt"},
+			want: []string{"tunnel", "--url", "https://localhost:9090", "--no-autoupdate", "--origin-ca-pool", "/etc/friday/s2s-ca.crt"},
+		},
+		{
+			name: "named tunnel http",
+			opts: Options{Port: 9090, TunnelToken: "tok"},
+			want: []string{"tunnel", "run", "--token", "tok", "--url", "http://localhost:9090"},
+		},
+		{
+			name: "named tunnel https with ca",
+			opts: Options{Port: 9090, TunnelToken: "tok", TLS: true, OriginCA: "/etc/friday/s2s-ca.crt"},
+			want: []string{"tunnel", "run", "--token", "tok", "--url", "https://localhost:9090", "--origin-ca-pool", "/etc/friday/s2s-ca.crt"},
+		},
+		{
+			name: "ca without tls is dropped — origin-ca-pool only meaningful when origin speaks https",
+			opts: Options{Port: 9090, OriginCA: "/etc/friday/s2s-ca.crt"},
+			want: []string{"tunnel", "--url", "http://localhost:9090", "--no-autoupdate"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := &Manager{opts: tc.opts}
+			got := m.buildArgs()
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("buildArgs() mismatch\n  got:  %v\n  want: %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Pass `FRIDAY_TLS_CA` to cloudflared as `--origin-ca-pool` so it can verify the local webhook-tunnel listener's s2s cert.
- Without this, cloudflared's system trust store has no entry for the private s2s CA → it x509-errors on the loopback hop and the public edge returns **502** to every inbound webhook.
- Preserves the mesh's mutual-auth posture instead of disabling verify on the hop.

## Background
When `FRIDAY_TLS_CERT`/`KEY` are set, the webhook-tunnel listener and the daemon both speak HTTPS with a cert signed by `~/.atlas/tls/s2s-ca.crt`. The existing TLS support upgrades the cloudflared origin URL from `http://localhost:9090` to `https://localhost:9090`, but doesn't tell cloudflared which CA to trust on that hop — so every webhook delivery 502s.

Repro: with TLS env set, run `deno task webhook-tunnel`, then POST any payload to the public tunnel URL. You'll see `Unable to reach the origin service` from Cloudflare's edge.

After this change: cloudflared verifies the webhook-tunnel's leaf against the same s2s CA the rest of the mesh uses, and inbound webhooks reach the daemon normally.

## Test plan
- [x] `go test ./tools/webhook-tunnel/...` green
- [x] Locally verified end-to-end: GitHub Issue `@mention` → bot reply in ~10s; same for PR comments
- [x] No `--no-tls-verify` anywhere — every hop still authenticated