### PR TITLE
revert: remove SEO meta tags and text changes from desktop app shell

### DIFF
--- a/tools/agent-playground/src/routes/+layout.svelte
+++ b/tools/agent-playground/src/routes/+layout.svelte
@@ -83,7 +83,7 @@
 
   /**
    * Bare `/` opens chat mode. Cmd/Ctrl+/ opens switcher mode.
-   * Bare `/` is suppressed while typing in inputs/textareas/contentEditables;
+   * Bare `/` is suppressed while typing in inputs/textareas/contenteditables;
    * the modified form is allowed to fire from anywhere.
    */
   function handleGlobalKeydown(e: KeyboardEvent) {
@@ -116,52 +116,7 @@
 <svelte:window onkeydown={handleGlobalKeydown} />
 
 <svelte:head>
-  <title>Friday \u2014 The complete agent harness platform</title>
-  <meta name="description" content="Friday is an agent harness platform that runs on your machine. Memory, tools, scheduling, and orchestration built in. Describe what you want in plain language and get a production-grade agent workflow in minutes." />
-
-  <!-- Open Graph -->
-  <meta property="og:title" content="Friday \u2014 The complete agent harness platform" />
-  <meta property="og:description" content="Friday is an agent harness platform that runs on your machine. Memory, tools, scheduling, and orchestration built in. Describe what you want in plain language and get a production-grade agent workflow in minutes." />
-  <meta property="og:type" content="website" />
-
-  <!-- Twitter Card -->
-  <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Friday \u2014 The complete agent harness platform" />
-  <meta name="twitter:description" content="Friday is an agent harness platform that runs on your machine. Memory, tools, scheduling, and orchestration built in. Describe what you want in plain language and get a production-grade agent workflow in minutes." />
-
-  <!-- JSON-LD Structured Data -->
-  {@html `<script type="application/ld+json">${JSON.stringify({
-    "@context": "https://schema.org",
-    "@graph": [
-      {
-        "@type": "SoftwareApplication",
-        "name": "Friday",
-        "applicationCategory": "DeveloperApplication",
-        "operatingSystem": "macOS, Windows, Linux",
-        "description": "Friday is an agent harness platform. Memory, MCP tool integrations, scheduling, and FSM-backed orchestration built in. Describe your workflow in plain language and get a production-grade agent running in minutes.",
-        "url": "https://hellofriday.ai",
-        "offers": {
-          "@type": "Offer",
-          "price": "0",
-          "priceCurrency": "USD"
-        }
-      },
-      {
-        "@type": "FAQPage",
-        "mainEntity": [
-          {
-            "@type": "Question",
-            "name": "What is Friday?",
-            "acceptedAnswer": {
-              "@type": "Answer",
-              "text": "Friday is an agent harness platform. It wraps your language model with memory, tools, scheduling, and orchestration so you get a complete, reliable agent, not just a prompt. Describe what you want in plain language and Friday builds a workflow that runs on schedule, every time."
-            }
-          }
-        ]
-      }
-    ]
-  })}<\/script>`}
-
+  <title>Friday Studio</title>
   {#if !isChromeless}
     <!--
       The chromeless export-preview omits the favicon link entirely; the

--- a/tools/agent-playground/src/routes/platform/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/+page.svelte
@@ -20,31 +20,31 @@
   {:else if visibleWorkspaces.length === 0}
     <div class="empty-content">
       <pre class="ascii-logo">{`
-                     .=*%@@%*=.
-                        .=*%@@@@@@@@@@%*=.
-                         .=*%@@@@@@@@@@@@@@@*:
-                        .%@@@@@@@@@@@@@@@@@@%:
-                       =%@@@@@@@@@@@@@@@@@@%:
-                      :%@@@@@@@@@@@@@@@@@@%:
-                     +@@@@@@@@@@@@@@@@@@%*.
-                    +@@@@@@@@@@@@@@@@%*:
-                 +@@@@@@@@@@@@@@@%*:
-              +@@@@@@@@@@@@@@%*:
-          .*@@@@@@@@@@@@*=.
+                   .=*%@@%*=.
+                    .=%@@@@@@@@@@%*=.
+                     .=%@@@@@@@@@@@@@@@*:
+                    .%@@@@@@@@@@@@@@@@@@%:
+                    =%@@@@@@@@@@@@@@@@@@@%:
+                   :%@@@@@@@@@@@@@@@@@@@@%:
+                   +@@@@@@@@@@@@@@@@@@@@%*.
+                  +@@@@@@@@@@@@@@@@@@@%*:
+                +@@@@@@@@@@@@@@@@@%*:
+              +@@@@@@@@@@@@@@@%*:
+            .*@@@@@@@@@@@@*=.
 
-      .=*%@@@@@@@@%*=.
- .=*%@@@@@@@@@@@@@:
-.%@@@@@@@@@@@@@@@@@:
-=%@@@@@@@@@@@@@@@@:
-.=%@@@@@@@@@@@@@@@@:
- .=%@@@@@@@@@@@@@@@:
- .*@@@@@@@@@@@@@@*.
-   .=%@@@@@%*=.
-  .=+*+=.`}</pre>
-      <h2 class="empty-title">Friday \u2014 The complete agent harness platform</h2>
+        .=*@@@@@@@%*.
+   .=%@@@@@@@@@@@@:
+  .%@@@@@@@@@@@@@@:
+  =%@@@@@@@@@@@@@@:
+ .=%@@@@@@@@@@@@@@:
+  .=%@@@@@@@@@@@@@:
+  .*@@@@@@@@@@@@*.
+    .=%@@@@@@%*=.
+   .=+*+=.`}</pre>
+      <h2 class="empty-title">Friday Agent Studio & Toolkit</h2>
       <p class="empty-description">
-        Memory, tools, scheduling, and orchestration built in. Describe what you
-        want in plain language and get a production-grade agent workflow in minutes.
+        Orchestrate agentic workflows from a single config file. Versionable,
+        shareable, repeatable. Drop a workspace.yml to get started.
         <a
           class="learn-more"
           href="https://docs.hellofriday.ai/core-concepts/spaces"


### PR DESCRIPTION
## What

Reverts the changes from PR #376 that incorrectly modified the desktop app shell.

### Why

PR #376 was scoped to SEO metadata on the hellofriday.ai marketing site. It accidentally also modified two files in the desktop app (`tools/agent-playground`), causing:
- The browser tab to show `Friday \u2014 The complete agent harness platform` with a Unicode-escaped em dash instead of the expected app title
- The empty-state screen to show updated marketing copy instead of the original `Friday Agent Studio & Toolkit` heading

### Files reverted

**`tools/agent-playground/src/routes/+layout.svelte`**
- Removes injected `<title>`, `<meta name="description">`, OG tags, Twitter card tags, and JSON-LD block from `<svelte:head>`
- Restores file to its exact pre-PR state

**`tools/agent-playground/src/routes/platform/+page.svelte`**
- Restores `<h2>` to `Friday Agent Studio & Toolkit`
- Restores description paragraph to original copy

### What is NOT reverted

The SEO changes to the hellofriday.ai marketing site (PR #18 on the `hellofriday.ai` repo) are correct and untouched.