### PR TITLE
fix(credential-resolver): env-var fallback before declaring provider missing

### DIFF
--- a/packages/core/src/mcp-registry/credential-resolver.test.ts
+++ b/packages/core/src/mcp-registry/credential-resolver.test.ts
@@ -219,6 +219,85 @@ describe("resolveCredentialsByProvider", () => {
     expect((error as Error).message).toContain("not a registered provider");
   });
 
+  // Env-var fallback: a bundled atlas agent declares a Link credential
+  // requirement (e.g. hubspot's HUBSPOT_ACCESS_TOKEN), the user has set
+  // that env var in `~/.friday/local/.env` instead of configuring a Link
+  // credential via Settings → Connections, the runtime works because the
+  // bundled agent reads from env directly. The validator path used to
+  // reject the workspace upload with `missing_providers: ["hubspot"]`
+  // even though everything works at runtime — the fallback below makes
+  // resolveCredentialsByProvider accept the env var as a configured
+  // credential and synthesize a CredentialSummary for it.
+  describe("env-var fallback (~/.friday/local/.env)", () => {
+    const ENV_KEY = "HUBSPOT_ACCESS_TOKEN";
+    let originalValue: string | undefined;
+
+    beforeEach(() => {
+      originalValue = process.env[ENV_KEY];
+    });
+
+    afterEach(() => {
+      if (originalValue === undefined) delete process.env[ENV_KEY];
+      else process.env[ENV_KEY] = originalValue;
+    });
+
+    it("returns a synthetic 'env:' credential when InvalidProviderError would have fired but env is set", async () => {
+      // Link service has no record of hubspot AND no credentials —
+      // would normally throw InvalidProviderError ("not a registered
+      // provider"). With env-var fallback + HUBSPOT_ACCESS_TOKEN set,
+      // we synthesize a CredentialSummary instead.
+      globalThis.fetch = mockSummaryFetch("hubspot", [], []);
+      process.env[ENV_KEY] = "pat-na2-fake-test-token";
+
+      const credentials = await resolveCredentialsByProvider("hubspot");
+      expect(credentials.length).toEqual(1);
+      // biome-ignore lint/style/noNonNullAssertion: length asserted above
+      expect(credentials[0]!.id).toEqual(`env:${ENV_KEY}`);
+      // biome-ignore lint/style/noNonNullAssertion: length asserted above
+      expect(credentials[0]!.provider).toEqual("hubspot");
+      // biome-ignore lint/style/noNonNullAssertion: length asserted above
+      expect(credentials[0]!.type).toEqual("env");
+      // biome-ignore lint/style/noNonNullAssertion: length asserted above
+      expect(credentials[0]!.isDefault).toEqual(true);
+    });
+
+    it("returns a synthetic 'env:' credential when CredentialNotFoundError would have fired but env is set", async () => {
+      // Link service knows about hubspot but has zero credentials —
+      // would normally throw CredentialNotFoundError. Env-var fallback
+      // takes priority over throwing.
+      globalThis.fetch = mockSummaryFetch("hubspot", [], [{ id: "hubspot" }]);
+      process.env[ENV_KEY] = "pat-na2-fake-test-token";
+
+      const credentials = await resolveCredentialsByProvider("hubspot");
+      expect(credentials.length).toEqual(1);
+      // biome-ignore lint/style/noNonNullAssertion: length asserted above
+      expect(credentials[0]!.id).toEqual(`env:${ENV_KEY}`);
+    });
+
+    it("does NOT fall back to env when env var is unset", async () => {
+      delete process.env[ENV_KEY];
+      globalThis.fetch = mockSummaryFetch("hubspot", [], []);
+
+      const error = await resolveCredentialsByProvider("hubspot").catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(InvalidProviderError);
+    });
+
+    it("does NOT fall back for providers with no bundled-agent declaration (no envKey to map)", async () => {
+      // Set an env var to prove that env-presence alone isn't enough —
+      // we need a known mapping from provider → envKey via the bundled
+      // agents registry. Random env vars don't get treated as
+      // credentials.
+      process.env.SOMETHING_RANDOM = "x";
+      globalThis.fetch = mockSummaryFetch("nonexistent-provider-xyz", [], []);
+
+      const error = await resolveCredentialsByProvider("nonexistent-provider-xyz").catch(
+        (e: unknown) => e,
+      );
+      expect(error).toBeInstanceOf(InvalidProviderError);
+      delete process.env.SOMETHING_RANDOM;
+    });
+  });
+
   it("returns all credentials when multiple exist", async () => {
     globalThis.fetch = mockSummaryFetch("slack", [
       {

--- a/packages/core/src/mcp-registry/credential-resolver.ts
+++ b/packages/core/src/mcp-registry/credential-resolver.ts
@@ -1,5 +1,6 @@
 import process from "node:process";
 import type { LinkCredentialRef } from "@atlas/agent-sdk";
+import { bundledAgentsRegistry } from "@atlas/bundled-agents/registry";
 import { client, DetailedError, parseResult } from "@atlas/client/v2";
 import type { MCPServerConfig } from "@atlas/config";
 import type { Logger } from "@atlas/logger";
@@ -115,6 +116,42 @@ export function getLinkAuthHeaders(): Record<string, string> {
   return { Authorization: `Bearer ${atlasKey}` };
 }
 
+/** Find the env-var name a bundled atlas agent uses to receive a Link
+ * credential for the given provider. Returns the first match across all
+ * bundled agents — the registry is keyed by agent id, but for any one
+ * provider all agents declare the same env var (e.g. every bundled agent
+ * that uses HubSpot reads `HUBSPOT_ACCESS_TOKEN`). Returns undefined when
+ * no bundled agent declares this provider — in that case the env-var
+ * fallback below has no var name to check, and the call falls through to
+ * the original error path. */
+function findEnvKeyForProvider(provider: string): string | undefined {
+  for (const entry of Object.values(bundledAgentsRegistry)) {
+    for (const field of entry.requiredConfig) {
+      if (field.from === "link" && field.provider === provider) {
+        return field.envKey;
+      }
+    }
+  }
+  return undefined;
+}
+
+/** Build a synthetic CredentialSummary for a credential supplied via
+ * environment variable rather than a Link credential record. The
+ * `id: "env:..."` prefix is intentional so any caller that downstream
+ * fetches by id (e.g. to refresh an OAuth token) can short-circuit on
+ * the prefix and skip the Link round-trip. */
+function envCredentialSummary(provider: string, envKey: string): CredentialSummary {
+  return {
+    id: `env:${envKey}`,
+    provider,
+    label: `${provider} (from env: ${envKey})`,
+    type: "env",
+    displayName: null,
+    userIdentifier: null,
+    isDefault: true,
+  };
+}
+
 export async function resolveCredentialsByProvider(provider: string): Promise<CredentialSummary[]> {
   const result = await parseResult(
     client.link.v1.summary.$get({ query: { provider } }, { headers: getLinkAuthHeaders() }),
@@ -125,6 +162,18 @@ export async function resolveCredentialsByProvider(provider: string): Promise<Cr
 
   const { credentials, providers } = result.data;
   if (credentials.length === 0) {
+    // Env-var fallback: many users configure secrets via
+    // `~/.friday/local/.env` rather than Settings → Connections. For
+    // bundled atlas agents that declare a Link credential
+    // requirement (e.g. hubspot's `HUBSPOT_ACCESS_TOKEN`), check the
+    // daemon's process.env for the corresponding env var first and
+    // accept it as a configured credential. The bundled agent runtime
+    // already reads from env, so this only changes the validator's
+    // verdict — no runtime change.
+    const envKey = findEnvKeyForProvider(provider);
+    if (envKey && process.env[envKey]) {
+      return [envCredentialSummary(provider, envKey)];
+    }
     const isKnownProvider = providers.some((p) => p.id === provider);
     if (!isKnownProvider) throw new InvalidProviderError(provider);
     throw new CredentialNotFoundError(provider);


### PR DESCRIPTION
## Summary

A user uploading a workspace.yml via Studio's "Add space → Upload File" gets blocked with \`error: \"missing_providers\", providers: [\"hubspot\"]\` even when \`HUBSPOT_ACCESS_TOKEN\` is set in \`~/.friday/local/.env\`. The bundled hubspot agent reads from env at runtime, so once you work around the validator the job runs fine — the validator was the only thing rejecting the upload.

This is the daemon-side fix for the chain documented in [bucketlist-cs#7](https://github.com/friday-platform/bucketlist-cs/pull/7) discovery + the QA round on the fresh-installer VM.

## The chain

1. \`POST /api/workspaces/create\` calls \`injectBundledAgentRefs\` (\`apps/atlasd/routes/workspaces/inject-bundled-agents.ts:8\`) — auto-injects a Link credential ref env var on every \`type: atlas\` agent declared in the workspace, based on the bundled-agents registry's \`requiredConfig\` field
2. For hubspot the registry declares \`requiredConfig: [{ from: 'link', envKey: 'HUBSPOT_ACCESS_TOKEN', provider: 'hubspot', key: 'access_token' }]\`, so \`env.HUBSPOT_ACCESS_TOKEN: { from: 'link', provider: 'hubspot', key: 'access_token' }\` gets injected
3. \`extractCredentials\` finds the injected ref → \`uniqueProviders = ['hubspot']\`
4. \`resolveCredentialsByProvider('hubspot')\` calls Link's \`/v1/summary?provider=hubspot\` → in dev mode (and apparently in some prod configs too), Link doesn't know about hubspot → returns empty \`providers\` list
5. \`isKnownProvider\` is false → throws \`InvalidProviderError\`
6. Call site at \`apps/atlasd/routes/workspaces/index.ts:557-562\` collects the provider into \`invalidProviders\` → returns 400 \`missing_providers\`

## Fix

In \`resolveCredentialsByProvider\`, before throwing \`InvalidProviderError\` or \`CredentialNotFoundError\`, look up the env-var name the bundled atlas agents register for this provider via \`bundledAgentsRegistry\`, then check \`process.env\`. If the var is set, return a synthetic \`CredentialSummary { id: 'env:<KEY>', type: 'env', isDefault: true, ... }\`.

Why \`id: 'env:...'\` prefix: lets downstream callers short-circuit Link refresh logic — you can't refresh an env-supplied credential.

## Why not fix \`injectBundledAgentRefs\` instead?

Two cleaner reasons to fix at the resolver layer rather than the injector:

- The resolver is the single chokepoint where "is this provider configured?" actually gets decided. Skipping injection would mean the workspace's runtime config no longer carries the credential ref at all, which removes the declarative requirement that the setup page uses to render Connect buttons.
- Other call sites (MCP server requirement validators, etc.) ask the same "configured?" question. Fixing the resolver fixes them all in one place.

## Tests

Added 4 new cases to \`credential-resolver.test.ts\` under a new \`env-var fallback\` describe block:

- env-var present, would-have-been InvalidProviderError → returns synthetic
- env-var present, would-have-been CredentialNotFoundError → returns synthetic
- env-var absent → still throws InvalidProviderError (no false-positive)
- unknown provider with no bundled-agent declaration → no fallback (random env vars don't get treated as credentials)

317 / 317 in \`packages/core/src/mcp-registry/credential-resolver.test.ts\`. Type-check clean.

## Test plan

- [ ] On a fresh installer setup with \`HUBSPOT_ACCESS_TOKEN\` in \`~/.friday/local/.env\` but NO Settings → Connections HubSpot configured: \"Add space → Upload File → bucketlist-cs/workspace.yml\" succeeds (no \`missing_providers\` block)
- [ ] When \`HUBSPOT_ACCESS_TOKEN\` is unset: same upload still blocks with \`missing_providers: [\"hubspot\"]\` (no false-positives)
- [ ] When a real Link credential exists for hubspot: that one wins (env-var fallback only kicks in when Link returns zero credentials)