### PR TITLE
fix(studio-release): disable gh pager in publish output

### DIFF
--- a/scripts/studio-release.sh
+++ b/scripts/studio-release.sh
@@ -205,7 +205,7 @@ cmd_publish() {
   fi
 
   echo "→ Run $run_id:"
-  gh run view "$run_id" --json displayTitle,headBranch,createdAt,status,conclusion \
+  GH_PAGER=cat gh run view "$run_id" --json displayTitle,headBranch,createdAt,status,conclusion \
     --template '  Title  : {{ .displayTitle }}
   Branch : {{ .headBranch }}
   When   : {{ .createdAt }}


### PR DESCRIPTION
## Summary
- `./scripts/studio-release.sh publish installer` was stalling on a `less` `(END)` prompt mid-flow, requiring `q` to continue.
- Root cause: `gh run view` pipes through `$PAGER` when stdout is a TTY.
- Fix: prefix that single call with `GH_PAGER=cat` so the run summary streams straight through.

## Test plan
- [ ] Run `./scripts/studio-release.sh publish installer` and confirm it flows from "→ Run …" straight into "→ Deriving version from artifacts…" without a pager prompt.