### PR TITLE
feat(llm): add OpenRouter as an opt-in LLM provider

### DIFF
--- a/packages/llm/src/model-catalog.test.ts
+++ b/packages/llm/src/model-catalog.test.ts
@@ -226,7 +226,9 @@ describe("model-catalog — cache", () => {
     await getCatalog();
     await getCatalog();
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // One catalog fetch = 2 HTTP calls (gateway + openrouter). Cache hit on
+    // calls 2 and 3 means no further requests.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("dedupes concurrent callers onto a single in-flight fetch (no thundering herd)", async () => {
@@ -254,7 +256,9 @@ describe("model-catalog — cache", () => {
     } as unknown as Response);
     await Promise.all([a, b, c]);
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // 2 HTTP calls per catalog fetch (gateway + openrouter); the three
+    // concurrent callers share the one in-flight fetchCatalog.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it("discards an in-flight fetch's result when invalidateCatalog runs before it resolves", async () => {
@@ -298,7 +302,8 @@ describe("model-catalog — cache", () => {
 
     // Next call must start a fresh fetch, not return the stale cached one.
     const after = await getCatalog();
-    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // 2 catalog fetches × 2 HTTP calls each (gateway + openrouter) = 4.
+    expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(find(after, "anthropic").models.map((m) => m.id)).toEqual(["claude-haiku-4-5"]);
   });
 });

--- a/packages/llm/src/model-catalog.ts
+++ b/packages/llm/src/model-catalog.ts
@@ -12,6 +12,9 @@
  * - **Groq `/openai/v1/models`** (authenticated with `GROQ_API_KEY`):
  *   the gateway surfaces only 1 Groq model, so when the user has a
  *   Groq key we hit Groq directly for the full catalog.
+ * - **OpenRouter `/api/v1/models`** (public, unauthenticated): the gateway
+ *   doesn't proxy OpenRouter, so we hit it directly. Filtered server-side
+ *   to tool-capable chat models via `?supported_parameters=tools`.
  *
  * Everything is cached in memory for {@link CACHE_TTL_MS} (1h by
  * default) and prewarmed at daemon startup via {@link prewarmCatalog}
