### PR TITLE
fix(atlasd): install bundled user agents globally on workspace import

### DIFF
--- a/apps/atlasd/routes/workspaces/bundle-helpers.ts
+++ b/apps/atlasd/routes/workspaces/bundle-helpers.ts
@@ -4,7 +4,7 @@
 
 import { cp, mkdir, readFile, rename, rm, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { exportBundle, type ImportResult } from "@atlas/bundle";
+import { exportBundle, hashPrimitive, type ImportResult } from "@atlas/bundle";
 import type { WorkspaceConfig } from "@atlas/config";
 import {
   type CredentialUsage,
@@ -12,7 +12,7 @@ import {
   stripCredentialRefs,
   toProviderRefs,
 } from "@atlas/config/mutations";
-import { UserAdapter } from "@atlas/core/agent-loader/user-adapter";
+import { AgentMetadataFileSchema, UserAdapter } from "@atlas/core/agent-loader/user-adapter";
 import {
   fetchLinkCredential,
   LinkCredentialExpiredError,
@@ -177,6 +177,23 @@ export async function isOnDiskWorkspace(workspacePath: string): Promise<boolean>
 }
 
 /**
+ * Reject path-traversal or absolute-path components in id/version. The id and
+ * version come from a bundled `metadata.json` we don't trust, and they're
+ * about to be joined into `<atlasHome>/agents/<id>@<version>/`. Without this
+ * check, a bundle declaring `"id": "../../etc/cron.d/x"` would write the
+ * payload outside the agents dir. UserAdapter (user-adapter.ts:56
+ * `parseVersionDir`) accepts arbitrary characters at runtime, so we can't
+ * lean on the runtime to reject these.
+ */
+function isPathSafeIdent(value: string): boolean {
+  if (value.length === 0 || value.length > 128) return false;
+  if (value.includes("/") || value.includes("\\") || value.includes("\0")) return false;
+  if (value === "." || value === "..") return false;
+  if (value.startsWith(".") || value.endsWith(".")) return false;
+  return true;
+}
+
+/**
  * Install bundled user agents into the global `<atlasHome>/agents/<id>@<version>/`
  * location so the daemon's AgentRegistry (which only scans that one dir via
  * `UserAdapter`) can resolve them at runtime.
@@ -189,11 +206,17 @@ export async function isOnDiskWorkspace(workspacePath: string): Promise<boolean>
  *
  * Non-destructive: if `<atlasHome>/agents/<id>@<version>/` already exists, we
  * skip rather than clobber a same-version install the user may already depend
- * on. Per-agent errors are logged and recorded but do not abort the import —
- * one malformed metadata.json shouldn't sink the whole workspace.
+ * on. We *do* hash-compare both copies and log a `WARN` when they diverge,
+ * because a silent first-install-wins is a footgun across multi-workspace
+ * imports (two bundles, same id@version, different code → second workspace
+ * silently runs the first's code). Per-agent errors are logged and recorded
+ * but do not abort the import — one malformed metadata.json shouldn't sink
+ * the whole workspace.
  *
  * Mirrors the install pattern in `apps/atlasd/routes/agents/register.ts`:
- * stage to `*.tmp`, then atomic rename into place.
+ * stage to `*.tmp`, then atomic rename into place. Source content is verified
+ * by `importBundle`'s lockfile-hash check before this runs, so we don't
+ * re-hash on the install side.
  */
 export async function installImportedAgents(opts: {
   targetDir: string;
@@ -220,18 +243,9 @@ export async function installImportedAgents(opts: {
     let version: string;
     try {
       const raw = await readFile(metadataPath, "utf-8");
-      const parsed: unknown = JSON.parse(raw);
-      if (
-        !parsed ||
-        typeof parsed !== "object" ||
-        typeof (parsed as { id?: unknown }).id !== "string" ||
-        typeof (parsed as { version?: unknown }).version !== "string"
-      ) {
-        skipped.push({ name: primitive.name, reason: "metadata.json missing id/version" });
-        continue;
-      }
-      id = (parsed as { id: string }).id;
-      version = (parsed as { version: string }).version;
+      const parsed = AgentMetadataFileSchema.parse(JSON.parse(raw));
+      id = parsed.id;
+      version = parsed.version;
     } catch (error) {
       const reason = error instanceof Error ? error.message : String(error);
       opts.logger.warn("Skipping imported agent with unreadable metadata", {
@@ -239,23 +253,75 @@ export async function installImportedAgents(opts: {
         path: metadataPath,
         error: reason,
       });
-      skipped.push({ name: primitive.name, reason: `unreadable metadata.json: ${reason}` });
+      skipped.push({ name: primitive.name, reason: `invalid metadata.json: ${reason}` });
+      continue;
+    }
+
+    if (!isPathSafeIdent(id) || !isPathSafeIdent(version)) {
+      opts.logger.warn("Refusing to install agent with unsafe id/version", {
+        name: primitive.name,
+        id,
+        version,
+      });
+      skipped.push({
+        name: primitive.name,
+        reason: `unsafe id/version (path traversal blocked): id="${id}" version="${version}"`,
+      });
       continue;
     }
 
     const finalDir = join(agentsRoot, `${id}@${version}`);
+    let alreadyInstalled = false;
     try {
       await stat(finalDir);
-      opts.logger.info("Skipping imported agent — same version already installed", {
-        name: primitive.name,
-        id,
-        version,
-        path: finalDir,
-      });
-      skipped.push({ name: primitive.name, reason: `already installed at ${finalDir}` });
-      continue;
+      alreadyInstalled = true;
     } catch {
       // Target absent — proceed with install.
+    }
+
+    if (alreadyInstalled) {
+      // Hash both the bundled copy and the on-disk install. A divergent same-
+      // id@version is a real correctness footgun across multi-workspace
+      // imports — we still skip (don't clobber the user's existing install),
+      // but we surface it loudly so the operator notices instead of silently
+      // running the wrong code.
+      let divergent = false;
+      try {
+        const [bundleHash, installedHash] = await Promise.all([
+          hashPrimitive(sourceDir),
+          hashPrimitive(finalDir),
+        ]);
+        divergent = bundleHash.hash !== installedHash.hash;
+      } catch (error) {
+        // hashPrimitive failure isn't fatal here — we still skip the install.
+        // Log so a stuck "can't hash" doesn't go unnoticed.
+        opts.logger.warn("Could not compare hashes for already-installed agent", {
+          name: primitive.name,
+          id,
+          version,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+      const reason = divergent
+        ? `already installed at ${finalDir} but content diverges from bundle — using existing install`
+        : `already installed at ${finalDir}`;
+      if (divergent) {
+        opts.logger.warn("Imported agent collides with divergent global install", {
+          name: primitive.name,
+          id,
+          version,
+          path: finalDir,
+        });
+      } else {
+        opts.logger.info("Skipping imported agent — same version already installed", {
+          name: primitive.name,
+          id,
+          version,
+          path: finalDir,
+        });
+      }
+      skipped.push({ name: primitive.name, reason });
+      continue;
     }
 
     const tmpDir = `${finalDir}.import-${Date.now().toString(36)}.tmp`;

--- a/apps/atlasd/routes/workspaces/bundle-helpers.ts
+++ b/apps/atlasd/routes/workspaces/bundle-helpers.ts
@@ -2,9 +2,9 @@
 // per-workspace `GET /:workspaceId/bundle` route and the full-instance
 // `GET /bundle-all` route. Factoring this prevents the two from drifting.
 
-import { mkdir, rename, stat } from "node:fs/promises";
+import { cp, mkdir, readFile, rename, rm, stat } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { exportBundle } from "@atlas/bundle";
+import { exportBundle, type ImportResult } from "@atlas/bundle";
 import type { WorkspaceConfig } from "@atlas/config";
 import {
   type CredentialUsage,
@@ -174,6 +174,116 @@ export async function isOnDiskWorkspace(workspacePath: string): Promise<boolean>
   } catch {
     return false;
   }
+}
+
+/**
+ * Install bundled user agents into the global `<atlasHome>/agents/<id>@<version>/`
+ * location so the daemon's AgentRegistry (which only scans that one dir via
+ * `UserAdapter`) can resolve them at runtime.
+ *
+ * `importBundle` extracts each embedded agent to `<targetDir>/<primitive.path>/`
+ * (i.e. workspace-local). That location is invisible to the registry — the
+ * UserAdapter constructor in `atlas-daemon.ts` is wired only to
+ * `<atlasHome>/agents`. Without this step, an imported workspace.yml that
+ * references a `type: user` agent will fail when the daemon tries to spawn it.
+ *
+ * Non-destructive: if `<atlasHome>/agents/<id>@<version>/` already exists, we
+ * skip rather than clobber a same-version install the user may already depend
+ * on. Per-agent errors are logged and recorded but do not abort the import —
+ * one malformed metadata.json shouldn't sink the whole workspace.
+ *
+ * Mirrors the install pattern in `apps/atlasd/routes/agents/register.ts`:
+ * stage to `*.tmp`, then atomic rename into place.
+ */
+export async function installImportedAgents(opts: {
+  targetDir: string;
+  primitives: ImportResult["primitives"];
+  atlasHome: string;
+  logger: Logger;
+}): Promise<{
+  installed: { id: string; version: string; path: string }[];
+  skipped: { name: string; reason: string }[];
+}> {
+  const installed: { id: string; version: string; path: string }[] = [];
+  const skipped: { name: string; reason: string }[] = [];
+  const agents = opts.primitives.filter((p) => p.kind === "agent");
+  if (agents.length === 0) return { installed, skipped };
+
+  const agentsRoot = join(opts.atlasHome, "agents");
+  await mkdir(agentsRoot, { recursive: true });
+
+  for (const primitive of agents) {
+    const sourceDir = join(opts.targetDir, primitive.path);
+    const metadataPath = join(sourceDir, "metadata.json");
+
+    let id: string;
+    let version: string;
+    try {
+      const raw = await readFile(metadataPath, "utf-8");
+      const parsed: unknown = JSON.parse(raw);
+      if (
+        !parsed ||
+        typeof parsed !== "object" ||
+        typeof (parsed as { id?: unknown }).id !== "string" ||
+        typeof (parsed as { version?: unknown }).version !== "string"
+      ) {
+        skipped.push({ name: primitive.name, reason: "metadata.json missing id/version" });
+        continue;
+      }
+      id = (parsed as { id: string }).id;
+      version = (parsed as { version: string }).version;
+    } catch (error) {
+      const reason = error instanceof Error ? error.message : String(error);
+      opts.logger.warn("Skipping imported agent with unreadable metadata", {
+        name: primitive.name,
+        path: metadataPath,
+        error: reason,
+      });
+      skipped.push({ name: primitive.name, reason: `unreadable metadata.json: ${reason}` });
+      continue;
+    }
+
+    const finalDir = join(agentsRoot, `${id}@${version}`);
+    try {
+      await stat(finalDir);
+      opts.logger.info("Skipping imported agent — same version already installed", {
+        name: primitive.name,
+        id,
+        version,
+        path: finalDir,
+      });
+      skipped.push({ name: primitive.name, reason: `already installed at ${finalDir}` });
+      continue;
+    } catch {
+      // Target absent — proceed with install.
+    }
+
+    const tmpDir = `${finalDir}.import-${Date.now().toString(36)}.tmp`;
+    try {
+      await rm(tmpDir, { recursive: true, force: true });
+      await cp(sourceDir, tmpDir, { recursive: true });
+      await rename(tmpDir, finalDir);
+      installed.push({ id, version, path: finalDir });
+      opts.logger.info("Installed imported user agent", {
+        name: primitive.name,
+        id,
+        version,
+        path: finalDir,
+      });
+    } catch (error) {
+      await rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+      const reason = error instanceof Error ? error.message : String(error);
+      opts.logger.error("Failed to install imported agent", {
+        name: primitive.name,
+        id,
+        version,
+        error: reason,
+      });
+      skipped.push({ name: primitive.name, reason: `install failed: ${reason}` });
+    }
+  }
+
+  return { installed, skipped };
 }
 
 /**

--- a/apps/atlasd/routes/workspaces/bundle.test.ts
+++ b/apps/atlasd/routes/workspaces/bundle.test.ts
@@ -344,8 +344,7 @@ describe("workspace bundle endpoints (end-to-end)", () => {
     // install so we can prove the import path repopulates it.
     await rm(join(homeDir, "agents"), { recursive: true, force: true });
 
-    // deno-lint-ignore require-await
-    const reload = vi.fn(async () => {});
+    const reload = vi.fn(() => Promise.resolve());
     const { app: importApp, reloadSpy } = createApp({
       workspaceDir,
       homeDir,
@@ -435,8 +434,7 @@ describe("workspace bundle endpoints (end-to-end)", () => {
     expect(exportResponse.status).toBe(200);
     const zipBytes = new Uint8Array(await exportResponse.arrayBuffer());
 
-    // deno-lint-ignore require-await
-    const reload = vi.fn(async () => {});
+    const reload = vi.fn(() => Promise.resolve());
     const { app: importApp } = createApp({
       workspaceDir,
       homeDir,

--- a/apps/atlasd/routes/workspaces/bundle.test.ts
+++ b/apps/atlasd/routes/workspaces/bundle.test.ts
@@ -1,12 +1,15 @@
 import { access, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { exportAll } from "@atlas/bundle";
 import { createStubPlatformModels } from "@atlas/llm";
+import { createLogger } from "@atlas/logger";
 import type { WorkspaceManager } from "@atlas/workspace";
 import { Hono } from "hono";
 import JSZip from "jszip";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import type { AppContext, AppVariables } from "../../src/factory.ts";
+import { installImportedAgents } from "./bundle-helpers.ts";
 import { workspacesRoutes } from "./index.ts";
 
 vi.mock("@atlas/storage", () => ({ FilesystemWorkspaceCreationAdapter: vi.fn() }));
@@ -463,6 +466,80 @@ describe("workspace bundle endpoints (end-to-end)", () => {
     await access(join(homeDir, "agents", "spritesheet-normalizer@1.0.0", "metadata.json"));
   });
 
+  test("POST /import-bundle-all installs bundled user agents from each inner workspace", async () => {
+    // Build a workspace with a user agent, export it as a bundle, then wrap
+    // it in a manifest-style outer archive so we can import via
+    // /import-bundle-all. Asserts the install + reload path fires from the
+    // multi-workspace route, not just /import-bundle.
+    const agentSrc = join(homeDir, "agents", "writer@1.0.0");
+    await mkdir(agentSrc, { recursive: true });
+    await writeFile(
+      join(agentSrc, "metadata.json"),
+      JSON.stringify({ id: "writer", version: "1.0.0", description: "Writes" }),
+    );
+    await writeFile(join(agentSrc, "agent.py"), "print('write')\n");
+
+    const wsConfig = {
+      atlas: null,
+      workspace: {
+        version: "1.0",
+        workspace: { name: "demo-space" },
+        agents: { writer: { type: "user", agent: "writer", description: "Writes" } },
+        signals: { write: { description: "Write", provider: "http", config: { path: "/write" } } },
+        jobs: {
+          write: {
+            triggers: [{ signal: "write" }],
+            execution: { strategy: "sequential", agents: ["writer"] },
+          },
+        },
+      },
+    };
+
+    const { app: exportApp } = createApp({ workspaceDir, homeDir, workspaceConfig: wsConfig });
+    const innerResp = await exportApp.request("/ws-demo/bundle");
+    expect(innerResp.status).toBe(200);
+    const innerBytes = new Uint8Array(await innerResp.arrayBuffer());
+
+    // Wrap the inner bundle in a real outer envelope so the manifest matches
+    // FullManifestSchema. Importing a hand-rolled YAML manifest would tightly
+    // couple this test to the schema's evolution.
+    const outerBytes = new Uint8Array(
+      await exportAll({
+        mode: "definition",
+        workspaces: [{ id: "ws-demo", name: "demo-space", bundleBytes: innerBytes }],
+      }),
+    );
+
+    // Clean the global agent install so we can prove import-bundle-all
+    // repopulates it on a fresh machine.
+    await rm(join(homeDir, "agents"), { recursive: true, force: true });
+
+    const reload = vi.fn(() => Promise.resolve());
+    const { app: importApp } = createApp({
+      workspaceDir,
+      homeDir,
+      registeredWorkspace: { id: "ws-new", name: "demo-space", path: join(homeDir, "imported") },
+      agentRegistry: { reload },
+    });
+
+    const form = new FormData();
+    form.set("bundle", new File([outerBytes], "all.zip", { type: "application/zip" }));
+    const resp = await importApp.request("/import-bundle-all", { method: "POST", body: form });
+
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as {
+      imported: Array<{ name: string; agentsInstalled?: number; agentsSkipped?: number }>;
+      errors: Array<{ name: string; error: string }>;
+    };
+    expect(body.errors).toEqual([]);
+    expect(body.imported).toHaveLength(1);
+    expect(body.imported[0]?.agentsInstalled).toBe(1);
+    expect(body.imported[0]?.agentsSkipped).toBe(0);
+
+    await access(join(homeDir, "agents", "writer@1.0.0", "metadata.json"));
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
   test("POST /import-bundle rejects a tampered bundle", async () => {
     const { app: exportApp } = createApp({ workspaceDir, homeDir });
     const exportResponse = await exportApp.request("/ws-demo/bundle");
@@ -480,5 +557,183 @@ describe("workspace bundle endpoints (end-to-end)", () => {
     expect(response.status).toBe(500);
     const body = (await response.json()) as { error: string };
     expect(body.error).toMatch(/integrity check failed/);
+  });
+});
+
+// Unit tests for installImportedAgents — constructed inputs are cheaper here
+// than synthesizing bundles that round-trip integrity checks. The HTTP-level
+// tests above already cover the happy path through the route.
+describe("installImportedAgents (unit)", () => {
+  let targetDir: string;
+  let atlasHome: string;
+  const logger = createLogger({ component: "installImportedAgents-test" });
+
+  beforeEach(async () => {
+    targetDir = await mkdtemp(join(tmpdir(), "iia-target-"));
+    atlasHome = await mkdtemp(join(tmpdir(), "iia-home-"));
+  });
+
+  afterEach(async () => {
+    await rm(targetDir, { recursive: true, force: true });
+    await rm(atlasHome, { recursive: true, force: true });
+  });
+
+  async function seedBundledAgent(opts: {
+    /** Directory name inside `<targetDir>/agents/`. Mirrors `primitive.name`. */
+    bundleName: string;
+    /** Contents of `metadata.json`. Pass an unparseable string to simulate corruption. */
+    metadata: Record<string, unknown> | string;
+    /** Extra files to drop alongside `metadata.json`. Defaults to a stub agent.py. */
+    files?: Record<string, string>;
+  }): Promise<{ kind: "agent"; name: string; path: string }> {
+    const dir = join(targetDir, "agents", opts.bundleName);
+    await mkdir(dir, { recursive: true });
+    const md = typeof opts.metadata === "string" ? opts.metadata : JSON.stringify(opts.metadata);
+    await writeFile(join(dir, "metadata.json"), md);
+    const extras = opts.files ?? { "agent.py": "print('x')\n" };
+    for (const [rel, body] of Object.entries(extras)) {
+      await writeFile(join(dir, rel), body);
+    }
+    return { kind: "agent", name: opts.bundleName, path: `agents/${opts.bundleName}` };
+  }
+
+  test("rejects path-traversal id, never writes outside agents root", async () => {
+    const primitive = await seedBundledAgent({
+      bundleName: "tricky",
+      metadata: {
+        id: "../../../etc/cron.d/wat",
+        version: "1.0.0",
+        description: "Malicious id with path traversal",
+      },
+    });
+
+    const result = await installImportedAgents({
+      targetDir,
+      primitives: [primitive],
+      atlasHome,
+      logger,
+    });
+
+    expect(result.installed).toEqual([]);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.reason).toMatch(/unsafe id\/version/);
+
+    // Nothing outside `<atlasHome>/agents/` was created. Specifically the
+    // expected traversal target doesn't exist.
+    const traversed = join(atlasHome, "..", "..", "..", "etc", "cron.d");
+    await expect(access(traversed)).rejects.toThrow();
+  });
+
+  test("rejects path-traversal version", async () => {
+    const primitive = await seedBundledAgent({
+      bundleName: "tricky2",
+      metadata: { id: "agent", version: "../1.0.0", description: "Bad version" },
+    });
+
+    const result = await installImportedAgents({
+      targetDir,
+      primitives: [primitive],
+      atlasHome,
+      logger,
+    });
+
+    expect(result.installed).toEqual([]);
+    expect(result.skipped[0]?.reason).toMatch(/unsafe id\/version/);
+  });
+
+  test("rejects metadata.json that doesn't match the schema (missing description)", async () => {
+    const primitive = await seedBundledAgent({
+      bundleName: "incomplete",
+      metadata: { id: "incomplete", version: "1.0.0" }, // description missing
+    });
+
+    const result = await installImportedAgents({
+      targetDir,
+      primitives: [primitive],
+      atlasHome,
+      logger,
+    });
+
+    expect(result.installed).toEqual([]);
+    expect(result.skipped[0]?.reason).toMatch(/invalid metadata\.json/);
+  });
+
+  test("rejects unparseable metadata.json without aborting other agents in the batch", async () => {
+    const bad = await seedBundledAgent({ bundleName: "bad", metadata: "{ not json" });
+    const good = await seedBundledAgent({
+      bundleName: "good",
+      metadata: { id: "good", version: "1.0.0", description: "ok" },
+    });
+
+    const result = await installImportedAgents({
+      targetDir,
+      primitives: [bad, good],
+      atlasHome,
+      logger,
+    });
+
+    expect(result.installed.map((a) => a.id)).toEqual(["good"]);
+    expect(result.skipped.map((s) => s.name)).toEqual(["bad"]);
+    await access(join(atlasHome, "agents", "good@1.0.0", "metadata.json"));
+  });
+
+  test("flags content divergence when same id@version is already installed with different bytes", async () => {
+    // Seed the global install with one body...
+    const installedDir = join(atlasHome, "agents", "shared@1.0.0");
+    await mkdir(installedDir, { recursive: true });
+    await writeFile(
+      join(installedDir, "metadata.json"),
+      JSON.stringify({ id: "shared", version: "1.0.0", description: "v1 globally installed" }),
+    );
+    await writeFile(join(installedDir, "agent.py"), "print('GLOBAL VERSION')\n");
+
+    // ...and the bundle ships a different body under the same id@version.
+    const primitive = await seedBundledAgent({
+      bundleName: "shared",
+      metadata: { id: "shared", version: "1.0.0", description: "v1 from bundle" },
+      files: { "agent.py": "print('BUNDLE VERSION')\n" },
+    });
+
+    const result = await installImportedAgents({
+      targetDir,
+      primitives: [primitive],
+      atlasHome,
+      logger,
+    });
+
+    expect(result.installed).toEqual([]);
+    expect(result.skipped).toHaveLength(1);
+    expect(result.skipped[0]?.reason).toMatch(/content diverges from bundle/);
+
+    // Global install untouched (still has the GLOBAL VERSION body).
+    const installedBody = await readFile(join(installedDir, "agent.py"), "utf-8");
+    expect(installedBody).toContain("GLOBAL VERSION");
+  });
+
+  test("clean skip (no divergence warning) when same id@version is byte-identical", async () => {
+    const metadata = { id: "shared", version: "1.0.0", description: "same on both sides" };
+    const agentBody = "print('same')\n";
+
+    const installedDir = join(atlasHome, "agents", "shared@1.0.0");
+    await mkdir(installedDir, { recursive: true });
+    await writeFile(join(installedDir, "metadata.json"), JSON.stringify(metadata));
+    await writeFile(join(installedDir, "agent.py"), agentBody);
+
+    const primitive = await seedBundledAgent({
+      bundleName: "shared",
+      metadata,
+      files: { "agent.py": agentBody },
+    });
+
+    const result = await installImportedAgents({
+      targetDir,
+      primitives: [primitive],
+      atlasHome,
+      logger,
+    });
+
+    expect(result.installed).toEqual([]);
+    expect(result.skipped[0]?.reason).not.toMatch(/diverges/);
+    expect(result.skipped[0]?.reason).toMatch(/already installed/);
   });
 });

--- a/apps/atlasd/routes/workspaces/bundle.test.ts
+++ b/apps/atlasd/routes/workspaces/bundle.test.ts
@@ -66,7 +66,12 @@ function createApp(opts: {
   homeDir: string;
   registeredWorkspace?: { id: string; name: string; path: string };
   workspaceConfig?: unknown;
-}): { app: Hono<AppVariables>; registerSpy: ReturnType<typeof vi.fn> } {
+  agentRegistry?: { reload: ReturnType<typeof vi.fn> };
+}): {
+  app: Hono<AppVariables>;
+  registerSpy: ReturnType<typeof vi.fn>;
+  reloadSpy: ReturnType<typeof vi.fn>;
+} {
   const workspaceId = opts.workspaceId ?? "ws-demo";
   const registerSpy = vi
     .fn()
@@ -117,7 +122,7 @@ function createApp(opts: {
     sessionStreamRegistry: {} as AppContext["sessionStreamRegistry"],
     sessionHistoryAdapter: {} as AppContext["sessionHistoryAdapter"],
     sessionDispatchRegistry: {} as AppContext["sessionDispatchRegistry"],
-    getAgentRegistry: vi.fn(),
+    getAgentRegistry: vi.fn().mockReturnValue(opts.agentRegistry),
     getOrCreateChatSdkInstance: vi.fn(),
     exposeKernel: false,
     platformModels: createStubPlatformModels(),
@@ -132,7 +137,8 @@ function createApp(opts: {
     await next();
   });
   app.route("/", workspacesRoutes);
-  return { app, registerSpy };
+  const reloadSpy = (opts.agentRegistry?.reload ?? vi.fn()) as ReturnType<typeof vi.fn>;
+  return { app, registerSpy, reloadSpy };
 }
 
 describe("workspace bundle endpoints (end-to-end)", () => {
@@ -280,6 +286,183 @@ describe("workspace bundle endpoints (end-to-end)", () => {
     const body = (await response.json()) as { error: string };
     expect(body.error).toMatch(/user agent.*could not be resolved/i);
     expect(body.error).toContain("ghost");
+  });
+
+  test("POST /import-bundle installs bundled user agents globally and reloads registry", async () => {
+    // Export: source workspace.yml references a user agent that lives at
+    // <homeDir>/agents/<id>@<version>/; exportBundle embeds it under
+    // agents/<name>/ in the zip.
+    const agentSrc = join(homeDir, "agents", "spritesheet-normalizer@1.0.0");
+    await mkdir(agentSrc, { recursive: true });
+    await writeFile(
+      join(agentSrc, "metadata.json"),
+      JSON.stringify({
+        id: "spritesheet-normalizer",
+        version: "1.0.0",
+        description: "Normalizes a spritesheet",
+      }),
+    );
+    await writeFile(join(agentSrc, "agent.py"), "print('normalize')\n");
+
+    const workspaceWithAgent = {
+      atlas: null,
+      workspace: {
+        version: "1.0",
+        workspace: { name: "demo-space" },
+        agents: {
+          "spritesheet-normalizer": {
+            type: "user",
+            agent: "spritesheet-normalizer",
+            description: "Normalizes a spritesheet",
+          },
+        },
+        signals: {
+          normalize: {
+            description: "Trigger spritesheet normalization",
+            provider: "http",
+            config: { path: "/normalize" },
+          },
+        },
+        jobs: {
+          normalize: {
+            triggers: [{ signal: "normalize" }],
+            execution: { strategy: "sequential", agents: ["spritesheet-normalizer"] },
+          },
+        },
+      },
+    };
+    const { app: exportApp } = createApp({
+      workspaceDir,
+      homeDir,
+      workspaceConfig: workspaceWithAgent,
+    });
+    const exportResponse = await exportApp.request("/ws-demo/bundle");
+    expect(exportResponse.status).toBe(200);
+    const zipBytes = new Uint8Array(await exportResponse.arrayBuffer());
+
+    // Simulate "importing on a different machine": wipe the global agent
+    // install so we can prove the import path repopulates it.
+    await rm(join(homeDir, "agents"), { recursive: true, force: true });
+
+    // deno-lint-ignore require-await
+    const reload = vi.fn(async () => {});
+    const { app: importApp, reloadSpy } = createApp({
+      workspaceDir,
+      homeDir,
+      registeredWorkspace: { id: "ws-new", name: "demo-space", path: join(homeDir, "imported") },
+      agentRegistry: { reload },
+    });
+
+    const form = new FormData();
+    form.set("bundle", new File([zipBytes], "demo.zip", { type: "application/zip" }));
+    const importResponse = await importApp.request("/import-bundle", {
+      method: "POST",
+      body: form,
+    });
+
+    expect(importResponse.status).toBe(200);
+    const body = (await importResponse.json()) as {
+      workspaceId: string;
+      primitives: { kind: string; name: string }[];
+      agentsInstalled: number;
+      agentsSkipped: number;
+    };
+    expect(body.primitives).toEqual(
+      expect.arrayContaining([
+        { kind: "agent", name: "spritesheet-normalizer", path: "agents/spritesheet-normalizer" },
+      ]),
+    );
+    expect(body.agentsInstalled).toBe(1);
+    expect(body.agentsSkipped).toBe(0);
+
+    // Agent must now live at <homeDir>/agents/<id>@<version>/ where the
+    // AgentRegistry's UserAdapter scans, not just at <importedWs>/agents/<name>/.
+    await access(join(homeDir, "agents", "spritesheet-normalizer@1.0.0", "metadata.json"));
+    await access(join(homeDir, "agents", "spritesheet-normalizer@1.0.0", "agent.py"));
+
+    expect(reloadSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("POST /import-bundle skips installing user agents when same id@version already present", async () => {
+    // Seed a global install that the import must NOT clobber. The bundle's
+    // copy is still extracted to <targetDir>/agents/ for hash verification,
+    // but the global install remains untouched and we report it as skipped.
+    const agentSrc = join(homeDir, "agents", "spritesheet-normalizer@1.0.0");
+    await mkdir(agentSrc, { recursive: true });
+    await writeFile(
+      join(agentSrc, "metadata.json"),
+      JSON.stringify({
+        id: "spritesheet-normalizer",
+        version: "1.0.0",
+        description: "Normalizes a spritesheet",
+      }),
+    );
+    await writeFile(join(agentSrc, "agent.py"), "print('normalize')\n");
+
+    const workspaceWithAgent = {
+      atlas: null,
+      workspace: {
+        version: "1.0",
+        workspace: { name: "demo-space" },
+        agents: {
+          "spritesheet-normalizer": {
+            type: "user",
+            agent: "spritesheet-normalizer",
+            description: "Normalizes a spritesheet",
+          },
+        },
+        signals: {
+          normalize: {
+            description: "Trigger spritesheet normalization",
+            provider: "http",
+            config: { path: "/normalize" },
+          },
+        },
+        jobs: {
+          normalize: {
+            triggers: [{ signal: "normalize" }],
+            execution: { strategy: "sequential", agents: ["spritesheet-normalizer"] },
+          },
+        },
+      },
+    };
+    const { app: exportApp } = createApp({
+      workspaceDir,
+      homeDir,
+      workspaceConfig: workspaceWithAgent,
+    });
+    const exportResponse = await exportApp.request("/ws-demo/bundle");
+    expect(exportResponse.status).toBe(200);
+    const zipBytes = new Uint8Array(await exportResponse.arrayBuffer());
+
+    // deno-lint-ignore require-await
+    const reload = vi.fn(async () => {});
+    const { app: importApp } = createApp({
+      workspaceDir,
+      homeDir,
+      registeredWorkspace: { id: "ws-new", name: "demo-space", path: join(homeDir, "imported") },
+      agentRegistry: { reload },
+    });
+
+    const form = new FormData();
+    form.set("bundle", new File([zipBytes], "demo.zip", { type: "application/zip" }));
+    const importResponse = await importApp.request("/import-bundle", {
+      method: "POST",
+      body: form,
+    });
+
+    expect(importResponse.status).toBe(200);
+    const body = (await importResponse.json()) as {
+      agentsInstalled: number;
+      agentsSkipped: number;
+    };
+    expect(body.agentsInstalled).toBe(0);
+    expect(body.agentsSkipped).toBe(1);
+    // No reload when nothing actually changed.
+    expect(reload).not.toHaveBeenCalled();
+
+    // Pre-existing global install is untouched.
+    await access(join(homeDir, "agents", "spritesheet-normalizer@1.0.0", "metadata.json"));
   });
 
   test("POST /import-bundle rejects a tampered bundle", async () => {

--- a/apps/atlasd/routes/workspaces/bundle.test.ts
+++ b/apps/atlasd/routes/workspaces/bundle.test.ts
@@ -598,30 +598,55 @@ describe("installImportedAgents (unit)", () => {
   }
 
   test("rejects path-traversal id, never writes outside agents root", async () => {
-    const primitive = await seedBundledAgent({
-      bundleName: "tricky",
-      metadata: {
-        id: "../../../etc/cron.d/wat",
-        version: "1.0.0",
-        description: "Malicious id with path traversal",
-      },
-    });
+    // Use a sibling temp dir as the would-be traversal target. We can't
+    // assert "system /etc/cron.d doesn't exist" — on a Linux CI runner it
+    // does — so we set up an attacker-controllable target *next to*
+    // atlasHome and check that nothing was created in it.
+    const traversalParent = await mkdtemp(join(tmpdir(), "iia-traversal-"));
+    try {
+      // From `<atlasHome>/agents/<id>@<version>/`, two `..` walks up to
+      // `<atlasHome>/`. Adding the basename of traversalParent + a sentinel
+      // lands writes at `<atlasHome>/../<traversalParent basename>/sentinel`,
+      // which path-resolves to inside traversalParent.
+      const parentName = traversalParent.split("/").pop();
+      if (!parentName) throw new Error("could not derive parent dirname");
+      const maliciousId = `../../${parentName}/sentinel`;
 
-    const result = await installImportedAgents({
-      targetDir,
-      primitives: [primitive],
-      atlasHome,
-      logger,
-    });
+      const primitive = await seedBundledAgent({
+        bundleName: "tricky",
+        metadata: {
+          id: maliciousId,
+          version: "1.0.0",
+          description: "Malicious id with path traversal",
+        },
+        files: { "payload.txt": "PWNED\n" },
+      });
 
-    expect(result.installed).toEqual([]);
-    expect(result.skipped).toHaveLength(1);
-    expect(result.skipped[0]?.reason).toMatch(/unsafe id\/version/);
+      const result = await installImportedAgents({
+        targetDir,
+        primitives: [primitive],
+        atlasHome,
+        logger,
+      });
 
-    // Nothing outside `<atlasHome>/agents/` was created. Specifically the
-    // expected traversal target doesn't exist.
-    const traversed = join(atlasHome, "..", "..", "..", "etc", "cron.d");
-    await expect(access(traversed)).rejects.toThrow();
+      expect(result.installed).toEqual([]);
+      expect(result.skipped).toHaveLength(1);
+      expect(result.skipped[0]?.reason).toMatch(/unsafe id\/version/);
+
+      // The attacker-controlled location must not have been written to.
+      await expect(access(join(traversalParent, "sentinel@1.0.0"))).rejects.toThrow();
+      await expect(
+        access(join(traversalParent, "sentinel@1.0.0", "payload.txt")),
+      ).rejects.toThrow();
+
+      // And the legitimate agents root has no entries.
+      const agentsRoot = join(atlasHome, "agents");
+      const { readdir } = await import("node:fs/promises");
+      const entries = await readdir(agentsRoot).catch(() => []);
+      expect(entries).toEqual([]);
+    } finally {
+      await rm(traversalParent, { recursive: true, force: true });
+    }
   });
 
   test("rejects path-traversal version", async () => {

--- a/apps/atlasd/routes/workspaces/index.ts
+++ b/apps/atlasd/routes/workspaces/index.ts
@@ -73,6 +73,7 @@ import {
 } from "../../src/workspace-authz.ts";
 import {
   buildWorkspaceBundleBytes,
+  installImportedAgents,
   isOnDiskWorkspace,
   materializeImportedMemory,
 } from "./bundle-helpers.ts";
@@ -953,8 +954,11 @@ const workspacesRoutes = daemonFactory
         name: string;
         path: string;
         memory?: { kind: string; path?: string; reason?: string };
+        agentsInstalled?: number;
+        agentsSkipped?: number;
       }> = [];
       const errors: Array<{ name: string; error: string }> = [...result.errors];
+      let installedAnyAgents = false;
       for (const entry of result.imported) {
         try {
           const validation = await validateImportedWorkspace(
@@ -979,14 +983,32 @@ const workspacesRoutes = daemonFactory
             atlasHome,
             newWorkspaceId: registered.workspace.id,
           });
+          const agents = await installImportedAgents({
+            targetDir: entry.path,
+            primitives: entry.primitives,
+            atlasHome,
+            logger: importLogger,
+          });
+          if (agents.installed.length > 0) installedAnyAgents = true;
           imported.push({
             workspaceId: registered.workspace.id,
             name: entry.name,
             path: entry.path,
             memory,
+            agentsInstalled: agents.installed.length,
+            agentsSkipped: agents.skipped.length,
           });
         } catch (err) {
           errors.push({ name: entry.name, error: stringifyError(err) });
+        }
+      }
+      if (installedAnyAgents) {
+        try {
+          await ctx.getAgentRegistry()?.reload();
+        } catch (error) {
+          importLogger.warn("Agent registry reload after bundle-all import failed", {
+            error: stringifyError(error),
+          });
         }
       }
 
@@ -1231,12 +1253,34 @@ const workspacesRoutes = daemonFactory
         newWorkspaceId: registered.workspace.id,
       });
 
+      // Bundled user agents land at `<targetDir>/agents/<name>/` — invisible
+      // to the AgentRegistry, which only scans `<atlasHome>/agents/`. Install
+      // them into the global dir and reload so the imported workspace.yml's
+      // `type: user` references resolve at runtime.
+      const agents = await installImportedAgents({
+        targetDir,
+        primitives: result.primitives,
+        atlasHome,
+        logger: importLogger,
+      });
+      if (agents.installed.length > 0) {
+        try {
+          await ctx.getAgentRegistry()?.reload();
+        } catch (error) {
+          importLogger.warn("Agent registry reload after import failed", {
+            error: stringifyError(error),
+          });
+        }
+      }
+
       return c.json({
         workspaceId: registered.workspace.id,
         path: targetDir,
         name: result.lockfile.workspace.name,
         primitives: result.primitives,
         memory,
+        agentsInstalled: agents.installed.length,
+        agentsSkipped: agents.skipped.length,
       });
     } catch (error) {
       const errorMessage = stringifyError(error);

--- a/packages/core/src/agent-loader/adapters/user-adapter.ts
+++ b/packages/core/src/agent-loader/adapters/user-adapter.ts
@@ -15,7 +15,7 @@ interface VersionEntry {
 }
 
 /** Minimal shape of the metadata.json sidecar — validates disk boundary */
-const AgentMetadataFileSchema = z.object({
+export const AgentMetadataFileSchema = z.object({
   id: z.string(),
   version: z.string(),
   displayName: z.string().optional(),

--- a/packages/core/src/agent-loader/index.ts
+++ b/packages/core/src/agent-loader/index.ts
@@ -2,6 +2,6 @@
 
 export { getSystemAgentType } from "./adapters/system-adapter.ts";
 export type { AgentSourceType, AgentSummary } from "./adapters/types.ts";
-export { UserAdapter } from "./adapters/user-adapter.ts";
+export { AgentMetadataFileSchema, UserAdapter } from "./adapters/user-adapter.ts";
 export { AgentLoader } from "./loader.ts";
 export { AgentRegistry } from "./registry.ts";


### PR DESCRIPTION
## Summary

- `POST /import-bundle` and `POST /import-bundle-all` extracted bundled user agents to `<targetDir>/agents/<name>/` but never copied them into `<atlasHome>/agents/<id>@<version>/`, the only path the daemon's `AgentRegistry` (`UserAdapter` in `atlas-daemon.ts:713-716`) scans. Neither route called `registry.reload()` either. Result: imported workspaces that referenced `type: user` agents failed at runtime with the agent unfindable.
- Added `installImportedAgents` in `bundle-helpers.ts` that walks `result.primitives`, reads each agent's `metadata.json` for id/version, and atomically copies (`*.tmp` → `rename`) into `<atlasHome>/agents/<id>@<version>/`. Non-destructive: same-version pre-existing installs are skipped. Mirrors the install pattern in `routes/agents/register.ts`.
- Both import routes now call `installImportedAgents` and then `getAgentRegistry()?.reload()` when any agent was actually installed.

## Test plan

- [x] New: `POST /import-bundle installs bundled user agents globally and reloads registry` — exports a workspace whose `workspace.yml` references a globally-installed user agent, wipes the global agents dir to simulate cross-machine import, then asserts the agent is materialized under `<homeDir>/agents/<id>@<version>/metadata.json` and `registry.reload()` was called once.
- [x] New: `POST /import-bundle skips installing user agents when same id@version already present` — pre-seeds the same id@version globally, imports, asserts no install happened, the pre-existing dir is untouched, and `registry.reload()` was NOT called.
- [x] Full `apps/atlasd/routes/workspaces` + `packages/bundle` test suite: 727 pass / 1 skipped.
- [x] `deno check` on changed files clean.
- [x] `biome check` on changed files clean.