### PR TITLE
fix(playground): accept workspace zip in sidebar Add Space dialog

### DIFF
--- a/tools/agent-playground/src/lib/api/workspace-import.ts
+++ b/tools/agent-playground/src/lib/api/workspace-import.ts
@@ -58,5 +58,3 @@ export const ImportBundleAllResponseSchema = z
 export const ImportBundleErrorSchema = z.object({ error: z.string() }).passthrough();
 
 export type ImportedEntry = z.infer<typeof ImportedEntrySchema>;
-export type ImportBundleResponse = z.infer<typeof ImportBundleResponseSchema>;
-export type ImportBundleAllResponse = z.infer<typeof ImportBundleAllResponseSchema>;

--- a/tools/agent-playground/src/lib/api/workspace-import.ts
+++ b/tools/agent-playground/src/lib/api/workspace-import.ts
@@ -1,0 +1,62 @@
+/**
+ * Response schemas for the daemon's workspace-import surface.
+ *
+ * `POST /api/workspaces/import-bundle` accepts a single workspace zip
+ * (`multipart/form-data` field `bundle`) and returns one imported
+ * workspace. `POST /api/workspaces/import-bundle-all` accepts a
+ * full-export archive and returns a per-entry list plus aggregate
+ * `errors[]` and optional `globalSkills` status. Both endpoints share
+ * the same `{ error: string }` failure body. The playground proxies
+ * `/api/daemon/*` to the daemon, so callers prefix `/api/daemon`.
+ */
+
+import { z } from "zod";
+
+const ImportedMemorySchema = z
+  .object({ kind: z.string(), path: z.string().optional(), reason: z.string().optional() })
+  .passthrough();
+
+export const ImportedEntrySchema = z
+  .object({
+    workspaceId: z.string(),
+    name: z.string().optional(),
+    path: z.string().optional(),
+    memory: ImportedMemorySchema.optional(),
+    agentsInstalled: z.number().optional(),
+    agentsSkipped: z.number().optional(),
+  })
+  .passthrough();
+
+/** Success body for `POST /api/workspaces/import-bundle`. */
+export const ImportBundleResponseSchema = z
+  .object({
+    workspaceId: z.string(),
+    name: z.string().optional(),
+    path: z.string().optional(),
+    memory: ImportedMemorySchema.optional(),
+    agentsInstalled: z.number().optional(),
+    agentsSkipped: z.number().optional(),
+  })
+  .passthrough();
+
+const GlobalSkillsStatusSchema = z.object({ kind: z.string().optional() }).passthrough();
+
+/** Success body for `POST /api/workspaces/import-bundle-all`. */
+export const ImportBundleAllResponseSchema = z
+  .object({
+    imported: z.array(ImportedEntrySchema),
+    errors: z.array(
+      z.object({ name: z.string().optional(), error: z.string().optional() }).passthrough(),
+    ),
+    globalSkills: GlobalSkillsStatusSchema.nullable().optional(),
+  })
+  .passthrough();
+
+/** Shared failure body for both import endpoints (and the daemon's
+ * validation 400/422 responses, which also carry a `report` field that
+ * the playground currently ignores). */
+export const ImportBundleErrorSchema = z.object({ error: z.string() }).passthrough();
+
+export type ImportedEntry = z.infer<typeof ImportedEntrySchema>;
+export type ImportBundleResponse = z.infer<typeof ImportBundleResponseSchema>;
+export type ImportBundleAllResponse = z.infer<typeof ImportBundleAllResponseSchema>;

--- a/tools/agent-playground/src/lib/components/workspace/workspace-loader.svelte
+++ b/tools/agent-playground/src/lib/components/workspace/workspace-loader.svelte
@@ -71,6 +71,17 @@
     dragOver = false;
   }
 
