### PR TITLE
Launcher: raise RLIMIT_NOFILE so the supervised tree stops hitting EMFILE

### DIFF
--- a/tools/friday-launcher/main.go
+++ b/tools/friday-launcher/main.go
@@ -137,6 +137,13 @@ func main() {
 		return
 	}
 
+	// Raise the soft RLIMIT_NOFILE before any child is spawned, so the
+	// supervised tree inherits the higher cap via fork(). macOS default
+	// for launchd-spawned processes is 256 — friday daemon eats through
+	// that over multi-day uptime (MCP children + NATS + HTTP). See
+	// rlimit_unix.go for the incident this prevents. No-op on Windows.
+	raiseFileLimit()
+
 	// Single-instance handshake: try the flock. If it fails, signal
 	// the running launcher and exit.
 	lock, ok, err := acquirePidLock()

--- a/tools/friday-launcher/rlimit_unix.go
+++ b/tools/friday-launcher/rlimit_unix.go
@@ -1,0 +1,75 @@
+//go:build !windows
+
+package main
+
+import "syscall"
+
+// targetFileLimit is the soft RLIMIT_NOFILE we try to raise to at
+// launcher boot. 65536 is ~256x the macOS default soft limit (256 for
+// processes launched via launchd / LaunchServices / `open`) and well
+// below the kern.maxfilesperproc kernel ceiling (default 245760 on
+// modern macOS). Leaves enough headroom for the friday daemon to
+// supervise 5 services, hold a NATS connection, run cron timers, and
+// keep spawning per-workspace MCP children across multi-day uptime.
+//
+// Why bump it here in the launcher (not inside friday itself): every
+// supervised child inherits the launcher's rlimits via fork(), so one
+// setrlimit at launcher boot covers the whole supervised tree without
+// plumbing the value through each spawn site. Incident 2026-05-14:
+// after ~49h uptime, friday hit "Too many open files (os error 24)"
+// spawning a Snowflake MCP server, which silently broke a daily
+// flash-report job — the analyst agent fell back on stale memory and
+// kept emailing a 3-day-old report.
+const targetFileLimit = 65536
+
+// fallbackFileLimit is the older-macOS-friendly cap. macOS 10.7..10.11
+// clamped the unprivileged setrlimit ceiling at OPEN_MAX (10240); on
+// those builds a target of 65536 returns EINVAL. The retry path uses
+// this so we still get a meaningful bump (~40x the 256 default) where
+// we can't go higher.
+const fallbackFileLimit = 10240
+
+// raiseFileLimit raises the soft RLIMIT_NOFILE toward targetFileLimit,
+// falling back to fallbackFileLimit if the kernel rejects the higher
+// value. Non-fatal: a failed raise just puts us back on the historical
+// "works until it doesn't" cliff. Logged once per boot.
+func raiseFileLimit() {
+	var rl syscall.Rlimit
+	if err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rl); err != nil {
+		log.Warn("getrlimit RLIMIT_NOFILE failed; FD cap unchanged",
+			"error", err)
+		return
+	}
+	oldSoft := rl.Cur
+
+	// Modern macOS reports rl.Max as RLIM_INFINITY (a very large
+	// number); the rl.Max cap only really binds on Linux hosts where
+	// the operator has set `ulimit -Hn`. Either way, never try to
+	// raise above the hard cap.
+	for _, want := range []uint64{targetFileLimit, fallbackFileLimit} {
+		target := want
+		if rl.Max != 0 && target > rl.Max {
+			target = rl.Max
+		}
+		if rl.Cur >= target {
+			log.Info("RLIMIT_NOFILE already adequate; no change",
+				"soft", rl.Cur, "hard", rl.Max,
+				"target", targetFileLimit)
+			return
+		}
+		attempt := rl
+		attempt.Cur = target
+		if err := syscall.Setrlimit(
+			syscall.RLIMIT_NOFILE, &attempt); err == nil {
+			log.Info("raised RLIMIT_NOFILE",
+				"old_soft", oldSoft, "new_soft", target,
+				"hard", rl.Max)
+			return
+		}
+	}
+	log.Warn("setrlimit RLIMIT_NOFILE failed at every tier; "+
+		"FD cap unchanged",
+		"soft", oldSoft, "hard", rl.Max,
+		"tried_target", targetFileLimit,
+		"tried_fallback", fallbackFileLimit)
+}

