### PR TITLE
chore: bump friday-agent-sdk to 0.1.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,7 +143,7 @@ RUN apt-get update && \
 # When bumping, keep both in sync — same constant, two places.
 # To bump: see UPDATING-AGENT-SDK.md at the repo root (three pin sites
 # must agree; CI enforces via scripts/check-sdk-pin-sync.ts).
-ENV FRIDAY_AGENT_SDK_VERSION=0.1.8 \
+ENV FRIDAY_AGENT_SDK_VERSION=0.1.9 \
     UV_PYTHON_INSTALL_DIR=/data/atlas/uv/python \
     UV_CACHE_DIR=/data/atlas/uv/cache \
     FRIDAY_UV_PATH=/usr/local/bin/uv

--- a/apps/studio-installer/src-tauri/src/commands/prewarm_agent_sdk.rs
+++ b/apps/studio-installer/src-tauri/src/commands/prewarm_agent_sdk.rs
@@ -52,7 +52,7 @@ use crate::friday_home::friday_home_dir;
 /// in the husky pre-commit hook for the three pin files.
 ///
 /// To bump: see UPDATING-AGENT-SDK.md at the repo root.
-const BUNDLED_AGENT_SDK_VERSION: &str = "0.1.8";
+const BUNDLED_AGENT_SDK_VERSION: &str = "0.1.9";
 
 /// Wall-clock cap on the uv pre-warm. uv's network ops (cpython
 /// download + PyPI fetch) finish in 5–30s on a healthy connection.

--- a/packages/system/skills/writing-friday-python-agents/SKILL.md
+++ b/packages/system/skills/writing-friday-python-agents/SKILL.md
@@ -10,7 +10,16 @@ description: >
   authored or modified, or when upsert_agent was just called with
   type:user. Do NOT load to decide whether to author a user agent —
   that decision belongs in the workspace-chat agent_types rules.
+vendored-from: friday-platform/agent-sdk@832d539ded2c87d1a2c4ee91a2cfc8407b68eb74
+vendored-path: packages/python/skills/writing-friday-python-agents/
+vendored-version: 0.1.9
 ---
+
+<!--
+  This skill is vendored from the friday-agent-sdk repo. Edits should land
+  upstream first; scripts/sync-sdk-skill.ts re-vendors for the pinned
+  FRIDAY_AGENT_SDK_VERSION (see tools/friday-launcher/paths.go).
+-->
 
 # Writing Friday Python Agents
 
@@ -56,16 +65,16 @@ Three things are non-negotiable:
 All capabilities live on `AgentContext` and are always initialized. They may be
 stubs in test contexts, but never `None`.
 
