### PR TITLE
refactor(playground): derive buildHonoProxy mount prefix from label

### DIFF
--- a/tools/agent-playground/src/lib/server/proxy.hono.test.ts
+++ b/tools/agent-playground/src/lib/server/proxy.hono.test.ts
@@ -23,15 +23,14 @@ describe("buildHonoProxy (compiled binary wrapper)", () => {
     globalThis.fetch = originalFetch;
   });
 
-  function call(prefix: string, upstream: string, label: string, url: string) {
-    const handler = buildHonoProxy(prefix, upstream, label);
+  function call(upstream: string, label: string, url: string) {
+    const handler = buildHonoProxy(upstream, label);
     const request = new Request(url, { method: "GET" });
     return handler({ req: { url: request.url, raw: request } });
   }
 
-  it("strips the prefix from the path and forwards to the upstream", async () => {
+  it("strips the /api/${label} prefix from the path and forwards to the upstream", async () => {
     await call(
-      "/api/daemon",
       "https://daemon.local:8080",
       "daemon",
       "https://localhost:5200/api/daemon/api/workspaces/x?foo=1",
@@ -43,7 +42,6 @@ describe("buildHonoProxy (compiled binary wrapper)", () => {
 
   it("delegates OAuth-critical semantics (X-Forwarded-* + redirect:manual) to executeProxyFetch", async () => {
     await call(
-      "/api/daemon",
       "https://daemon.local:8080",
       "daemon",
       "https://localhost:5200/api/daemon/api/link/v1/oauth/authorize/google-calendar",
@@ -54,5 +52,17 @@ describe("buildHonoProxy (compiled binary wrapper)", () => {
     expect(headers.get("x-forwarded-host")).toBe("localhost:5200");
     expect(headers.get("x-forwarded-proto")).toBe("https");
     expect(headers.get("x-forwarded-prefix")).toBe("/api/daemon");
+  });
+
+  it("stamps x-forwarded-prefix matching the stripped mount prefix (single source of truth)", async () => {
+    await call(
+      "https://tunnel.local:9090",
+      "tunnel",
+      "https://localhost:5200/api/tunnel/v1/webhook/abc?foo=1",
+    );
+    const target = fetchMock.mock.calls[0]?.[0] as URL;
+    expect(target.toString()).toBe("https://tunnel.local:9090/v1/webhook/abc?foo=1");
+    const headers = (fetchMock.mock.calls[0]?.[1] as RequestInit).headers as Headers;
+    expect(headers.get("x-forwarded-prefix")).toBe("/api/tunnel");
   });
 });

--- a/tools/agent-playground/src/lib/server/proxy.ts
+++ b/tools/agent-playground/src/lib/server/proxy.ts
@@ -255,17 +255,26 @@ export function buildProxyHandler({ upstream, label }: BuildProxyOptions): Reque
   };
 }
 
-/** Build a Hono handler that reverse-proxies requests matching `prefix` to
- * the upstream service. Used by the compiled `playground` binary
- * (`static-server.ts`) where the SvelteKit dev server is unavailable and
- * Hono mounts the `/api/{daemon,tunnel}/*` routes directly. Lives here
- * (next to `buildProxyHandler` + `executeProxyFetch`) so both runtimes
- * share the same OAuth-critical semantics and can be exercised by a
- * single Node-compatible test suite. */
-export function buildHonoProxy(prefix: string, upstream: string, label: string) {
+/** Build a Hono handler that reverse-proxies requests mounted at
+ * `/api/${label}/*` to the upstream service. Used by the compiled
+ * `playground` binary (`static-app.ts`) where the SvelteKit dev server is
+ * unavailable and Hono mounts the `/api/{daemon,tunnel}/*` routes directly.
+ * Lives here (next to `buildProxyHandler` + `executeProxyFetch`) so both
+ * runtimes share the same OAuth-critical semantics and can be exercised by
+ * a single Node-compatible test suite.
+ *
+ * The mount prefix is derived from `label` (`/api/${label}`) — the same
+ * value `executeProxyFetch` stamps into `x-forwarded-prefix`. Keeping one
+ * source of truth prevents the two from silently diverging (mount stripped
+ * `/foo` while the upstream received `x-forwarded-prefix: /api/daemon`
+ * would surface as wrong external URLs downstream, e.g. OAuth callbacks). */
+export function buildHonoProxy(upstream: string, label: string) {
+  const prefix = `/api/${label}`;
   return (c: { req: { url: string; raw: Request } }) => {
     const url = new URL(c.req.url);
-    const path = url.pathname.replace(new RegExp(`^${prefix}`), "");
+    const path = url.pathname.startsWith(prefix)
+      ? url.pathname.slice(prefix.length)
+      : url.pathname;
     const target = new URL(path + url.search, upstream);
     return executeProxyFetch(target, c.req.raw, label);
   };

--- a/tools/agent-playground/src/lib/server/static-app.ts
+++ b/tools/agent-playground/src/lib/server/static-app.ts
@@ -18,8 +18,8 @@ export interface BuildStaticAppOptions {
  */
 export function buildStaticApp(options: BuildStaticAppOptions): Hono {
   const proxies = new Hono()
-    .all("/api/daemon/*", buildHonoProxy("/api/daemon", options.daemonUrl, "daemon"))
-    .all("/api/tunnel/*", buildHonoProxy("/api/tunnel", options.tunnelUrl, "tunnel"));
+    .all("/api/daemon/*", buildHonoProxy(options.daemonUrl, "daemon"))
+    .all("/api/tunnel/*", buildHonoProxy(options.tunnelUrl, "tunnel"));
 
   const app = new Hono()
     .route("/", proxies)


### PR DESCRIPTION
## Summary

`buildHonoProxy(prefix, upstream, label)` took both `prefix` and `label` where, by construction at both call sites, `prefix === \"/api/\" + label`:

```ts
.all(\"/api/daemon/*\", buildHonoProxy(\"/api/daemon\", DAEMON_URL, \"daemon\"))
.all(\"/api/tunnel/*\", buildHonoProxy(\"/api/tunnel\", TUNNEL_URL, \"tunnel\"))
```

The invariant was implicit and unenforced. A mismatched mount (e.g. `buildHonoProxy(\"/foo\", url, \"daemon\")`) would silently strip `/foo` from the request path while still stamping `x-forwarded-prefix: /api/daemon` on the upstream — surfacing downstream as wrong external URLs (OAuth callbacks, etc.) with nothing failing loudly at the mount point.

Drop the `prefix` parameter; derive it inside the function as `/api/\${label}`. Single source of truth, invariant enforced by construction.

Also swap `replace(new RegExp(prefix), \"\")` for a literal `startsWith + slice` so the prefix can't be reinterpreted as a regex pattern (no exploit today with hardcoded labels, but the regex shape is a general footgun).

Closes #316.

## Scope

- `tools/agent-playground/src/lib/server/proxy.ts` — signature change + regex → literal swap
- `tools/agent-playground/src/lib/server/static-app.ts` — both call sites updated
- `tools/agent-playground/src/lib/server/proxy.hono.test.ts` — existing 2 tests updated for new signature; added a third tunnel-label case that pins the x-forwarded-prefix / stripped-path single-source-of-truth property

## Risks

- **Behavioral:** none under the only two call sites — both used the `/api/\${label}` invariant already, so the derived prefix produces the identical strip + forward header.
- **Signature break:** internal API only, no external consumers. The function is exported from one file and called from one other (and tests). \`grep -rn buildHonoProxy\` confirms.
- **Regex → startsWith:** identical behavior on the production inputs (\"/api/daemon\", \"/api/tunnel\"). Strictly safer because metacharacters in the prefix can no longer alter matching.
- **Coordination:** PR #293 is renaming \`tools/agent-playground\` → \`apps/studio-ui\`. Either order works — whichever lands first, the other rebases trivially (three small file edits, no semantic conflict).

## Test plan

- [x] \`npx vitest run src/lib/server/proxy.hono.test.ts\` — 3/3 pass (existing 2 + new tunnel-label case)
- [x] \`npx vitest run src/lib/server/\` — 79 pass / 1 pre-existing unrelated flake in \`mcp.test.ts\` (Deno.openKv unavailable in vitest env, untouched by this diff)
- [x] \`deno check\` clean on proxy.ts + static-app.ts