### PR TITLE
fix(playground): resolve daemon URL at runtime in discover + execute routes

### DIFF
--- a/tools/agent-playground/src/lib/daemon-url.ts
+++ b/tools/agent-playground/src/lib/daemon-url.ts
@@ -1,25 +1,3 @@
-/** Base URL of the local Atlas daemon, used by the SvelteKit SSR proxy
- * (`/api/daemon/*` route). The scheme is injected at build time by vite
- * via the `__FRIDAY_DAEMON_BASE_URL__` define key (see vite.config.ts).
- * We can't read it from `process.env` because vite's
- * `define: { "process.env": "{}" }` wipes that for everything that goes
- * through the route SSR transform — an http→https daemon mismatch trips
- * an HTTPParserError as soon as the daemon starts the TLS handshake on a
- * cleartext request.
- *
- * The compiled binary uses `static-server.ts` which reads `FRIDAYD_URL`
- * from env directly. */
-declare const __FRIDAY_DAEMON_BASE_URL__: string | undefined;
-declare const __FRIDAY_TUNNEL_BASE_URL__: string | undefined;
-export const DAEMON_BASE_URL =
-	typeof __FRIDAY_DAEMON_BASE_URL__ !== "undefined"
-		? __FRIDAY_DAEMON_BASE_URL__
-		: "http://localhost:8080";
-export const TUNNEL_BASE_URL =
-	typeof __FRIDAY_TUNNEL_BASE_URL__ !== "undefined"
-		? __FRIDAY_TUNNEL_BASE_URL__
-		: "http://localhost:9090";
-
 /** Browser-facing daemon URL — same-origin proxy path served by
  * `/api/daemon/[...path]/+server.ts` (dev) or `static-server.ts` (prod).
  * Using same-origin means the browser only ever needs to trust the
@@ -28,13 +6,16 @@ export const TUNNEL_BASE_URL =
  * NODE_EXTRA_CA_CERTS-aware fetch behind the scenes.
  *
  * Browser-only — every caller is a click handler / mount effect / popup
- * URL builder. */
+ * URL builder. Server-side code should call `effectiveDaemonUrl()` from
+ * `$lib/server/daemon-url` instead. */
 export function daemonUrl(): string {
 	return `${globalThis.location.origin}/api/daemon`;
 }
 
 /** Browser-facing webhook-tunnel URL — same-origin proxy path served by
- * `/api/tunnel/[...path]/+server.ts` (dev) or `static-server.ts` (prod). */
+ * `/api/tunnel/[...path]/+server.ts` (dev) or `static-server.ts` (prod).
+ * Server-side code should call `effectiveTunnelUrl()` from
+ * `$lib/server/daemon-url` instead. */
 export function tunnelUrl(): string {
 	return `${globalThis.location.origin}/api/tunnel`;
 }

--- a/tools/agent-playground/src/lib/server/daemon-url.ts
+++ b/tools/agent-playground/src/lib/server/daemon-url.ts
@@ -1,24 +1,40 @@
 import { env } from "node:process";
 
 /**
- * Vite injects this constant for SSR-transformed Hono routes in dev. The
- * compiled static server does not run through Vite, so the runtime-env branch
- * below is the production path.
+ * Vite injects these constants for SSR-transformed modules in dev. The
+ * compiled static server does not run through Vite, so the runtime-env
+ * branches below are the production path.
  */
 declare const __FRIDAY_DAEMON_BASE_URL__: string | undefined;
+declare const __FRIDAY_TUNNEL_BASE_URL__: string | undefined;
+
+function s2sScheme(): "http" | "https" {
+  return env.FRIDAY_TLS_CERT && env.FRIDAY_TLS_KEY ? "https" : "http";
+}
 
 /**
- * Resolve the daemon URL for server-side Hono routes.
+ * Resolve the daemon URL for server-side callers.
  *
- * Dev uses Vite's injected URL so the route survives `process.env` define
- * rewriting. The compiled binary reads runtime env directly, matching
- * `static-server.ts` and the launcher-managed TLS/port configuration.
+ * Dev uses Vite's injected URL so the value survives `process.env` define
+ * rewriting. The compiled binary reads runtime env directly, matching the
+ * launcher-managed TLS/port configuration.
  */
 export function effectiveDaemonUrl(): string {
   if (typeof __FRIDAY_DAEMON_BASE_URL__ !== "undefined") {
     return __FRIDAY_DAEMON_BASE_URL__;
   }
+  return env.FRIDAYD_URL ?? `${s2sScheme()}://localhost:8080`;
+}
 
-  const s2sScheme = env.FRIDAY_TLS_CERT && env.FRIDAY_TLS_KEY ? "https" : "http";
-  return env.FRIDAYD_URL ?? `${s2sScheme}://localhost:8080`;
+/**
+ * Resolve the webhook-tunnel URL for server-side callers. Same dev/prod
+ * split as {@link effectiveDaemonUrl}; the launcher writes
+ * `EXTERNAL_TUNNEL_URL` into .env so the compiled binary picks it up at
+ * runtime.
+ */
+export function effectiveTunnelUrl(): string {
+  if (typeof __FRIDAY_TUNNEL_BASE_URL__ !== "undefined") {
+    return __FRIDAY_TUNNEL_BASE_URL__;
+  }
+  return env.EXTERNAL_TUNNEL_URL ?? `${s2sScheme()}://localhost:9090`;
 }