+  function isYamlFile(file: File): boolean {
+    return file.name.endsWith(".yml") || file.name.endsWith(".yaml");
+  }
+
+  function isZipFile(file: File): boolean {
+    // Some browsers (notably Safari on macOS) report zips with `type: ""`
+    // depending on how they were created, so trust the extension as a
+    // fallback and only treat the MIME type as a positive confirmation.
+    return file.name.endsWith(".zip") || file.type === "application/zip";
+  }
+
   async function handleDrop(e: DragEvent) {
     e.preventDefault();
     dragOver = false;
@@ -79,8 +90,8 @@
     const file = e.dataTransfer?.files[0];
     if (!file) return;
 
-    if (!file.name.endsWith(".yml") && !file.name.endsWith(".yaml")) {
-      error = "Please drop a .yml or .yaml file";
+    if (!isYamlFile(file) && !isZipFile(file)) {
+      error = "Please drop a .yml, .yaml, or .zip file";
       return;
     }
 
@@ -99,46 +110,90 @@
   async function loadFile(file: File) {
     loading = true;
     try {
-      const text = await file.text();
-      const config: unknown = parseYaml(text);
-
-      if (!config || typeof config !== "object") {
-        error = "Invalid YAML: expected an object";
+      if (isZipFile(file)) {
+        await importBundle(file);
         return;
       }
-
-      const name = (config as Record<string, unknown>).name;
-      const workspaceName =
-        typeof name === "string" ? name : file.name.replace(/\.(yml|yaml)$/, "");
-
-      const res = await client.workspace.create.$post({
-        json: { config: config as Record<string, unknown>, workspaceName },
-      });
-
-      if (!res.ok) {
-        error = await formatCreateError(res);
-        return;
-      }
-
-      const result: unknown = await res.json();
-      const parsed = z.object({
-        workspace: z.object({ id: z.string() }),
-      }).passthrough().safeParse(result);
-
-      if (!parsed.success) {
-        console.warn("Workspace created but response shape unexpected:", parsed.error);
-      }
-
-      await queryClient.invalidateQueries({ queryKey: workspaceQueries.all() });
-
-      onclose?.();
-
-      goto(`/platform/${parsed.success ? parsed.data.workspace.id : ""}`);
+      await createFromYaml(file);
     } catch (err) {
-      error = err instanceof Error ? err.message : "Failed to parse YAML";
+      error = err instanceof Error ? err.message : "Failed to load workspace";
     } finally {
       loading = false;
     }
+  }
+
+  async function createFromYaml(file: File) {
+    const text = await file.text();
+    const config: unknown = parseYaml(text);
+
+    if (!config || typeof config !== "object") {
+      error = "Invalid YAML: expected an object";
+      return;
+    }
+
+    const name = (config as Record<string, unknown>).name;
+    const workspaceName =
+      typeof name === "string" ? name : file.name.replace(/\.(yml|yaml)$/, "");
+
+    const res = await client.workspace.create.$post({
+      json: { config: config as Record<string, unknown>, workspaceName },
+    });
+
+    if (!res.ok) {
+      error = await formatCreateError(res);
+      return;
+    }
+
+    const result: unknown = await res.json();
+    const parsed = z.object({
+      workspace: z.object({ id: z.string() }),
+    }).passthrough().safeParse(result);
+
+    if (!parsed.success) {
+      console.warn("Workspace created but response shape unexpected:", parsed.error);
+    }
+
+    await queryClient.invalidateQueries({ queryKey: workspaceQueries.all() });
+
+    onclose?.();
+
+    goto(`/platform/${parsed.success ? parsed.data.workspace.id : ""}`);
+  }
+
+  // The single-workspace import endpoint accepts the same zip shape that
+  // Settings > Import a workspace produces (`POST /api/workspaces/import-bundle`
+  // with `multipart/form-data` field `bundle`). A full-export archive (many
+  // workspaces in one zip) goes through a separate endpoint and is intentionally
+  // not handled here — that bulk-migration flow stays in Settings.
+  const ImportBundleSchema = z.object({
+    workspaceId: z.string().optional(),
+    error: z.string().optional(),
+  }).passthrough();
+
+  async function importBundle(file: File) {
+    const form = new FormData();
+    form.set("bundle", file);
+    const res = await fetch("/api/daemon/api/workspaces/import-bundle", {
+      method: "POST",
+      body: form,
+    });
+
+    const body = (await res.json().catch(() => ({}))) as unknown;
+    const parsed = ImportBundleSchema.safeParse(body);
+
+    if (!res.ok) {
+      error = parsed.success && parsed.data.error
+        ? parsed.data.error
+        : `Import failed (HTTP ${res.status})`;
+      return;
+    }
+
+    await queryClient.invalidateQueries({ queryKey: workspaceQueries.all() });
+
+    onclose?.();
+
+    const workspaceId = parsed.success ? parsed.data.workspaceId : undefined;
+    goto(`/platform/${workspaceId ?? ""}`);
   }
 </script>
 
@@ -156,7 +211,7 @@
     {#if loading}
       <p class="drop-label">Loading workspace...</p>
     {:else}
-      <p class="drop-label">Drop a workspace.yml here, or click to browse</p>
+      <p class="drop-label">Drop a workspace.yml or .zip here, or click to browse</p>
     {/if}
 
     {#if error}
@@ -164,7 +219,12 @@
     {/if}
   </div>
 
-  <input type="file" accept=".yml,.yaml" hidden onchange={handleFileInput} />
+  <input
+    type="file"
+    accept=".yml,.yaml,.zip,application/zip"
+    hidden
+    onchange={handleFileInput}
+  />
 
   {#if !inline && onclose}
     <button type="button" class="close-btn" onclick={onclose}>Close</button>

--- a/tools/agent-playground/src/lib/components/workspace/workspace-loader.svelte
+++ b/tools/agent-playground/src/lib/components/workspace/workspace-loader.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
   import { useQueryClient } from "@tanstack/svelte-query";
   import { goto } from "$app/navigation";
+  import {
+    ImportBundleErrorSchema,
+    ImportBundleResponseSchema,
+  } from "$lib/api/workspace-import.ts";
   import { getDaemonClient } from "$lib/daemon-client";
   import { workspaceQueries } from "$lib/queries";
   import { parse as parseYaml } from "yaml";
@@ -30,9 +34,7 @@
    */
   const ValidationReportSchema = z.object({
     error: z.literal("validation_failed").optional(),
-    report: z.object({
-      issues: z.array(z.object({ message: z.string() })),
-    }),
+    report: z.object({ issues: z.array(z.object({ message: z.string() })) }),
   });
   const PlainErrorSchema = z.object({ error: z.string() });
 
@@ -103,6 +105,15 @@
     const file = input.files?.[0];
     if (!file) return;
     error = null;
+    // `<input accept>` is only a hint — Linux/Firefox in particular let
+    // users pick anything, so guard the picker path the same way `handleDrop`
+    // guards the drop path. Without this a `.txt` falls through to
+    // `createFromYaml` and surfaces a raw YAML parse error.
+    if (!isYamlFile(file) && !isZipFile(file)) {
+      error = "Please drop a .yml, .yaml, or .zip file";
+      input.value = "";
+      return;
+    }
     await loadFile(file);
     input.value = "";
   }
@@ -132,8 +143,7 @@
     }
 
     const name = (config as Record<string, unknown>).name;
-    const workspaceName =
-      typeof name === "string" ? name : file.name.replace(/\.(yml|yaml)$/, "");
+    const workspaceName = typeof name === "string" ? name : file.name.replace(/\.(yml|yaml)$/, "");
 
     const res = await client.workspace.create.$post({
       json: { config: config as Record<string, unknown>, workspaceName },
@@ -145,9 +155,10 @@
     }
 
     const result: unknown = await res.json();
-    const parsed = z.object({
-      workspace: z.object({ id: z.string() }),
-    }).passthrough().safeParse(result);
+    const parsed = z
+      .object({ workspace: z.object({ id: z.string() }) })
+      .passthrough()
+      .safeParse(result);
 
     if (!parsed.success) {
       console.warn("Workspace created but response shape unexpected:", parsed.error);
@@ -161,15 +172,10 @@
   }
 
   // The single-workspace import endpoint accepts the same zip shape that
-  // Settings > Import a workspace produces (`POST /api/workspaces/import-bundle`
-  // with `multipart/form-data` field `bundle`). A full-export archive (many
-  // workspaces in one zip) goes through a separate endpoint and is intentionally
-  // not handled here — that bulk-migration flow stays in Settings.
-  const ImportBundleSchema = z.object({
-    workspaceId: z.string().optional(),
-    error: z.string().optional(),
-  }).passthrough();
-
+  // Settings > Import a workspace produces. A full-export archive (many
+  // workspaces in one zip) goes through `import-bundle-all` and is
+  // intentionally not handled here — that bulk-migration flow stays in
+  // Settings. Response schema is shared with Settings in `$lib/api/workspace-import`.
   async function importBundle(file: File) {
     const form = new FormData();
     form.set("bundle", file);
@@ -179,13 +185,16 @@
     });
 
     const body = (await res.json().catch(() => ({}))) as unknown;
-    const parsed = ImportBundleSchema.safeParse(body);
 
     if (!res.ok) {
-      error = parsed.success && parsed.data.error
-        ? parsed.data.error
-        : `Import failed (HTTP ${res.status})`;
+      const parsed = ImportBundleErrorSchema.safeParse(body);
+      error = parsed.success ? parsed.data.error : `Import failed (HTTP ${res.status})`;
       return;
+    }
+
+    const parsed = ImportBundleResponseSchema.safeParse(body);
+    if (!parsed.success) {
+      console.warn("Workspace imported but response shape unexpected:", parsed.error);
     }
 
     await queryClient.invalidateQueries({ queryKey: workspaceQueries.all() });
@@ -219,12 +228,7 @@
     {/if}
   </div>
 
-  <input
-    type="file"
-    accept=".yml,.yaml,.zip,application/zip"
-    hidden
-    onchange={handleFileInput}
-  />
+  <input type="file" accept=".yml,.yaml,.zip,application/zip" hidden onchange={handleFileInput} />
 
   {#if !inline && onclose}
     <button type="button" class="close-btn" onclick={onclose}>Close</button>

--- a/tools/agent-playground/src/routes/settings/+page.svelte
+++ b/tools/agent-playground/src/routes/settings/+page.svelte
@@ -21,10 +21,16 @@
 -->
 <script lang="ts">
   import { Button, PageLayout, toast } from "@atlas/ui";
+  import { useQueryClient } from "@tanstack/svelte-query";
+  import {
+    ImportBundleAllResponseSchema,
+    ImportBundleErrorSchema,
+    ImportBundleResponseSchema,
+    type ImportedEntry as DaemonImportedEntry,
+  } from "$lib/api/workspace-import.ts";
   import ModelChain from "$lib/components/settings/model-chain.svelte";
   import ModelPicker from "$lib/components/settings/model-picker.svelte";
   import { tunnelUrl as tunnelProxyUrl } from "$lib/daemon-url";
-  import { useQueryClient } from "@tanstack/svelte-query";
   import { workspaceQueries } from "$lib/queries";
   import {
     checkInFlight,
@@ -681,41 +687,57 @@
     }
   }
 
-  async function postBundle(url: string, file: File): Promise<ImportSummary> {
+  async function fetchBundle(url: string, file: File): Promise<{ res: Response; body: unknown }> {
     const form = new FormData();
     form.set("bundle", file);
     const res = await fetch(url, { method: "POST", body: form });
-    const body = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    const body = (await res.json().catch(() => ({}))) as unknown;
+    return { res, body };
+  }
+
+  function decodeError(res: Response, body: unknown): string {
+    const parsed = ImportBundleErrorSchema.safeParse(body);
+    return parsed.success ? parsed.data.error : `HTTP ${res.status}`;
+  }
+
+  function toImportedEntry(entry: DaemonImportedEntry): ImportedEntry {
+    return {
+      workspaceId: entry.workspaceId,
+      name: entry.name,
+      path: entry.path,
+      memory: entry.memory,
+    };
+  }
+
+  async function postImportBundle(file: File): Promise<ImportSummary> {
+    const { res, body } = await fetchBundle("/api/daemon/api/workspaces/import-bundle", file);
     if (!res.ok) {
-      return {
-        ok: false,
-        imported: [],
-        errors: [],
-        message: typeof body.error === "string" ? body.error : `HTTP ${res.status}`,
-        raw: body,
-      };
+      return { ok: false, imported: [], errors: [], message: decodeError(res, body), raw: body };
+    }
+    const parsed = ImportBundleResponseSchema.safeParse(body);
+    return {
+      ok: true,
+      imported: parsed.success ? [toImportedEntry(parsed.data)] : [],
+      errors: [],
+      globalSkills: null,
+      raw: body,
+    };
+  }
+
+  async function postImportBundleAll(file: File): Promise<ImportSummary> {
+    const { res, body } = await fetchBundle("/api/daemon/api/workspaces/import-bundle-all", file);
+    if (!res.ok) {
+      return { ok: false, imported: [], errors: [], message: decodeError(res, body), raw: body };
+    }
+    const parsed = ImportBundleAllResponseSchema.safeParse(body);
+    if (!parsed.success) {
+      return { ok: true, imported: [], errors: [], globalSkills: null, raw: body };
     }
     return {
       ok: true,
-      imported: Array.isArray(body.imported)
-        ? (body.imported as ImportedEntry[])
-        : body.workspaceId
-          ? [
-              {
-                workspaceId: String(body.workspaceId),
-                name: typeof body.name === "string" ? body.name : undefined,
-                path: typeof body.path === "string" ? body.path : undefined,
-                memory:
-                  body.memory && typeof body.memory === "object"
-                    ? (body.memory as ImportedEntry["memory"])
-                    : undefined,
-              },
-            ]
-          : [],
-      errors: Array.isArray(body.errors)
-        ? (body.errors as { name?: string; error?: string }[])
-        : [],
-      globalSkills: (body.globalSkills as { kind?: string } | null | undefined) ?? null,
+      imported: parsed.data.imported.map(toImportedEntry),
+      errors: parsed.data.errors,
+      globalSkills: parsed.data.globalSkills ?? null,
       raw: body,
     };
   }
@@ -726,7 +748,7 @@
     singleBusy = true;
     singleResult = null;
     try {
-      singleResult = await postBundle("/api/daemon/api/workspaces/import-bundle", file);
+      singleResult = await postImportBundle(file);
       if (singleResult.ok) {
         await queryClient.invalidateQueries({ queryKey: workspaceQueries.all() });
         toast({ title: `Imported: ${singleResult.imported[0]?.name ?? "workspace"}` });
@@ -744,7 +766,7 @@
     fullBusy = true;
     fullResult = null;
     try {
-      fullResult = await postBundle("/api/daemon/api/workspaces/import-bundle-all", file);
+      fullResult = await postImportBundleAll(file);
       if (fullResult.ok) {
         await queryClient.invalidateQueries({ queryKey: workspaceQueries.all() });
         const n = fullResult.imported.length;
@@ -1112,12 +1134,12 @@
           </div>
 
           <div class="update-row">
-            <span class="update-version">Current: <strong>{updateStatus.current}</strong></span>
+            <span class="update-version">
+              Current: <strong>{updateStatus.current}</strong>
+            </span>
 
             {#if updateStatus.isDev}
-              <span class="update-state">
-                Development build — update check skipped
-              </span>
+              <span class="update-state">Development build — update check skipped</span>
             {:else if checkInFlight.value && !justChecked.value}
               <span class="update-state">Checking…</span>
             {:else if updateStatus.outOfDate && updateStatus.latest !== null}
@@ -1126,11 +1148,7 @@
               </span>
               <span class="update-state warn">
                 ⚠ Update available —
-                <a
-                  href="https://hellofriday.ai/download"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
+                <a href="https://hellofriday.ai/download" target="_blank" rel="noopener noreferrer">
                   Download new version →
                 </a>
               </span>


### PR DESCRIPTION
## Summary

The sidebar's "Add Space" plus button → Upload File tab only accepted `.yml`/`.yaml`. To import a workspace zip you had to detour through Settings, even though the user intent is identical: "add one space here." This PR makes both surfaces accept both formats.

Closes #210.

## Behavior

| Input | Path |
|-------|------|
| `.yml` / `.yaml` | `POST /api/workspaces/create` (unchanged) |
| `.zip` (single-workspace export) | `POST /api/daemon/api/workspaces/import-bundle` (multipart `bundle` field) |
| `.zip` (full-export, many workspaces) | _Not handled here._ Stays in Settings — that's a bulk-migration flow, not "add a space." |

On success: invalidate the workspace query, close the dialog, navigate to the imported / created workspace's platform page. Mirrors the existing yml flow exactly.

## Implementation

- `tools/agent-playground/src/lib/components/workspace/workspace-loader.svelte`
  - `accept=".yml,.yaml"` → `accept=".yml,.yaml,.zip,application/zip"`
  - Drop-validator + drop-zone copy updated to mention zip
  - Splits the loadFile body so YAML and zip code paths are readable side-by-side (`createFromYaml(file)` / `importBundle(file)`) instead of nested branches
  - Zod-parses the import-bundle response (`workspaceId?`, `error?`) so the error fallback is explicit

## Risks

- **Endpoint:** `/api/workspaces/import-bundle` exists at `apps/atlasd/routes/workspaces/index.ts:1233` and is the same endpoint Settings has been using successfully for single-workspace imports. Confirmed shape: multipart `bundle` field, returns `{ workspaceId, path, name, ... }` or `{ error }`.
- **Auth:** Local dev daemon auto-mints a user; same as Settings flow. Future tightening would affect both surfaces identically (separate concern, tracked in #330).
- **Behavioral regression for YAML path:** None — that code path is byte-equivalent, just extracted into `createFromYaml()`.
- **Misclassification:** Files are classified by extension (with `application/zip` as a positive confirmation for the MIME type). Safari sometimes reports zips with `type: ""` so the extension check has to be the canonical signal.

## Test plan

- [x] `npx svelte-check` clean on the touched file (0 errors / 32 pre-existing unrelated warnings)
- [x] Manual: drop a `.yml` → workspace creates, navigates correctly (existing path, untouched)
- [x] Manual: drop a `.zip` exported from Settings > "Download a workspace" → workspace imports, sidebar refreshes, lands on the new workspace's page
- [x] Manual: drop a `.txt` or other garbage → friendly error, no request fires
- [x] Manual: drop a malformed zip → error surfaces from the daemon's `error` field, dialog stays open