--- a/tools/friday-launcher/rlimit_unix_test.go
+++ b/tools/friday-launcher/rlimit_unix_test.go
@@ -1,0 +1,101 @@
+//go:build !windows
+
+package main
+
+import (
+	"syscall"
+	"testing"
+)
+
+// TestRaiseFileLimit_BumpsSoftToward64K asserts the post-call soft
+// limit is at least the prior soft limit, and — when the hard limit
+// allows it — reaches targetFileLimit. The "at least" guard is what
+// load-bears the incident fix: the launcher must never leave the
+// process with a lower cap than the caller's shell already had.
+//
+// The test runs in-process (setrlimit mutates the test binary's own
+// rlimit, not the launcher process's). Cleanup restores the prior
+// limits so later tests in the same binary aren't subject to the
+// bumped cap — important because go test runs the whole package's
+// tests in one process.
+func TestRaiseFileLimit_BumpsSoftToward64K(t *testing.T) {
+	var before syscall.Rlimit
+	if err := syscall.Getrlimit(
+		syscall.RLIMIT_NOFILE, &before); err != nil {
+		t.Fatalf("getrlimit before: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &before)
+	})
+
+	raiseFileLimit()
+
+	var after syscall.Rlimit
+	if err := syscall.Getrlimit(
+		syscall.RLIMIT_NOFILE, &after); err != nil {
+		t.Fatalf("getrlimit after: %v", err)
+	}
+
+	if after.Cur < before.Cur {
+		t.Fatalf("soft cap regressed: before=%d after=%d",
+			before.Cur, after.Cur)
+	}
+	// On CI hosts where the test binary already inherits a soft cap
+	// >= targetFileLimit, raiseFileLimit logs "already adequate" and
+	// is a no-op. Otherwise the post-call soft should reach the
+	// target (modern macOS / Linux) or the fallback (the rare older
+	// macOS path) — anything less means the retry tier silently
+	// gave up.
+	if before.Cur < targetFileLimit {
+		if after.Cur != targetFileLimit &&
+			after.Cur != fallbackFileLimit {
+			t.Fatalf("soft cap landed at unexpected value: "+
+				"before=%d after=%d target=%d fallback=%d",
+				before.Cur, after.Cur,
+				targetFileLimit, fallbackFileLimit)
+		}
+	}
+}
+
+// TestRaiseFileLimit_NoOpWhenAlreadyHigh verifies raiseFileLimit
+// leaves the rlimit alone when the caller already has a soft cap
+// >= targetFileLimit. Catches a regression where the function
+// blindly calls setrlimit and accidentally LOWERS the cap (e.g. if
+// a future refactor forgets the early-return on rl.Cur >= target).
+func TestRaiseFileLimit_NoOpWhenAlreadyHigh(t *testing.T) {
+	var before syscall.Rlimit
+	if err := syscall.Getrlimit(
+		syscall.RLIMIT_NOFILE, &before); err != nil {
+		t.Fatalf("getrlimit before: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &before)
+	})
+
+	// Pre-raise to target so the function should be a no-op. Skip
+	// if the host won't even let us reach the target — there's
+	// nothing meaningful to assert against in that case.
+	primed := before
+	primed.Cur = targetFileLimit
+	if before.Max != 0 && primed.Cur > before.Max {
+		primed.Cur = before.Max
+	}
+	if err := syscall.Setrlimit(
+		syscall.RLIMIT_NOFILE, &primed); err != nil {
+		t.Skipf("host rejects setrlimit at target tier (%d), "+
+			"can't exercise the no-op path: %v",
+			primed.Cur, err)
+	}
+
+	raiseFileLimit()
+
+	var after syscall.Rlimit
+	if err := syscall.Getrlimit(
+		syscall.RLIMIT_NOFILE, &after); err != nil {
+		t.Fatalf("getrlimit after: %v", err)
+	}
+	if after.Cur != primed.Cur {
+		t.Fatalf("soft cap changed unexpectedly: "+
+			"primed=%d after=%d", primed.Cur, after.Cur)
+	}
+}

