### PR TITLE
fix(bootstrap): copy VFS skill dirs to real temp before packing archive

### DIFF
--- a/packages/system/skills/bootstrap.test.ts
+++ b/packages/system/skills/bootstrap.test.ts
@@ -17,9 +17,12 @@
  * (no churn writes).
  */
 
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { join } from "node:path";
 import type { Skill, SkillStorageAdapter, SkillSummary } from "@atlas/skills";
-import { _setSkillStorageForTest } from "@atlas/skills";
+import { _setSkillStorageForTest, extractArchiveContents, packSkillArchive } from "@atlas/skills";
 import type { Result } from "@atlas/utils";
+import { makeTempDir } from "@atlas/utils/temp.server";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock `computeSkillHash` so the resurrection test can pin a stored
@@ -34,7 +37,7 @@ vi.mock("@atlas/skills", async () => {
   return { ...actual, computeSkillHash: mockComputeSkillHash };
 });
 
-import { ensureSystemSkills } from "./bootstrap.ts";
+import { copySkillDirToReal, ensureSystemSkills } from "./bootstrap.ts";
 
 interface StoredSkill {
   skillId: string;
@@ -256,5 +259,69 @@ describe("ensureSystemSkills — orphan tombstone pass", () => {
     // publish ran (which writes disabled:false) or because setDisabled
     // was called explicitly.
     expect(store.get("agent-action-handshake")?.disabled).toBe(false);
+  });
+});
+
+describe("copySkillDirToReal", () => {
+  // Each test gets a fresh source dir and cleans up both src + dest.
+  let srcDir: string;
+  let destDir: string | undefined;
+
+  beforeEach(() => {
+    srcDir = makeTempDir({ prefix: "atlas-skill-src-" });
+    destDir = undefined;
+  });
+
+  afterEach(async () => {
+    await rm(srcDir, { recursive: true, force: true });
+    if (destDir) await rm(destDir, { recursive: true, force: true });
+  });
+
+  it("copies flat files verbatim", async () => {
+    await writeFile(join(srcDir, "SKILL.md"), "# Skill\n");
+    await writeFile(join(srcDir, "extra.txt"), "hello");
+
+    destDir = await copySkillDirToReal(srcDir);
+
+    expect(await readFile(join(destDir, "SKILL.md"), "utf-8")).toBe("# Skill\n");
+    expect(await readFile(join(destDir, "extra.txt"), "utf-8")).toBe("hello");
+  });
+
+  it("recursively copies nested subdirectories", async () => {
+    await mkdir(join(srcDir, "references"), { recursive: true });
+    await writeFile(join(srcDir, "SKILL.md"), "# Skill\n");
+    await writeFile(join(srcDir, "references", "api.md"), "# API ref\n");
+    await mkdir(join(srcDir, "references", "deep"), { recursive: true });
+    await writeFile(join(srcDir, "references", "deep", "nested.md"), "nested");
+
+    destDir = await copySkillDirToReal(srcDir);
+
+    expect(await readFile(join(destDir, "references", "api.md"), "utf-8")).toBe("# API ref\n");
+    expect(await readFile(join(destDir, "references", "deep", "nested.md"), "utf-8")).toBe(
+      "nested",
+    );
+  });
+
+  it("produces a dest tree that packSkillArchive can tar without error", async () => {
+    await mkdir(join(srcDir, "references"), { recursive: true });
+    await writeFile(join(srcDir, "SKILL.md"), "# Skill\n");
+    await writeFile(join(srcDir, "references", "ref.md"), "# Reference\n");
+
+    destDir = await copySkillDirToReal(srcDir);
+
+    // packSkillArchive must not throw and the archive must contain both files.
+    const archive = await packSkillArchive(destDir);
+    const contents = await extractArchiveContents(archive);
+    expect(Object.keys(contents)).toContain("SKILL.md");
+    expect(Object.keys(contents)).toContain("references/ref.md");
+  });
+
+  it("returns an independent copy — mutations to src do not affect dest", async () => {
+    await writeFile(join(srcDir, "SKILL.md"), "original");
+
+    destDir = await copySkillDirToReal(srcDir);
+
+    await writeFile(join(srcDir, "SKILL.md"), "mutated");
+    expect(await readFile(join(destDir, "SKILL.md"), "utf-8")).toBe("original");
   });
 });

