### PR TITLE
fix(mcp): pin @ai-sdk/mcp to 1.0.41 — 1.0.42 broke HTTP transport

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,6 +87,12 @@ updates:
       # in packages/mcp-server. Pinned to ~1.28.x until upstream fixes typing.
       - dependency-name: "@modelcontextprotocol/sdk"
         versions: [">= 1.29.0"]
+      # @ai-sdk/mcp 1.0.42 assigns to StreamableHTTPClientTransport.protocolVersion,
+      # which is a getter-only property — every HTTP MCP initialize throws and the
+      # server is silently skipped. Pinned to 1.0.41 until upstream fixes it.
+      # See PR #370 for context.
+      - dependency-name: "@ai-sdk/mcp"
+        versions: [">= 1.0.42"]
       # undici 8.x calls webidl.util.markAsUncloneable, which Deno's webidl
       # shim doesn't expose — daemon crashes on startup loading CacheStorage.
       # Hold majors until Deno catches up. See PR #89 for context.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,9 @@ updates:
         patterns:
           - "ai"
           - "@ai-sdk/*"
+      tanstack:
+        patterns:
+          - "@tanstack/*"
     ignore:
       # Vite 8 uses Rolldown (Rust native bindings) which fails on Alpine/musl
       # Docker images — rolldown-binding.linux-x64-musl.node not found.

--- a/deno.lock
+++ b/deno.lock
@@ -29,10 +29,11 @@
     "jsr:@std/testing@1": "1.0.18",
     "jsr:@std/testing@^1.0.16": "1.0.18",
     "jsr:@std/yaml@1": "1.1.0",
+    "npm:@ai-sdk/anthropic@^3.0.76": "3.0.78_zod@4.4.3",
     "npm:@ai-sdk/anthropic@^3.0.78": "3.0.78_zod@4.4.3",
     "npm:@ai-sdk/google@^3.0.74": "3.0.74_zod@4.4.3",
     "npm:@ai-sdk/groq@^3.0.39": "3.0.39_zod@4.4.3",
-    "npm:@ai-sdk/mcp@^1.0.42": "1.0.42_zod@4.4.3",
+    "npm:@ai-sdk/mcp@1.0.41": "1.0.41_zod@4.4.3",
     "npm:@ai-sdk/openai@^3.0.64": "3.0.64_zod@4.4.3",
     "npm:@ai-sdk/provider@^3.0.10": "3.0.10",
     "npm:@ai-sdk/svelte@^4.0.183": "4.0.183_svelte@5.55.7_zod@4.4.3",
@@ -52,7 +53,7 @@
     "npm:@deno/kv@0.13": "0.13.0",
     "npm:@eslint/compat@^2.1.0": "2.1.0_eslint@10.3.0",
     "npm:@eslint/js@^10.0.1": "10.0.1_eslint@10.3.0",
-    "npm:@hono/mcp@~0.2.5": "0.2.5_@modelcontextprotocol+sdk@1.28.0__zod@4.4.3_hono@4.12.18_zod@4.4.3",
+    "npm:@hono/mcp@~0.2.5": "0.2.5_@modelcontextprotocol+sdk@1.29.0__zod@4.4.3_hono@4.12.18_zod@4.4.3",
     "npm:@hono/standard-validator@~0.2.2": "0.2.2_@standard-schema+spec@1.1.0_hono@4.12.18",
     "npm:@hono/zod-validator@0.8": "0.8.0_hono@4.12.18_zod@4.4.3",
     "npm:@hono/zod-validator@0.8.0": "0.8.0_hono@4.12.18_zod@4.4.3",
@@ -110,6 +111,7 @@
     "npm:@xmldom/xmldom@~0.9.10": "0.9.10",
     "npm:ai-sdk-provider-claude-code@^3.4.4": "3.4.4_zod@4.4.3",
     "npm:ai@^6.0.141": "6.0.183_zod@4.4.3",
+    "npm:ai@^6.0.177": "6.0.183_zod@4.4.3",
     "npm:ai@^6.0.183": "6.0.183_zod@4.4.3",
     "npm:chat@4.28.1": "4.28.1",
     "npm:chat@^4.28.1": "4.28.1",
@@ -320,8 +322,8 @@
         "zod"
       ]
     },
