### PR TITLE
fix(test): remove racy pre-flush status check in doctor preflight test

### DIFF
--- a/apps/atlasd/routes/mcp-registry.test.ts
+++ b/apps/atlasd/routes/mcp-registry.test.ts
@@ -706,8 +706,10 @@ describe("MCP Registry Routes", () => {
       });
 
       expect(res.status).toBe(201);
+      // PreflightSettingUpSchema.parse validates status:"setting_up" in the HTTP response
+      // body. A separate testAdapter.get check here is a race — all mocks resolve
+      // immediately, so the doctor task completes during the res.json() await.
       const body = PreflightSettingUpSchema.parse(await res.json());
-      expect((await testAdapter.get(body.server_id))?.status).toBe("setting_up");
 
       await _flushDoctorTasksForTest();
       const persisted = await testAdapter.get(body.server_id);


### PR DESCRIPTION
## Summary

- Removes a racy intermediate assertion in the `doctor path: bare entry → 201 setting_up` test that has been failing on main since #323.
- The assertion checked that the persisted entry status was still `setting_up` immediately after the HTTP response returned — but all doctor mocks (`fetchReadme`, `runDoctor`, `adapter.update`) resolve as microtasks, so the background task completes during the `res.json()` await before the status check runs.
- The HTTP response body is already validated as `status: "setting_up"` by `PreflightSettingUpSchema.parse`, making the persistence check redundant. The post-flush assertions (`awaiting_confirm`, `doctor_report.verdict`, `mockRunDoctor` call count) still cover the full state transition.

## Test plan

- [x] `deno task test apps/atlasd/routes/mcp-registry.test.ts` — all 99 tests pass locally