### PR TITLE
fix(ci): sync studio-installer lockfile + extend dependabot auto-sync

### DIFF
--- a/.github/workflows/dependabot-lockfile.yml
+++ b/.github/workflows/dependabot-lockfile.yml
@@ -1,11 +1,15 @@
 name: Sync Deno lockfile + deno.json for Dependabot PRs
 
-# Runs after Dependabot updates package.json. Does two things:
+# Runs after Dependabot updates package.json. Does three things:
 #   1. `deno install` so deno.lock matches the new package.json.
 #   2. Syncs `npm:<pkg>@<ver>` pins in every deno.json to whatever the
 #      workspace package.json files now declare — without this a group bump
 #      like `hono` lands in package.json but deno.json stays on the old
 #      version, producing dual-package-hazard typecheck failures.
+#   3. Re-runs `npm install --package-lock-only` in apps/studio-installer,
+#      which has its own standalone package-lock.json (isolated from the npm
+#      workspace) used by studio-installer-build.yml — Dependabot bumps
+#      package.json there but leaves the lockfile, breaking `npm ci`.
 #
 # Triggered as pull_request_target so the workflow runs with secrets, then
 # checks out and pushes via DEPENDABOT_PAT (a classic PAT with `repo` scope,
@@ -73,11 +77,23 @@ jobs:
       - name: Re-install after deno.json sync
         run: deno install
 
+      # Sync apps/studio-installer/package-lock.json. The installer has its own
+      # standalone lockfile (not part of the npm workspace) consumed by
+      # studio-installer-build.yml via `npm ci`. Dependabot updates the
+      # package.json there but leaves the lockfile stale, breaking the build.
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      - name: Sync studio-installer package-lock.json
+        run: npm install --package-lock-only --prefix apps/studio-installer
+
       - name: Commit lockfile changes
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
-          commit_message: "chore: sync deno.lock + deno.json [dependabot skip]"
-          file_pattern: "deno.lock deno.json deno.jsonc **/deno.json **/deno.jsonc"
+          commit_message: "chore: sync deno.lock + deno.json + studio-installer lock [dependabot skip]"
+          file_pattern: "deno.lock deno.json deno.jsonc **/deno.json **/deno.jsonc apps/studio-installer/package-lock.json"
           commit_user_name: "github-actions[bot]"
           commit_user_email: "41898282+github-actions[bot]@users.noreply.github.com"
           push_options: "--force-with-lease"

--- a/apps/studio-installer/package-lock.json
+++ b/apps/studio-installer/package-lock.json
@@ -14,9 +14,9 @@
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "~6.2.4",
         "@tauri-apps/cli": "2.11.0",
-        "svelte": "^5.55.7",
+        "svelte": "^5.55.8",
         "typescript": "^5.9.3",
-        "vite": "^7.3.2"
+        "vite": "^7.3.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1482,9 +1482,9 @@
       }
     },
     "node_modules/svelte": {
-      "version": "5.55.7",
-      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.7.tgz",
-      "integrity": "sha512-ymI5ykLPwIHW839E053FQbI1G+jnRFJEw3Kv5Y4njixVWywQBx+NUFpkkKyk5LIb36Fg9DVXSYpqiGekLD0hyw==",
+      "version": "5.55.8",
+      "resolved": "https://registry.npmjs.org/svelte/-/svelte-5.55.8.tgz",
+      "integrity": "sha512-4D6lyrMHmDaZalQOEBMCWCCidyZjSnec14/oPn0k627G6goxcck9xqMwz1tFLlQz+ZFvtTTHfFOlUayuAz0z6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1541,9 +1541,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

- Regenerate `apps/studio-installer/package-lock.json` to match the recent `svelte 5.55.7→5.55.8` (#381) and `vite 7.3.2→7.3.3` (#385) bumps — unblocks `Build (windows/macos-intel/macos-arm)` jobs failing with *"lock file's svelte@5.55.7 does not satisfy svelte@5.55.8"*.
- Teach `.github/workflows/dependabot-lockfile.yml` to also sync this lockfile so the same break doesn't reoccur on the next Dependabot bump touching the installer.

## Root cause

The installer has its own standalone `package-lock.json` (intentionally isolated from the root npm workspace — `studio-installer-build.yml` runs `cd / && npm ci --prefix apps/studio-installer` to dodge the workspace). The auto-sync workflow only refreshed `deno.lock` / `deno.json` files, so Dependabot's `package.json` bumps left the installer lockfile stale and broke `npm ci`.

Failing run: https://github.com/friday-platform/friday-studio/actions/runs/26070212509

## Test plan

- [ ] `studio-installer-build` matrix (windows, macos-intel, macos-arm) goes green on this PR
- [ ] Next Dependabot PR touching `apps/studio-installer/package.json` shows the auto-sync workflow updating `apps/studio-installer/package-lock.json` in the same commit