@@ -33,17 +36,15 @@ import { PROVIDER_ENV_VARS, type ValidProvider } from "./util.ts";
  * picker. When we add a dedicated "Claude Code" role (wiring the
  * claude-code agent's hardcoded `selectModel` to user config), we'll
  * expose it again behind that role's scoped picker.
- *
- * `openrouter` is also excluded — it's opt-in via `friday.yml` and
- * intentionally absent from the Settings picker UI.
  */
-export type CatalogProvider = Exclude<ValidProvider, "openrouter">;
+export type CatalogProvider = ValidProvider;
 
 const CATALOG_PROVIDERS: readonly CatalogProvider[] = [
   "anthropic",
   "openai",
   "google",
   "groq",
+  "openrouter",
 ] as const;
 
 export interface ModelInfo {
@@ -101,6 +102,9 @@ export interface Catalog {
 const GATEWAY_URL = "https://ai-gateway.vercel.sh/v4/ai/config";
 const GATEWAY_HEADERS = { "ai-gateway-protocol-version": "0.0.1" };
 const GROQ_URL = "https://api.groq.com/openai/v1/models";
+// Server-side filter to tool-capable chat models — OpenRouter publishes 500+
+// model slugs and the unfiltered list dwarfs every other provider's picker.
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/models?supported_parameters=tools";
 
 const FETCH_TIMEOUT_MS = 3_000;
 /** One hour — models don't change intra-session. Prewarm covers first paint. */
@@ -111,6 +115,7 @@ const ENV_VAR_BY_CATALOG_PROVIDER: Record<CatalogProvider, string> = {
   openai: PROVIDER_ENV_VARS.openai,
   google: PROVIDER_ENV_VARS.google,
   groq: PROVIDER_ENV_VARS.groq,
+  openrouter: PROVIDER_ENV_VARS.openrouter,
 };
 
 /**
@@ -133,6 +138,12 @@ export const PROVIDER_META: Record<CatalogProvider, ProviderMeta> = {
   },
   google: { name: "Google", letter: "G", keyPrefix: "AIza", helpUrl: "aistudio.google.com/apikey" },
   groq: { name: "Groq", letter: "Q", keyPrefix: "gsk_", helpUrl: "console.groq.com/keys" },
+  openrouter: {
+    name: "OpenRouter",
+    letter: "R",
+    keyPrefix: "sk-or-v1-",
+    helpUrl: "openrouter.ai/keys",
+  },
 };
 
 // ─── Schemas ───────────────────────────────────────────────────────────────
@@ -147,6 +158,10 @@ const gatewayModelSchema = z.object({
 const gatewayResponseSchema = z.object({ models: z.array(gatewayModelSchema) });
 
 const groqResponseSchema = z.object({ data: z.array(z.object({ id: z.string() })) });
+
+const openrouterModelSchema = z.object({ id: z.string(), name: z.string() });
+const openrouterResponseSchema = z.object({ data: z.array(openrouterModelSchema) });
+type OpenRouterModel = z.infer<typeof openrouterModelSchema>;
 
 // ─── Fetchers ──────────────────────────────────────────────────────────────
 
@@ -178,6 +193,16 @@ async function fetchGroq(apiKey: string): Promise<string[]> {
   return parsed.data.map((m) => m.id);
 }
 
+async function fetchOpenRouter(): Promise<OpenRouterModel[]> {
+  const res = await fetch(OPENROUTER_URL, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+  if (!res.ok) {
+    await discardBody(res);
+    throw new Error(`openrouter returned HTTP ${res.status}`);
+  }
+  const parsed = openrouterResponseSchema.parse(await res.json());
+  return parsed.data;
+}
+
 // ─── Filters / normalization ───────────────────────────────────────────────
 
 /**
@@ -202,6 +227,8 @@ function groupGatewayModels(models: GatewayModel[]): Record<CatalogProvider, Mod
     openai: [],
     google: [],
     groq: [],
+    // OpenRouter is fetched directly from openrouter.ai, not the gateway.
+    openrouter: [],
   };
   for (const m of models) {
     // Gateway uses `modelType: null` for most language models; explicit
@@ -331,11 +358,12 @@ function resolveCredential(provider: CatalogProvider): {
 async function fetchCatalog(): Promise<Catalog> {
   const groqKey = process.env.GROQ_API_KEY;
 
-  // Fire gateway and (optionally) groq in parallel. allSettled so one
-  // provider timing out doesn't take the whole catalog with it.
-  const [gatewayResult, groqResult] = await Promise.allSettled([
+  // Fire gateway, openrouter, and (optionally) groq in parallel. allSettled
+  // so one provider timing out doesn't take the whole catalog with it.
+  const [gatewayResult, groqResult, openrouterResult] = await Promise.allSettled([
     fetchGateway(),
     groqKey ? fetchGroq(groqKey) : Promise.reject(new Error("no GROQ_API_KEY")),
+    fetchOpenRouter(),
   ]);
 
   const gatewayBuckets =
@@ -358,6 +386,19 @@ async function fetchCatalog(): Promise<Catalog> {
       ? String(groqResult.reason instanceof Error ? groqResult.reason.message : groqResult.reason)
       : null;
 
+  const openrouterModels =
+    openrouterResult.status === "fulfilled"
+      ? openrouterResult.value.map((m) => ({ id: m.id, displayName: m.name }))
+      : null;
+  const openrouterError =
+    openrouterResult.status === "rejected"
+      ? String(
+          openrouterResult.reason instanceof Error
+            ? openrouterResult.reason.message
+            : openrouterResult.reason,
+        )
+      : null;
+
   const entries: CatalogEntry[] = CATALOG_PROVIDERS.map((provider) => {
     const cred = resolveCredential(provider);
     let models: ModelInfo[] = [];
@@ -370,6 +411,12 @@ async function fetchCatalog(): Promise<Catalog> {
         error = groqError;
       }
       // else: no key, no models, no error — UI shows the `envVar` hint.
+    } else if (provider === "openrouter") {
+      if (openrouterModels) {
+        models = openrouterModels;
+      } else if (openrouterError) {
+        error = openrouterError;
+      }
     } else if (gatewayBuckets) {
       models = gatewayBuckets[provider];
     } else if (gatewayError) {

--- a/packages/llm/src/model-catalog.ts
+++ b/packages/llm/src/model-catalog.ts
@@ -33,8 +33,11 @@ import { PROVIDER_ENV_VARS, type ValidProvider } from "./util.ts";
  * picker. When we add a dedicated "Claude Code" role (wiring the
  * claude-code agent's hardcoded `selectModel` to user config), we'll
  * expose it again behind that role's scoped picker.
+ *
+ * `openrouter` is also excluded — it's opt-in via `friday.yml` and
+ * intentionally absent from the Settings picker UI.
  */
-export type CatalogProvider = ValidProvider;
+export type CatalogProvider = Exclude<ValidProvider, "openrouter">;
 
 const CATALOG_PROVIDERS: readonly CatalogProvider[] = [
   "anthropic",

--- a/packages/llm/src/openrouter.ts
+++ b/packages/llm/src/openrouter.ts
@@ -1,0 +1,41 @@
+import process from "node:process";
+import { createOpenAI, type OpenAIProvider, type OpenAIProviderSettings } from "@ai-sdk/openai";
+import { createProxyFetch, PROVIDER_ENV_VARS } from "./util.ts";
+
+/**
+ * Configuration options for creating an OpenRouter client
+ */
+interface OpenRouterOptions {
+  /** API key for OpenRouter. Defaults to OPENROUTER_API_KEY env var */
+  apiKey?: string;
+  /** HTTP proxy URL. Defaults to OPENROUTER_PROXY_URL env var */
+  httpProxy?: string;
+}
+
+/**
+ * Creates an OpenRouter client.
+ *
+ * OpenRouter exposes an OpenAI-compatible Chat Completions API, so we point
+ * @ai-sdk/openai at openrouter.ai/api/v1. The `HTTP-Referer` and
+ * `X-OpenRouter-Title` headers identify Friday on openrouter.ai/rankings —
+ * without them usage is anonymous and won't surface on the app's leaderboard.
+ *
+ * @param opts Configuration options for the OpenRouter client
+ * @returns Configured OpenAI provider instance pointed at OpenRouter
+ */
+export function createOpenRouterWithOptions(opts: OpenRouterOptions = {}): OpenAIProvider {
+  const httpProxy = opts.httpProxy || process.env.OPENROUTER_PROXY_URL;
+
+  const openrouterOptions: OpenAIProviderSettings = {
+    apiKey: opts.apiKey || process.env[PROVIDER_ENV_VARS.openrouter],
+    baseURL: "https://openrouter.ai/api/v1",
+    headers: {
+      "HTTP-Referer": "https://hellofriday.ai/",
+      "X-OpenRouter-Title": "Friday",
+    },
+  };
+  if (httpProxy) {
+    openrouterOptions.fetch = createProxyFetch(httpProxy);
+  }
+  return createOpenAI(openrouterOptions);
+}

--- a/packages/llm/src/openrouter.ts
+++ b/packages/llm/src/openrouter.ts
@@ -29,10 +29,7 @@ export function createOpenRouterWithOptions(opts: OpenRouterOptions = {}): OpenA
   const openrouterOptions: OpenAIProviderSettings = {
     apiKey: opts.apiKey || process.env[PROVIDER_ENV_VARS.openrouter],
     baseURL: "https://openrouter.ai/api/v1",
-    headers: {
-      "HTTP-Referer": "https://hellofriday.ai/",
-      "X-OpenRouter-Title": "Friday",
-    },
+    headers: { "HTTP-Referer": "https://hellofriday.ai/", "X-OpenRouter-Title": "Friday" },
   };
   if (httpProxy) {
     openrouterOptions.fetch = createProxyFetch(httpProxy);

--- a/packages/llm/src/registry-id.ts
+++ b/packages/llm/src/registry-id.ts
@@ -4,7 +4,14 @@
  * used by both `platform-models.ts` and `fsm-engine`'s adapter.
  */
 
-export const REGISTRY_PROVIDERS = ["anthropic", "claude-code", "google", "groq", "openai"] as const;
+export const REGISTRY_PROVIDERS = [
+  "anthropic",
+  "claude-code",
+  "google",
+  "groq",
+  "openai",
+  "openrouter",
+] as const;
 
 export type RegistryProvider = (typeof REGISTRY_PROVIDERS)[number];
 
@@ -18,7 +25,8 @@ export type RegistryModelId =
   | `claude-code:${string}`
   | `google:${string}`
   | `groq:${string}`
-  | `openai:${string}`;
+  | `openai:${string}`
+  | `openrouter:${string}`;
 
 export function isRegistryProvider(p: string): p is RegistryProvider {
   return (REGISTRY_PROVIDERS as readonly string[]).includes(p);
@@ -40,5 +48,7 @@ export function buildRegistryModelId(provider: RegistryProvider, model: string):
       return `groq:${model}`;
     case "openai":
       return `openai:${model}`;
+    case "openrouter":
+      return `openrouter:${model}`;
   }
 }

--- a/packages/llm/src/registry.ts
+++ b/packages/llm/src/registry.ts
@@ -9,6 +9,7 @@ import { createAnthropicWithOptions } from "./anthropic.ts";
 import { createGoogleWithOptions } from "./google.ts";
 import { createGroqWithOptions } from "./groq.ts";
 import { createOpenAIWithOptions } from "./openai.ts";
+import { createOpenRouterWithOptions } from "./openrouter.ts";
 
 /**
  * Strips the CLAUDECODE env var to prevent infinite nesting when
@@ -104,6 +105,7 @@ function createRegistry() {
       google: googleViaLitellm,
       groq: groqViaLitellm,
       openai: litellmChatProvider,
+      openrouter: createChatCompletionsProvider(createOpenRouterWithOptions()),
     });
   }
 
@@ -114,6 +116,7 @@ function createRegistry() {
     google: createGoogleWithOptions(),
     groq: createGroqWithOptions(),
     openai: createOpenAIWithOptions(),
+    openrouter: createChatCompletionsProvider(createOpenRouterWithOptions()),
   });
 }
 

--- a/packages/llm/src/util.ts
+++ b/packages/llm/src/util.ts
@@ -34,9 +34,10 @@ export const PROVIDER_ENV_VARS: Record<ValidProvider, string> = {
   google: "GEMINI_API_KEY",
   groq: "GROQ_API_KEY",
   openai: "OPENAI_API_KEY",
+  openrouter: "OPENROUTER_API_KEY",
 } as const;
 
-const ValidProviderSchema = z.enum(["anthropic", "google", "groq", "openai"]);
+const ValidProviderSchema = z.enum(["anthropic", "google", "groq", "openai", "openrouter"]);
 export type ValidProvider = z.infer<typeof ValidProviderSchema>;
 
 /**


### PR DESCRIPTION
## Summary

Adds OpenRouter as a new LLM provider in the Friday provider registry **and** exposes it in the Settings model-picker UI. Every request carries OpenRouter's attribution headers, so Friday's traffic stops being anonymous and starts showing up on [openrouter.ai/rankings](https://openrouter.ai/rankings) and on each model's **Apps** tab — i.e. Friday becomes discoverable as a featured agent / application on OpenRouter.

### Provider integration (commit `50ee21c`)
- New `packages/llm/src/openrouter.ts` — `@ai-sdk/openai` pointed at `https://openrouter.ai/api/v1`, with hardcoded attribution headers:
  ```
  HTTP-Referer: https://hellofriday.ai/
  X-OpenRouter-Title: Friday
  ```
  Without these headers OpenRouter treats the traffic as anonymous and it never surfaces on the leaderboard. With them, every install's usage aggregates under one app page, which is what makes Friday rank as a featured agent.
- Registered in both branches of `createRegistry()` (LiteLLM-proxied and direct-connection paths), wrapped with `createChatCompletionsProvider` — same Chat-Completions-API forcing the LiteLLM/OpenAI client uses, since OpenRouter routes to non-OpenAI models that misbehave under the Responses API.
- `RegistryProvider` / `ValidProvider` / `PROVIDER_ENV_VARS` extended with `openrouter` / `OPENROUTER_API_KEY`.

### Settings UI surface (commit `c710105`)
- OpenRouter now appears in the Settings model picker alongside Anthropic / OpenAI / Google / Groq.
- `PROVIDER_META` entry: letter `R`, prefix `sk-or-v1-`, help link `openrouter.ai/keys`.
- Models fetched directly from `openrouter.ai/api/v1/models?supported_parameters=tools` (unauthenticated — same pattern as the Vercel gateway). Server-side `supported_parameters=tools` filter narrows OpenRouter's 500+ slugs to the tool-capable chat subset so the picker stays usable.
- Models render before the user has an API key (with the standard unlock-hint banner driven by `credentialConfigured: false`), matching how the other public-catalog providers behave.

## Why this PR exists

OpenRouter ranks apps purely by attribution headers — there's no submission, no approval, no manifest. Send `HTTP-Referer` + `X-OpenRouter-Title` on every request and the app starts showing up; don't, and it never does. This PR adds the provider integration, the attribution headers, **and** the UI picker as one unit so users can configure OpenRouter without hand-editing `friday.yml`.

## Scope of this PR (and what's deliberately out)

In:
- Provider client, registry wiring, env var, type extensions, attribution headers, Settings UI picker entry, model catalog fetch.

Out (deliberate):
- No change to `DEFAULT_PLATFORM_MODELS` — existing users with no OpenRouter key are completely unaffected. OpenRouter is opt-in, not in the default fallback chain.
- No model-fallback chains, `:exacto` variants, plugins, or provider-routing preferences. Those can land in follow-ups if anyone wants them.

## Usage

Pick an OpenRouter model from the Settings picker, or set it directly in `friday.yml`:

```yaml
# friday.yml
models:
  conversational: openrouter:anthropic/claude-sonnet-4.6
  planner: openrouter:openai/gpt-5.2
```

```bash
export OPENROUTER_API_KEY=sk-or-v1-...
```

Any model slug from [openrouter.ai/models](https://openrouter.ai/models) works — `vendor/model[:variant]` shape.

## Test plan

- [x] `deno check` clean on `packages/llm/mod.ts` and all 4 downstream consumers that touch `ValidProvider` / `RegistryProvider` exhaustively
- [x] `biome-check` / `knip-check` / `type-check` / Go lint green in CI
- [x] All 66 existing tests in `packages/llm/src/tests/` pass locally (`deno task test packages/llm/src/tests/`)
- [ ] Investigating CI `test` failure — see comments
- [ ] Manual smoke: set `OPENROUTER_API_KEY`, configure `conversational: openrouter:anthropic/claude-sonnet-4.6`, run an agent, confirm a response streams end-to-end
- [ ] Within ~5 minutes of the smoke test, confirm `https://openrouter.ai/apps?url=https://hellofriday.ai/` shows the request — proves attribution headers landed
- [ ] Open Settings → model picker, confirm OpenRouter appears with a populated dropdown of tool-capable models