-    "@ai-sdk/mcp@1.0.42_zod@4.4.3": {
-      "integrity": "sha512-ctRhX9vNLXvjGSFf+RlM+ZutIhlzIgMPWzo2BoJKfIW9JzLneA/57bZkkaUvWSdbYFu1FCyxMarNV/4D/pOUzA==",
+    "@ai-sdk/mcp@1.0.41_zod@4.4.3": {
+      "integrity": "sha512-AfA0jb6tTnfcieLx1d6breTmuae0fz67UNcBrCgZqPqaZ1NIlJT5uyXx+78pgYOuDHo0GtHECVhI1a9lkZnzgA==",
       "dependencies": [
         "@ai-sdk/provider",
         "@ai-sdk/provider-utils",
@@ -1132,10 +1134,10 @@
     "@floating-ui/utils@0.2.11": {
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg=="
     },
-    "@hono/mcp@0.2.5_@modelcontextprotocol+sdk@1.28.0__zod@4.4.3_hono@4.12.18_zod@4.4.3": {
+    "@hono/mcp@0.2.5_@modelcontextprotocol+sdk@1.29.0__zod@4.4.3_hono@4.12.18_zod@4.4.3": {
       "integrity": "sha512-JsaJes7VlNvUrUQ9j2b9C13xjFLvyKQY515aWtsdJ9cwhBmWz5od2yUCbDu7cX38GeADmlLmpu4BKNNAV6G27w==",
       "dependencies": [
-        "@modelcontextprotocol/sdk@1.28.0_zod@4.4.3",
+        "@modelcontextprotocol/sdk@1.29.0_zod@4.4.3",
         "hono",
         "hono-rate-limiter",
         "pkce-challenge",
@@ -6454,7 +6456,7 @@
       "packages/mcp": {
         "packageJson": {
           "dependencies": [
-            "npm:@ai-sdk/mcp@^1.0.42",
+            "npm:@ai-sdk/mcp@1.0.41",
             "npm:@modelcontextprotocol/sdk@1.28",
             "npm:ai@^6.0.183",
             "npm:vitest@^4.1.6",

--- a/deno.lock
+++ b/deno.lock
@@ -90,7 +90,7 @@
     "npm:@sveltejs/vite-plugin-svelte@^6.2.4": "6.2.4_svelte@5.55.7_vite@7.3.3__@types+node@25.6.2__yaml@2.9.0_yaml@2.9.0",
     "npm:@sveltejs/vite-plugin-svelte@~6.2.4": "6.2.4_svelte@5.55.7_vite@7.3.3__@types+node@25.6.2__yaml@2.9.0_yaml@2.9.0",
     "npm:@tanstack/query-core@^5.100.10": "5.100.10",
-    "npm:@tanstack/svelte-query@^6.1.28": "6.1.28_svelte@5.55.7",
+    "npm:@tanstack/svelte-query@^6.1.29": "6.1.29_svelte@5.55.7",
     "npm:@tanstack/svelte-table@9.0.0-alpha.46": "9.0.0-alpha.46_svelte@5.55.7",
     "npm:@tanstack/svelte-table@^9.0.0-alpha.46": "9.0.0-alpha.46_svelte@5.55.7",
     "npm:@tanstack/svelte-virtual@~3.13.24": "3.13.24_svelte@5.55.7",
@@ -2172,16 +2172,13 @@
     "@tanstack/query-core@5.100.10": {
       "integrity": "sha512-8UR0yJR+GiQ40m3lPhUr0xbfAupe6GSQiksSBSa9SM2NjezFyxXCIA69/lz8cSoNKZLrw1/PktIyQBJcVeMi3w=="
     },
-    "@tanstack/query-core@5.100.9": {
-      "integrity": "sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ=="
-    },
     "@tanstack/store@0.11.0": {
       "integrity": "sha512-WlzzCt3xi0G6pCAJu1U+2jiECwabETDpQDi3hfkFZvJii9AuZqEKbOiVarX1/bWhTNjU486yQtJCCasi/0q+Cw=="
     },
-    "@tanstack/svelte-query@6.1.28_svelte@5.55.7": {
-      "integrity": "sha512-B4uh/fvn+t67LyWzY8Sb+yqyxJS2hc27Nwf+bfz7vy+ilzfJIHORoCm9/6Arsg4pdH8DCBMLMWZTvMgvSUd/pg==",
+    "@tanstack/svelte-query@6.1.29_svelte@5.55.7": {
+      "integrity": "sha512-qB6hv21JzGvUtKcqUFhbhYEp1qp2/x/PgBaeQVNCkz+BvygLCv/+OMnrzzi5hLoIDJgIbEtQSoX3xW85OYJ9JA==",
       "dependencies": [
-        "@tanstack/query-core@5.100.9",
+        "@tanstack/query-core",
         "svelte"
       ]
     },
@@ -6642,7 +6639,7 @@
             "npm:@sveltejs/kit@^2.60.1",
             "npm:@sveltejs/vite-plugin-svelte@~6.2.4",
             "npm:@tanstack/query-core@^5.100.10",
-            "npm:@tanstack/svelte-query@^6.1.28",
+            "npm:@tanstack/svelte-query@^6.1.29",
             "npm:@tanstack/svelte-table@9.0.0-alpha.46",
             "npm:@tanstack/svelte-virtual@~3.13.24",
             "npm:@types/deno@2.5.0",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -5,7 +5,7 @@
   "main": "./mod.ts",
   "exports": { ".": "./mod.ts" },
   "dependencies": {
-    "@ai-sdk/mcp": "^1.0.42",
+    "@ai-sdk/mcp": "1.0.41",
     "@atlas/config": "workspace:*",
     "@atlas/logger": "workspace:*",
     "@modelcontextprotocol/sdk": "~1.28.0",

--- a/packages/mcp/src/create-mcp-tools.ts
+++ b/packages/mcp/src/create-mcp-tools.ts
@@ -274,10 +274,14 @@ export async function createMCPTools(
         });
       } else {
         const message = error instanceof Error ? error.message : String(error);
+        const cause = error instanceof Error && error.cause;
+        const causeMessage =
+          cause instanceof Error ? cause.message : cause ? String(cause) : undefined;
         logger.warn("MCP server skipped due to connection error", {
           operation: "mcp_connect",
           serverId: value.serverId,
           error: message,
+          cause: causeMessage,
         });
       }
       continue;

--- a/tools/agent-playground/package.json
+++ b/tools/agent-playground/package.json
@@ -35,7 +35,7 @@
     "@melt-ui/svelte": "~0.86.6",
     "@opentelemetry/api": "^1.9.1",
     "@tanstack/query-core": "^5.100.10",
-    "@tanstack/svelte-query": "^6.1.28",
+    "@tanstack/svelte-query": "^6.1.29",
     "@tanstack/svelte-table": "9.0.0-alpha.46",
     "@tanstack/svelte-virtual": "~3.13.24",
     "@types/deno": "2.5.0",


### PR DESCRIPTION
## Summary

Every HTTP MCP server connection has been failing since Saturday with:

> `Cannot set property protocolVersion of #<StreamableHTTPClientTransport> which has only a getter`

Root cause: \`@ai-sdk/mcp@1.0.42\` (pulled in by #357) introduced

\`\`\`js
this.transport.protocolVersion = result.protocolVersion;
\`\`\`

but \`StreamableHTTPClientTransport.protocolVersion\` is — and has been since at least 1.28 — a getter with no setter. The assignment throws on every initialize, the connect fails, and the server is silently skipped. Tools like google-gmail (and atlas-platform internally) became unreachable.

Pin \`@ai-sdk/mcp\` to \`1.0.41\` exactly until upstream resolves it.

## Bonus diagnostic improvement

The \`MCPStartupError\` path captures stderr from the child as \`error.cause\` but \`create-mcp-tools.ts\` was only logging \`error.message\`. The swallowed cause is what hid a separate uvx silent-exit issue while diagnosing this one. Surface it in the warn log going forward so the next mystery is one log line away from solved.

## Test plan

- [x] \`deno task typecheck\` — passes
- [x] \`deno task test\` — passes
- [x] \`deno run -A npm:knip\` — clean
- [x] Local daemon repro: google-gmail goes from "failed to start or expose tools" to \`Connected MCP server { toolCount: 14 }\`