### PR TITLE
dev: share FRIDAY_HOME across dev:playground subprocesses

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -37,7 +37,7 @@
     "atlas": "FRIDAY_HOME=$HOME/.atlas deno run -q --allow-all --unstable-worker-options --unstable-kv --unstable-raw-imports --env-file apps/atlas-cli/src/otel-bootstrap.ts",
     "atlas:dev": "FRIDAY_HOME=$HOME/.atlas deno run -q --allow-all --unstable-worker-options --unstable-kv --unstable-raw-imports --env-file scripts/dev-watcher.ts",
     "start": "FRIDAY_HOME=$HOME/.atlas deno run --allow-all --unstable-worker-options --unstable-kv --unstable-raw-imports apps/atlas-cli/src/otel-bootstrap.ts",
-    "dev:playground": "FAST_DEVELOPMENT=true LINK_DEV_MODE=true deno run -A npm:concurrently@^9.2.1 -n daemon,link,playground,tunnel -c blue,green,magenta,cyan 'deno task atlas:dev daemon start' 'cd apps/link && deno task dev' 'deno task playground' 'deno task webhook-tunnel'",
+    "dev:playground": "FRIDAY_HOME=$HOME/.atlas FAST_DEVELOPMENT=true LINK_DEV_MODE=true deno run -A npm:concurrently@^9.2.1 -n daemon,link,playground,tunnel -c blue,green,magenta,cyan 'deno task atlas:dev daemon start' 'cd apps/link && deno task dev' 'deno task playground' 'deno task webhook-tunnel'",
     "webhook-tunnel": "go run ./tools/webhook-tunnel",
     "test": "OTEL_DENO=true DENO_TESTING=true LINK_DEV_MODE=true DEV_MODE=true vitest run",
     "fmt": "deno run -A npm:@biomejs/biome format --write",


### PR DESCRIPTION
## Summary
- `deno task dev:playground` now sets `FRIDAY_HOME=$HOME/.atlas` for the whole concurrently group, so the link, playground, and webhook-tunnel children land in the same Friday home as `atlasd`.
- Previously only the daemon got the prefix (via `atlas:dev`); link silently fell back to `~/.friday/local` while the daemon used `~/.atlas`. That split-brain left MCP registry entries pointing at Link providers that lived under a different `FRIDAY_HOME` — orphan dynamic providers after a wipe of either directory.

## Test plan
- [x] `deno task dev:playground`
- [x] Verify link reads/writes `~/.atlas/link-providers.db` (no new files appear under `~/.friday/local/`)
- [x] Install an MCP from the registry that requires a dynamic Link provider; confirm the Connect button works end-to-end

## Migration
First restart after this lands, link starts at an empty `~/.atlas/link-providers.db`. Existing dynamic providers under `~/.friday/local/link-providers.db*` and `~/.friday/local/link-data/` need to be either re-connected through the UI or copied into `~/.atlas/` while the daemon is stopped.