--- a/tools/agent-playground/src/lib/server/routes/discover.ts
+++ b/tools/agent-playground/src/lib/server/routes/discover.ts
@@ -4,12 +4,7 @@ import { Hono } from "hono";
 import JSZip from "jszip";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
-// Daemon URL is injected at vite-config time (FRIDAYD_URL or fallback,
-// scheme upgraded to https:// when TLS is detected). We can't read
-// `process.env.FRIDAYD_URL` here directly: SSR routes go through vite's
-// transform which has `define: { "process.env": "{}" }`, collapsing the
-// read to undefined. See ../../daemon-url.ts and vite.config.ts.
-import { DAEMON_BASE_URL as DAEMON_URL } from "../../daemon-url.ts";
+import { effectiveDaemonUrl } from "../daemon-url.ts";
 
 // REPO/PATH/REF/GITHUB_TOKEN are read for completeness but are subject to
 // the same `process.env` wipe at SSR transform time — the env-override
@@ -350,7 +345,7 @@ export const discoverRoute = new Hono()
       `${slug}.zip`,
     );
 
-    const res = await fetch(`${DAEMON_URL}/api/workspaces/import-bundle`, {
+    const res = await fetch(`${effectiveDaemonUrl()}/api/workspaces/import-bundle`, {
       method: "POST",
       body: formData,
     });

--- a/tools/agent-playground/src/lib/server/routes/execute.ts
+++ b/tools/agent-playground/src/lib/server/routes/execute.ts
@@ -10,12 +10,7 @@ import { parseSSEEvents } from "@atlas/utils/sse";
 import { zValidator } from "@hono/zod-validator";
 import { Hono } from "hono";
 import { z } from "zod";
-// Daemon URL is injected at vite-config time (FRIDAYD_URL or fallback,
-// scheme upgraded to https:// when TLS is detected). We can't read
-// `process.env` here directly: SSR routes go through vite's transform
-// which has `define: { "process.env": "{}" }`, collapsing the read to
-// undefined. See ../../daemon-url.ts and tools/agent-playground/vite.config.ts.
-import { DAEMON_BASE_URL } from "../../daemon-url.ts";
+import { effectiveDaemonUrl } from "../daemon-url.ts";
 import { PlaygroundContextAdapter } from "../lib/context.ts";
 import { createSSEStream } from "../lib/sse.ts";
 
@@ -45,9 +40,10 @@ export const executeRoute = new Hono().post("/", zValidator("json", ExecuteBody)
     }
     // Relay SSE events from daemon — raw Response passthrough is silently buffered by Hono
     return createSSEStream(async (emitter, signal) => {
+      const daemonUrl = effectiveDaemonUrl();
       const url = workspaceId
-        ? `${DAEMON_BASE_URL}/api/agents/${agentId}/run?workspaceId=${encodeURIComponent(workspaceId)}`
-        : `${DAEMON_BASE_URL}/api/agents/${agentId}/run`;
+        ? `${daemonUrl}/api/agents/${agentId}/run?workspaceId=${encodeURIComponent(workspaceId)}`
+        : `${daemonUrl}/api/agents/${agentId}/run`;
       const res = await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/tools/agent-playground/src/routes/api/daemon/[...path]/+server.ts
+++ b/tools/agent-playground/src/routes/api/daemon/[...path]/+server.ts
@@ -1,7 +1,7 @@
-import { DAEMON_BASE_URL } from "$lib/daemon-url";
+import { effectiveDaemonUrl } from "$lib/server/daemon-url";
 import { buildProxyHandler } from "$lib/server/proxy";
 
-const handler = buildProxyHandler({ upstream: DAEMON_BASE_URL, label: "daemon" });
+const handler = buildProxyHandler({ upstream: effectiveDaemonUrl(), label: "daemon" });
 
 export const GET = handler;
 export const POST = handler;

--- a/tools/agent-playground/src/routes/api/tunnel/[...path]/+server.ts
+++ b/tools/agent-playground/src/routes/api/tunnel/[...path]/+server.ts
@@ -1,7 +1,7 @@
-import { TUNNEL_BASE_URL } from "$lib/daemon-url";
+import { effectiveTunnelUrl } from "$lib/server/daemon-url";
 import { buildProxyHandler } from "$lib/server/proxy";
 
-const handler = buildProxyHandler({ upstream: TUNNEL_BASE_URL, label: "tunnel" });
+const handler = buildProxyHandler({ upstream: effectiveTunnelUrl(), label: "tunnel" });
 
 export const GET = handler;
 export const POST = handler;

--- a/tools/agent-playground/static-server.ts
+++ b/tools/agent-playground/static-server.ts
@@ -11,7 +11,7 @@ import process from "node:process";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { serveStatic } from "hono/deno";
-import { effectiveDaemonUrl } from "./src/lib/server/daemon-url.ts";
+import { effectiveDaemonUrl, effectiveTunnelUrl } from "./src/lib/server/daemon-url.ts";
 import { buildStaticApp } from "./src/lib/server/static-app.ts";
 import { resolveBrowserTlsPaths } from "./tls-paths.ts";
 
@@ -34,12 +34,11 @@ const SCHEME = TLS ? "https" : "http";
 // origin's browser cert. They're separate listeners with separate certs.
 // The launcher migrates stale http:// values in .env to https:// at boot
 // (tools/friday-launcher/cert_env.go::migrateStaleURLSchemes) when the
-// s2s mesh is up, so a literal env-var read here matches whatever the
-// daemon / tunnel actually listen on. No consumer-side auto-upgrade
-// needed — single source of truth lives in the launcher.
-const S2S_SCHEME = process.env.FRIDAY_TLS_CERT && process.env.FRIDAY_TLS_KEY ? "https" : "http";
+// s2s mesh is up, so the runtime env-var reads inside the helpers below
+// match whatever the daemon / tunnel actually listen on. No consumer-side
+// auto-upgrade needed — single source of truth lives in the launcher.
 const DAEMON_URL = effectiveDaemonUrl();
-const TUNNEL_URL = process.env.EXTERNAL_TUNNEL_URL ?? `${S2S_SCHEME}://localhost:9090`;
+const TUNNEL_URL = effectiveTunnelUrl();
 
 // Resolve `./build` relative to this source file, so the path is correct
 // both when running via `deno run` from any cwd and when running as a


### PR DESCRIPTION
## Summary

Closes #371

**Commit 1 — fix the regression (`f244eeec`)**

- `routes/discover.ts` and `routes/execute.ts` imported `DAEMON_BASE_URL` from the **vite-define-baked** helper (`src/lib/daemon-url.ts`). At production build time `scripts/build-studio.ts` runs `npm run build` without `FRIDAYD_URL` set, so vite froze the constant to the fallback `http://localhost:8080`. The launcher then starts the real daemon on `https://localhost:18080`, every import-bundle POST hits ECONNREFUSED, UI shows "Import failed (500)". Bundled-agent execution was silently broken the same way.
- Swap both routes to `effectiveDaemonUrl()` from `src/lib/server/daemon-url.ts` — the runtime resolver that `routes/export.ts` already uses. It still honors vite's define in dev and falls through to runtime `FRIDAYD_URL` in the compiled binary.

**Commit 2 — remove the trap (`fa6aaf87`)**

- Deleted `DAEMON_BASE_URL` and `TUNNEL_BASE_URL` from `src/lib/daemon-url.ts`. These constants existed only as syntactic sugar for two dev-only SvelteKit catch-all proxies; `adapter-static` strips those files from the production build. In exchange they offered a load-bearing footgun: any server-side caller that typed the obvious name got a build-time-frozen URL. That's the trap Commit 1's bug fell into.
- Added `effectiveTunnelUrl()` mirroring the daemon helper. Migrated `src/routes/api/{daemon,tunnel}/[...path]/+server.ts` and `static-server.ts` onto the runtime helpers — one resolution path for each URL, no more inline env reads duplicating the helpers' logic.
- `src/lib/daemon-url.ts` now holds only the browser-facing `daemonUrl()` / `tunnelUrl()` same-origin helpers, with comments pointing server-side callers at `$lib/server/daemon-url`. Both helpers reference `globalThis.location.origin` — if anyone re-imports them server-side, they crash loudly instead of silently freezing a URL.

**Regression history**

Introduced by #243 (TLS rollout — moved discover/execute off `process.env.FRIDAYD_URL` onto the build-time-baked constant). Detonated by #320 (launcher started the daemon on 18080). Diagnosed and *partially* fixed in #334 (`effectiveDaemonUrl` was created and applied to the new export route only — discover/execute were left on the stale helper).

## Test Plan

- [x] `deno check` on touched files clean (142 unrelated workspace-chat errors pre-date this branch — verified via stash)
- [x] No remaining references to `DAEMON_BASE_URL` / `TUNNEL_BASE_URL` in the tree
- [ ] `deno task dev:playground` — confirm discover catalog import still works (regression-protect the dev path) and that the dev `/api/daemon/*` + `/api/tunnel/*` catch-all proxies still forward correctly
- [ ] Build via `scripts/build-studio.ts`, launch from installer, click "Add workspace" on a discover catalog item — expect successful workspace import, no 500
- [ ] Bundled-agent run from compiled playground — expect SSE stream, no ECONNREFUSED to localhost:8080 in logs
- [ ] Webhook-tunnel reachability from the compiled binary — settings page status fetch, signal-row tunnel calls (covers the new `effectiveTunnelUrl()` migration)
- [ ] Tail `~/.friday/local/logs/launcher-stdout.log` during the above — confirm no `error sending request for url (http://localhost:8080/...)` or `localhost:9090` entries when env points elsewhere