### PR TITLE
fix(atlasd): force-evict LRU MCP sessions when no idle candidates exist

### DIFF
--- a/apps/atlasd/src/atlas-daemon.test.ts
+++ b/apps/atlasd/src/atlas-daemon.test.ts
@@ -448,6 +448,196 @@ describe("AtlasDaemon idle/session cleanup", () => {
     expect(agentSessions.has("agent-session")).toBe(false);
     expect(platformSessions.has("platform-session")).toBe(false);
   });
+
+  it("force-evicts LRU platform sessions when no idle candidates exist and we're over the limit", async () => {
+    // Reproduces the production starvation: long-lived SSE/MCP streams keep
+    // `activeRequests > 0` forever, so the old eviction path filtered them
+    // ALL out and `toEvict.length` was always 0 — the warning fired every
+    // 60s with no progress and the map grew unbounded.
+    const daemon = new AtlasDaemon({ port: 0 });
+    const sessions = (
+      daemon as unknown as { platformMcpSessions: Map<string, Record<string, unknown>> }
+    ).platformMcpSessions;
+    const maxSessions = (daemon as unknown as { MAX_PLATFORM_SESSIONS: number })
+      .MAX_PLATFORM_SESSIONS;
+
+    const closes: Array<ReturnType<typeof vi.fn>> = [];
+    const now = Date.now();
+    // Fill the map past the limit, all sessions in-flight (activeRequests > 0).
+    for (let i = 0; i < maxSessions + 5; i++) {
+      const close = vi.fn().mockResolvedValue(undefined);
+      closes.push(close);
+      sessions.set(`active-session-${i}`, {
+        server: {},
+        transport: { close, onclose: () => undefined },
+        createdAt: now - (maxSessions + 5 - i) * 1000,
+        lastUsed: now - (maxSessions + 5 - i) * 1000, // earliest is i=0
+        activeRequests: 1,
+      });
+    }
+    expect(sessions.size).toBe(maxSessions + 5);
+
+    await (
+      daemon as unknown as { performPlatformSessionCleanup: () => Promise<void> }
+    ).performPlatformSessionCleanup();
+
+    // Down to the limit exactly, evicted the 5 LRU (oldest lastUsed).
+    expect(sessions.size).toBe(maxSessions);
+    for (let i = 0; i < 5; i++) {
+      expect(sessions.has(`active-session-${i}`)).toBe(false);
+      expect(closes[i]).toHaveBeenCalledOnce();
+    }
+    for (let i = 5; i < maxSessions + 5; i++) {
+      expect(sessions.has(`active-session-${i}`)).toBe(true);
+    }
+  });
+
+  it("prefers idle platform sessions over active ones when evicting", async () => {
+    const daemon = new AtlasDaemon({ port: 0 });
+    const sessions = (
+      daemon as unknown as { platformMcpSessions: Map<string, Record<string, unknown>> }
+    ).platformMcpSessions;
+    const maxSessions = (daemon as unknown as { MAX_PLATFORM_SESSIONS: number })
+      .MAX_PLATFORM_SESSIONS;
+
+    const now = Date.now();
+    // 3 over the limit. The oldest 2 are *active*, but there are 2 *idle*
+    // sessions in the middle — the idle ones should go first even though
+    // they're newer, then we still need 1 more from the active LRU pool.
+    const activeOldClose = vi.fn().mockResolvedValue(undefined);
+    sessions.set("active-oldest", {
+      server: {},
+      transport: { close: activeOldClose, onclose: () => undefined },
+      createdAt: now - 100_000,
+      lastUsed: now - 100_000,
+      activeRequests: 1,
+    });
+    const activeOlderClose = vi.fn().mockResolvedValue(undefined);
+    sessions.set("active-older", {
+      server: {},
+      transport: { close: activeOlderClose, onclose: () => undefined },
+      createdAt: now - 90_000,
+      lastUsed: now - 90_000,
+      activeRequests: 1,
+    });
+    const idle1Close = vi.fn().mockResolvedValue(undefined);
+    sessions.set("idle-mid-1", {
+      server: {},
+      transport: { close: idle1Close, onclose: () => undefined },
+      createdAt: now - 60_000,
+      lastUsed: now - 60_000,
+      activeRequests: 0,
+    });
+    const idle2Close = vi.fn().mockResolvedValue(undefined);
+    sessions.set("idle-mid-2", {
+      server: {},
+      transport: { close: idle2Close, onclose: () => undefined },
+      createdAt: now - 50_000,
+      lastUsed: now - 50_000,
+      activeRequests: 0,
+    });
+
+    // Fill the rest with active recent sessions (we don't want them evicted).
+    for (let i = 0; i < maxSessions - 1; i++) {
+      sessions.set(`active-recent-${i}`, {
+        server: {},
+        transport: { close: vi.fn().mockResolvedValue(undefined), onclose: () => undefined },
+        createdAt: now - i,
+        lastUsed: now - i,
+        activeRequests: 1,
+      });
+    }
+    expect(sessions.size).toBe(maxSessions + 3);
+
+    await (
+      daemon as unknown as { performPlatformSessionCleanup: () => Promise<void> }
+    ).performPlatformSessionCleanup();
+
+    expect(sessions.size).toBe(maxSessions);
+    // Both idle ones evicted (preferred), plus the oldest active one as fallback.
+    expect(sessions.has("idle-mid-1")).toBe(false);
+    expect(sessions.has("idle-mid-2")).toBe(false);
+    expect(sessions.has("active-oldest")).toBe(false);
+    expect(sessions.has("active-older")).toBe(true);
+    expect(idle1Close).toHaveBeenCalledOnce();
+    expect(idle2Close).toHaveBeenCalledOnce();
+    expect(activeOldClose).toHaveBeenCalledOnce();
+    expect(activeOlderClose).not.toHaveBeenCalled();
+  });
+
+  it("force-evicts LRU agent sessions when no idle candidates exist", async () => {
+    // Symmetric coverage for the agent path — same bug, same fix.
+    const daemon = new AtlasDaemon({ port: 0 });
+    const sessions = (daemon as unknown as { agentSessions: Map<string, Record<string, unknown>> })
+      .agentSessions;
+    const maxSessions = (daemon as unknown as { MAX_AGENT_SESSIONS: number }).MAX_AGENT_SESSIONS;
+
+    const closes: Array<ReturnType<typeof vi.fn>> = [];
+    const stops: Array<ReturnType<typeof vi.fn>> = [];
+    const now = Date.now();
+    for (let i = 0; i < maxSessions + 3; i++) {
+      const close = vi.fn().mockResolvedValue(undefined);
+      const stop = vi.fn().mockResolvedValue(undefined);
+      closes.push(close);
+      stops.push(stop);
+      sessions.set(`active-agent-${i}`, {
+        server: { stop },
+        transport: { close, onclose: () => undefined },
+        createdAt: now - (maxSessions + 3 - i) * 1000,
+        lastUsed: now - (maxSessions + 3 - i) * 1000,
+        activeRequests: 1,
+      });
+    }
+    expect(sessions.size).toBe(maxSessions + 3);
+
+    await (
+      daemon as unknown as { performAgentSessionCleanup: () => Promise<void> }
+    ).performAgentSessionCleanup();
+
+    expect(sessions.size).toBe(maxSessions);
+    for (let i = 0; i < 3; i++) {
+      expect(sessions.has(`active-agent-${i}`)).toBe(false);
+      expect(closes[i]).toHaveBeenCalledOnce();
+      expect(stops[i]).toHaveBeenCalledOnce();
+    }
+    for (let i = 3; i < maxSessions + 3; i++) {
+      expect(sessions.has(`active-agent-${i}`)).toBe(true);
+    }
+  });
+
+  it("does not evict anything when at or under the platform session limit", async () => {
+    // Regression guard: the new force-evict path must NOT kick in unless
+    // we're strictly over the limit.
+    const daemon = new AtlasDaemon({ port: 0 });
+    const sessions = (
+      daemon as unknown as { platformMcpSessions: Map<string, Record<string, unknown>> }
+    ).platformMcpSessions;
+    const maxSessions = (daemon as unknown as { MAX_PLATFORM_SESSIONS: number })
+      .MAX_PLATFORM_SESSIONS;
+
+    const closes: Array<ReturnType<typeof vi.fn>> = [];
+    for (let i = 0; i < maxSessions; i++) {
+      const close = vi.fn().mockResolvedValue(undefined);
+      closes.push(close);
+      sessions.set(`session-${i}`, {
+        server: {},
+        transport: { close, onclose: () => undefined },
+        createdAt: Date.now(),
+        lastUsed: Date.now(),
+        activeRequests: 1,
+      });
+    }
+    expect(sessions.size).toBe(maxSessions);
+
+    await (
+      daemon as unknown as { performPlatformSessionCleanup: () => Promise<void> }
+    ).performPlatformSessionCleanup();
+
+    expect(sessions.size).toBe(maxSessions);
+    for (const close of closes) {
+      expect(close).not.toHaveBeenCalled();
+    }
+  });
 });
 
 describe("AtlasDaemon.shutdown stops the Discord Gateway service", () => {

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -2873,13 +2873,22 @@ export class AtlasDaemon {
 
       const toEvict = [...toEvictIdle, ...toEvictActive];
 
-      logger.warn("Evicting LRU agent sessions due to limit", {
+      // Force-evicting an active session aborts the client's in-flight MCP
+      // stream — escalate to `error` so on-call notices a user-visible
+      // disconnect rather than dismissing it as benign idle cleanup.
+      const evictionContext = {
         evictionCount: toEvict.length,
         idleEvicted: toEvictIdle.length,
         activeEvicted: toEvictActive.length,
+        evictedSessionIds: toEvict.map(([id]) => id),
         totalSessions: this.agentSessions.size,
         maxSessions: this.MAX_AGENT_SESSIONS,
-      });
+      };
+      if (toEvictActive.length > 0) {
+        logger.error("Evicting LRU agent sessions due to limit", evictionContext);
+      } else {
+        logger.warn("Evicting LRU agent sessions due to limit", evictionContext);
+      }
 
       for (const [sessionId] of toEvict) {
         await this.cleanupAgentSession(sessionId);
@@ -2959,13 +2968,21 @@ export class AtlasDaemon {
 
       const toEvict = [...toEvictIdle, ...toEvictActive];
 
-      logger.warn("Evicting LRU platform sessions due to limit", {
+      // See `performAgentSessionCleanup` — `error` when we're killing
+      // in-flight streams, `warn` for clean idle eviction.
+      const evictionContext = {
         evictionCount: toEvict.length,
         idleEvicted: toEvictIdle.length,
         activeEvicted: toEvictActive.length,
+        evictedSessionIds: toEvict.map(([id]) => id),
         totalSessions: this.platformMcpSessions.size,
         maxSessions: this.MAX_PLATFORM_SESSIONS,
-      });
+      };
+      if (toEvictActive.length > 0) {
+        logger.error("Evicting LRU platform sessions due to limit", evictionContext);
+      } else {
+        logger.warn("Evicting LRU platform sessions due to limit", evictionContext);
+      }
 
       for (const [sessionId] of toEvict) {
         await this.cleanupPlatformSession(sessionId);

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -2845,16 +2845,38 @@ export class AtlasDaemon {
       }
     }
 
-    // Enforce session limit (LRU eviction)
+    // Enforce session limit (LRU eviction).
+    //
+    // Two-pass strategy:
+    //   1. Prefer evicting sessions with no active requests (clean tear-down).
+    //   2. If we're still over the limit, force-evict the LRU sessions even
+    //      if they have in-flight requests — otherwise long-lived SSE/MCP
+    //      streams (whose `activeRequests` never drops to zero until the
+    //      client disconnects) pin the map forever, the warning fires every
+    //      60s with `evictionCount: 0`, and new sessions get crowded out.
     if (this.agentSessions.size > this.MAX_AGENT_SESSIONS) {
-      const sortedSessions = Array.from(this.agentSessions.entries())
-        .filter(([, session]) => session.activeRequests === 0)
-        .sort((a, b) => a[1].lastUsed - b[1].lastUsed);
+      const overage = this.agentSessions.size - this.MAX_AGENT_SESSIONS;
 
-      const toEvict = sortedSessions.slice(0, this.agentSessions.size - this.MAX_AGENT_SESSIONS);
+      const sortedByLastUsed = Array.from(this.agentSessions.entries()).sort(
+        (a, b) => a[1].lastUsed - b[1].lastUsed,
+      );
+
+      const idleFirst = sortedByLastUsed.filter(([, s]) => s.activeRequests === 0);
+      const toEvictIdle = idleFirst.slice(0, overage);
+
+      const remainingOverage = overage - toEvictIdle.length;
+      const evictedIdleIds = new Set(toEvictIdle.map(([id]) => id));
+      const toEvictActive =
+        remainingOverage > 0
+          ? sortedByLastUsed.filter(([id]) => !evictedIdleIds.has(id)).slice(0, remainingOverage)
+          : [];
+
+      const toEvict = [...toEvictIdle, ...toEvictActive];
 
       logger.warn("Evicting LRU agent sessions due to limit", {
         evictionCount: toEvict.length,
+        idleEvicted: toEvictIdle.length,
+        activeEvicted: toEvictActive.length,
         totalSessions: this.agentSessions.size,
         maxSessions: this.MAX_AGENT_SESSIONS,
       });
@@ -2914,19 +2936,33 @@ export class AtlasDaemon {
       }
     }
 
-    // Enforce session limit (LRU eviction)
+    // Enforce session limit (LRU eviction). See `performAgentSessionCleanup`
+    // for the two-pass rationale — long-lived SSE streams keep
+    // `activeRequests > 0` and would otherwise pin the map indefinitely,
+    // causing the eviction warning to fire every 60s with no progress.
     if (this.platformMcpSessions.size > this.MAX_PLATFORM_SESSIONS) {
-      const sortedSessions = Array.from(this.platformMcpSessions.entries())
-        .filter(([, session]) => session.activeRequests === 0)
-        .sort((a, b) => a[1].lastUsed - b[1].lastUsed);
+      const overage = this.platformMcpSessions.size - this.MAX_PLATFORM_SESSIONS;
 
-      const toEvict = sortedSessions.slice(
-        0,
-        this.platformMcpSessions.size - this.MAX_PLATFORM_SESSIONS,
+      const sortedByLastUsed = Array.from(this.platformMcpSessions.entries()).sort(
+        (a, b) => a[1].lastUsed - b[1].lastUsed,
       );
+
+      const idleFirst = sortedByLastUsed.filter(([, s]) => s.activeRequests === 0);
+      const toEvictIdle = idleFirst.slice(0, overage);
+
+      const remainingOverage = overage - toEvictIdle.length;
+      const evictedIdleIds = new Set(toEvictIdle.map(([id]) => id));
+      const toEvictActive =
+        remainingOverage > 0
+          ? sortedByLastUsed.filter(([id]) => !evictedIdleIds.has(id)).slice(0, remainingOverage)
+          : [];
+
+      const toEvict = [...toEvictIdle, ...toEvictActive];
 
       logger.warn("Evicting LRU platform sessions due to limit", {
         evictionCount: toEvict.length,
+        idleEvicted: toEvictIdle.length,
+        activeEvicted: toEvictActive.length,
         totalSessions: this.platformMcpSessions.size,
         maxSessions: this.MAX_PLATFORM_SESSIONS,
       });


### PR DESCRIPTION
## Summary

- LRU eviction in `performPlatformSessionCleanup` / `performAgentSessionCleanup` filtered eviction candidates by `activeRequests === 0`. Long-lived SSE streams keep `activeRequests >= 1` for the lifetime of a browser tab, so the eligible pool was empty and the map grew unbounded.
- Switch to a two-pass eviction: idle sessions first (clean tear-down), then force-evict LRU active sessions if still over the limit. Warning log now reports `idleEvicted` + `activeEvicted` so the breakdown is visible.

## What broke in prod

Studio chat panel stuck on "Connecting..." with the daemon spamming this warning every 60s:

```
"Evicting LRU platform sessions due to limit"
evictionCount:0 totalSessions:164 maxSessions:100
```

`totalSessions` was strictly increasing because no session was ever eligible. Only daemon restart recovered it.

## Tests

Four new vitest cases in `apps/atlasd/src/atlas-daemon.test.ts` covering:
- Starvation: 105 active sessions, force-evicts 5 LRU.
- Mixed pool: idle ones go first, then active LRU fills the gap.
- Same coverage for the agent path (`agentSessions`).
- Regression guard: do NOT evict at or below the limit.

All 16 tests pass: \`deno task test apps/atlasd/src/atlas-daemon.test.ts\` → 16/16 ✓

## Test plan

- [x] Unit tests pass (16/16)
- [x] Hot-swapped daemon to the fix branch and observed in `~/.atlas/logs/global.log`:
  ```
  evictionCount:13 idleEvicted:13 activeEvicted:0 totalSessions:113 maxSessions:100
  evictionCount:110 idleEvicted:110 activeEvicted:0 totalSessions:210 maxSessions:100
  evictionCount:3 idleEvicted:3 activeEvicted:0 totalSessions:103 maxSessions:100
  ```
  i.e. the map actually drops back to ≤100 instead of pinning forever.
- [x] Studio chat reconnected on a fresh tab after the over-limit + eviction.
- [x] End-to-end chat flow worked post-eviction (sent message, Friday responded).
- [x] `activeEvicted > 0` path is covered by unit tests (couldn't trigger from outside since MCP `initialize` returns synchronously and frees `activeRequests` before the 60s cleanup tick).