### PR TITLE
Launcher: KeepAlive=Crashed so crashed launchers auto-recover

### DIFF
--- a/tools/friday-launcher/autostart_darwin.go
+++ b/tools/friday-launcher/autostart_darwin.go
@@ -25,11 +25,15 @@ import (
 //
 // RunAtLoad=true triggers (re-)launch at login.
 //
-// KeepAlive={Crashed: true} tells launchd to restart the job on any
-// "abnormal exit" — which per Apple's docs means EITHER:
-//
-//   - the process exited with a non-zero status code, OR
-//   - the process was terminated by an uncaught signal.
+// KeepAlive={Crashed: true, SuccessfulExit: false} is the BOTH-keys
+// form required for crash-recovery to actually fire on macOS 26
+// (Tahoe). Apple's docs claim `{Crashed: true}` alone should suffice
+// — but empirically (2026-05 QA on darwin/arm64 26.4.1) launchd
+// sets the `after crash => 1` semaphore on SIGKILL yet refuses to
+// respawn until SuccessfulExit=false is ALSO present. The two-key
+// combination means "restart if (last exit was abnormal) OR (last
+// exit was non-successful)" — covers both SIGKILL/panic and exit-N,
+// while a clean exit 0 still leaves the job stopped.
 //
 // Note the breadth: launchd doesn't distinguish "panic / segfault /
 // OOM / uncaught signal" from "the launcher's main() returned an
@@ -77,24 +81,26 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
   <dict>
     <key>Crashed</key>
     <true/>
+    <key>SuccessfulExit</key>
+    <false/>
   </dict>
 </dict>
 </plist>`
 
 // IMPORTANT: if you change the KeepAlive dict's shape in plistTemplate
-// above (add/remove sub-keys, flip Crashed to false, etc.), update
-// hasCrashOnlyKeepAlive() below to match. The staleness check is
+// above (add/remove sub-keys, flip a value, etc.), update
+// hasCanonicalKeepAlive() below to match. The staleness check is
 // strict-equality; any drift between template and predicate causes an
 // infinite rewrite loop on every launcher boot. The round-trip test
 // TestEnableAutostartProducesNonStalePlist enforces this invariant.
 
 // launchAgent mirrors the subset of the plist we read back. KeepAlive
 // is `any` because the schema is a discriminated union — `<false/>`
-// (the v0.0.x shape) parses to `bool`, the new `<dict><key>Crashed</key>
-// <true/></dict>` parses to `map[string]any`. Pinning the field to
-// `bool` made the new shape unmarshal-fail silently, which would mean
-// every staleness check returned "not stale" for installs that
-// already have the dict form — defeating the migration check below.
+// (the v0.0.x shape) parses to `bool`, the dict form parses to
+// `map[string]any`. Pinning the field to `bool` made the new shape
+// unmarshal-fail silently, which would mean every staleness check
+// returned "not stale" for installs that already have the dict form —
+// defeating the migration check below.
 type launchAgent struct {
 	Label            string   `plist:"Label"`
 	ProgramArguments []string `plist:"ProgramArguments"`
@@ -166,23 +172,29 @@ func readLaunchAgent() (launchAgent, bool) {
 	return agent, true
 }
 
-// hasCrashOnlyKeepAlive reports whether the parsed plist's KeepAlive
-// value is exactly `{Crashed: true}` — the shape this launcher now
-// writes. The historical shape (`<false/>` → `bool(false)`) and any
-// other dict shape both return false, marking the plist for rewrite.
-// Strict-equality check (single key, value true) so a future plist
-// that adds more KeepAlive sub-keys for a new feature is correctly
-// detected as different + rewritten.
-func hasCrashOnlyKeepAlive(agent launchAgent) bool {
+// hasCanonicalKeepAlive reports whether the parsed plist's KeepAlive
+// value is exactly `{Crashed: true, SuccessfulExit: false}` — the
+// shape this launcher now writes. The historical shape
+// (`<false/>` → `bool(false)`), the intermediate `{Crashed: true}`-
+// only shape that an earlier draft of this PR shipped, and any
+// other dict shape all return false, marking the plist for rewrite.
+// Strict-equality check (exactly these two keys with these two values)
+// so a future plist that adds more KeepAlive sub-keys for a new
+// feature is correctly detected as different + rewritten.
+func hasCanonicalKeepAlive(agent launchAgent) bool {
 	m, ok := agent.KeepAlive.(map[string]any)
 	if !ok {
 		return false
 	}
-	if len(m) != 1 {
+	if len(m) != 2 {
 		return false
 	}
 	crashed, ok := m["Crashed"].(bool)
-	return ok && crashed
+	if !ok || !crashed {
+		return false
+	}
+	successfulExit, ok := m["SuccessfulExit"].(bool)
+	return ok && !successfulExit
 }
 
 // isAutostartStale reports whether the LaunchAgent plist needs to
@@ -224,7 +236,7 @@ func isAutostartStale() (bool, string) {
 	if registered == "" || registered != launcherBundleID {
 		return true, autostartReasonBundleIDMismatch
 	}
-	if !hasCrashOnlyKeepAlive(agent) {
+	if !hasCanonicalKeepAlive(agent) {
 		return true, autostartReasonKeepAliveMismatch
 	}
 	return false, ""

--- a/tools/friday-launcher/autostart_darwin.go
+++ b/tools/friday-launcher/autostart_darwin.go
@@ -23,9 +23,32 @@ import (
 // switches `open` from "treat remaining tokens as document paths"
 // to "pass them as argv to the bundled executable."
 //
-// KeepAlive=false because process-compose handles child restart
-// internally; we only want launchd to (re-)launch us at login.
-// RunAtLoad=true triggers that.
+// RunAtLoad=true triggers (re-)launch at login.
+//
+// KeepAlive={Crashed: true} narrows launchd's restart trigger to
+// "the process exited abnormally" — non-zero exit code or terminated
+// by an uncaught signal. Two paths benefit:
+//
+//   - launcher panics / segfaults / OOMs → launchd brings it back
+//     within seconds, so a transient bug doesn't leave the user
+//     staring at a dead tray icon until next login. Without this,
+//     `KeepAlive=false` meant any crash stayed crashed.
+//   - process-compose's runner fails fatally and the launcher's
+//     watchdog can't recover → same recovery path.
+//
+// Deliberate non-triggers (i.e. when launchd MUST NOT restart):
+//
+//   - User clicks "Quit" in the tray menu → performShutdown runs,
+//     main() returns 0, launchd sees clean exit, leaves it stopped.
+//   - User toggles "Start at login" off → plistPath() is removed
+//     entirely (`disableAutostart`), so KeepAlive doesn't matter.
+//   - Installer's `terminate_studio_processes` SIGTERM → launcher's
+//     signal handler runs performShutdown and exits 0. Same clean
+//     exit, so launchd doesn't fight the installer's deliberate
+//     downtime window. (The installer-cancel trap is a separate
+//     issue tracked elsewhere.)
+//
+// Apple docs: <https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html#//apple_ref/doc/uid/10000172i-SW7>
 const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -43,15 +66,25 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
   <key>RunAtLoad</key>
   <true/>
   <key>KeepAlive</key>
-  <false/>
+  <dict>
+    <key>Crashed</key>
+    <true/>
+  </dict>
 </dict>
 </plist>`
 
+// launchAgent mirrors the subset of the plist we read back. KeepAlive
+// is `any` because the schema is a discriminated union — `<false/>`
+// (the v0.0.x shape) parses to `bool`, the new `<dict><key>Crashed</key>
+// <true/></dict>` parses to `map[string]any`. Pinning the field to
+// `bool` made the new shape unmarshal-fail silently, which would mean
+// every staleness check returned "not stale" for installs that
+// already have the dict form — defeating the migration check below.
 type launchAgent struct {
 	Label            string   `plist:"Label"`
 	ProgramArguments []string `plist:"ProgramArguments"`
 	RunAtLoad        bool     `plist:"RunAtLoad"`
-	KeepAlive        bool     `plist:"KeepAlive"`
+	KeepAlive        any      `plist:"KeepAlive"`
 }
 
 func plistPath() string {
@@ -87,12 +120,8 @@ func isAutostartEnabled() bool {
 // path." A v0.0.8-format plist (where ProgramArguments[0] is the
 // raw exe path) returns "" so the migration code knows to rewrite.
 func currentAutostartBundleID() string {
-	data, err := os.ReadFile(plistPath())
-	if err != nil {
-		return ""
-	}
-	var agent launchAgent
-	if _, err := plist.Unmarshal(data, &agent); err != nil {
+	agent, ok := readLaunchAgent()
+	if !ok {
 		return ""
 	}
 	args := agent.ProgramArguments
@@ -106,20 +135,69 @@ func currentAutostartBundleID() string {
 	return args[2]
 }
 
+// readLaunchAgent reads + unmarshals the plist into a launchAgent
+// once, so both bundle-ID extraction and KeepAlive-shape checks share
+// one file read. Returns (zero, false) for any failure — missing
+// file, IO error, malformed XML.
+func readLaunchAgent() (launchAgent, bool) {
+	data, err := os.ReadFile(plistPath())
+	if err != nil {
+		return launchAgent{}, false
+	}
+	var agent launchAgent
+	if _, err := plist.Unmarshal(data, &agent); err != nil {
+		return launchAgent{}, false
+	}
+	return agent, true
+}
+
+// hasCrashOnlyKeepAlive reports whether the parsed plist's KeepAlive
+// value is exactly `{Crashed: true}` — the shape this launcher now
+// writes. The historical shape (`<false/>` → `bool(false)`) and any
+// other dict shape both return false, marking the plist for rewrite.
+// Strict-equality check (single key, value true) so a future plist
+// that adds more KeepAlive sub-keys for a new feature is correctly
+// detected as different + rewritten.
+func hasCrashOnlyKeepAlive(agent launchAgent) bool {
+	m, ok := agent.KeepAlive.(map[string]any)
+	if !ok {
+		return false
+	}
+	if len(m) != 1 {
+		return false
+	}
+	crashed, ok := m["Crashed"].(bool)
+	return ok && crashed
+}
+
 // isAutostartStale reports whether the LaunchAgent plist needs to
 // be rewritten. Cross-platform contract — see autostart_linux.go +
 // autostart_windows.go for the per-OS interpretation.
 //
-// Darwin: stale iff a plist is present AND its registered bundle
-// ID differs from launcherBundleID (covers both the v0.0.8-format
-// plist and a future bundle-ID rename). An absent plist is NOT
-// stale — it means the user toggled "Start at login" off via the
-// tray, and Decision #36 says a deliberately-disabled autostart
-// stays disabled. Without the registered != "" guard, the
+// Darwin: stale iff a plist is present AND any of:
+//   - registered bundle ID differs from launcherBundleID (covers
+//     v0.0.8-format plists with a raw exe path, and future bundle-ID
+//     renames);
+//   - KeepAlive is anything other than `{Crashed: true}` (covers
+//     v0.0.x-format plists that used `<false/>`, so the
+//     crash-recovery upgrade rolls out automatically on next launcher
+//     boot).
+//
+// An absent plist is NOT stale — it means the user toggled "Start at
+// login" off via the tray, and Decision #36 says a deliberately-
+// disabled autostart stays disabled. Without that guard, the
 // autostartSelfRegister staleness-repair pass would silently
-// re-enable autostart on every launcher start, ignoring the
-// user's preference. Mirrors autostart_windows.go's check.
+// re-enable autostart on every launcher start, ignoring the user's
+// preference. Mirrors autostart_windows.go's "is the file there at
+// all" check.
 func isAutostartStale() bool {
+	agent, ok := readLaunchAgent()
+	if !ok {
+		return false
+	}
 	registered := currentAutostartBundleID()
-	return registered != "" && registered != launcherBundleID
+	if registered == "" || registered != launcherBundleID {
+		return true
+	}
+	return !hasCrashOnlyKeepAlive(agent)
 }

--- a/tools/friday-launcher/autostart_darwin.go
+++ b/tools/friday-launcher/autostart_darwin.go
@@ -190,17 +190,17 @@ func hasCrashOnlyKeepAlive(agent launchAgent) bool {
 // Cross-platform contract — see autostart_linux.go +
 // autostart_windows.go for the per-OS interpretation. The reason is
 // "" when stale=false, and otherwise an identifier the caller can
-// log to triage repeated migrations (e.g. "I see keepalive_shape on
+// log to triage repeated migrations (e.g. "I see keepalive_mismatch on
 // every boot" → template/predicate drift).
 //
 // Darwin: stale iff a plist is present AND any of:
 //   - registered bundle ID differs from launcherBundleID (covers
 //     v0.0.8-format plists with a raw exe path, and future bundle-ID
-//     renames) → reason "bundle_id_mismatch";
+//     renames) → reason autostartReasonBundleIDMismatch;
 //   - KeepAlive is anything other than `{Crashed: true}` (covers
 //     v0.0.x-format plists that used `<false/>`, so the
 //     crash-recovery upgrade rolls out automatically on next launcher
-//     boot) → reason "keepalive_shape".
+//     boot) → reason autostartReasonKeepAliveMismatch.
 //
 // An absent plist is NOT stale — it means the user toggled "Start at
 // login" off via the tray, and Decision #36 says a deliberately-
@@ -222,10 +222,10 @@ func isAutostartStale() (bool, string) {
 	}
 	registered := currentAutostartBundleID()
 	if registered == "" || registered != launcherBundleID {
-		return true, "bundle_id_mismatch"
+		return true, autostartReasonBundleIDMismatch
 	}
 	if !hasCrashOnlyKeepAlive(agent) {
-		return true, "keepalive_shape"
+		return true, autostartReasonKeepAliveMismatch
 	}
 	return false, ""
 }

--- a/tools/friday-launcher/autostart_darwin.go
+++ b/tools/friday-launcher/autostart_darwin.go
@@ -25,16 +25,20 @@ import (
 //
 // RunAtLoad=true triggers (re-)launch at login.
 //
-// KeepAlive={Crashed: true} narrows launchd's restart trigger to
-// "the process exited abnormally" — non-zero exit code or terminated
-// by an uncaught signal. Two paths benefit:
+// KeepAlive={Crashed: true} tells launchd to restart the job on any
+// "abnormal exit" — which per Apple's docs means EITHER:
 //
-//   - launcher panics / segfaults / OOMs → launchd brings it back
-//     within seconds, so a transient bug doesn't leave the user
-//     staring at a dead tray icon until next login. Without this,
-//     `KeepAlive=false` meant any crash stayed crashed.
-//   - process-compose's runner fails fatally and the launcher's
-//     watchdog can't recover → same recovery path.
+//   - the process exited with a non-zero status code, OR
+//   - the process was terminated by an uncaught signal.
+//
+// Note the breadth: launchd doesn't distinguish "panic / segfault /
+// OOM / uncaught signal" from "the launcher's main() returned an
+// error after the user clicked a dismissible dialog." Any `os.Exit`
+// with a non-zero code counts. Audit existing exit sites
+// (preflight failures, port-bind conflicts after the
+// port-in-use dialog, etc.) before assuming launchd will only catch
+// genuine crashes — paths that today exit 1 will now be relaunched
+// by launchd ~10 s later (Apple's throttle floor).
 //
 // Deliberate non-triggers (i.e. when launchd MUST NOT restart):
 //
@@ -47,6 +51,10 @@ import (
 //     exit, so launchd doesn't fight the installer's deliberate
 //     downtime window. (The installer-cancel trap is a separate
 //     issue tracked elsewhere.)
+//
+// The intent is "crashes auto-recover" — for that to hold, fatal-but-
+// user-actionable error paths should exit 0 (treat the dialog as the
+// recovery surface) rather than exit 1 (relaunch loop).
 //
 // Apple docs: <https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPSystemStartup/Chapters/CreatingLaunchdJobs.html#//apple_ref/doc/uid/10000172i-SW7>
 const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
@@ -72,6 +80,13 @@ const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
   </dict>
 </dict>
 </plist>`
+
+// IMPORTANT: if you change the KeepAlive dict's shape in plistTemplate
+// above (add/remove sub-keys, flip Crashed to false, etc.), update
+// hasCrashOnlyKeepAlive() below to match. The staleness check is
+// strict-equality; any drift between template and predicate causes an
+// infinite rewrite loop on every launcher boot. The round-trip test
+// TestEnableAutostartProducesNonStalePlist enforces this invariant.
 
 // launchAgent mirrors the subset of the plist we read back. KeepAlive
 // is `any` because the schema is a discriminated union — `<false/>`
@@ -171,33 +186,46 @@ func hasCrashOnlyKeepAlive(agent launchAgent) bool {
 }
 
 // isAutostartStale reports whether the LaunchAgent plist needs to
-// be rewritten. Cross-platform contract — see autostart_linux.go +
-// autostart_windows.go for the per-OS interpretation.
+// be rewritten, returning a short reason tag for the rewrite log.
+// Cross-platform contract — see autostart_linux.go +
+// autostart_windows.go for the per-OS interpretation. The reason is
+// "" when stale=false, and otherwise an identifier the caller can
+// log to triage repeated migrations (e.g. "I see keepalive_shape on
+// every boot" → template/predicate drift).
 //
 // Darwin: stale iff a plist is present AND any of:
 //   - registered bundle ID differs from launcherBundleID (covers
 //     v0.0.8-format plists with a raw exe path, and future bundle-ID
-//     renames);
+//     renames) → reason "bundle_id_mismatch";
 //   - KeepAlive is anything other than `{Crashed: true}` (covers
 //     v0.0.x-format plists that used `<false/>`, so the
 //     crash-recovery upgrade rolls out automatically on next launcher
-//     boot).
+//     boot) → reason "keepalive_shape".
 //
 // An absent plist is NOT stale — it means the user toggled "Start at
 // login" off via the tray, and Decision #36 says a deliberately-
 // disabled autostart stays disabled. Without that guard, the
 // autostartSelfRegister staleness-repair pass would silently
 // re-enable autostart on every launcher start, ignoring the user's
-// preference. Mirrors autostart_windows.go's "is the file there at
-// all" check.
-func isAutostartStale() bool {
+// preference. A malformed/unreadable plist also returns not-stale
+// for the same Decision #36 reason: we don't know what the user
+// wanted, so we don't overwrite.
+//
+// The "absent → not stale" half mirrors autostart_windows.go (and the
+// linux no-op). Beyond that, darwin's check is strictly richer
+// because the plist schema is richer (bundle ID + KeepAlive shape);
+// Windows has only an exe-path equality check.
+func isAutostartStale() (bool, string) {
 	agent, ok := readLaunchAgent()
 	if !ok {
-		return false
+		return false, ""
 	}
 	registered := currentAutostartBundleID()
 	if registered == "" || registered != launcherBundleID {
-		return true
+		return true, "bundle_id_mismatch"
 	}
-	return !hasCrashOnlyKeepAlive(agent)
+	if !hasCrashOnlyKeepAlive(agent) {
+		return true, "keepalive_shape"
+	}
+	return false, ""
 }

--- a/tools/friday-launcher/autostart_darwin_test.go
+++ b/tools/friday-launcher/autostart_darwin_test.go
@@ -136,6 +136,8 @@ func TestCurrentAutostartBundleID_CurrentFormatReturnsBundleID(t *testing.T) {
   <dict>
     <key>Crashed</key>
     <true/>
+    <key>SuccessfulExit</key>
+    <false/>
   </dict>
 </dict>
 </plist>`
@@ -218,82 +220,119 @@ func TestCurrentAutostartBundleID_TooFewArgsReturnsEmpty(t *testing.T) {
 	}
 }
 
-// TestHasCrashOnlyKeepAlive_BoolFalse: the historical v0.0.x plist
+// TestHasCanonicalKeepAlive_BoolFalse: the historical v0.0.x plist
 // shape (`<key>KeepAlive</key><false/>`) parses to `bool(false)`,
-// which must be rejected by hasCrashOnlyKeepAlive so the staleness
+// which must be rejected by hasCanonicalKeepAlive so the staleness
 // pass rewrites it with the dict form. THIS IS THE LOAD-BEARING PATH
 // FOR THE v0.0.x → crash-recovery KeepAlive MIGRATION — without it,
 // users who deployed before the upgrade would never get the new
 // shape and crashed launchers would stay dead.
-func TestHasCrashOnlyKeepAlive_BoolFalse(t *testing.T) {
-	if hasCrashOnlyKeepAlive(launchAgent{KeepAlive: false}) {
-		t.Error("hasCrashOnlyKeepAlive(bool false) = true, want false")
+func TestHasCanonicalKeepAlive_BoolFalse(t *testing.T) {
+	if hasCanonicalKeepAlive(launchAgent{KeepAlive: false}) {
+		t.Error("hasCanonicalKeepAlive(bool false) = true, want false")
 	}
 }
 
-// TestHasCrashOnlyKeepAlive_BoolTrue: defensively rejects the
+// TestHasCanonicalKeepAlive_BoolTrue: defensively rejects the
 // `<key>KeepAlive</key><true/>` shape too. Friday has never written
 // that, but a hand-edited or future-altered plist mustn't sneak past
 // the staleness check just because the value is "truthy."
-func TestHasCrashOnlyKeepAlive_BoolTrue(t *testing.T) {
-	if hasCrashOnlyKeepAlive(launchAgent{KeepAlive: true}) {
-		t.Error("hasCrashOnlyKeepAlive(bool true) = true, want false")
+func TestHasCanonicalKeepAlive_BoolTrue(t *testing.T) {
+	if hasCanonicalKeepAlive(launchAgent{KeepAlive: true}) {
+		t.Error("hasCanonicalKeepAlive(bool true) = true, want false")
 	}
 }
 
-// TestHasCrashOnlyKeepAlive_DictWithCrashedTrue: the canonical shape
-// we write today. This is the only input that should return true.
-func TestHasCrashOnlyKeepAlive_DictWithCrashedTrue(t *testing.T) {
-	agent := launchAgent{KeepAlive: map[string]any{"Crashed": true}}
-	if !hasCrashOnlyKeepAlive(agent) {
-		t.Error("hasCrashOnlyKeepAlive({Crashed: true}) = false, want true")
-	}
-}
-
-// TestHasCrashOnlyKeepAlive_DictWithCrashedFalse: a dict with the
-// right key but the wrong value — `{Crashed: false}` would tell
-// launchd to restart on CLEAN exit instead of crash, the opposite of
-// what we want. Must be rejected so the rewrite path replaces it.
-func TestHasCrashOnlyKeepAlive_DictWithCrashedFalse(t *testing.T) {
-	agent := launchAgent{KeepAlive: map[string]any{"Crashed": false}}
-	if hasCrashOnlyKeepAlive(agent) {
-		t.Error("hasCrashOnlyKeepAlive({Crashed: false}) = true, want false")
-	}
-}
-
-// TestHasCrashOnlyKeepAlive_DictWithExtraKey: a dict that has
-// {Crashed: true} but also a second sub-key (NetworkState,
-// SuccessfulExit, AfterInitialDemand, etc.) is not our canonical
-// shape. Strict-equality match: extra keys → stale, because future
-// versions of this launcher may add a key for a new feature and the
-// staleness check needs to fire so the upgrade rolls out.
-func TestHasCrashOnlyKeepAlive_DictWithExtraKey(t *testing.T) {
+// TestHasCanonicalKeepAlive_DictCrashedAndSuccessfulExit: the canonical
+// shape we write today — both keys, both with their canonical values.
+// This is the ONLY input that should return true.
+func TestHasCanonicalKeepAlive_DictCrashedAndSuccessfulExit(t *testing.T) {
 	agent := launchAgent{KeepAlive: map[string]any{
 		"Crashed":        true,
 		"SuccessfulExit": false,
 	}}
-	if hasCrashOnlyKeepAlive(agent) {
-		t.Error("hasCrashOnlyKeepAlive({Crashed:true, SuccessfulExit:false}) = true, want false")
+	if !hasCanonicalKeepAlive(agent) {
+		t.Error("hasCanonicalKeepAlive({Crashed:true, SuccessfulExit:false}) = false, want true")
 	}
 }
 
-// TestHasCrashOnlyKeepAlive_EmptyDict: a plist with `<key>KeepAlive
+// TestHasCanonicalKeepAlive_DictCrashedOnly: the intermediate shape
+// shipped by an earlier draft of this PR — `{Crashed: true}` alone
+// without `SuccessfulExit: false`. THIS IS THE LOAD-BEARING PATH for
+// migrating users who already received the broken intermediate shape
+// (a single-key dict that macOS 26.x launchd silently ignores for
+// crash-recovery purposes — confirmed empirically 2026-05-19 on
+// darwin/arm64 26.4.1: SIGKILL sets `after crash => 1` but never
+// triggers respawn). Must be rejected so the staleness pass rewrites
+// it with the two-key form that actually fires respawn.
+func TestHasCanonicalKeepAlive_DictCrashedOnly(t *testing.T) {
+	agent := launchAgent{KeepAlive: map[string]any{"Crashed": true}}
+	if hasCanonicalKeepAlive(agent) {
+		t.Error("hasCanonicalKeepAlive({Crashed:true} only) = true, want false (intermediate broken shape — must migrate to two-key)")
+	}
+}
+
+// TestHasCanonicalKeepAlive_DictCrashedFalse: a dict with the right
+// keys but the wrong "Crashed" value — `{Crashed:false, SuccessfulExit:
+// false}` would tell launchd to leave crashes alone (opposite of
+// what we want). Must be rejected.
+func TestHasCanonicalKeepAlive_DictCrashedFalse(t *testing.T) {
+	agent := launchAgent{KeepAlive: map[string]any{
+		"Crashed":        false,
+		"SuccessfulExit": false,
+	}}
+	if hasCanonicalKeepAlive(agent) {
+		t.Error("hasCanonicalKeepAlive({Crashed:false, SuccessfulExit:false}) = true, want false")
+	}
+}
+
+// TestHasCanonicalKeepAlive_DictSuccessfulExitTrue: the wrong
+// SuccessfulExit value — `{Crashed:true, SuccessfulExit:true}` would
+// fight the user's Quit (restart on every clean exit too). Reject.
+func TestHasCanonicalKeepAlive_DictSuccessfulExitTrue(t *testing.T) {
+	agent := launchAgent{KeepAlive: map[string]any{
+		"Crashed":        true,
+		"SuccessfulExit": true,
+	}}
+	if hasCanonicalKeepAlive(agent) {
+		t.Error("hasCanonicalKeepAlive({Crashed:true, SuccessfulExit:true}) = true, want false")
+	}
+}
+
+// TestHasCanonicalKeepAlive_DictWithExtraKey: a dict that has the two
+// canonical keys with canonical values PLUS a third sub-key
+// (NetworkState, AfterInitialDemand, etc.) is not our canonical shape.
+// Strict-equality match: extra keys → stale, because future versions
+// of this launcher may add a key for a new feature and the staleness
+// check needs to fire so the upgrade rolls out.
+func TestHasCanonicalKeepAlive_DictWithExtraKey(t *testing.T) {
+	agent := launchAgent{KeepAlive: map[string]any{
+		"Crashed":            true,
+		"SuccessfulExit":     false,
+		"AfterInitialDemand": true,
+	}}
+	if hasCanonicalKeepAlive(agent) {
+		t.Error("hasCanonicalKeepAlive({Crashed,SuccessfulExit,AfterInitialDemand}) = true, want false")
+	}
+}
+
+// TestHasCanonicalKeepAlive_EmptyDict: a plist with `<key>KeepAlive
 // </key><dict></dict>` is technically valid launchd syntax (means
-// "always keep alive") — definitely not our crash-only shape. Reject.
-func TestHasCrashOnlyKeepAlive_EmptyDict(t *testing.T) {
-	if hasCrashOnlyKeepAlive(launchAgent{KeepAlive: map[string]any{}}) {
-		t.Error("hasCrashOnlyKeepAlive(empty dict) = true, want false")
+// "always keep alive") — definitely not canonical. Reject.
+func TestHasCanonicalKeepAlive_EmptyDict(t *testing.T) {
+	if hasCanonicalKeepAlive(launchAgent{KeepAlive: map[string]any{}}) {
+		t.Error("hasCanonicalKeepAlive(empty dict) = true, want false")
 	}
 }
 
-// TestHasCrashOnlyKeepAlive_AbsentField: a plist with no KeepAlive
-// key at all (default: never restart) parses to a nil any. Reject —
-// even though the behaviour is "no restart on anything," it's not
-// the shape we now own, and we want the upgrade to install our
-// explicit `{Crashed: true}` dict.
-func TestHasCrashOnlyKeepAlive_AbsentField(t *testing.T) {
-	if hasCrashOnlyKeepAlive(launchAgent{KeepAlive: nil}) {
-		t.Error("hasCrashOnlyKeepAlive(nil) = true, want false")
+// TestHasCanonicalKeepAlive_AbsentField: a plist with no KeepAlive key
+// at all (default: never restart) parses to a nil any. Reject — even
+// though the behaviour is "no restart on anything," it's not the
+// shape we now own, and we want the upgrade to install our explicit
+// two-key dict.
+func TestHasCanonicalKeepAlive_AbsentField(t *testing.T) {
+	if hasCanonicalKeepAlive(launchAgent{KeepAlive: nil}) {
+		t.Error("hasCanonicalKeepAlive(nil) = true, want false")
 	}
 }
 
@@ -328,6 +367,46 @@ func TestIsAutostartStale_OldKeepAliveShapeIsStale(t *testing.T) {
 	stale, reason := isAutostartStale()
 	if !stale {
 		t.Error("isAutostartStale() = false for old KeepAlive shape, want true (migration must fire)")
+	}
+	if reason != autostartReasonKeepAliveMismatch {
+		t.Errorf("isAutostartStale() reason = %q, want %q", reason, autostartReasonKeepAliveMismatch)
+	}
+}
+
+// TestIsAutostartStale_IntermediateCrashedOnlyIsStale: an installed
+// plist with the correct bundle ID and the single-key `{Crashed:true}`
+// dict — the shape an earlier draft of this PR shipped. macOS 26.x
+// launchd silently ignores that shape for crash-recovery (the
+// `after crash` semaphore is satisfied but no respawn fires), so we
+// migrate it to the two-key form that actually works.
+func TestIsAutostartStale_IntermediateCrashedOnlyIsStale(t *testing.T) {
+	path := withFakePlist(t)
+	intermediate := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>ai.hellofriday.studio</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/open</string>
+    <string>-b</string>
+    <string>` + launcherBundleID + `</string>
+    <string>--args</string>
+    <string>--no-browser</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>Crashed</key><true/>
+  </dict>
+</dict>
+</plist>`
+	if err := os.WriteFile(path, []byte(intermediate), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stale, reason := isAutostartStale()
+	if !stale {
+		t.Error("isAutostartStale() = false for {Crashed:true}-only plist, want true (intermediate shape must migrate to two-key)")
 	}
 	if reason != autostartReasonKeepAliveMismatch {
 		t.Errorf("isAutostartStale() reason = %q, want %q", reason, autostartReasonKeepAliveMismatch)
@@ -405,7 +484,7 @@ func TestCurrentAutostartBundleID_WrongPrefixReturnsEmpty(t *testing.T) {
 // TestEnableAutostartProducesNonStalePlist pins the load-bearing
 // round-trip invariant: whatever plistTemplate writes today must be
 // accepted as canonical by isAutostartStale on read-back. If a future
-// edit changes the template (or hasCrashOnlyKeepAlive) in a way that
+// edit changes the template (or hasCanonicalKeepAlive) in a way that
 // breaks this round-trip, every launcher boot would mark its own
 // freshly-written plist as stale, rewrite it, mark it stale on the
 // next boot, ad infinitum. Every other test in this file uses
@@ -428,6 +507,6 @@ func TestEnableAutostartProducesNonStalePlist(t *testing.T) {
 	}
 	stale, reason := isAutostartStale()
 	if stale {
-		t.Errorf("freshly-written plist is stale: reason=%q. Either plistTemplate drifted from hasCrashOnlyKeepAlive(), or the bundle-ID match broke — fix one to match the other.", reason)
+		t.Errorf("freshly-written plist is stale: reason=%q. Either plistTemplate drifted from hasCanonicalKeepAlive(), or the bundle-ID match broke — fix one to match the other.", reason)
 	}
 }

--- a/tools/friday-launcher/autostart_darwin_test.go
+++ b/tools/friday-launcher/autostart_darwin_test.go
@@ -90,7 +90,8 @@ func TestCurrentAutostartBundleID_V008FormatReturnsEmpty(t *testing.T) {
 }
 
 // TestCurrentAutostartBundleID_CurrentFormatReturnsBundleID: the
-// happy path — a Stack 3 plist returns its bundle ID. Pinned
+// happy path — a current plist (with the crash-recovery KeepAlive
+// dict from the v0.0.10+ upgrade) returns its bundle ID. Pinned
 // against the canonical launcherBundleID const so a future ID
 // rename forces a deliberate test update.
 func TestCurrentAutostartBundleID_CurrentFormatReturnsBundleID(t *testing.T) {
@@ -109,7 +110,11 @@ func TestCurrentAutostartBundleID_CurrentFormatReturnsBundleID(t *testing.T) {
     <string>--no-browser</string>
   </array>
   <key>RunAtLoad</key><true/>
-  <key>KeepAlive</key><false/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>Crashed</key>
+    <true/>
+  </dict>
 </dict>
 </plist>`
 	if err := os.WriteFile(path, []byte(currentPlist), 0o600); err != nil {
@@ -117,6 +122,14 @@ func TestCurrentAutostartBundleID_CurrentFormatReturnsBundleID(t *testing.T) {
 	}
 	if got := currentAutostartBundleID(); got != launcherBundleID {
 		t.Errorf("got %q, want %q", got, launcherBundleID)
+	}
+	// Sister assertion: a canonically-shaped plist must NOT be marked
+	// stale. Without this, the staleness-repair pass would rewrite the
+	// plist on every launcher start — chewing through file I/O for no
+	// reason AND breaking any "the plist was rewritten" signal that
+	// telemetry might want to attach in future.
+	if isAutostartStale() {
+		t.Error("isAutostartStale() = true on canonically-shaped plist, want false")
 	}
 }
 
@@ -176,6 +189,150 @@ func TestCurrentAutostartBundleID_TooFewArgsReturnsEmpty(t *testing.T) {
 	}
 	if got := currentAutostartBundleID(); got != "" {
 		t.Errorf("got %q, want \"\" for ProgramArguments len < 3", got)
+	}
+}
+
+// TestHasCrashOnlyKeepAlive_BoolFalse: the historical v0.0.x plist
+// shape (`<key>KeepAlive</key><false/>`) parses to `bool(false)`,
+// which must be rejected by hasCrashOnlyKeepAlive so the staleness
+// pass rewrites it with the dict form. THIS IS THE LOAD-BEARING PATH
+// FOR THE v0.0.x → crash-recovery KeepAlive MIGRATION — without it,
+// users who deployed before the upgrade would never get the new
+// shape and crashed launchers would stay dead.
+func TestHasCrashOnlyKeepAlive_BoolFalse(t *testing.T) {
+	if hasCrashOnlyKeepAlive(launchAgent{KeepAlive: false}) {
+		t.Error("hasCrashOnlyKeepAlive(bool false) = true, want false")
+	}
+}
+
+// TestHasCrashOnlyKeepAlive_BoolTrue: defensively rejects the
+// `<key>KeepAlive</key><true/>` shape too. Friday has never written
+// that, but a hand-edited or future-altered plist mustn't sneak past
+// the staleness check just because the value is "truthy."
+func TestHasCrashOnlyKeepAlive_BoolTrue(t *testing.T) {
+	if hasCrashOnlyKeepAlive(launchAgent{KeepAlive: true}) {
+		t.Error("hasCrashOnlyKeepAlive(bool true) = true, want false")
+	}
+}
+
+// TestHasCrashOnlyKeepAlive_DictWithCrashedTrue: the canonical shape
+// we write today. This is the only input that should return true.
+func TestHasCrashOnlyKeepAlive_DictWithCrashedTrue(t *testing.T) {
+	agent := launchAgent{KeepAlive: map[string]any{"Crashed": true}}
+	if !hasCrashOnlyKeepAlive(agent) {
+		t.Error("hasCrashOnlyKeepAlive({Crashed: true}) = false, want true")
+	}
+}
+
+// TestHasCrashOnlyKeepAlive_DictWithCrashedFalse: a dict with the
+// right key but the wrong value — `{Crashed: false}` would tell
+// launchd to restart on CLEAN exit instead of crash, the opposite of
+// what we want. Must be rejected so the rewrite path replaces it.
+func TestHasCrashOnlyKeepAlive_DictWithCrashedFalse(t *testing.T) {
+	agent := launchAgent{KeepAlive: map[string]any{"Crashed": false}}
+	if hasCrashOnlyKeepAlive(agent) {
+		t.Error("hasCrashOnlyKeepAlive({Crashed: false}) = true, want false")
+	}
+}
+
+// TestHasCrashOnlyKeepAlive_DictWithExtraKey: a dict that has
+// {Crashed: true} but also a second sub-key (NetworkState,
+// SuccessfulExit, AfterInitialDemand, etc.) is not our canonical
+// shape. Strict-equality match: extra keys → stale, because future
+// versions of this launcher may add a key for a new feature and the
+// staleness check needs to fire so the upgrade rolls out.
+func TestHasCrashOnlyKeepAlive_DictWithExtraKey(t *testing.T) {
+	agent := launchAgent{KeepAlive: map[string]any{
+		"Crashed":        true,
+		"SuccessfulExit": false,
+	}}
+	if hasCrashOnlyKeepAlive(agent) {
+		t.Error("hasCrashOnlyKeepAlive({Crashed:true, SuccessfulExit:false}) = true, want false")
+	}
+}
+
+// TestHasCrashOnlyKeepAlive_EmptyDict: a plist with `<key>KeepAlive
+// </key><dict></dict>` is technically valid launchd syntax (means
+// "always keep alive") — definitely not our crash-only shape. Reject.
+func TestHasCrashOnlyKeepAlive_EmptyDict(t *testing.T) {
+	if hasCrashOnlyKeepAlive(launchAgent{KeepAlive: map[string]any{}}) {
+		t.Error("hasCrashOnlyKeepAlive(empty dict) = true, want false")
+	}
+}
+
+// TestHasCrashOnlyKeepAlive_AbsentField: a plist with no KeepAlive
+// key at all (default: never restart) parses to a nil any. Reject —
+// even though the behaviour is "no restart on anything," it's not
+// the shape we now own, and we want the upgrade to install our
+// explicit `{Crashed: true}` dict.
+func TestHasCrashOnlyKeepAlive_AbsentField(t *testing.T) {
+	if hasCrashOnlyKeepAlive(launchAgent{KeepAlive: nil}) {
+		t.Error("hasCrashOnlyKeepAlive(nil) = true, want false")
+	}
+}
+
+// TestIsAutostartStale_OldKeepAliveShapeIsStale: the migration
+// trigger — an installed plist that has the correct bundle ID but
+// the old `<key>KeepAlive</key><false/>` shape must be marked stale
+// so the next launcher boot rewrites it with the new dict. Without
+// this assertion, the v0.0.x → crash-recovery rollout would silently
+// no-op on every existing user's machine.
+func TestIsAutostartStale_OldKeepAliveShapeIsStale(t *testing.T) {
+	path := withFakePlist(t)
+	oldShape := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>ai.hellofriday.studio</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/bin/open</string>
+    <string>-b</string>
+    <string>` + launcherBundleID + `</string>
+    <string>--args</string>
+    <string>--no-browser</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><false/>
+</dict>
+</plist>`
+	if err := os.WriteFile(path, []byte(oldShape), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !isAutostartStale() {
+		t.Error("isAutostartStale() = false for old KeepAlive shape, want true (migration must fire)")
+	}
+}
+
+// TestIsAutostartStale_V008ShapeIsStale: a v0.0.8 plist (raw exe
+// path, no `/usr/bin/open -b` wrapper) has neither the right bundle
+// ID format NOR the new KeepAlive shape — must be stale. Codifies a
+// claim that was previously aspirational in the file's comments but
+// not actually asserted: the old isAutostartStale `registered != ""`
+// guard meant v0.0.8 plists were silently treated as "not stale."
+// The fix is implicit in the refactored isAutostartStale; this test
+// pins it down.
+func TestIsAutostartStale_V008ShapeIsStale(t *testing.T) {
+	path := withFakePlist(t)
+	v008Plist := `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>ai.hellofriday.studio</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/friday-launcher</string>
+    <string>--no-browser</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>KeepAlive</key><false/>
+</dict>
+</plist>`
+	if err := os.WriteFile(path, []byte(v008Plist), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !isAutostartStale() {
+		t.Error("isAutostartStale() = false for v0.0.8 plist, want true (migration must fire)")
 	}
 }
 

--- a/tools/friday-launcher/autostart_darwin_test.go
+++ b/tools/friday-launcher/autostart_darwin_test.go
@@ -188,8 +188,8 @@ func TestCurrentAutostartBundleID_DifferentBundleIDReturnsThatID(t *testing.T) {
 	if !stale {
 		t.Error("isAutostartStale = false, want true (bundle ID mismatch)")
 	}
-	if reason != "bundle_id_mismatch" {
-		t.Errorf("isAutostartStale reason = %q, want %q", reason, "bundle_id_mismatch")
+	if reason != autostartReasonBundleIDMismatch {
+		t.Errorf("isAutostartStale reason = %q, want %q", reason, autostartReasonBundleIDMismatch)
 	}
 }
 
@@ -329,8 +329,8 @@ func TestIsAutostartStale_OldKeepAliveShapeIsStale(t *testing.T) {
 	if !stale {
 		t.Error("isAutostartStale() = false for old KeepAlive shape, want true (migration must fire)")
 	}
-	if reason != "keepalive_shape" {
-		t.Errorf("isAutostartStale() reason = %q, want %q", reason, "keepalive_shape")
+	if reason != autostartReasonKeepAliveMismatch {
+		t.Errorf("isAutostartStale() reason = %q, want %q", reason, autostartReasonKeepAliveMismatch)
 	}
 }
 
@@ -367,10 +367,10 @@ func TestIsAutostartStale_V008ShapeIsStale(t *testing.T) {
 	}
 	// v0.0.8 plists fail the bundle-ID check first (raw exe path,
 	// no /usr/bin/open -b wrapper), so the reason is bundle_id_mismatch
-	// rather than keepalive_shape — even though the KeepAlive=<false/>
+	// rather than keepalive_mismatch — even though the KeepAlive=<false/>
 	// would ALSO trip the shape check if we got that far.
-	if reason != "bundle_id_mismatch" {
-		t.Errorf("isAutostartStale() reason = %q, want %q", reason, "bundle_id_mismatch")
+	if reason != autostartReasonBundleIDMismatch {
+		t.Errorf("isAutostartStale() reason = %q, want %q", reason, autostartReasonBundleIDMismatch)
 	}
 }
 
@@ -411,10 +411,20 @@ func TestCurrentAutostartBundleID_WrongPrefixReturnsEmpty(t *testing.T) {
 // next boot, ad infinitum. Every other test in this file uses
 // hand-rolled XML strings; this is the only one that exercises the
 // real template through the real read-back path.
+//
+// The bundle-ID assertion below is the "did the file actually parse"
+// half — without it, an unparseable template (typo'd tag, unescaped
+// `&`, missing closing element) would silently pass: readLaunchAgent
+// would fail, isAutostartStale would return (false, "") via its
+// Decision #36 guard, and !stale would be satisfied while the user's
+// real launcher writes garbage on every boot.
 func TestEnableAutostartProducesNonStalePlist(t *testing.T) {
 	withFakePlist(t)
 	if err := enableAutostart(); err != nil {
 		t.Fatalf("enableAutostart() error = %v", err)
+	}
+	if got := currentAutostartBundleID(); got != launcherBundleID {
+		t.Errorf("freshly-written plist parsed bundle ID = %q, want %q (plistTemplate is producing unparseable or wrong-shape XML)", got, launcherBundleID)
 	}
 	stale, reason := isAutostartStale()
 	if stale {

--- a/tools/friday-launcher/autostart_darwin_test.go
+++ b/tools/friday-launcher/autostart_darwin_test.go
@@ -40,8 +40,30 @@ func TestCurrentAutostartBundleID_AbsentReturnsEmpty(t *testing.T) {
 // Mirrors autostart_windows.go's `registered != ""` check.
 func TestIsAutostartStale_AbsentReturnsFalse(t *testing.T) {
 	withFakePlist(t)
-	if isAutostartStale() {
-		t.Error("isAutostartStale() = true with no plist on disk, want false (user-disabled autostart must stay disabled)")
+	stale, reason := isAutostartStale()
+	if stale {
+		t.Errorf("isAutostartStale() = (true, %q) with no plist on disk, want (false, \"\") (user-disabled autostart must stay disabled)", reason)
+	}
+	if reason != "" {
+		t.Errorf("isAutostartStale() reason = %q, want \"\" when not stale", reason)
+	}
+}
+
+// TestIsAutostartStale_MalformedXMLReturnsFalse pins the second
+// Decision #36 path: an unreadable/hand-edited plist must NOT be
+// silently rewritten — we don't know what the user wanted. The
+// new isAutostartStale early-returns false when readLaunchAgent
+// fails. A future refactor that flipped this to "treat unreadable
+// as stale, just rewrite" would slip past every other test in
+// this file; this assertion stops that.
+func TestIsAutostartStale_MalformedXMLReturnsFalse(t *testing.T) {
+	path := withFakePlist(t)
+	if err := os.WriteFile(path, []byte("not actual XML"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stale, reason := isAutostartStale()
+	if stale {
+		t.Errorf("isAutostartStale() = (true, %q) for malformed XML, want (false, \"\")", reason)
 	}
 }
 
@@ -128,8 +150,8 @@ func TestCurrentAutostartBundleID_CurrentFormatReturnsBundleID(t *testing.T) {
 	// plist on every launcher start — chewing through file I/O for no
 	// reason AND breaking any "the plist was rewritten" signal that
 	// telemetry might want to attach in future.
-	if isAutostartStale() {
-		t.Error("isAutostartStale() = true on canonically-shaped plist, want false")
+	if stale, reason := isAutostartStale(); stale {
+		t.Errorf("isAutostartStale() = (true, %q) on canonically-shaped plist, want (false, \"\")", reason)
 	}
 }
 
@@ -162,8 +184,12 @@ func TestCurrentAutostartBundleID_DifferentBundleIDReturnsThatID(t *testing.T) {
 	}
 	// And isAutostartStale should fire — the registered ID
 	// differs from launcherBundleID.
-	if !isAutostartStale() {
+	stale, reason := isAutostartStale()
+	if !stale {
 		t.Error("isAutostartStale = false, want true (bundle ID mismatch)")
+	}
+	if reason != "bundle_id_mismatch" {
+		t.Errorf("isAutostartStale reason = %q, want %q", reason, "bundle_id_mismatch")
 	}
 }
 
@@ -299,8 +325,12 @@ func TestIsAutostartStale_OldKeepAliveShapeIsStale(t *testing.T) {
 	if err := os.WriteFile(path, []byte(oldShape), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if !isAutostartStale() {
+	stale, reason := isAutostartStale()
+	if !stale {
 		t.Error("isAutostartStale() = false for old KeepAlive shape, want true (migration must fire)")
+	}
+	if reason != "keepalive_shape" {
+		t.Errorf("isAutostartStale() reason = %q, want %q", reason, "keepalive_shape")
 	}
 }
 
@@ -331,8 +361,16 @@ func TestIsAutostartStale_V008ShapeIsStale(t *testing.T) {
 	if err := os.WriteFile(path, []byte(v008Plist), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if !isAutostartStale() {
+	stale, reason := isAutostartStale()
+	if !stale {
 		t.Error("isAutostartStale() = false for v0.0.8 plist, want true (migration must fire)")
+	}
+	// v0.0.8 plists fail the bundle-ID check first (raw exe path,
+	// no /usr/bin/open -b wrapper), so the reason is bundle_id_mismatch
+	// rather than keepalive_shape — even though the KeepAlive=<false/>
+	// would ALSO trip the shape check if we got that far.
+	if reason != "bundle_id_mismatch" {
+		t.Errorf("isAutostartStale() reason = %q, want %q", reason, "bundle_id_mismatch")
 	}
 }
 
@@ -361,5 +399,25 @@ func TestCurrentAutostartBundleID_WrongPrefixReturnsEmpty(t *testing.T) {
 	}
 	if got := currentAutostartBundleID(); got != "" {
 		t.Errorf("got %q, want \"\" for non-/usr/bin/open prefix", got)
+	}
+}
+
+// TestEnableAutostartProducesNonStalePlist pins the load-bearing
+// round-trip invariant: whatever plistTemplate writes today must be
+// accepted as canonical by isAutostartStale on read-back. If a future
+// edit changes the template (or hasCrashOnlyKeepAlive) in a way that
+// breaks this round-trip, every launcher boot would mark its own
+// freshly-written plist as stale, rewrite it, mark it stale on the
+// next boot, ad infinitum. Every other test in this file uses
+// hand-rolled XML strings; this is the only one that exercises the
+// real template through the real read-back path.
+func TestEnableAutostartProducesNonStalePlist(t *testing.T) {
+	withFakePlist(t)
+	if err := enableAutostart(); err != nil {
+		t.Fatalf("enableAutostart() error = %v", err)
+	}
+	stale, reason := isAutostartStale()
+	if stale {
+		t.Errorf("freshly-written plist is stale: reason=%q. Either plistTemplate drifted from hasCrashOnlyKeepAlive(), or the bundle-ID match broke — fix one to match the other.", reason)
 	}
 }

--- a/tools/friday-launcher/autostart_linux.go
+++ b/tools/friday-launcher/autostart_linux.go
@@ -18,7 +18,7 @@ var (
 	_ = launcherBundleID
 )
 
-func enableAutostart() error   { return nil }
-func disableAutostart() error  { return nil }
-func isAutostartEnabled() bool { return false }
-func isAutostartStale() bool   { return false }
+func enableAutostart() error              { return nil }
+func disableAutostart() error             { return nil }
+func isAutostartEnabled() bool            { return false }
+func isAutostartStale() (bool, string)    { return false, "" }

--- a/tools/friday-launcher/autostart_linux.go
+++ b/tools/friday-launcher/autostart_linux.go
@@ -16,9 +16,12 @@ package main
 var (
 	_ = launchAgentLabel
 	_ = launcherBundleID
+	_ = autostartReasonBundleIDMismatch
+	_ = autostartReasonKeepAliveMismatch
+	_ = autostartReasonExePathMismatch
 )
 
-func enableAutostart() error              { return nil }
-func disableAutostart() error             { return nil }
-func isAutostartEnabled() bool            { return false }
-func isAutostartStale() (bool, string)    { return false, "" }
+func enableAutostart() error           { return nil }
+func disableAutostart() error          { return nil }
+func isAutostartEnabled() bool         { return false }
+func isAutostartStale() (bool, string) { return false, "" }

--- a/tools/friday-launcher/autostart_windows.go
+++ b/tools/friday-launcher/autostart_windows.go
@@ -109,7 +109,7 @@ func isAutostartStale() (bool, string) {
 	}
 	registered := currentAutostartPath()
 	if registered != "" && registered != exe {
-		return true, "exe_path_mismatch"
+		return true, autostartReasonExePathMismatch
 	}
 	return false, ""
 }

--- a/tools/friday-launcher/autostart_windows.go
+++ b/tools/friday-launcher/autostart_windows.go
@@ -95,17 +95,21 @@ func currentAutostartPath() string {
 }
 
 // isAutostartStale reports whether the registry entry needs to be
-// rewritten. Cross-platform contract — see autostart_darwin.go.
+// rewritten, returning a short reason tag for the rewrite log.
+// Cross-platform contract — see autostart_darwin.go.
 //
 // Windows: stale iff the registered exe path differs from
-// os.Executable(). Stack 3 doesn't change the Windows autostart
-// shape (no .app bundle on Windows), so the v0.0.8 behavior carries
-// forward unchanged.
-func isAutostartStale() bool {
+// os.Executable() → reason "exe_path_mismatch". Stack 3 doesn't
+// change the Windows autostart shape (no .app bundle on Windows),
+// so the v0.0.8 behavior carries forward unchanged.
+func isAutostartStale() (bool, string) {
 	exe, err := os.Executable()
 	if err != nil {
-		return false
+		return false, ""
 	}
 	registered := currentAutostartPath()
-	return registered != "" && registered != exe
+	if registered != "" && registered != exe {
+		return true, "exe_path_mismatch"
+	}
+	return false, ""
 }

--- a/tools/friday-launcher/main.go
+++ b/tools/friday-launcher/main.go
@@ -719,8 +719,8 @@ func autostartSelfRegister() error {
 		return nil
 	}
 	// Already initialized — staleness repair pass.
-	if isAutostartStale() {
-		log.Info("autostart entry stale; rewriting")
+	if stale, reason := isAutostartStale(); stale {
+		log.Info("autostart entry stale; rewriting", "reason", reason)
 		if err := enableAutostart(); err != nil {
 			return fmt.Errorf("enableAutostart (staleness): %w", err)
 		}

--- a/tools/friday-launcher/paths.go
+++ b/tools/friday-launcher/paths.go
@@ -28,6 +28,20 @@ const launchAgentLabel = "ai.hellofriday.studio"
 // suffixed value and rewrites the plist on next launcher start.
 const launcherBundleID = "ai.hellofriday.studio"
 
+// Reason tags returned by isAutostartStale() and logged alongside the
+// "autostart entry stale; rewriting" line in main.go. These flow into
+// user telemetry/support logs, so renames are an observability-contract
+// break — keep production and tests pointing at the same const.
+//
+// Naming convention: <subsystem>_mismatch. All three are platform-
+// specific (darwin uses the first two, windows the third), but the
+// consts live here so the package builds on all platforms.
+const (
+	autostartReasonBundleIDMismatch  = "bundle_id_mismatch"
+	autostartReasonKeepAliveMismatch = "keepalive_mismatch"
+	autostartReasonExePathMismatch   = "exe_path_mismatch"
+)
+
 // bundledAgentSDKVersion pins the friday-agent-sdk PyPI version that
 // the daemon spawns user agents against (apps/atlasd/src/agent-spawn.ts
 // reads this via FRIDAY_AGENT_SDK_VERSION). Bumping is a deliberate


### PR DESCRIPTION
## Summary

Switch the macOS LaunchAgent plist from `KeepAlive=<false/>` to
`KeepAlive=<dict><key>Crashed</key><true/><key>SuccessfulExit</key><false/></dict>`.
launchd will auto-restart the launcher on abnormal exit (panic, segfault,
OOM, uncaught signal, non-zero `os.Exit`) while leaving clean `exit 0`
paths (user clicks "Quit", installer SIGTERM, etc.) alone.

The migration is automatic: the launcher's existing
`autostartSelfRegister` staleness path picks up the old shape and
rewrites it on the next session.

## Why both `Crashed:true` AND `SuccessfulExit:false`

The natural-looking choice — single-key `{Crashed:true}` — does **not**
actually trigger respawn on macOS 26 (Tahoe). Empirically verified
2026-05-19 on darwin/arm64 26.4.1 with a minimal sleep-based plist:

| KeepAlive shape | SIGKILL respawn? |
|---|---|
| `{Crashed:true}` (single-key) | ❌ NO — `after crash => 1` semaphore set, but `runs` stays at 1 |
| `<true/>` (always) | ✓ — but fights every user Quit |
| `{Crashed:true, SuccessfulExit:false}` (this PR) | ✓ |

Apple's docs claim Crashed alone should suffice. macOS 26 disagrees.
The two-key form means "restart if (last exit was abnormal) OR (last
exit was non-successful)" — covers SIGKILL/panic and exit-N, while a
clean exit 0 still leaves the job stopped.

## What this addresses + what it doesn't

Manu incident #4 — "launcher recovery after external SIGTERM" — has
two failure classes underneath it:

| Class | Recovery path today | After this PR |
|---|---|---|
| Launcher crashes (panic / segfault / OOM / non-zero exit) | Stays dead until next login or user double-clicks Friday Studio.app | **launchd brings it back within seconds** |
| Installer SIGTERMs launcher then wizard exits before relaunching it | User must double-click Friday Studio.app | **Still requires user action** — installer-side guard is a separate change |

The installer-cancel trap stays open.

⚠️ **Audit `os.Exit(1)` sites before relying on "only crashes will respawn."**
launchd treats *any* non-zero exit as abnormal. Existing fatal-but-
user-actionable paths (preflight failure dialog, port-bind dialog,
etc.) will now respawn ~10 s later. For those paths, prefer
`os.Exit(0)` after showing the dialog — let the dialog be the
recovery surface, not launchd. Captured in the doc comment on
`plistTemplate`; tracked separately from this PR.

## Migration

Existing v0.0.x plists carry `KeepAlive=<false/>`. The launcher's
self-register staleness pass picks them up via the new
`hasCanonicalKeepAlive()` check and rewrites them to the canonical
two-key dict shape on the next session. No user action required.

`isAutostartStale()` returns `(bool, reason)` so the rewrite log
distinguishes the migration class:
- `reason=keepalive_mismatch` — v0.0.x `<false/>` or any non-canonical dict
- `reason=bundle_id_mismatch` — v0.0.8 raw-exe-path plists, future bundle-ID renames
- `reason=exe_path_mismatch` — Windows analogue

Reason tags are hoisted to consts in `paths.go` so production and
tests reference one source of truth (no silent rename of an
observability contract).

The staleness check is strict-equality on the canonical dict (exact
length, exact keys, exact values), so a future plist that adds more
KeepAlive sub-keys for a new feature also triggers a migration —
keeping the rollout mechanism reusable.

## Test plan

- [x] **24 darwin autostart unit tests** pass, covering:
  - 8 `hasCanonicalKeepAlive` shape tests including the intermediate
    single-key `{Crashed:true}` (must be rejected as broken) and the
    `{Crashed:true, SuccessfulExit:true}` shape (must be rejected as
    Quit-fighting)
  - 3 migration triggers: v0.0.x `<false/>`, v0.0.8 raw-exe-path,
    intermediate single-key `{Crashed:true}`
  - Malformed-XML safety (Decision #36)
  - Round-trip `enableAutostart() → !isAutostartStale()` invariant
    with positive bundle-ID assertion (catches unparseable template
    output)
- [x] **173/173 full launcher test suite** passes on real darwin/arm64 26.4.1
- [x] Cross-platform build: darwin / linux / windows
- [x] gofmt + go vet clean
- [x] **Real macOS arm64 VM (Tahoe 26.4.1)** end-to-end:
  - v0.0.x plist (`KeepAlive=<false/>`, correct bundle ID) → staleness
    fires with `reason=keepalive_mismatch`, plist rewritten to 2-key
  - v0.0.8 plist (raw exe path) → staleness fires with
    `reason=bundle_id_mismatch`, plist rewritten
  - Intermediate single-key `{Crashed:true}` plist → staleness fires
    with `reason=keepalive_mismatch`, plist rewritten
  - Malformed-XML plist → no rewrite, file untouched, no log line
  - Canonical 2-key plist on second boot → plist mtime unchanged,
    no rewrite log (idempotent)
- [x] **launchd crash-respawn verified** with the canonical 2-key
  shape via `launchctl bootstrap` + SIGKILL of the running process:
  respawn within ~3 s, `runs` counter 1→2. (Test used a
  `/bin/sleep 600` stand-in plist — launchd doesn't introspect the
  respawned binary, only the plist shape.)
- [x] **Clean exit-0 leaves the job stopped** with the same canonical
  shape: `runs` stayed at 1 for >28 s after a script exited cleanly.
  The Quit / deliberate-shutdown contract is preserved.

## Files

- `tools/friday-launcher/paths.go` — reason-tag consts shared across
  darwin/linux/windows
- `tools/friday-launcher/autostart_darwin.go` — plist template
  (now 2-key), `readLaunchAgent` shared helper, `hasCanonicalKeepAlive`,
  expanded `isAutostartStale` returning `(bool, reason)`
- `tools/friday-launcher/autostart_darwin_test.go` — full suite for
  the predicate + migration triggers + round-trip invariant
- `tools/friday-launcher/autostart_linux.go` — signature parity, no-op
- `tools/friday-launcher/autostart_windows.go` — signature parity,
  returns `exe_path_mismatch` reason
- `tools/friday-launcher/main.go` — caller logs the reason alongside
  the rewrite line