### PR TITLE
fix(mcp): show real workspace names in tool invoker dropdown

### DIFF
--- a/tools/agent-playground/src/lib/components/mcp/mcp-tool-invoker.svelte
+++ b/tools/agent-playground/src/lib/components/mcp/mcp-tool-invoker.svelte
@@ -33,7 +33,7 @@
   // ── Workspace context ──────────────────────────────────────────────────
   // An invocation always runs in a workspace context — the daemon route
   // requires it. Default to the first workspace once the list loads.
-  const workspacesQuery = createQuery(() => workspaceQueries.list());
+  const workspacesQuery = createQuery(() => workspaceQueries.enriched());
   const workspaces = $derived(workspacesQuery.data ?? []);
   let workspaceId = $state("");
   $effect.pre(() => {
@@ -246,7 +246,7 @@
             <option value="">No workspaces</option>
           {/if}
           {#each workspaces as ws (ws.id)}
-            <option value={ws.id}>{ws.name}</option>
+            <option value={ws.id}>{ws.displayName}</option>
           {/each}
         </select>
       </div>

--- a/tools/agent-playground/src/lib/components/mcp/mcp-workspace-usage.svelte
+++ b/tools/agent-playground/src/lib/components/mcp/mcp-workspace-usage.svelte
@@ -18,7 +18,7 @@
 
   let { serverId }: Props = $props();
 
-  const workspaceListQuery = createQuery(() => workspaceQueries.list());
+  const workspaceListQuery = createQuery(() => workspaceQueries.enriched());
   const workspaces = $derived(workspaceListQuery.data ?? []);
 
   const statusQueries = createQueries(() => ({
@@ -35,7 +35,7 @@
     return workspaces.flatMap((ws, i): Row[] => {
       const enabledServer = statusQueries[i]?.data?.enabled.find((s) => s.id === serverId);
       if (!enabledServer) return [];
-      return [{ workspaceId: ws.id, workspaceName: ws.name || ws.id, enabledServer }];
+      return [{ workspaceId: ws.id, workspaceName: ws.displayName, enabledServer }];
     });
   });
 </script>


### PR DESCRIPTION
## Summary

- The workspace picker on `/mcp/<server>/tools` (Invoke a tool) was rendering the daemon's raw `name` field, which is the literal `"workspace"` for templated workspaces — so the dropdown showed multiple indistinguishable `workspace` entries instead of the names users see everywhere else.
- Same bug in the Connections → Enabled-in-these-workspaces list.
- Switch both to `workspaceQueries.enriched()` + `ws.displayName`, matching the sidebar / command-palette / workspace-dropdown convention.

## Test plan

- [x] `deno task check` passes (0 errors)
- [x] UI: open `/mcp/<server>/tools`, click **Load tools**, confirm the Workspace context dropdown shows the per-workspace `workspace.yml` names (e.g. `Personal`, `San Diego Surf Watch`, `Bucketlist CS Knowledge Agent`) instead of `workspace`/`workspace`/`workspace`.
- [ ] UI: on Connections, confirm "Enabled in these workspaces" links use the same display names.