### PR TITLE
fix(webhook-tunnel): resolve tunnel URL via EXTERNAL_TUNNEL_URL

### DIFF
--- a/apps/atlasd/src/services/communicator-wiring.test.ts
+++ b/apps/atlasd/src/services/communicator-wiring.test.ts
@@ -1,3 +1,4 @@
+import process from "node:process";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { deriveConnectionId, resolveTunnelUrl } from "./communicator-wiring.ts";
 
@@ -17,17 +18,21 @@ vi.mock("@atlas/core/mcp-registry/credential-resolver", async (importOriginal) =
 
 describe("resolveTunnelUrl", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
+  const savedEnv = { EXTERNAL_TUNNEL_URL: process.env.EXTERNAL_TUNNEL_URL };
 
   beforeEach(() => {
     fetchMock = vi.fn<(url: string) => Promise<Response>>();
     vi.stubGlobal("fetch", fetchMock);
+    delete process.env.EXTERNAL_TUNNEL_URL;
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    if (savedEnv.EXTERNAL_TUNNEL_URL === undefined) delete process.env.EXTERNAL_TUNNEL_URL;
+    else process.env.EXTERNAL_TUNNEL_URL = savedEnv.EXTERNAL_TUNNEL_URL;
   });
 
-  it("returns the public tunnel URL from /status", async () => {
+  it("returns the public tunnel URL from /status (default port)", async () => {
     fetchMock.mockResolvedValueOnce(
       new Response(
         JSON.stringify({ url: "https://abc-tunnel.cloudflare.example.com", secret: null }),
@@ -37,7 +42,30 @@ describe("resolveTunnelUrl", () => {
 
     const url = await resolveTunnelUrl();
     expect(url).toBe("https://abc-tunnel.cloudflare.example.com");
+    // No env var → default dev-rig listener (matches
+    // tools/webhook-tunnel/config.go's default port).
     expect(fetchMock).toHaveBeenCalledWith("http://localhost:9090/status");
+  });
+
+  // Installed-launcher rig: EXTERNAL_TUNNEL_URL is set by
+  // `tools/friday-launcher/cert_env.go` for every child process. Bare 9090
+  // has nothing listening because the launcher remaps webhook-tunnel to
+  // e.g. 19090. The original bug (chat_mCiYnHbUQs, 2026-05-18) was that
+  // this function ignored EXTERNAL_TUNNEL_URL and fell through to 9090.
+  it("uses EXTERNAL_TUNNEL_URL when the launcher exports it (installed rig)", async () => {
+    process.env.EXTERNAL_TUNNEL_URL = "https://localhost:19090";
+    fetchMock.mockResolvedValueOnce(
+      new Response(JSON.stringify({ url: "https://merit-rose.trycloudflare.com" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+
+    const url = await resolveTunnelUrl();
+    expect(url).toBe("https://merit-rose.trycloudflare.com");
+    expect(fetchMock).toHaveBeenCalledWith("https://localhost:19090/status");
+    // Negative: must NOT call the bare-default port when launcher remaps it.
+    expect(fetchMock).not.toHaveBeenCalledWith("http://localhost:9090/status");
   });
 
   it("throws a clear error when the tunnel is unreachable (network error)", async () => {

--- a/apps/atlasd/src/services/communicator-wiring.ts
+++ b/apps/atlasd/src/services/communicator-wiring.ts
@@ -64,12 +64,13 @@ function getLinkServiceUrl(): string {
 }
 
 /**
- * Local URL for webhook-tunnel's `/status` endpoint. Defaults to the
- * standard webhook-tunnel listener; override via `WEBHOOK_TUNNEL_URL`
- * for non-default ports / dev rigs. Scheme follows the s2s mesh.
+ * Local URL for webhook-tunnel's `/status` endpoint. `EXTERNAL_TUNNEL_URL`
+ * is the launcher's contract (`tools/friday-launcher/cert_env.go`) — the
+ * single source the agent-playground server also reads. Defaults to the
+ * `tools/webhook-tunnel/config.go` port for bare `deno task webhook-tunnel`.
  */
 function getWebhookTunnelUrl(): string {
-  return process.env.WEBHOOK_TUNNEL_URL ?? `${s2sScheme()}://localhost:9090`;
+  return process.env.EXTERNAL_TUNNEL_URL ?? `${s2sScheme()}://localhost:9090`;
 }
 
 const TunnelStatusSchema = z.object({ url: z.string().url().nullable().optional() });

--- a/packages/system/skills/friday-cli/references/cli.md
+++ b/packages/system/skills/friday-cli/references/cli.md
@@ -221,11 +221,14 @@ registry. No compilation step — the agent process is spawned per invocation an
 via NATS request/reply. See the `writing-friday-python-agents` skill for the full authoring flow.
 
 ### `agent exec`
-`agent exec <agent> -i <input> [--url http://localhost:5200] [--env K=V,K2=V2] [--json] [--stream]`
+`agent exec <agent> -i <input> [--url <playground-url>] [--env K=V,K2=V2] [--json] [--stream]`
 
-Executes an agent via the playground. Requires `deno task playground` running
-separately on :5200. Good for testing agents in isolation before wiring them
-into a workspace.
+Executes an agent via the playground. Requires the playground to be running.
+The `--url` default differs by rig — on installed Friday Studio it listens on
+`$FRIDAY_PORT_PLAYGROUND` (e.g. `http://localhost:15200`), on in-tree dev it's
+`http://localhost:5200`. Resolve from your env (`echo $FRIDAY_PORT_PLAYGROUND`,
+or read `EXTERNAL_DAEMON_URL`-style exports) rather than hardcoding the port.
+Good for testing agents in isolation before wiring them into a workspace.
 
 ---
 

--- a/packages/system/skills/wiring-external-webhooks/SKILL.md
+++ b/packages/system/skills/wiring-external-webhooks/SKILL.md
@@ -35,17 +35,28 @@ cloudflared, the upstream cannot reach it from the public internet,
 and recommending it is the original foot-gun that motivated this
 skill. If you cannot reach `/status` from your environment to fetch
 the real tunnel URL (run_code does not always have network access to
-localhost:9090), **STOP and ask the user to run the `/status` curl
+the local tunnel), **STOP and ask the user to run the `/status` curl
 themselves and paste the URL back** — do not synthesize a host or
 fall back to the `/api/workspaces/...` path.
 
 ## Get the tunnel URL in one call
 
+The local webhook-tunnel listens on whatever `$EXTERNAL_TUNNEL_URL`
+points at (the launcher / playground exports this; default is
+`https://localhost:9090` on bare-dev rigs). Always read it from the
+env — do not hardcode the port, it differs per rig:
+
 ```bash
-curl -sk https://localhost:9090/status | jq
+curl -sk "${EXTERNAL_TUNNEL_URL:-https://localhost:9090}/status" | jq
 # → { "url": "https://...trycloudflare.com",
 #     "providers": ["raw"], "pattern": "/hook/raw/{workspaceId}/{signalId}", ... }
 ```
+
+If that returns empty (exit 0 but no body), the port is wrong for
+this rig. Run `echo "$EXTERNAL_TUNNEL_URL"` to confirm what the
+launcher set, or `ps auxww | grep cloudflared` to read the `--url`
+flag the tunnel was started with — that's the actual local port.
+Do NOT silently move on; the URL is the whole point of this skill.
 
 `/status` is the single source of truth — it shows the current
 `trycloudflare` URL (rotates on tunnel restart) and confirms the

--- a/tools/qa/live-daemon/scenarios/webhook-setup-bitbucket.ts
+++ b/tools/qa/live-daemon/scenarios/webhook-setup-bitbucket.ts
@@ -822,6 +822,35 @@ async function runPointsAtStatusFirst(): Promise<EvalResult> {
         /\b(?:curl|wget|http)\b[^.\n]{0,60}(?:localhost|127\.0\.0\.1)(?::\d+)?\/hook\/[^\s)`]+/i,
       )?.[0],
     },
+    {
+      // Pinned 2026-05-18 after chat_mCiYnHbUQs: agent followed the
+      // skill's hardcoded `https://localhost:9090/status`, got empty stdout
+      // on the playground rig (webhook-tunnel listens on 19090 there via
+      // EXTERNAL_TUNNEL_URL), and improvised. Skill was fixed to teach
+      // the env-var form `"${EXTERNAL_TUNNEL_URL:-https://localhost:9090}"`.
+      // This check locks the contract: any mention of localhost:9090/status
+      // must come through $EXTERNAL_TUNNEL_URL (the {:-default} fallback is
+      // fine), never as a bare hardcoded port.
+      id: "tunnel-port-via-env-not-hardcoded",
+      description:
+        "When telling the user how to call /status, the local tunnel host comes from $EXTERNAL_TUNNEL_URL (the launcher / playground export) — never a bare hardcoded port like localhost:9090 (which is wrong on the playground rig)",
+      pass: (() => {
+        const text = result.text;
+        const mentionsBarePort = /localhost:9090\/status/.test(text);
+        // Anywhere in the response: ${EXTERNAL_TUNNEL_URL...}, $EXTERNAL_TUNNEL_URL,
+        // or even prose like "from $EXTERNAL_TUNNEL_URL" counts. Either it's
+        // not mentioning the bare port at all, or the env-var is in scope.
+        const referencesEnvVar = /\$\{?EXTERNAL_TUNNEL_URL/.test(text);
+        return !mentionsBarePort || referencesEnvVar;
+      })(),
+      evidence: (() => {
+        const barePort = result.text.match(/[^\s`'"]*localhost:9090\/status[^\s`'"]*/)?.[0];
+        const envForm = result.text.match(/[^\s`'"]*\$\{?EXTERNAL_TUNNEL_URL[^\s`'"]*/)?.[0];
+        if (envForm) return `env-var form: ${envForm.slice(0, 120)}`;
+        if (barePort) return `bare hardcoded port: ${barePort.slice(0, 120)}`;
+        return "(no /status curl mentioned)";
+      })(),
+    },
   ];
 
   metrics.checks = checks;
@@ -1492,10 +1521,10 @@ async function runNoAtlasdUrlFallback(): Promise<EvalResult> {
         /\b(?:please\s+)?(?:run|paste|share|provide|tell me|give me|copy)\b[^.\n]{0,80}(?:\/status|tunnel\s+URL|tunnel-url|public\s+(?:tunnel\s+)?(?:URL|hostname))/i.test(
           text,
         ) ||
-        /\bcurl\b[^.\n]{0,60}localhost:9090\/status/i.test(text),
+        /\bcurl\b[^.\n]{0,80}\$\{?EXTERNAL_TUNNEL_URL[^.\n]{0,40}\/status/i.test(text),
       evidence: text
         .match(
-          /\/hook\/raw\/[^\s)`]+|\b(?:run|paste|share|provide|tell me|give me|copy)[^.\n]{0,80}(?:\/status|tunnel\s+URL|public\s+(?:tunnel\s+)?(?:URL|hostname))[^.\n]{0,40}|\bcurl\b[^.\n]{0,60}\/status/i,
+          /\/hook\/raw\/[^\s)`]+|\b(?:run|paste|share|provide|tell me|give me|copy)[^.\n]{0,80}(?:\/status|tunnel\s+URL|public\s+(?:tunnel\s+)?(?:URL|hostname))[^.\n]{0,40}|\bcurl\b[^.\n]{0,80}\$\{?EXTERNAL_TUNNEL_URL[^.\n]{0,40}\/status/i,
         )?.[0]
         ?.slice(0, 200),
     },


### PR DESCRIPTION
😏

> The skill said nine-oh
> The launcher had moved the port
> Curl returned nothing

## Summary

- **Bug**: chat_mCiYnHbUQs followed `wiring-external-webhooks/SKILL.md`'s hardcoded `curl https://localhost:9090/status` and got empty stdout. The installed Friday launcher remaps webhook-tunnel to `FRIDAY_PORT_WEBHOOK_TUNNEL` (e.g. 19090) and exports `EXTERNAL_TUNNEL_URL` to every child process — but nothing was reading it. Same class of bug existed in `apps/atlasd/src/services/communicator-wiring.ts:72` (`resolveTunnelUrl()` for Telegram/Link wiring), which read the wrong env var (`WEBHOOK_TUNNEL_URL`, never exported) and silently fell through to the dead 9090 default.
- **Fix**: skill teaches `"${EXTERNAL_TUNNEL_URL:-https://localhost:9090}/status"`; atlasd reads `EXTERNAL_TUNNEL_URL` directly. Single source of truth — same env var `tools/agent-playground/.../daemon-url.ts:39` already consumes. Dropped `WEBHOOK_TUNNEL_URL` entirely (one call site, never documented, launcher never set it). Also tidies `friday-cli/references/cli.md`'s `agent exec --url` reference, which hardcoded the in-tree port and missed installed-rig 15200.
- **Eval coverage at both layers** — each proven to fire by reverting the source fix and watching the test go red:
  - `tools/qa/live-daemon/scenarios/webhook-setup-bitbucket.ts`: new `tunnel-port-via-env-not-hardcoded` check rejects any `localhost:9090/status` not wrapped in `$EXTERNAL_TUNNEL_URL`. Companion regex on `recommends-hook-raw-or-asks-for-tunnel-url` tightened to drop the loose bare-port branch.
  - `apps/atlasd/src/services/communicator-wiring.test.ts`: new "installed-rig" case sets `EXTERNAL_TUNNEL_URL=https://localhost:19090` and asserts fetch goes there, with explicit `not.toHaveBeenCalledWith` on the bare default port.

## Test Plan

- [x] **Live curl on the playground VM** with launcher-exported `EXTERNAL_TUNNEL_URL=https://localhost:19090` → returns real tunnel JSON (`active:true`, trycloudflare URL).
- [x] **Unit (regex), positive**: 3 representative agent outputs (env-var form, env-var only, no /status mention) — all pass.
- [x] **Unit (regex), negative**: hardcoded `https://localhost:9090/status` and http variant — both correctly fail.
- [x] **vitest** `apps/atlasd/src/services/communicator-wiring.test.ts` — 11/11 with fix; new "installed-rig" test fails on rolled-back source (proves negative).
- [x] **Live LLM eval** `webhook-setup-bitbucket.ts --only points-at-status-first` — 6/6 with fixed skill; new check correctly fires (5/6) when skill is rolled back to buggy form, evidence: `bare hardcoded port: https://localhost:9090/status`.
- [x] **Live LLM eval** `--only with-skill` — 13/13 contract checks pass.
- [x] **Live LLM eval** `--only no-atlasd-url-fallback` — 4/4 pass with the tightened regex requiring `$EXTERNAL_TUNNEL_URL`.
- [x] **Live LLM eval** `--only without-skill` (negative control) — still fails ≥1 positive-knowledge check, confirming the skill remains the load-bearing carrier.
- [x] **Audit**: grep'd every `EXTERNAL_TUNNEL_URL` / `WEBHOOK_TUNNEL_URL` / `localhost:9090` reference in the repo; verified live env on the macOS test VM via `ps -E -p <pid>` against running `friday` (atlasd), `webhook-tunnel`, and `playground` processes.