--- a/tools/friday-launcher/rlimit_windows.go
+++ b/tools/friday-launcher/rlimit_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package main
+
+// raiseFileLimit is a no-op on Windows. Windows uses per-process
+// HANDLEs (≈16M cap, far beyond anything Friday touches) instead of
+// the POSIX file-descriptor table that RLIMIT_NOFILE governs, so
+// there's nothing to raise. Stays defined so main.go can call it
+// unconditionally without a build-tagged call site.
+func raiseFileLimit() {}


### PR DESCRIPTION
## Summary
- macOS spawns the launcher (via launchd / LaunchServices / `open`) with a soft `RLIMIT_NOFILE` of **256** (or 10240 in some kernel contexts). Every supervised child inherits that cap via fork(), and the `friday` daemon — which holds a NATS connection, runs cron timers, and keeps spawning per-workspace MCP children — user through it over multi-day uptime.
- Bump the soft cap to **65536** once at launcher boot (before any child is spawned), so the whole supervised tree gets a sane FD ceiling for free. Falls back to 10240 if the kernel rejects the higher value (older-macOS clamp), never goes above the hard limit, and is a no-op when the inherited cap is already adequate. Windows is a no-op stub (HANDLEs aren't FDs).

## Why now

Incident **2026-05-14**: after ~49h uptime, `friday` started returning `Too many open files (os error 24)` when spawning the Snowflake MCP subprocess. The analyst agent silently fell back on chat memory and kept emailing a 3-day-old flash report. Eventually `friday` itself crashed on EMFILE; process-compose auto-restarted it but the underlying cap was still 10240, so the next failure was inevitable.

Logs from the incident:
```
"MCP server skipped due to connection error","serverId":"snowflake-fast",
"error":"Failed to spawn '/Users/.../python': Too many open files (os error 24)"
...
"error sending request for url (http://localhost:13100/...):
 tcp open error: Too many open files (os error 24)"
...
Error: Error: Too many open files (os error 24)   ← friday daemon crash
```

## Implementation notes

- Bump happens in `main.go` right after `setupLogging()` and the early-exit CLI modes (`--autostart` / `--uninstall`), but **before** the single-instance flock + preflight + supervisor boot — earliest spot that has a working logger and isn't a one-shot CLI path.
- `rlimit_unix.go` carries the darwin+linux implementation; `rlimit_windows.go` is a no-op stub so `main.go` can call it unconditionally.
- Two retry tiers: `65536` (modern macOS / Linux) → `10240` (older-macOS `OPEN_MAX` clamp). Non-fatal on failure — worst case we land back on the historical FD cliff, which is no worse than today.

## Test plan

- [x] `go test -run TestRaiseFileLimit -v ./...` — both new unit tests pass on darwin-arm64 (`already adequate; no change` path; the bump-and-restore path; rlimit restored in `t.Cleanup` so later tests in the same binary aren't affected).
- [x] `go test -short ./...` for the whole launcher package — clean.
- [x] `GOOS=linux go build` + `GOOS=windows go build` — both cross-compile.
- [x] **Real macOS arm64 VM (Tahoe 26.4.1, identical to the incident host)**: built the binary, scp'd over, ran against the live launcher. New binary logged `raised RLIMIT_NOFILE old_soft=10240 new_soft=65536` and handed off cleanly to the running launcher via SIGUSR1 (no disruption to the in-flight installation).
  ```json
  {"msg":"raised RLIMIT_NOFILE","old_soft":10240,"new_soft":65536,"hard":9223372036854775807}
  {"msg":"another launcher detected; sending wake","running_pid":613}
  ```

## Not in scope

- The FD *leak* in atlasd's MCP spawn / NATS / HTTP keep-alive paths is the upstream root cause; this PR only raises the ceiling so the leak doesn't bite users on day-2 anymore. Follow-up to audit `mcp_shared_process_spawn` and friends.
- The studio-installer's `terminate_studio_processes` SIGTERM path that finished off users launcher is also a separate issue (`KeepAlive=false` plist means there's no recovery if the installer kills the launcher and then fails its own extract).