--- a/packages/system/skills/bootstrap.test.ts
+++ b/packages/system/skills/bootstrap.test.ts
@@ -146,7 +146,7 @@ function makeStorageStub(initial: StoredSkill[]) {
     // just for test value the bootstrap pass doesn't read.
     listJobOnlySkillIds: vi.fn(),
   } as unknown as SkillStorageAdapter;
-  return { adapter, store, setDisabled, list };
+  return { adapter, store, setDisabled, list, publish };
 }
 
 describe("ensureSystemSkills — orphan tombstone pass", () => {
@@ -229,35 +229,35 @@ describe("ensureSystemSkills — orphan tombstone pass", () => {
     expect(calls).toHaveLength(0);
   });
 
-  it("re-enables a previously-tombstoned skill when its source dir is restored (hash-match path)", async () => {
-    // Resurrection scenario: skill X was published, then deleted and
-    // tombstoned, then the source dir came back (git revert, backup
-    // restore, etc.) with byte-identical content. Naive content-hash
-    // shortcut would skip publish entirely, leave `disabled: true`
-    // sticky, and the resurrected skill stays invisible forever
-    // despite being on disk.
-    //
-    // We force the bug's path by mocking `computeSkillHash` to return
-    // a fixed value AND seeding the registry with the exact same hash —
-    // the shortcut at `publishOne:163-171` then fires for sure. The
-    // resurrection fix must intercept this case and call setDisabled
-    // (or fall through to publish) regardless of hash match.
+  it("re-publishes (not just re-enables) a disabled skill even when hash matches", async () => {
+    // Resurrection via re-publish: a skill may have been tombstoned after
+    // a failed archive pack (e.g. the VFS fd bug), leaving archive=null
+    // in the DB with an otherwise-correct source-hash. A naive re-enable
+    // via setDisabled would restore visibility without healing the null
+    // archive. The fix is to fall through to publish for any disabled row,
+    // regardless of hash match — publish atomically re-enables and heals.
     mockComputeSkillHash.mockResolvedValue("identical-content-hash");
-    const { adapter, store } = makeStorageStub([
+    const { adapter, store, setDisabled, publish } = makeStorageStub([
       {
         skillId: "sk_resurrected",
         name: "agent-action-handshake",
-        disabled: true, // was tombstoned in a prior boot
-        sourceHash: "identical-content-hash", // matches what computeSkillHash returns now
+        disabled: true,
+        sourceHash: "identical-content-hash",
       },
     ]);
     _setSkillStorageForTest(adapter);
 
     await ensureSystemSkills();
 
-    // After bootstrap, the skill must be enabled — either because
-    // publish ran (which writes disabled:false) or because setDisabled
-    // was called explicitly.
+    // publish must have run (not just setDisabled) so the archive is healed.
+    expect(publish).toHaveBeenCalledWith(
+      "friday",
+      "agent-action-handshake",
+      expect.any(String),
+      expect.any(Object),
+    );
+    // setDisabled must NOT have been called — publish handles re-enabling.
+    expect(setDisabled).not.toHaveBeenCalledWith("sk_resurrected", false);
     expect(store.get("agent-action-handshake")?.disabled).toBe(false);
   });
 });
@@ -283,6 +283,7 @@ describe("copySkillDirToReal", () => {
 
     destDir = await copySkillDirToReal(srcDir);
 
+    expect(destDir).not.toBe(srcDir);
     expect(await readFile(join(destDir, "SKILL.md"), "utf-8")).toBe("# Skill\n");
     expect(await readFile(join(destDir, "extra.txt"), "utf-8")).toBe("hello");
   });
@@ -309,11 +310,14 @@ describe("copySkillDirToReal", () => {
 
     destDir = await copySkillDirToReal(srcDir);
 
-    // packSkillArchive must not throw and the archive must contain both files.
+    // packSkillArchive must not throw and the archive must contain both files
+    // with their original content intact.
     const archive = await packSkillArchive(destDir);
     const contents = await extractArchiveContents(archive);
     expect(Object.keys(contents)).toContain("SKILL.md");
     expect(Object.keys(contents)).toContain("references/ref.md");
+    expect(contents["SKILL.md"]).toBe("# Skill\n");
+    expect(contents["references/ref.md"]).toBe("# Reference\n");
   });
 
   it("returns an independent copy — mutations to src do not affect dest", async () => {

--- a/packages/system/skills/bootstrap.ts
+++ b/packages/system/skills/bootstrap.ts
@@ -18,12 +18,13 @@
  */
 
 import type { Dirent } from "node:fs";
-import { readdir, readFile, stat } from "node:fs/promises";
+import { mkdir, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createLogger } from "@atlas/logger";
 import { computeSkillHash, packSkillArchive, parseSkillMd, SkillStorage } from "@atlas/skills";
 import { SYSTEM_USER_ID } from "@atlas/skills/constants";
+import { makeTempDir } from "@atlas/utils/temp.server";
 
 const logger = createLogger({ name: "system-skill-bootstrap" });
 
@@ -194,8 +195,22 @@ async function publishOne(dir: string): Promise<string | null> {
   }
 
   // Pack archive if the directory has anything besides SKILL.md.
+  // `tar.create()` requests OS-level file descriptors from each source
+  // file. Inside a Deno-compiled binary the skill dirs live in an
+  // embedded virtual filesystem that cannot provide real OS fds, so
+  // `create()` throws "Failed to get OS file descriptor from file".
+  // Copying to a real temp dir first (readFile/writeFile work on VFS
+  // paths) gives tar the real fds it needs.
   const hasBundle = await hasSupportFiles(dir);
-  const archive = hasBundle ? new Uint8Array(await packSkillArchive(dir)) : undefined;
+  let archive: Uint8Array<ArrayBuffer> | undefined;
+  if (hasBundle) {
+    const realDir = await copySkillDirToReal(dir);
+    try {
+      archive = new Uint8Array(await packSkillArchive(realDir));
+    } finally {
+      await rm(realDir, { recursive: true, force: true }).catch(() => {});
+    }
+  }
 
   const result = await SkillStorage.publish(SYSTEM_SKILL_NAMESPACE, name, SYSTEM_USER_ID, {
     description,
@@ -223,4 +238,34 @@ async function hasSupportFiles(dir: string): Promise<boolean> {
     if (entry.isFile() || entry.isDirectory()) return true;
   }
   return false;
+}
+
+/**
+ * Recursively copies a skill directory tree to a fresh OS temp directory
+ * using only `readdir` / `readFile` / `writeFile`, which work on VFS
+ * paths inside a Deno-compiled binary. The result is a real on-disk tree
+ * with genuine OS file descriptors that `packSkillArchive` (via tar) can
+ * open without error.
+ *
+ * Exported for unit testing. Callers are responsible for removing the
+ * returned directory when done.
+ */
+export async function copySkillDirToReal(srcDir: string): Promise<string> {
+  const destDir = makeTempDir({ prefix: "atlas-skill-copy-" });
+  await copyEntries(srcDir, destDir);
+  return destDir;
+}
+
+async function copyEntries(srcDir: string, destDir: string): Promise<void> {
+  const entries = await readdir(srcDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const src = join(srcDir, entry.name);
+    const dest = join(destDir, entry.name);
+    if (entry.isDirectory()) {
+      await mkdir(dest, { recursive: true });
+      await copyEntries(src, dest);
+    } else if (entry.isFile()) {
+      await writeFile(dest, await readFile(src));
+    }
+  }
 }

--- a/packages/system/skills/bootstrap.ts
+++ b/packages/system/skills/bootstrap.ts
@@ -163,33 +163,16 @@ async function publishOne(dir: string): Promise<string | null> {
 
   const sourceHash = await computeSkillHash(dir);
 
-  // Shortcut: if the stored version already has this hash, don't touch.
-  // EXCEPT: if the stored row is disabled (a previous boot tombstoned
-  // it as an orphan), the source dir has clearly come back since the
-  // tombstone — re-enable it before short-circuiting. Without this,
-  // a deleted-then-restored skill stays invisible to
-  // `resolveVisibleSkills` despite being on disk.
+  // Shortcut: if the stored version already has this hash and is enabled,
+  // don't touch. Disabled rows fall through to re-publish even on a hash
+  // match: a prior boot may have tombstoned the skill after a failed archive
+  // pack (e.g. the VFS fd bug), leaving archive=null in the DB. Re-publishing
+  // heals the null archive and re-enables the skill atomically.
   const existing = await SkillStorage.get(SYSTEM_SKILL_NAMESPACE, name);
   if (existing.ok && existing.data) {
     const storedHash = existing.data.frontmatter["source-hash"];
-    if (typeof storedHash === "string" && storedHash === sourceHash) {
-      if (existing.data.disabled) {
-        const reEnable = await SkillStorage.setDisabled(existing.data.skillId, false);
-        if (!reEnable.ok) {
-          logger.warn("resurrection re-enable failed", {
-            name,
-            skillId: existing.data.skillId,
-            error: reEnable.error,
-          });
-        } else {
-          logger.info("re-enabled previously-tombstoned skill", {
-            name: `@${SYSTEM_SKILL_NAMESPACE}/${name}`,
-            skillId: existing.data.skillId,
-          });
-        }
-      } else {
-        logger.debug("bundled skill up to date", { name, hash: sourceHash.slice(0, 12) });
-      }
+    if (typeof storedHash === "string" && storedHash === sourceHash && !existing.data.disabled) {
+      logger.debug("bundled skill up to date", { name, hash: sourceHash.slice(0, 12) });
       return name;
     }
   }
@@ -208,7 +191,9 @@ async function publishOne(dir: string): Promise<string | null> {
     try {
       archive = new Uint8Array(await packSkillArchive(realDir));
     } finally {
-      await rm(realDir, { recursive: true, force: true }).catch(() => {});
+      await rm(realDir, { recursive: true, force: true }).catch((e) =>
+        logger.debug("cleanup failed", { error: e instanceof Error ? e.message : String(e) }),
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

- System skills with bundled support files (`references/`, `assets/`, `scripts/`) failed silently in compiled installer builds — 6 of ~11 system skills affected
- Root cause: `tar`'s `create()` calls `node:fs.open()` for OS-level file descriptors on source files; the Deno compiled binary embeds skill dirs in a virtual filesystem that cannot provide real OS fds, so it throws `"Failed to get OS file descriptor from file"`
- Fix: `copySkillDirToReal()` recursively copies the VFS dir to a real OS temp dir using `readFile`/`writeFile` (both work on VFS paths), then `packSkillArchive` runs on the real copy; temp dir is cleaned up in a `finally` block
- Affected skills: `authoring-skills`, `friday-cli`, `workspace-api`, `writing-friday-python-agents`, `writing-workspace-jobs`, `writing-workspace-signals`

## Test plan

- [ ] All 4 existing `ensureSystemSkills` tombstone tests still pass
- [ ] 4 new `copySkillDirToReal` tests cover: flat file copy, nested subdirectories, `packSkillArchive` succeeds on the copy output, independence from source mutations
- [ ] Typecheck clean, lint clean on changed files
- [ ] Requires new installer build to take effect for local installs