### PR TITLE
Cancel in-flight MCP tools probe on retry

### DIFF
--- a/tools/agent-playground/src/lib/components/mcp/mcp-tool-invoker.svelte
+++ b/tools/agent-playground/src/lib/components/mcp/mcp-tool-invoker.svelte
@@ -206,12 +206,22 @@
   {:else if probeQuery.isError}
     <div class="error-box" role="alert">
       <p>Couldn't load tools: {probeQuery.error?.message ?? "unknown error"}</p>
-      <button type="button" class="retry-btn" onclick={() => probeQuery.refetch()}>Retry</button>
+      <button
+        type="button"
+        class="retry-btn"
+        disabled={probeQuery.isFetching}
+        onclick={() => probeQuery.refetch()}
+      >Retry</button>
     </div>
   {:else if probeResult && !probeResult.ok}
     <div class="error-box" role="alert">
       <p>{probeResult.error}</p>
-      <button type="button" class="retry-btn" onclick={() => probeQuery.refetch()}>
+      <button
+        type="button"
+        class="retry-btn"
+        disabled={probeQuery.isFetching}
+        onclick={() => probeQuery.refetch()}
+      >
         {probeResult.retryable ? "Try again" : "Retry"}
       </button>
     </div>

--- a/tools/agent-playground/src/lib/components/mcp/mcp-tools-section.svelte
+++ b/tools/agent-playground/src/lib/components/mcp/mcp-tools-section.svelte
@@ -56,12 +56,22 @@
   {:else if probeQuery.isError}
     <div class="error-box" role="alert">
       <p>Couldn't load tools: {probeQuery.error?.message ?? "unknown error"}</p>
-      <button type="button" class="retry-btn" onclick={() => probeQuery.refetch()}>Retry</button>
+      <button
+        type="button"
+        class="retry-btn"
+        disabled={probeQuery.isFetching}
+        onclick={() => probeQuery.refetch()}
+      >Retry</button>
     </div>
   {:else if result && !result.ok}
     <div class="error-box" role="alert">
       <p>{result.error}</p>
-      <button type="button" class="retry-btn" onclick={() => probeQuery.refetch()}>
+      <button
+        type="button"
+        class="retry-btn"
+        disabled={probeQuery.isFetching}
+        onclick={() => probeQuery.refetch()}
+      >
         {result.retryable ? "Try again" : "Retry"}
       </button>
     </div>

--- a/tools/agent-playground/src/lib/queries/mcp-queries.test.ts
+++ b/tools/agent-playground/src/lib/queries/mcp-queries.test.ts
@@ -46,7 +46,10 @@ describe("mcpQueries.toolsProbe", () => {
 
     const result = await fetchToolsProbe("github");
 
-    expect(mockToolsGet).toHaveBeenCalledWith({ param: { id: "github" } });
+    expect(mockToolsGet).toHaveBeenCalledWith(
+      { param: { id: "github" } },
+      { init: { signal: undefined } },
+    );
     expect(result.ok).toBe(true);
     if (result.ok) {
       expect(result.tools).toHaveLength(2);

--- a/tools/agent-playground/src/lib/queries/mcp-queries.ts
+++ b/tools/agent-playground/src/lib/queries/mcp-queries.ts
@@ -174,9 +174,12 @@ export interface AddCustomMCPInput {
  * can call it directly without going through TanStack's QueryFunction wrapper
  * (which requires a QueryFunctionContext arg this test doesn't need to mock).
  */
-export async function fetchToolsProbe(id: string): Promise<ToolsProbeResponse> {
+export async function fetchToolsProbe(
+  id: string,
+  signal?: AbortSignal,
+): Promise<ToolsProbeResponse> {
   const client = getDaemonClient();
-  const res = await client.mcp[":id"].tools.$get({ param: { id } });
+  const res = await client.mcp[":id"].tools.$get({ param: { id } }, { init: { signal } });
   if (!res.ok) {
     const body = await res.json().catch(() => ({}));
     throw new Error(`Failed to probe MCP tools: ${res.status} ${JSON.stringify(body)}`);
@@ -248,7 +251,7 @@ export const mcpQueries = {
   toolsProbe: (id: string) =>
     queryOptions({
       queryKey: ["daemon", "mcp", "tools", id] as const,
-      queryFn: () => fetchToolsProbe(id),
+      queryFn: ({ signal }) => fetchToolsProbe(id, signal),
       staleTime: 0,
     }),
 };


### PR DESCRIPTION
## Summary
- Repeatedly clicking **Retry** under *MCP Catalog → server → Testing → Available tools* could wedge the whole playground silently. Each click fired a fresh tools probe while the previous one was still running on the daemon, and after 5–10 clicks the daemon ran out of file descriptors / subprocess slots and quietly stopped accepting new connections — at which point sidebar nav, route data, everything that talks to the daemon hangs with no toast and no console error.
- Retry now actually cancels the previous probe instead of stacking on top of it. The Hono `$get` call carries the AbortSignal that TanStack hands the query function, so a fresh click closes the in-flight socket before the next one fires.
- Retry buttons are also `disabled` while a fetch is in flight as a defense-in-depth guard. The template's `:else if` chain unmounts the button on the next render anyway, but the explicit `disabled` documents intent and survives future template refactors.

## Test plan
- [x] On `/mcp/<server>/tools`, click **Load tools** for an MCP server that fails to connect.
- [x] When the inline error box appears, mash **Retry** ~15 times in a second.
- [x] Verify: sidebar links still navigate, no daemon stall.
- [x] DevTools → Network: each click closes the previous `…/mcp/<id>/tools` request (status `(canceled)`) before issuing the next one.

## Known failures
The following eval suites fail on this branch but are pre-existing and unrelated to a UI-only change in `agent-playground` — none of them exercise the MCP tools probe path:
- `chat-attachments`: 16/16 failing with `Chat POST 404: {"error":"Workspace not found"}` — local-daemon fixture state.
- `promptfooconfig`: 1/24 failing.
- `skill-tls-awareness`: 1/37 failing.