### PR TITLE
fix(/api/workspaces/create): drop missing_providers hard-fail

### DIFF
--- a/apps/atlasd/routes/workspaces/import-credentials.test.ts
+++ b/apps/atlasd/routes/workspaces/import-credentials.test.ts
@@ -1,6 +1,7 @@
 import {
   CredentialNotFoundError,
   type fetchLinkCredential,
+  InvalidProviderError,
   LinkCredentialExpiredError,
   LinkCredentialNotFoundError,
   type resolveCredentialsByProvider,
@@ -702,6 +703,65 @@ describe("POST /create — credential resolution", () => {
     expect(body.unresolvedCredentials).toEqual(
       expect.arrayContaining(["mcp:github:GITHUB_TOKEN", "mcp:slack:SLACK_TOKEN"]),
     );
+  });
+
+  // Previously: providers Link doesn't recognize at all (InvalidProviderError)
+  // hard-failed the upload with 400 `missing_providers`. That blocked the
+  // installer-default workflow where users put `HUBSPOT_ACCESS_TOKEN`
+  // (and similar) in `~/.friday/local/.env` instead of registering a Link
+  // credential — the bundled atlas agent reads from env at runtime, so
+  // the workspace ran fine once you worked around the validator.
+  //
+  // Now: InvalidProviderError is treated the same as CredentialNotFound —
+  // the workspace imports successfully, the unresolved provider paths are
+  // tracked under `unresolvedCredentials`, and `requires_setup` flips so
+  // the per-workspace integrations sidebar can still surface a Connect
+  // button if the user wants to register a Link credential later.
+  test("creates workspace with requires_setup when providers are unknown to Link (InvalidProviderError)", async () => {
+    const { app, mockUpdateWorkspaceStatus } = createImportTestApp();
+    await mountRoutes(app);
+
+    mockResolveCredentialsByProvider.mockImplementation((provider: string) => {
+      return Promise.reject(new InvalidProviderError(provider));
+    });
+
+    const config = makeConfig({
+      tools: {
+        mcp: {
+          servers: {
+            hubspot: {
+              transport: { type: "stdio", command: "npx", args: ["-y", "server-hubspot"] },
+              env: {
+                HUBSPOT_ACCESS_TOKEN: { from: "link", provider: "hubspot", key: "access_token" },
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const response = await app.request("/create", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ config }),
+    });
+
+    expect(response.status).toBe(201);
+    const body = (await response.json()) as JsonBody;
+    expect(body.success).toBe(true);
+    expect(body.error).toBeUndefined();
+    expect(mockUpdateWorkspaceStatus).toHaveBeenCalledWith(
+      "ws-new",
+      "inactive",
+      expect.objectContaining({ metadata: expect.objectContaining({ requires_setup: true }) }),
+    );
+    expect(body.unresolvedCredentials).toEqual(
+      expect.arrayContaining(["mcp:hubspot:HUBSPOT_ACCESS_TOKEN"]),
+    );
+    // The provider-only ref is preserved in the written config so the
+    // setup page can render a Connect button later.
+    const hubspotRef = getWrittenRef("hubspot", "HUBSPOT_ACCESS_TOKEN");
+    expect(hubspotRef).toEqual({ from: "link", provider: "hubspot", key: "access_token" });
   });
 
   test("surfaces ambiguousProviders when multiple credentials exist for a provider", async () => {

--- a/apps/atlasd/routes/workspaces/index.ts
+++ b/apps/atlasd/routes/workspaces/index.ts
@@ -584,23 +584,25 @@ const workspacesRoutes = daemonFactory
           }
         }
 
-        if (invalidProviders.length > 0) {
-          return c.json(
-            {
-              error: "missing_providers",
-              message: "Cannot import workspace: required providers are not configured",
-              providers: invalidProviders,
-            },
-            400,
-          );
-        }
-
-        // Track unresolved provider refs for requires_setup flag, but keep them
-        // in the config — they're declarative requirements the setup page needs
-        // to show Connect buttons for MCP server credentials.
-        if (unresolvedProviders.length > 0) {
+        // Previously: `if (invalidProviders.length > 0)` returned a 400
+        // `missing_providers` to block the upload. That was wrong for the
+        // common installer setup where users put `HUBSPOT_ACCESS_TOKEN`
+        // (and similar) in `~/.friday/local/.env` rather than configuring
+        // a Link credential. The runtime path for bundled atlas agents
+        // already reads from `process.env`, so the workspace ran fine
+        // — only the validator was rejecting the upload.
+        //
+        // Treat unknown-to-Link providers the same way as
+        // CredentialNotFound: track them as `unresolvedCredentialPaths`
+        // so the setup page can still surface a Connect button if the
+        // user wants to register a Link credential later, and let the
+        // workspace import succeed. If the agent genuinely needs a
+        // credential and neither env nor Link have one, the runtime
+        // call site surfaces a clear error then.
+        const allUnresolvedProviders = [...unresolvedProviders, ...invalidProviders];
+        if (allUnresolvedProviders.length > 0) {
           unresolvedCredentialPaths = providerOnlyRefs
-            .filter((ref) => unresolvedProviders.includes(ref.provider))
+            .filter((ref) => allUnresolvedProviders.includes(ref.provider))
             .map((ref) => ref.path);
         }
 


### PR DESCRIPTION
## Summary

Workspace upload via Studio's "Add space → Upload File" was returning `400 missing_providers: ["hubspot"]` (or similar) on a fresh installer setup, even when the user had `HUBSPOT_ACCESS_TOKEN` set in `~/.friday/local/.env`. The bundled atlas agent reads from `process.env` at runtime — the workspace ran fine the moment the validator was bypassed. The validator was the only thing rejecting the upload.

This supersedes the closed PR #335 (env-var fallback in `resolveCredentialsByProvider`); we agreed the cleaner fix is to skip the missing-providers hard-fail at the import layer rather than synthesize fake credentials at the resolver layer.

## Change

`apps/atlasd/routes/workspaces/index.ts` — in the `/create` handler, treat `InvalidProviderError` the same as `CredentialNotFoundError`:

```diff
-if (invalidProviders.length > 0) {
-  return c.json({ error: "missing_providers", ... }, 400);
-}
-if (unresolvedProviders.length > 0) {
-  unresolvedCredentialPaths = providerOnlyRefs
-    .filter((ref) => unresolvedProviders.includes(ref.provider))
-    .map((ref) => ref.path);
-}
+const allUnresolvedProviders = [...unresolvedProviders, ...invalidProviders];
+if (allUnresolvedProviders.length > 0) {
+  unresolvedCredentialPaths = providerOnlyRefs
+    .filter((ref) => allUnresolvedProviders.includes(ref.provider))
+    .map((ref) => ref.path);
+}
```

The workspace imports successfully with `requires_setup: true`. The per-workspace integrations sidebar can still render Connect buttons for Link credentials. If the agent genuinely needs a credential at runtime and neither env nor Link have one, the runtime surfaces a clear error there — the import path is the wrong place for that check.

## Test

Added `creates workspace with requires_setup when providers are unknown to Link (InvalidProviderError)` to `apps/atlasd/routes/workspaces/import-credentials.test.ts`. Mirrors the existing `CredentialNotFoundError` coverage but uses `InvalidProviderError` to exercise the new code path. Asserts:

- response is 201 (was 400 before)
- workspace metadata gets `requires_setup: true`
- response body's `unresolvedCredentials` includes the provider path
- written config preserves the provider-only ref so the setup page can still render a Connect button

## Test plan

- [ ] Fresh installer with `HUBSPOT_ACCESS_TOKEN` set in `~/.friday/local/.env` but no Link credential: upload `bucketlist-cs/workspace.yml` via Studio's drop zone → succeeds
- [ ] Workspace's `Reindex Knowledge Corpus` and `Answer HubSpot Ticket` jobs run end-to-end (env var picked up at runtime)
- [ ] When neither env nor Link have a credential and the agent actually runs: get a clear runtime error, not a silent skip