### PR TITLE
fix(mcp): recover from uvx entrypoint-mismatch + capture subprocess stderr

### DIFF
--- a/packages/mcp/src/create-mcp-tools.stderr-capture.test.ts
+++ b/packages/mcp/src/create-mcp-tools.stderr-capture.test.ts
@@ -1,0 +1,105 @@
+// Real-subprocess test for stderr capture. Deliberately does NOT mock
+// @ai-sdk/mcp — that's the layer where the capture bug lives. Mock-only
+// coverage missed a Deno child_process compat issue where an in-memory
+// Writable passed as stderr silently fell back to "inherit", sending
+// subprocess output to the parent's stderr instead of the capture buffer.
+
+import process from "node:process";
+import type { MCPServerConfig } from "@atlas/config";
+import { describe, expect, it, vi } from "vitest";
+import { createMCPTools } from "./create-mcp-tools.ts";
+
+const fakeLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  child() {
+    return this;
+  },
+} as unknown as import("@atlas/logger").Logger;
+
+describe("createMCPTools stderr capture (real subprocess)", () => {
+  it("captures stderr from a failing subprocess and surfaces it in the connection-error log", async () => {
+    const configs: Record<string, MCPServerConfig> = {
+      bogus: {
+        transport: {
+          type: "stdio",
+          command: "sh",
+          args: ["-c", "echo 'CAPTURED_STDERR_TOKEN' >&2; exit 1"],
+        },
+      },
+    };
+
+    await createMCPTools(configs, fakeLogger);
+
+    expect(fakeLogger.warn).toHaveBeenCalledWith(
+      "MCP server skipped due to connection error",
+      expect.objectContaining({ error: expect.stringContaining("CAPTURED_STDERR_TOKEN") }),
+    );
+  });
+
+  it("retries with uvx --from when a real subprocess emits the uv entrypoint-mismatch hint", async () => {
+    // First attempt: fail with the uv hint on stderr. Second attempt: fail
+    // immediately with no hint. We assert two spawns happened and the second
+    // received the recovered --from args. Verifying the retry's args is the
+    // end-to-end proof that stderr capture → regex → retry actually flows.
+    //
+    // Use a marker file so we can branch on attempt-count from inside sh.
+    const marker = `/tmp/mcp-uvx-recovery-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const bt = "`"; // literal backtick — embedding inside template-literal breaks transform
+    const firstAttemptScript = [
+      `if [ -f ${marker} ]; then`,
+      `  echo 'second attempt' >&2`,
+      `  exit 1`,
+      `else`,
+      `  touch ${marker}`,
+      `  echo 'An executable named ${bt}my-pkg${bt} is not provided by package ${bt}my-pkg${bt}.' >&2`,
+      `  echo 'The following executables are available:' >&2`,
+      `  echo '- my-bin' >&2`,
+      `  echo '' >&2`,
+      `  echo 'Use ${bt}uvx --from my-pkg my-bin${bt} instead.' >&2`,
+      `  exit 1`,
+      `fi`,
+    ].join("\n");
+
+    const configs: Record<string, MCPServerConfig> = {
+      // command must be "uvx" so the recovery guard fires; sh -c invocation
+      // emulates uv's failure surface without requiring uv installed.
+      "fake-uvx": { transport: { type: "stdio", command: "uvx", args: ["my-pkg==1.0"] } },
+    };
+
+    try {
+      // Substitute the actual `uvx` binary by prepending a temp dir with a
+      // shell script named `uvx` to PATH.
+      const tmpdir = `/tmp/mcp-uvx-shim-${Date.now()}`;
+      const { mkdirSync, writeFileSync, chmodSync, rmSync } = await import("node:fs");
+      mkdirSync(tmpdir, { recursive: true });
+      writeFileSync(`${tmpdir}/uvx`, `#!/bin/sh\n${firstAttemptScript}\n`, "utf8");
+      chmodSync(`${tmpdir}/uvx`, 0o755);
+
+      const originalPath = process.env.PATH;
+      process.env.PATH = `${tmpdir}:${originalPath ?? ""}`;
+
+      try {
+        await createMCPTools(configs, fakeLogger);
+      } finally {
+        process.env.PATH = originalPath;
+        rmSync(tmpdir, { recursive: true, force: true });
+        const { existsSync, unlinkSync } = await import("node:fs");
+        if (existsSync(marker)) unlinkSync(marker);
+      }
+
+      expect(fakeLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("retrying"),
+        expect.objectContaining({
+          operation: "mcp_connect_recover",
+          recoveryArgs: ["--from", "my-pkg==1.0", "my-bin"],
+        }),
+      );
+    } finally {
+      const { existsSync, unlinkSync } = await import("node:fs");
+      if (existsSync(marker)) unlinkSync(marker);
+    }
+  }, 15_000);
+});

