### PR TITLE
Fix clipped Replace button on MCP Connections page

### DIFF
--- a/tools/agent-playground/src/lib/components/mcp/mcp-credential-picker.svelte
+++ b/tools/agent-playground/src/lib/components/mcp/mcp-credential-picker.svelte
@@ -56,7 +56,7 @@
     <span class="error">Failed to load credentials</span>
   {:else if credentials.length === 0}
     <span class="muted">No <code>{providerId}</code> credentials connected.</span>
-    <a class="add-link" href="/mcp/{serverId}">Add credential →</a>
+    <a class="add-link" href="/mcp/{serverId}/connections">Add credential →</a>
   {:else}
     <select
       class="cred-select"

--- a/tools/agent-playground/src/lib/components/mcp/mcp-credentials-list.svelte
+++ b/tools/agent-playground/src/lib/components/mcp/mcp-credentials-list.svelte
@@ -149,6 +149,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--size-px);
+    min-inline-size: 0;
     padding-block: var(--size-2);
   }
 
@@ -156,11 +157,15 @@
     align-items: center;
     display: flex;
     gap: var(--size-2);
+    min-inline-size: 0;
   }
 
   .cred-label {
     font-size: var(--font-size-4);
     font-weight: var(--font-weight-5);
+    min-inline-size: 0;
+    overflow-wrap: anywhere;
+    white-space: normal;
   }
 
   .cred-status {


### PR DESCRIPTION
## Summary
- On the MCP server **Connections** page, the Replace/Remove buttons could be clipped off the right edge when a credential's label was a long unbreakable string. Labels now wrap so the actions stay visible.
- In the per-workspace MCP settings, the "Add credential →" link on a required credential field now lands on the server's **Connections** tab (where credentials are actually managed), matching the existing "Manage →" link.

## Test plan
- [x] Open the playground, install or pick an MCP server whose credential label is a long token-shaped string, navigate to **Connections** → confirm the Replace and Remove buttons render fully inside the row.
- [x] In a workspace's MCP settings, find a server with a required credential field that's not connected → click "Add credential →" → confirm you land on `/mcp/<server>/connections` (not the overview tab).