-| Capability  | Access        | What it does                                              |
-| ----------- | ------------- | --------------------------------------------------------- |
-| LLM         | `ctx.llm`     | Generate text or structured objects via host LLM registry |
-| HTTP        | `ctx.http`    | Make outbound HTTP requests (TLS handled by host)         |
-| MCP Tools   | `ctx.tools`   | Call MCP server tools (GitHub, Jira, databases, etc.)     |
-| Input       | `ctx.input`   | Read structured action input / `inputFrom` artifact refs  |
-| Streaming   | `ctx.stream`  | Emit progress/intent events to the UI                     |
-| Environment | `ctx.env`     | Read environment variables (API keys, config)             |
-| Config      | `ctx.config`  | Agent-specific configuration from workspace               |
-| Session     | `ctx.session` | Session metadata (id, workspace_id, user_id, datetime)    |
+| Capability  | Access        | What it does                                                                      |
+| ----------- | ------------- | --------------------------------------------------------------------------------- |
+| LLM         | `ctx.llm`     | Generate text or structured objects via host LLM registry                         |
+| HTTP        | `ctx.http`    | Make outbound HTTP requests (TLS handled by host)                                 |
+| MCP Tools   | `ctx.tools`   | Call MCP server tools (GitHub, Jira, databases, etc.)                             |
+| Input       | `ctx.input`   | Read `inputFrom` upstream-step docs (NOT the signal payload — that's in `prompt`) |
+| Streaming   | `ctx.stream`  | Emit progress/intent events to the UI                                             |
+| Environment | `ctx.env`     | Read environment variables (API keys, config)                                     |
+| Config      | `ctx.config`  | Agent-specific configuration from workspace                                       |
+| Session     | `ctx.session` | Session metadata (id, workspace_id, user_id, datetime)                            |
 
 ### ctx.llm — LLM Generation
 
@@ -134,88 +143,19 @@ def execute(prompt: str, ctx: AgentContext):
 `{{env.VARIABLE}}` in MCP config references agent environment variables.
 Currently only `stdio` transport is supported.
 
-**Do not bypass `ctx.tools`.** Python agents must not call local MCP HTTP endpoints such as `http(s)://localhost:8002/mcp`, hardcode bearer tokens, or guess provider-specific tool names. Use `ctx.tools.list()` to inspect the runtime tool surface and `ctx.tools.call(name, args)` to invoke it. Host-side tool calls are credentialed, audited, and recorded in session history; direct HTTP calls are invisible to Friday and commonly fail with unknown-tool or invalid-token errors.
+**Do not bypass `ctx.tools`.** Python agents must not call local MCP HTTP endpoints such as `http://localhost:8002/mcp`, hardcode bearer tokens, or guess provider-specific tool names. Use `ctx.tools.list()` to inspect the runtime tool surface and `ctx.tools.call(name, args)` to invoke it. Host-side tool calls are credentialed, audited, and recorded in session history; direct HTTP calls are invisible to Friday and commonly fail with unknown-tool or invalid-token errors.
 
 If `ctx.tools.call` raises `ToolCallError("Unknown tool ...")`, list tools and fix the workspace/agent config rather than retrying a guessed name.
 
-### Human input — `request_human_input` (platform tool)
+### Platform-injected tools
 
-When a user agent needs a decision, approval, or disambiguation, call the
-platform tool instead of streaming a question and hoping a later chat turn
-resumes the process:
-
-```python
-choice = ctx.tools.call("request_human_input", {
-    "question": "What should I do with these messages?",
-    "options": [
-        {"label": "Archive", "value": "archive"},
-        {"label": "Keep", "value": "keep"},
-    ],
-})
-# returns JSON text/content with status, answer, and elicitationId
-```
-
-The host creates an Activity/sidebar `open-question` elicitation, blocks this
-same tool call until the user answers/declines/expires, then resumes the agent
-with the answer. Use this for interactive review workflows; do not implement a
-local polling loop or direct `/api/elicitations` HTTP calls.
-
-### Memory — `save_memory_entry` / `list_memory_entries` (platform tools)
-
-The host injects platform memory tools into every agent's tool surface
-automatically — no MCP declaration needed. Most-used:
-
-```python
-# Append a single fact. The store handles persistence + ordering.
-ctx.tools.call("save_memory_entry", {
-    "memoryName": "preferences",
-    "text": "Always archive newsletters from substack.com",
-})
-
-# Read recent entries. (The 20 most recent narrative entries are
-# auto-injected into the LLM-side system prompt every turn — Python
-# agents don't see those, so call list_memory_entries explicitly when you need
-# durable state across runs.)
-result = ctx.tools.call("list_memory_entries", {
-    "memoryName": "preferences",
-    "limit": 50,
-})
-```
-
-**Append semantics — one call per fact, never read-concat-write.**
-
-```python
-# ✅ Correct — one fact per call. Concurrent writers compose cleanly.
-for fact in new_preferences:
-    ctx.tools.call("save_memory_entry", {"memoryName": "preferences", "text": fact})
-
-# ❌ Wrong — read-concat-write. Concurrent writers clobber each other,
-#    fights the platform's append/dedup logic, and the next run starts
-#    from a stale snapshot.
-existing = ctx.tools.call("list_memory_entries", {"memoryName": "preferences"})
-combined = existing["text"] + "\n" + "\n".join(new_preferences)
-ctx.tools.call("save_memory_entry", {"memoryName": "preferences", "text": combined})
-```
-
-**Footgun: `ToolCallError` on validation failure.** `ctx.tools.call`
-raises if the store isn't declared in `workspace.yml`, if the entry
-exceeds size limits, or if the host rejects the write. Never swallow
-with bare `except Exception` — that silently drops writes. Surface
-the error through `err()` or let it propagate.
-
-```python
-from friday_agent_sdk import ToolCallError
-
-try:
-    ctx.tools.call("save_memory_entry", {"memoryName": "preferences", "text": fact})
-except ToolCallError as e:
-    return err(f"save_memory_entry failed: {e}")
-```
-
-**Stores must use the `narrative` strategy.** Friday's runtime today
-only implements narrative storage; stores declared with other strategies
-(`retrieval`, `dedup`, `kv`) exist in the schema but throw at write time.
-If you're authoring a workspace, just use narrative.
+The host may inject additional tools into `ctx.tools` beyond what you declared
+in `mcp={...}` — workflows like human-input elicitations, memory writes,
+artifact handling. These are platform features, not SDK features; their names,
+arg shapes, and semantics belong to whichever platform you're running on. Call
+`ctx.tools.list()` at runtime to see what's actually available, and consult the
+platform's own docs for which tools to call. The SDK contract is just
+`ctx.tools.call(name, args) -> dict` and `ToolCallError` on failure.
 
 ### ctx.stream — Progress Events
 
@@ -229,36 +169,49 @@ Emit progress _before_ expensive operations so the UI shows what's happening.
 
 ## Structured Input Handling
 
-### ctx.input — Runtime-provided action input
+A `type: user` agent receives input through one of two channels. Pick by how
+the job is wired, not by preference:
 
-For workspace jobs, prefer `ctx.input` over prompt scraping when consuming
-upstream `inputFrom` data. Producers may compact bulky outputs into summary +
-artifact refs; downstream Python agents should dereference those refs through
-host capabilities, not ask the producer to inline large payloads.
+| Channel              | Where it arrives | Read with                  | Use for                                          |
+| -------------------- | ---------------- | -------------------------- | ------------------------------------------------ |
+| Signal payload       | `prompt` string  | `parse_input(prompt, ...)` | Fields the trigger signal was fired with         |
+| Upstream step output | `ctx.input`      | `ctx.input.get("doc-id")`  | `outputTo`/`inputFrom` handoff from a prior step |
+
+`ctx.input` does NOT carry the signal payload — a job triggered by a signal
+with no upstream producer has an empty `ctx.input`. If you guessed a key for
+`ctx.input.get(...)` and got nothing back, you almost certainly wanted the
+signal payload — read `prompt` with `parse_input` instead.
+
+### ctx.input — Upstream step output
+
+When the action declares `inputFrom`, use `ctx.input` rather than scraping the
+prompt. Producers may compact bulky outputs into summary + artifact refs;
+downstream agents dereference those refs through host capabilities instead of
+asking the producer to inline large payloads.
 
 ```python
-payload = ctx.input.artifact_json("fetched-emails")
-emails = payload.get("emails", [])
+# Compact value (whatever the upstream step put in its outputTo doc)
+payload = ctx.input.get("emails-result")
 
-return ok({"count": len(emails), "firstId": emails[0]["id"] if emails else None})
+# Or, when the doc carries artifact refs, hydrate the JSON contents
+payload = ctx.input.artifact_json("emails-result")
+emails = payload.get("emails", [])
+return ok({"count": len(emails)})
 ```
 
-Useful methods:
+Useful methods (all take an optional `doc-id`; omit it to operate on the full
+raw input):
 
-- `ctx.input.get("doc-id")` — compact input payload for an `inputFrom` document.
-- `ctx.input.require("doc-id")` — same, but raises if missing.
-- `ctx.input.artifact_refs("doc-id")` — artifact refs attached to the input.
-- `ctx.input.artifact_json("doc-id")` — fetches via `get_artifact` and parses JSON contents.
+- `ctx.input.get(name, default=None)` — compact input payload for an `inputFrom` document.
+- `ctx.input.require(name)` — same, but raises `ValueError` if missing.
+- `ctx.input.artifact_refs(name)` — artifact refs attached to the input.
+- `ctx.input.artifact_json(name)` — fetch via `get_artifact` and parse JSON contents.
 
 `prompt` still exists for natural-language task instructions and backwards
 compatibility, but `parse_input(prompt)` is not the right abstraction for
 multi-step `outputTo`/`inputFrom` handoffs.
 
-Friday sends "enriched prompts" — markdown with embedded JSON containing task
-details, signal data, and context. Code agents can still extract structured data
-from these for simple one-shot prompts.
-
-### parse_input — Simple extraction
+### parse_input — Signal-payload extraction
 
 ```python
 from friday_agent_sdk import parse_input
@@ -357,79 +310,16 @@ When in doubt: if the operation touches a network boundary or needs credentials,
 use the host capability. If it's pure data manipulation, standard library or
 installed packages are fine.
 
-## Getting Agents Into Friday
+## Getting Agents Into a Workspace
 
-### Register via the daemon HTTP API
+The SDK's job ends at the file: a registered `@agent` function plus
+`run()` in `__main__`. How that file becomes a usable agent on the host
+is a platform concern (Friday Studio's CLI, an in-tree dev daemon, a
+deployment pipeline) — see your platform's docs for the registration
+command, and do not have the agent code shell out to a daemon to
+register itself.
 
-Friday's daemon URL and TLS settings live in the daemon `.env` —
-`${FRIDAY_HOME:-~/.friday/local}/.env` on installed Friday Studio (written
-by the launcher automatically) or `~/.atlas/.env` for in-tree dev (written
-by `bash scripts/setup-tls.sh`). Source whichever exists once per shell so
-the curl examples below work whether your install is on plain HTTP or
-HTTPS:
-
-```bash
-set -a
-. "${FRIDAY_HOME:-$HOME/.friday/local}/.env" 2>/dev/null \
-  || . "$HOME/.atlas/.env" 2>/dev/null || true
-set +a
-```
-
-**Rule: every daemon HTTP call below uses `curl -k`, not `curl`.**
-Plain `curl` against `$FRIDAYD_URL` on a TLS install fails with `self
-signed certificate in certificate chain`.
-
-Register your agent by POSTing the entrypoint's absolute path to the daemon:
-
-```bash
-curl -k -sf -X POST \
-  "$FRIDAYD_URL/api/agents/register" \
-  -H 'Content-Type: application/json' \
-  -d '{"entrypoint": "/abs/path/to/your-agent/agent.py"}'
-```
-
-`entrypoint` must be an absolute path. The daemon spawns it with
-`FRIDAY_VALIDATE_ID`, collects metadata over NATS, copies the source directory
-into the agents registry (under `{FRIDAY_HOME}/agents/{id}@{version}/` — the
-home dir is mid-migration from `~/.atlas` to `~/.friday/local`), and reloads
-the registry. No compilation step — the agent process is spawned per
-invocation and communicates with the host via NATS request/reply. The daemon sets `FRIDAY_NATS_URL` for registration and execution; agent code should not open its own NATS connection or assume `nats://localhost:4222`.
-
-The register response returns `agent.path` (the install dir). To look up the
-source path of an existing agent, query `GET /api/agents/:id` and read
-`sourceLocation` rather than constructing the path from a constant.
-
-The Friday daemon's bind address is whatever the launcher (installed
-Friday Studio: typically `:18080`) or `deno task atlas daemon start`
-(in-tree dev: typically `:8080`) wrote to the daemon `.env`. Don't
-hardcode the URL — use `$FRIDAYD_URL`. The scheme switches to `https://`
-when TLS is on (automatically configured by the launcher for installed
-Studio; opt-in via `bash scripts/setup-tls.sh` for in-tree dev).
-
-### Test directly
-
-Execute an agent without going through the full FSM pipeline. Replace
-`my-agent` with your agent id (the `id=` value from the `@agent` decorator):
-
-```bash
-curl -k -sf -X POST \
-  "$FRIDAYD_URL/api/agents/my-agent/run?workspaceId=user" \
-  -H 'Content-Type: application/json' \
-  -d '{"input": "test prompt"}'
-```
-
-Or via the playground API on `localhost:5200` (HTTPS when TLS is on —
-the playground always trusts mkcert's CA via the system trust store):
-
-```bash
-curl -sf "${PLAYGROUND_URL:-http://localhost:5200}/api/agents/my-agent/run" \
-  -H 'Content-Type: application/json' \
-  -d '{"input": "test prompt"}'
-```
-
-### Workspace Configuration
-
-Register your agent in `workspace.yml`:
+Once the platform knows about it, reference it in `workspace.yml`:
 
 ```yaml
 agents:
@@ -437,14 +327,20 @@ agents:
     type: user
 ```
 
-Friday adds the `user:` prefix automatically — you specify `my-agent`,
-Friday resolves it to `user:my-agent`.
+The `id` matches the `id=` value from the `@agent` decorator. The host
+resolves `type: user` to the registered Python agent and routes
+invocations into your `execute` function over NATS.
+
+The agent process is spawned per invocation by the host; it sets
+`FRIDAY_VALIDATE_ID` (registration) or `FRIDAY_SESSION_ID` (execution)
+plus `NATS_URL`, and `run()` handles the rest. Your code should not
+open its own NATS connection.
 
 ## Casing Convention
 
 This is a subtle but real source of bugs:
 
-- **Decorator kwargs**: `snake_case` (Pythonic) — `display_name`, `input_schema`, `use_workspace_skills`
+- **Decorator kwargs**: `snake_case` (Pythonic) — `display_name`, `use_workspace_skills`
 - **Dict values inside decorator**: `camelCase` (matches host Zod schemas) — `linkRef`, `displayName` inside environment dicts
 - **MCP config keys**: `camelCase` in transport config
 - **Result data**: your choice, but `snake_case` is conventional for Python agents

--- a/packages/system/skills/writing-friday-python-agents/references/api.md
+++ b/packages/system/skills/writing-friday-python-agents/references/api.md
@@ -10,6 +10,7 @@ Complete reference for the `friday_agent_sdk` Python package.
 - [ctx.llm — Llm](#ctxllm)
 - [ctx.http — Http](#ctxhttp)
 - [ctx.tools — Tools](#ctxtools)
+- [ctx.input — AgentInput](#ctxinput)
 - [ctx.stream — StreamEmitter](#ctxstream)
 - [Response Types](#response-types)
 - [Result Types](#result-types)
@@ -22,25 +23,28 @@ Complete reference for the `friday_agent_sdk` Python package.
 
 ```python
 from friday_agent_sdk import (
-    # Decorator
+    # Decorator + entry point
     agent,
-
-    # Entry point
     run,
 
     # Parsing
     parse_input,
     parse_operation,
 
-    # Result constructors
-    ok,
-    err,
+    # Result constructors + types
+    ok, err,
+    OkResult, ErrResult, AgentResult, AgentExtras,
+    ArtifactRef, OutlineRef,
 
-    # Result types
-    OkResult, ErrResult, AgentResult,
-
-    # Context
+    # Context + structured input
     AgentContext,
+    AgentInput, InputArtifactRef,
+    SessionData,
+    SkillDefinition,
+
+    # Capability classes (rarely constructed by user code; useful for typing)
+    Llm, Http, Tools, StreamEmitter,
+    ToolDefinition,
 
     # Response types
     LlmResponse, HttpResponse,
@@ -48,8 +52,8 @@ from friday_agent_sdk import (
     # Exceptions
     LlmError, HttpError, ToolCallError,
 
-    # Streaming
-    StreamEmitter,
+    # Version
+    __version__,
 )
 ```
 
@@ -67,14 +71,24 @@ def agent(
     summary: str | None = None,                 # One-line summary
     constraints: str | None = None,             # What the agent cannot do
     examples: list[str] | None = None,          # Example prompts that invoke this agent
-    input_schema: type | None = None,           # Dataclass type — extracted as JSON Schema for docs
-    output_schema: type | None = None,          # Dataclass type — passed to ctx.output_schema at runtime
     environment: dict[str, Any] | None = None,  # Required/optional env vars
     mcp: dict[str, Any] | None = None,          # MCP server configurations
     llm: dict[str, Any] | None = None,          # Default LLM provider/model
-    use_workspace_skills: bool = False,         # Access workspace-level skills
+    use_workspace_skills: bool = False,         # When True, host populates ctx.skills with workspace skills
 ) -> Callable
 ```
+
+The decorator also accepts `input_schema: type | None` and `output_schema:
+type | None` for forward compatibility, but neither is currently serialized to
+the host — they are no-ops today. `ctx.output_schema` (below) is host-driven
+and unrelated to these kwargs.
+
+### use_workspace_skills
+
+When set to `True`, the host attaches the workspace's resolved skills to
+`ctx.skills` (a `list[SkillDefinition]` of `{name, description, instructions}`).
+Leave it `False` if your agent does not consult workspace-defined skills — the
+list is empty when this flag is off.
 
 ### environment
 
@@ -129,17 +143,19 @@ llm={
 ```python
 @dataclass
 class AgentContext:
-    env: dict[str, str]             # Environment variables (always present, may be empty)
-    config: dict                    # Agent-specific config from workspace (always present)
-    session: SessionData | None     # Session metadata
-    output_schema: dict | None      # JSON Schema from output_schema decorator param
-    tools: Tools                    # MCP tool capability (always initialized)
-    llm: Llm                        # LLM generation capability (always initialized)
-    http: Http                      # HTTP fetch capability (always initialized)
-    stream: StreamEmitter           # Progress streaming capability (always initialized)
+    env: dict[str, str]                 # Environment variables (always present, may be empty)
+    config: dict                        # Agent-specific config from workspace (always present)
+    skills: list[SkillDefinition]       # Workspace skills when use_workspace_skills=True, else []
+    session: SessionData | None         # Session metadata
+    output_schema: dict | None          # JSON Schema sent by the host on execute (e.g., from an FSM action's outputType); None when the host sends nothing
+    input: AgentInput                   # Structured action input (always initialized)
+    tools: Tools                        # MCP tool capability (always initialized)
+    llm: Llm                            # LLM generation capability (always initialized)
+    http: Http                          # HTTP fetch capability (always initialized)
+    stream: StreamEmitter               # Progress streaming capability (always initialized)
 ```
 
-`env` and `config` are guaranteed non-None. Capabilities are always initialized; they may be stubs in test contexts that raise `RuntimeError` if called without proper setup.
+`env`, `config`, `skills`, and `input` are guaranteed non-None. Capabilities are always initialized; they may be stubs in test contexts that raise `RuntimeError` if called without proper setup.
 
 ### SessionData
 
@@ -151,6 +167,18 @@ class SessionData:
     user_id: str                    # User who initiated the session
     datetime: str                   # ISO datetime string
 ```
+
+### SkillDefinition
+
+```python
+@dataclass
+class SkillDefinition:
+    name: str
+    description: str
+    instructions: str
+```
+
+Populated on `ctx.skills` when the agent is declared with `use_workspace_skills=True`.
 
 ---
 
@@ -233,6 +261,56 @@ def call(name: str, args: dict) -> dict
 ```
 
 Raises `ToolCallError` on failure.
+
+---
+
+## ctx.input
+
+Structured runtime input. `ctx.input` is the typed counterpart to the
+`prompt` string: it exposes the compact `inputFrom`/config payload without
+asking agents to scrape JSON out of markdown.
+
+`raw` is populated from the host's execute payload (the `context.input`
+section of the NATS execute message). When the host sends nothing structured,
+`raw` is `{}` and every accessor returns the same empty-state shape.
+
+```python
+class AgentInput:
+    raw: dict           # Full structured input as supplied by the host
+    config: dict        # Shortcut for raw.get("config", {}) — the inputFrom-keyed dict
+
+    def get(name: str | None = None, default: Any = None) -> Any: ...
+    def require(name: str | None = None) -> Any: ...
+    def artifact_refs(name: str | None = None) -> list[InputArtifactRef]: ...
+    def artifact_json(name: str | None = None) -> Any: ...
+```
+
+Behavior notes:
+
+- `get(name)` looks first in `raw["config"][name]` (the usual `inputFrom`
+  shape) and falls back to `raw[name]`. Returns `default` when missing.
+- `get()` with no name returns the full `raw` dict.
+- `require(name)` raises `ValueError` if missing; `require()` with no name
+  raises if `raw` is empty.
+- `artifact_refs(name)` walks the selected payload and collects any
+  `artifactRef` / `artifactRefs` entries into a deduplicated list. Useful
+  when you want to introspect refs before fetching.
+- `artifact_json(name)` resolves those refs through `get_artifact` and
+  returns the parsed JSON — a single payload if one ref, a list if many.
+  Raises `ValueError` when no refs are present and `ToolCallError` when
+  `ctx.tools` is not initialized.
+
+```python
+@dataclass(frozen=True)
+class InputArtifactRef:
+    id: str
+    type: str = "Artifact"
+    summary: str = ""
+```
+
+`ctx.input` is intended for `inputFrom` upstream-step output. Signal-payload
+fields the trigger fired with arrive in the `prompt` string — parse them with
+`parse_input(prompt, ...)` instead.
 
 ---
 

--- a/packages/system/skills/writing-friday-python-agents/references/constraints.md
+++ b/packages/system/skills/writing-friday-python-agents/references/constraints.md
@@ -4,7 +4,6 @@
 
 - [Environment and Extension Guidance](#environment-and-extension-guidance)
 - [Casing Rules](#casing-rules)
-- [Build Pipeline](#build-pipeline)
 - [Common Mistakes and Fixes](#common-mistakes-and-fixes)
 - [One Agent Per Module](#one-agent-per-module)
 - [Streaming LLM Responses](#streaming-llm-responses)
@@ -53,12 +52,12 @@ The SDK spans a Python/JavaScript boundary. Casing conventions differ on each si
 
 ### Your code (Python side)
 
-| Context          | Convention   | Example                                                |
-| ---------------- | ------------ | ------------------------------------------------------ |
-| Decorator kwargs | `snake_case` | `display_name`, `input_schema`, `use_workspace_skills` |
-| Dataclass fields | `snake_case` | `issue_key`, `max_results`                             |
-| Function names   | `snake_case` | `_handle_view`, `_build_auth`                          |
-| Variable names   | `snake_case` | `api_key`, `response_data`                             |
+| Context          | Convention   | Example                                |
+| ---------------- | ------------ | -------------------------------------- |
+| Decorator kwargs | `snake_case` | `display_name`, `use_workspace_skills` |
+| Dataclass fields | `snake_case` | `issue_key`, `max_results`             |
+| Function names   | `snake_case` | `_handle_view`, `_build_auth`          |
+| Variable names   | `snake_case` | `api_key`, `response_data`             |
 
 ### Dict values passed to host
 
@@ -74,24 +73,8 @@ The `_bridge.py` module converts decorator metadata to camelCase when serializin
 
 - `display_name` → `displayName`
 - `use_workspace_skills` → `useWorkspaceSkills`
-- `input_schema` → `inputSchema` (after JSON Schema extraction)
 
 You don't need to worry about this conversion — just use snake_case in Python and the bridge handles it.
-
----
-
-## Build Pipeline
-
-`atlas agent register` handles the full pipeline:
-
-```
-agent.py → spawn with FRIDAY_VALIDATE_ID → metadata.json over NATS
-         → copy source dir to ~/.friday/local/agents/{id}@{version}/
-         → write metadata.json sidecar
-         → reload registry
-```
-
-You don't run NATS directly. If registration fails, the error message includes the phase (`prereqs`, `validate`, `write`) and details.
 
 ---
 

--- a/packages/system/skills/writing-friday-python-agents/references/examples.md
+++ b/packages/system/skills/writing-friday-python-agents/references/examples.md
@@ -10,6 +10,7 @@ capability pattern.
 - [Tier 3: HTTP API Integration](#tier-3-http-api-integration)
 - [Tier 4: MCP Tools](#tier-4-mcp-tools)
 - [Tier 5: Multi-Operation Dispatch](#tier-5-multi-operation-dispatch)
+- [Tier 6: Consuming Upstream Step Output (ctx.input)](#tier-6-consuming-upstream-step-output)
 - [Patterns Summary](#patterns-summary)
 
 ---
@@ -309,14 +310,95 @@ Key points:
 
 ---
 
+## Tier 6: Consuming Upstream Step Output
+
+When the action is wired into an FSM with `inputFrom: <doc-id>`, the upstream
+step's output arrives in `ctx.input`, NOT in `prompt`. Use `ctx.input.get(...)`
+for compact payloads and `ctx.input.artifact_json(...)` when the upstream
+producer compacted bulky data into artifact refs.
+
+Workspace wiring (for context — this is what makes `ctx.input` populated):
+
+```yaml
+jobs:
+  daily-brief:
+    fsm:
+      initial: idle
+      states:
+        idle:
+          on: { run-brief: { target: fetch } }
+        fetch:
+          entry:
+            - type: agent
+              agentId: gmail-fetcher
+              outputTo: emails-result
+            - type: emit
+              event: DONE
+          on: { DONE: { target: count } }
+        count:
+          entry:
+            - type: agent
+              agentId: email-counter # ← the agent below
+              inputFrom: emails-result
+          type: final
+```
+
+The downstream agent:
+
+```python
+from friday_agent_sdk import agent, ok, err, AgentContext, ToolCallError, run
+
+@agent(
+    id="email-counter",
+    version="1.0.0",
+    description="Counts emails from an upstream fetcher and returns top-line stats",
+)
+def execute(prompt: str, ctx: AgentContext):
+    # First try the compact value the producer wrote into outputTo
+    payload = ctx.input.get("emails-result")
+
+    # When the producer compacted bulky data into an artifact, hydrate it
+    if not isinstance(payload, dict) or "emails" not in payload:
+        try:
+            payload = ctx.input.artifact_json("emails-result")
+        except (ValueError, ToolCallError) as e:
+            return err(f"No upstream emails to count: {e}")
+
+    emails = payload.get("emails", []) if isinstance(payload, dict) else []
+    return ok({
+        "count": len(emails),
+        "first_subject": emails[0].get("subject") if emails else None,
+    })
+
+
+if __name__ == "__main__":
+    run()
+```
+
+Key points:
+
+- `ctx.input.get("doc-id")` returns the upstream step's compact `outputTo`
+  payload. The `doc-id` is the upstream `outputTo` value, not a guess.
+- `ctx.input.artifact_json("doc-id")` resolves artifact refs the producer
+  attached, fetching the underlying JSON through `get_artifact`. Use this
+  when the compact payload is a summary + refs rather than the full data.
+- An empty `ctx.input` means the action wasn't wired with `inputFrom` — check
+  the FSM job, or look in `prompt` if the data was passed on the signal
+  payload instead.
+- Do NOT ask upstream producers to inline large payloads to avoid `ctx.input`;
+  hydrate refs in the consumer instead.
+
+---
+
 ## Patterns Summary
 
-| Pattern            | When to use                                  | Key imports                          |
-| ------------------ | -------------------------------------------- | ------------------------------------ |
-| Echo/passthrough   | Testing, simple transforms                   | `ok, run`                            |
-| LLM generation     | Text analysis, classification, summarization | `ok, err, LlmError, run`             |
-| HTTP integration   | External API calls                           | `ok, err, HttpError, run`            |
-| MCP tools          | Pre-built service integrations               | `ok, err, ToolCallError, run`        |
-| Multi-operation    | Agents handling multiple distinct tasks      | `ok, err, parse_operation, run`      |
-| Structured output  | When you need typed JSON from LLM            | `generate_object` + JSON Schema dict |
-| Streaming progress | Long-running tasks                           | `ctx.stream.progress()`              |
+| Pattern             | When to use                                  | Key imports                          |
+| ------------------- | -------------------------------------------- | ------------------------------------ |
+| Echo/passthrough    | Testing, simple transforms                   | `ok, run`                            |
+| LLM generation      | Text analysis, classification, summarization | `ok, err, LlmError, run`             |
+| HTTP integration    | External API calls                           | `ok, err, HttpError, run`            |
+| MCP tools           | Pre-built service integrations               | `ok, err, ToolCallError, run`        |
+| Multi-operation     | Agents handling multiple distinct tasks      | `ok, err, parse_operation, run`      |
+| Upstream-step input | Agent is wired with `inputFrom: <doc-id>`    | `ctx.input.get / artifact_json`      |
+| Structured output   | When you need typed JSON from LLM            | `generate_object` + JSON Schema dict |
+| Streaming progress  | Long-running tasks                           | `ctx.stream.progress()`              |

--- a/tools/friday-launcher/paths.go
+++ b/tools/friday-launcher/paths.go
@@ -37,7 +37,7 @@ const launcherBundleID = "ai.hellofriday.studio"
 //
 // To bump: see UPDATING-AGENT-SDK.md at the repo root (three pin sites
 // must agree; CI enforces via scripts/check-sdk-pin-sync.ts).
-const bundledAgentSDKVersion = "0.1.8"
+const bundledAgentSDKVersion = "0.1.9"
 
 func friendlyHome() string {
 	if v := os.Getenv("FRIDAY_LAUNCHER_HOME"); v != "" {


### PR DESCRIPTION
## Summary

- Three pin sites bumped 0.1.8 → 0.1.9 (`tools/friday-launcher/paths.go`, `Dockerfile`, `apps/studio-installer/src-tauri/src/commands/prewarm_agent_sdk.rs`).
- Re-vendored `packages/system/skills/writing-friday-python-agents/` from upstream tag `v0.1.9` (commit `832d539`) via `scripts/sync-sdk-skill.ts`.

`v0.1.9` brings the skill cleanup from agent-sdk#22: `ctx.input` now appears in `references/api.md` with full method signatures, the SDK no longer teaches daemon HTTP registration calls, the dataclass→JSON-Schema overclaim for `output_schema`/`input_schema` is gone (those kwargs are documented as accepted-but-no-op until the bridge serializes them), the NATS env var is correctly named `NATS_URL`, and a Tier 6 example covers `inputFrom` consumption via `ctx.input.get`/`artifact_json`.

Followed `UPDATING-AGENT-SDK.md` end-to-end.

## Test plan

- [x] `deno run -A scripts/check-sdk-pin-sync.ts` → ✓ all sites pinned to 0.1.9
- [x] `deno run -A scripts/sync-sdk-skill.ts --check` → ✓ in sync
- [x] `deno task typecheck` → pass
- [x] `deno task knip` → pass
- [x] `deno task test` → pass