--- a/packages/mcp/src/create-mcp-tools.test.ts
+++ b/packages/mcp/src/create-mcp-tools.test.ts
@@ -1,3 +1,4 @@
+import { writeSync } from "node:fs";
 import process from "node:process";
 import type { MCPServerConfig } from "@atlas/config";
 import {
@@ -820,6 +821,267 @@ describe("createMCPTools", () => {
 
     await resultA.dispose();
     await resultB.dispose();
+  });
+
+  describe("uvx --from recovery", () => {
+    // fakeLogger.warn accumulates across tests; clear it before each so
+    // not.toHaveBeenCalledWith(...) assertions only see this test's calls.
+    beforeEach(() => {
+      (fakeLogger.warn as unknown as ReturnType<typeof vi.fn>).mockClear();
+    });
+
+    // attemptStdio writes subprocess stderr to a temp file (the fd is passed
+    // to the transport). To simulate that under mocks, MockStdioTransport
+    // writes our test stderr into that fd synchronously; the real
+    // attemptStdio reads it back via fstat/read.
+    function writeStderrToFd(opts: { stderr: number }, content: string) {
+      writeSync(opts.stderr, content);
+    }
+
+    it("retries uvx with --from when uv emits the entrypoint-mismatch hint", async () => {
+      const uvHint = [
+        "An executable named `bitbucket-mcp-py` is not provided by package `bitbucket-mcp-py`.",
+        "The following executables are available:",
+        "- bitbucket-mcp",
+        "",
+        "Use `uvx --from bitbucket-mcp-py bitbucket-mcp` instead.",
+      ].join("\n");
+
+      let attempt = 0;
+      MockStdioTransport.mockImplementation(function (this: unknown, opts: { stderr: number }) {
+        attempt++;
+        if (attempt === 1) writeStderrToFd(opts, uvHint);
+      });
+
+      mockTools
+        .mockImplementationOnce(() => Promise.reject(new Error("Connection closed")))
+        .mockImplementationOnce(() =>
+          Promise.resolve({ "bb-tool": { description: "ok", parameters: {} } }),
+        );
+      mockClose.mockResolvedValue(undefined);
+      mockCreateMCPClient.mockResolvedValue({ tools: mockTools, close: mockClose });
+
+      const configs: Record<string, MCPServerConfig> = {
+        bitbucket: {
+          transport: { type: "stdio", command: "uvx", args: ["bitbucket-mcp-py==1.2.3"] },
+        },
+      };
+
+      const result = await createMCPTools(configs, fakeLogger);
+
+      expect(result.tools).toHaveProperty("bb-tool");
+      expect(MockStdioTransport).toHaveBeenCalledTimes(2);
+      expect(MockStdioTransport).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ args: ["--from", "bitbucket-mcp-py==1.2.3", "bitbucket-mcp"] }),
+      );
+      expect(fakeLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining("retrying"),
+        expect.objectContaining({
+          operation: "mcp_connect_recover",
+          serverId: "bitbucket",
+          recoveryArgs: ["--from", "bitbucket-mcp-py==1.2.3", "bitbucket-mcp"],
+        }),
+      );
+    });
+
+    it("does not retry when stderr lacks the uv hint", async () => {
+      MockStdioTransport.mockImplementation(function (this: unknown, opts: { stderr: number }) {
+        writeStderrToFd(opts, "ENOENT: command not found\n");
+      });
+      mockTools.mockImplementation(() => Promise.reject(new Error("Connection closed")));
+      mockClose.mockResolvedValue(undefined);
+      mockCreateMCPClient.mockResolvedValue({ tools: mockTools, close: mockClose });
+
+      const configs: Record<string, MCPServerConfig> = {
+        bogus: { transport: { type: "stdio", command: "uvx", args: ["nonexistent-pkg"] } },
+      };
+
+      await createMCPTools(configs, fakeLogger);
+
+      expect(MockStdioTransport).toHaveBeenCalledTimes(1);
+      expect(fakeLogger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("retrying"),
+        expect.anything(),
+      );
+    });
+
+    it("strips ANSI color codes from the captured hint before parsing", async () => {
+      // uv wraps the package name and entrypoint in CSI color codes when it
+      // detects a terminal-ish stderr. The recovery parser must strip them or
+      // the captured argv will contain raw ESC bytes.
+      const ESC = "";
+      const coloredHint = [
+        `An executable named \`${ESC}[36mfoo-pkg${ESC}[39m\` is not provided by package \`${ESC}[36mfoo-pkg${ESC}[39m\`.`,
+        "The following executables are available:",
+        `- ${ESC}[36mfoo-bin${ESC}[39m`,
+        "",
+        `Use \`uvx --from ${ESC}[36mfoo-pkg${ESC}[39m ${ESC}[36mfoo-bin${ESC}[39m\` instead.`,
+      ].join("\n");
+
+      let attempt = 0;
+      MockStdioTransport.mockImplementation(function (this: unknown, opts: { stderr: number }) {
+        attempt++;
+        if (attempt === 1) writeStderrToFd(opts, coloredHint);
+      });
+
+      mockTools
+        .mockImplementationOnce(() => Promise.reject(new Error("Connection closed")))
+        .mockImplementationOnce(() =>
+          Promise.resolve({ x: { description: "ok", parameters: {} } }),
+        );
+      mockClose.mockResolvedValue(undefined);
+      mockCreateMCPClient.mockResolvedValue({ tools: mockTools, close: mockClose });
+
+      const configs: Record<string, MCPServerConfig> = {
+        colored: { transport: { type: "stdio", command: "uvx", args: ["foo-pkg==2.0"] } },
+      };
+
+      await createMCPTools(configs, fakeLogger);
+
+      expect(MockStdioTransport).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ args: ["--from", "foo-pkg==2.0", "foo-bin"] }),
+      );
+    });
+
+    it("does not retry when the command is not uvx, even if stderr contains the hint", async () => {
+      const hint = "Use `uvx --from foo-pkg foo-bin` instead.";
+      MockStdioTransport.mockImplementation(function (this: unknown, opts: { stderr: number }) {
+        writeStderrToFd(opts, hint);
+      });
+      mockTools.mockImplementation(() => Promise.reject(new Error("Connection closed")));
+      mockClose.mockResolvedValue(undefined);
+      mockCreateMCPClient.mockResolvedValue({ tools: mockTools, close: mockClose });
+
+      const configs: Record<string, MCPServerConfig> = {
+        wrapper: { transport: { type: "stdio", command: "my-wrapper", args: ["foo-pkg"] } },
+      };
+
+      await createMCPTools(configs, fakeLogger);
+
+      expect(MockStdioTransport).toHaveBeenCalledTimes(1);
+      expect(fakeLogger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("retrying"),
+        expect.anything(),
+      );
+    });
+
+    it("does not retry when the original args already contain --from", async () => {
+      const hint = "Use `uvx --from foo-pkg foo-bin` instead.";
+      MockStdioTransport.mockImplementation(function (this: unknown, opts: { stderr: number }) {
+        writeStderrToFd(opts, hint);
+      });
+      mockTools.mockImplementation(() => Promise.reject(new Error("Connection closed")));
+      mockClose.mockResolvedValue(undefined);
+      mockCreateMCPClient.mockResolvedValue({ tools: mockTools, close: mockClose });
+
+      const configs: Record<string, MCPServerConfig> = {
+        already: {
+          transport: { type: "stdio", command: "uvx", args: ["--from", "foo-pkg", "wrong-entry"] },
+        },
+      };
+
+      await createMCPTools(configs, fakeLogger);
+
+      expect(MockStdioTransport).toHaveBeenCalledTimes(1);
+      expect(fakeLogger.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining("retrying"),
+        expect.anything(),
+      );
+    });
+
+    it("falls back to uv's suggested package when no positional carries the name", async () => {
+      const hint = "Use `uvx --from solo-pkg solo-bin` instead.";
+      let attempt = 0;
+      MockStdioTransport.mockImplementation(function (this: unknown, opts: { stderr: number }) {
+        attempt++;
+        if (attempt === 1) writeStderrToFd(opts, hint);
+      });
+      mockTools
+        .mockImplementationOnce(() => Promise.reject(new Error("Connection closed")))
+        .mockImplementationOnce(() =>
+          Promise.resolve({ t: { description: "ok", parameters: {} } }),
+        );
+      mockClose.mockResolvedValue(undefined);
+      mockCreateMCPClient.mockResolvedValue({ tools: mockTools, close: mockClose });
+
+      const configs: Record<string, MCPServerConfig> = {
+        // args contain no token that includes "solo-pkg" — flag-only case.
+        // The recovery falls back to uv's suggested package, preserving the
+        // original `--quiet` flag.
+        flagsonly: { transport: { type: "stdio", command: "uvx", args: ["--quiet"] } },
+      };
+
+      await createMCPTools(configs, fakeLogger);
+
+      expect(MockStdioTransport).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ args: ["--quiet", "--from", "solo-pkg", "solo-bin"] }),
+      );
+    });
+
+    it("recovers from --python flag-with-value invocations", async () => {
+      // `uvx --python 3.11 mypkg` — the previous "first non-flag arg" heuristic
+      // would have picked "3.11"; substring match correctly picks "mypkg".
+      const hint = "Use `uvx --from mypkg mybin` instead.";
+      let attempt = 0;
+      MockStdioTransport.mockImplementation(function (this: unknown, opts: { stderr: number }) {
+        attempt++;
+        if (attempt === 1) writeStderrToFd(opts, hint);
+      });
+      mockTools
+        .mockImplementationOnce(() => Promise.reject(new Error("Connection closed")))
+        .mockImplementationOnce(() =>
+          Promise.resolve({ t: { description: "ok", parameters: {} } }),
+        );
+      mockClose.mockResolvedValue(undefined);
+      mockCreateMCPClient.mockResolvedValue({ tools: mockTools, close: mockClose });
+
+      const configs: Record<string, MCPServerConfig> = {
+        py: {
+          transport: { type: "stdio", command: "uvx", args: ["--python", "3.11", "mypkg==1.0"] },
+        },
+      };
+
+      await createMCPTools(configs, fakeLogger);
+
+      expect(MockStdioTransport).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({ args: ["--python", "3.11", "--from", "mypkg==1.0", "mybin"] }),
+      );
+    });
+
+    it("preserves both stderr outputs when the retry also fails", async () => {
+      const firstHint = "Use `uvx --from foo-pkg foo-bin` instead.";
+      const retryError = "RETRY_FAILURE_TOKEN: something else went wrong";
+      let attempt = 0;
+      MockStdioTransport.mockImplementation(function (this: unknown, opts: { stderr: number }) {
+        attempt++;
+        writeStderrToFd(opts, attempt === 1 ? firstHint : retryError);
+      });
+      mockTools.mockImplementation(() => Promise.reject(new Error("Connection closed")));
+      mockClose.mockResolvedValue(undefined);
+      mockCreateMCPClient.mockResolvedValue({ tools: mockTools, close: mockClose });
+
+      const configs: Record<string, MCPServerConfig> = {
+        both: { transport: { type: "stdio", command: "uvx", args: ["foo-pkg"] } },
+      };
+
+      await createMCPTools(configs, fakeLogger);
+
+      // The surfaced error should carry both stderrs — the original uv hint
+      // (so the operator knows why we retried) and the retry's distinct
+      // failure (so they know it didn't fix things).
+      expect(fakeLogger.warn).toHaveBeenCalledWith(
+        "MCP server skipped due to connection error",
+        expect.objectContaining({ error: expect.stringContaining(firstHint) }),
+      );
+      expect(fakeLogger.warn).toHaveBeenCalledWith(
+        "MCP server skipped due to connection error",
+        expect.objectContaining({ error: expect.stringContaining("RETRY_FAILURE_TOKEN") }),
+      );
+    });
   });
 
   describe("timeout behaviour", () => {

--- a/packages/mcp/src/create-mcp-tools.ts
+++ b/packages/mcp/src/create-mcp-tools.ts
@@ -11,8 +11,11 @@
 
 import { Buffer } from "node:buffer";
 import { spawn as defaultSpawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { closeSync, fstatSync, openSync, readSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import process from "node:process";
-import { Writable } from "node:stream";
 import { experimental_createMCPClient as createMCPClient } from "@ai-sdk/mcp";
 import { Experimental_StdioMCPTransport as StdioMCPTransport } from "@ai-sdk/mcp/mcp-stdio";
 import type { MCPServerConfig, MCPServerToolFilter } from "@atlas/config";
@@ -452,6 +455,133 @@ function interpolateArg(arg: string): string {
   return arg.replaceAll("${HOME}", home).replaceAll("${FRIDAY_HOME}", getFridayHome());
 }
 
+type StdioAttempt =
+  | { ok: true; client: MCPClient; tools: Record<string, Tool> }
+  | { ok: false; error: Error; stderr: string };
+
+async function attemptStdio(
+  command: string,
+  args: readonly string[],
+  env: Record<string, string>,
+): Promise<StdioAttempt> {
+  // Pipe subprocess stderr through a temp file so we can read it on failure.
+  // Two simpler approaches don't work reliably:
+  //   - Passing an in-memory Writable: Deno's node:child_process compat
+  //     silently falls back to "inherit", sending stderr to the parent.
+  //   - Passing "pipe" and attaching a 'data' listener after createMCPClient
+  //     resolves: by then a fast-exiting subprocess has already closed, and
+  //     Deno's pipe drains buffered data on close — too late to recover it.
+  // A real OS file descriptor sidesteps both: the kernel writes synchronously
+  // and we can read after the subprocess dies.
+  const tmpPath = path.join(tmpdir(), `mcp-stderr-${randomBytes(8).toString("hex")}.log`);
+  const fd = openSync(tmpPath, "w+");
+  let fdOpen = true;
+
+  const readStderr = (): string => {
+    const stats = fstatSync(fd);
+    const size = Number(stats.size);
+    if (size === 0) return "";
+    const buf = Buffer.alloc(size);
+    readSync(fd, buf, 0, size, 0);
+    return buf.toString("utf8").trim();
+  };
+
+  let client: MCPClient | undefined;
+  try {
+    try {
+      client = await createMCPClient({
+        transport: new StdioMCPTransport({ command, args: [...args], env, stderr: fd }),
+      });
+    } catch (err) {
+      // The transport's start() can reject (e.g. ENOENT, or the subprocess
+      // dies before completing the MCP handshake). Capture stderr from the
+      // temp file and return failure rather than letting it propagate.
+      const stderr = readStderr();
+      const error = err instanceof Error ? err : new Error(String(err));
+      return { ok: false, error, stderr };
+    }
+
+    // Verify the subprocess is actually responding AND capture tools in one call.
+    // createMCPClient can succeed for stdio even when the server isn't ready yet.
+    try {
+      const tools = await client.tools();
+      return { ok: true, client, tools };
+    } catch (err) {
+      await client.close().catch(() => {});
+      const stderr = readStderr();
+      const error = err instanceof Error ? err : new Error(String(err));
+      return { ok: false, error, stderr };
+    }
+  } finally {
+    // Close the parent's fd in all cases — the subprocess (if still running)
+    // has its own duped fd. Unlink the file to keep /tmp clean; on Unix the
+    // subprocess can keep writing to the now-anonymous file, freed on exit.
+    if (fdOpen) {
+      try {
+        closeSync(fd);
+      } catch {
+        // ignore
+      }
+      fdOpen = false;
+    }
+    try {
+      unlinkSync(tmpPath);
+    } catch {
+      // ignore — file may not exist on Windows after close
+    }
+  }
+}
+
+/**
+ * `uvx <pkg>` looks for an executable matching the package name. When the
+ * registry entry's identifier differs from the package's entrypoint (e.g.
+ * `bitbucket-mcp-py` vs `bitbucket-mcp`), uv refuses and prints the exact
+ * recovery in its own error:
+ *
+ *   Use `uvx --from <pkg> <entrypoint>` instead.
+ *
+ * We parse that suggestion and re-attach the original version spec so the
+ * pin is preserved. Returns null if the stderr doesn't match.
+ */
+function recoverUvxFromArgs(
+  command: string,
+  args: readonly string[],
+  stderr: string,
+): readonly string[] | null {
+  if (command !== "uvx") return null;
+  // User-authored configs may already be in the corrected `--from` form; if
+  // uv still emits a hint in that case it's about something we can't fix by
+  // rewriting args, so we leave the failure to surface as-is.
+  if (args.includes("--from")) return null;
+  // uv may emit ANSI color codes around the package name and entrypoint when
+  // it thinks stderr is a terminal. Strip them before matching so the
+  // captured tokens are clean argv values.
+  // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI is the intent
+  const plain = stderr.replace(/\[[0-9;]*m/g, "");
+  const match = /Use `uvx --from ([^\s`]+) ([^\s`]+)` instead\./.exec(plain);
+  if (!match) return null;
+  const suggestedPkg = match[1];
+  const entrypoint = match[2];
+  if (!suggestedPkg || !entrypoint) return null;
+  // Find the original positional that carries the suggested package name —
+  // a substring match preserves any version pin (`pkg==1.2.3` includes `pkg`)
+  // and naturally skips value-taking flags like `--python 3.11` whose value
+  // wouldn't contain the package name. Splice `--from <spec> <entry>` in
+  // place of the package, keeping any uvx flags before it and any entrypoint
+  // args after it. Fall back to appending if no positional matched.
+  const pkgIdx = args.findIndex((a) => a.includes(suggestedPkg));
+  if (pkgIdx >= 0) {
+    return [
+      ...args.slice(0, pkgIdx),
+      "--from",
+      args[pkgIdx]!,
+      entrypoint,
+      ...args.slice(pkgIdx + 1),
+    ];
+  }
+  return [...args, "--from", suggestedPkg, entrypoint];
+}
+
 async function connectStdio(
   transport: Extract<MCPServerConfig["transport"], { type: "stdio" }>,
   resolvedEnv: Record<string, string>,
@@ -476,52 +606,51 @@ async function connectStdio(
     args: expandedArgs,
   });
 
-  // Capture subprocess stderr so startup errors (e.g. ENOENT on a root path)
-  // are included in the thrown error instead of silently dropped.
-  const stderrChunks: Buffer[] = [];
-  const stderrCapture = new Writable({
-    write(chunk: Buffer, _encoding, callback) {
-      stderrChunks.push(chunk);
-      callback();
-    },
-  });
+  let result = await attemptStdio(command, expandedArgs, mergedEnv);
+  let firstStderr: string | undefined;
 
-  const client = await createMCPClient({
-    transport: new StdioMCPTransport({
-      command,
-      args: expandedArgs,
-      env: mergedEnv,
-      stderr: stderrCapture,
-    }),
-  });
+  if (!result.ok) {
+    const recoveryArgs = recoverUvxFromArgs(command, expandedArgs, result.stderr);
+    if (recoveryArgs) {
+      logger.warn(`MCP stdio retrying "${serverId}" with uvx --from form`, {
+        operation: "mcp_connect_recover",
+        serverId,
+        command,
+        originalArgs: expandedArgs,
+        recoveryArgs,
+        firstStderr: result.stderr || undefined,
+      });
+      // Hold the triggering stderr so it survives if the retry also fails —
+      // otherwise the only diagnostic for the failure mode this code targets
+      // would be lost in `result`'s reassignment below.
+      firstStderr = result.stderr;
+      result = await attemptStdio(command, recoveryArgs, mergedEnv);
+    }
+  }
 
-  // Verify the subprocess is actually responding AND capture tools in one call.
-  // createMCPClient can succeed for stdio even when the server isn't ready yet.
-  let tools: Record<string, Tool>;
-  try {
-    tools = await client.tools();
-  } catch (err) {
-    // Close the client to kill the orphaned subprocess before re-throwing
-    await client.close().catch(() => {});
-    const stderrOutput = Buffer.concat(stderrChunks).toString("utf8").trim();
+  if (!result.ok) {
+    const combinedStderr =
+      firstStderr && result.stderr !== firstStderr
+        ? `first: ${firstStderr} | retry: ${result.stderr}`
+        : result.stderr;
     logger.debug(`MCP stdio tools() failed for "${serverId}"`, {
       operation: "mcp_connect",
       serverId,
-      error: err instanceof Error ? err.message : String(err),
-      stderrOutput: stderrOutput || undefined,
+      error: result.error.message,
+      stderrOutput: combinedStderr || undefined,
     });
     // Prepend subprocess stderr to the error message so callers see the
     // actual failure reason (e.g. "ENOENT: no such file or directory")
     // rather than just the generic "Connection closed" from the transport.
-    if (stderrOutput && err instanceof Error) {
-      err.message = `${stderrOutput} (${err.message})`;
+    if (combinedStderr) {
+      result.error.message = `${combinedStderr} (${result.error.message})`;
     }
-    throw err;
+    throw result.error;
   }
 
   logger.debug(`MCP stdio connected for "${serverId}"`, { operation: "mcp_connect", serverId });
 
-  return { client, tools };
+  return { client: result.client, tools: result.tools };
 }
 
 /**


### PR DESCRIPTION
## Summary

- PyPI MCP servers whose binary name differs from the package name (e.g. a package that ships a different-named CLI) now connect. `uvx` was refusing them with a hint to use `uvx --from <pkg> <entry>`; the daemon swallowed the hint and showed only "Connection closed". `connectStdio` now parses that hint and retries once with the corrected form, keeping any `uvx` flags before the package (`--python 3.11`), the version pin, and any args passed to the entrypoint.
- Subprocess stderr from failed MCP starts now lands in the connection-error log. Previously it leaked to the parent process's stderr and never reached operators — passing an in-memory `Writable` as the spawn stderr silently fell back to "inherit" under Deno's `node:child_process` compat. Capture now goes through a real file descriptor.
- If the recovery retry also fails, both stderr outputs are surfaced — the original hint and the retry's distinct failure — so the operator can tell whether the recovery picked the wrong entrypoint or hit something else.

## Test plan

- [x] Configure an MCP server using a PyPI package whose binary differs from the package name; daemon starts the server (look for `MCP stdio retrying ... with uvx --from form` in logs)
- [x] Configure a deliberately-broken `uvx` server (bogus package); daemon log shows the real uv error in the connection-error line instead of "Connection closed"
- [x] Existing `uvx pkg==version` servers connect on the first attempt with no retry log