### PR TITLE
fix(config): validate execution.agents refs and trigger.signal refs

### DIFF
--- a/packages/config/src/validate-workspace.test.ts
+++ b/packages/config/src/validate-workspace.test.ts
@@ -436,6 +436,60 @@ describe("validateWorkspace reference integrity", () => {
     expect(err!.path).toBe("jobs.my_job.fsm.states.step1.entry[0].agentId");
   });
 
+  it("errors on unknown agent ID in execution.agents (string form)", () => {
+    const result = validateWorkspace({
+      version: "1.0",
+      workspace: { name: "Test" },
+      agents: {
+        known: {
+          type: "llm",
+          description: "Known",
+          config: { provider: "anthropic", model: "claude-sonnet-4-5", prompt: "Hi" },
+        },
+      },
+      jobs: { my_job: { triggers: [{ signal: "s1" }], execution: { agents: ["unknown-agent"] } } },
+      signals: { s1: { provider: "http", description: "S1", config: { path: "/s1" } } },
+    });
+    expect(result.status).toBe("error");
+    const err = result.errors.find((e) => e.code === "unknown_agent_id");
+    expect(err).toBeDefined();
+    expect(err!.path).toBe("jobs.my_job.execution.agents[0]");
+  });
+
+  it("errors on unknown agent ID in execution.agents (object form)", () => {
+    const result = validateWorkspace({
+      version: "1.0",
+      workspace: { name: "Test" },
+      agents: {},
+      jobs: { my_job: { triggers: [{ signal: "s1" }], execution: { agents: [{ id: "ghost" }] } } },
+      signals: { s1: { provider: "http", description: "S1", config: { path: "/s1" } } },
+    });
+    expect(result.status).toBe("error");
+    const err = result.errors.find((e) => e.code === "unknown_agent_id");
+    expect(err).toBeDefined();
+    expect(err!.path).toBe("jobs.my_job.execution.agents[0].id");
+  });
+
+  it("errors on trigger referencing undefined signal", () => {
+    const result = validateWorkspace({
+      version: "1.0",
+      workspace: { name: "Test" },
+      agents: {
+        a1: {
+          type: "llm",
+          description: "x",
+          config: { provider: "anthropic", model: "claude-sonnet-4-5", prompt: "hi" },
+        },
+      },
+      signals: { s1: { provider: "http", description: "S1", config: { path: "/s1" } } },
+      jobs: { my_job: { triggers: [{ signal: "nonexistent" }], execution: { agents: ["a1"] } } },
+    });
+    expect(result.status).toBe("error");
+    const err = result.errors.find((e) => e.code === "unknown_signal");
+    expect(err).toBeDefined();
+    expect(err!.path).toBe("jobs.my_job.triggers[0].signal");
+  });
+
   it("errors on unknown tool in agent config.tools", () => {
     const result = validateWorkspace({
       version: "1.0",
@@ -531,8 +585,13 @@ describe("validateWorkspace semantic warnings", () => {
           description: "Orphan",
           config: { provider: "anthropic", model: "claude-sonnet-4-5", prompt: "Hi" },
         },
+        used: {
+          type: "llm",
+          description: "Used",
+          config: { provider: "anthropic", model: "claude-sonnet-4-5", prompt: "Hi" },
+        },
       },
-      jobs: { my_job: { triggers: [{ signal: "s1" }], execution: { agents: ["other"] } } },
+      jobs: { my_job: { triggers: [{ signal: "s1" }], execution: { agents: ["used"] } } },
       signals: { s1: { provider: "http", description: "S1", config: { path: "/s1" } } },
     });
     expect(result.status).toBe("warning");

--- a/packages/config/src/validate-workspace.ts
+++ b/packages/config/src/validate-workspace.ts
@@ -89,6 +89,7 @@ export function validateWorkspace(
   checkAgentReferences(config, errors);
   checkToolReferences(config, registry, errors);
   checkMemoryReferences(config, errors);
+  checkUnknownSignal(config, errors);
 
   // ── Semantic warnings ──────────────────────────────────────────────────────
   checkMissingToolsArray(config, warnings);
@@ -126,6 +127,44 @@ function checkAgentReferences(config: WorkspaceConfig, issues: Issue[]): void {
         `Job '${response.jobId}' FSM state '${response.stateId}' references agent '${agentId}', ` +
         `but no such agent is defined under agents.*.`,
     });
+  }
+
+  // Execution-style job references (mirror of checkOrphanAgents' execution walk).
+  for (const [jobId, job] of Object.entries(config.jobs ?? {})) {
+    const specs = job.execution?.agents ?? [];
+    for (let i = 0; i < specs.length; i++) {
+      const spec = specs[i];
+      const agentId = agentIdFromSpec(spec);
+      if (!agentId) continue;
+      if (definedAgents.has(agentId)) continue;
+      const suffix = typeof spec === "string" ? "" : ".id";
+      issues.push({
+        code: "unknown_agent_id",
+        path: `jobs.${jobId}.execution.agents[${i}]${suffix}`,
+        message:
+          `Job '${jobId}' execution references agent '${agentId}', ` +
+          `but no such agent is defined under agents.*.`,
+      });
+    }
+  }
+}
+
+function checkUnknownSignal(config: WorkspaceConfig, issues: Issue[]): void {
+  const definedSignals = new Set(Object.keys(config.signals ?? {}));
+  for (const [jobId, job] of Object.entries(config.jobs ?? {})) {
+    const triggers = job.triggers ?? [];
+    for (let i = 0; i < triggers.length; i++) {
+      const signal = triggers[i]?.signal;
+      if (!signal) continue;
+      if (definedSignals.has(signal)) continue;
+      issues.push({
+        code: "unknown_signal",
+        path: `jobs.${jobId}.triggers[${i}].signal`,
+        message:
+          `Job '${jobId}' trigger references signal '${signal}', ` +
+          `but no such signal is defined under signals.*.`,
+      });
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

`validateWorkspace()` has two gaps in its reference-integrity layer that let invalid workspaces ship silently:

1. **`execution.agents[]` not checked for unknown refs.** `checkAgentReferences` only walks FSM agent references. A job with `execution: { agents: [\"ghost\"] }` where `ghost` isn't defined passed validation as `status: \"ok\"`.

2. **Triggers referencing undefined signals not flagged.** `checkDeadSignals` catches *defined-but-untriggered* signals (warning). There was no mirror for *triggered-but-undefined* (error), so a job with `triggers: [{ signal: \"nonexistent\" }]` passed.

The fix is small because the asymmetry was already half-resolved: `checkOrphanAgents` (the inverse-direction agent check) already walks both FSM and `execution.agents` via the existing `agentIdFromSpec()` helper. `checkAgentReferences` just needed to reuse it.

## Changes

- `checkAgentReferences`: extended with an `execution.agents[]` walk (mirror of `checkOrphanAgents`). Emits `unknown_agent_id` with path `jobs.<id>.execution.agents[<i>]` (string form) or `jobs.<id>.execution.agents[<i>].id` (object form).
- New `checkUnknownSignal`: emits `unknown_signal` with path `jobs.<id>.triggers[<i>].signal`. Follows the naming pattern of `unknown_agent_id` / `unknown_tool` / `unknown_memory_store`. Wired into `validateWorkspace()` alongside the other reference-integrity checks.
- Three new tests in `validate-workspace.test.ts`: execution.agents string form, execution.agents object form, trigger→signal.
- Updated the existing `orphan_agent` test, which was masking the first bug (its `execution.agents: [\"other\"]` referenced an undefined agent — the new check correctly flags this, so the test now defines a `used` agent).

## Context

Found while writing a Deno validator for `friday-platform/friday-studio-examples` that delegates schema validation to `@atlas/config`. Two example workspaces would have shipped with dangling refs that the Python validator (being deprecated) had caught but `validateWorkspace()` didn't.

## Test plan

- [x] `deno task test packages/config/src/validate-workspace.test.ts` — 55 tests pass (including 3 new + 1 updated)
- [x] `deno check packages/config/src/validate-workspace.ts`
- [x] `deno check packages/config/src/validate-workspace.test.ts`
- [ ] CI green