### PR TITLE
fix(mcp): skip doctor for curated providers; surface real enable errors

### DIFF
--- a/apps/atlasd/routes/mcp-registry.test.ts
+++ b/apps/atlasd/routes/mcp-registry.test.ts
@@ -663,6 +663,38 @@ describe("MCP Registry Routes", () => {
       fetchSpy.mockRestore();
     });
 
+    // A curated annotation with `providerId` means the curators have already
+    // routed credentials to an existing Link provider — the configTemplate is
+    // fully specified and the doctor has nothing to analyze. Without this case
+    // in the skip predicate, Notion/Linear/Atlassian/PostHog land in
+    // `setting_up`, the doctor returns `unknown` (no envs to enumerate from
+    // a bare HTTP remote), and enable_mcp_server then 409s on `needs_manual_config`.
+    it.each([
+      "com.notion/mcp",
+      "app.linear/linear",
+      "com.atlassian/atlassian-mcp-server",
+      "io.github.PostHog/mcp",
+    ])("fast path: annotated HTTP-remote %s → 201 ready, no doctor", async (canonicalName) => {
+      mockFetchLatest.mockResolvedValue(createHttpRemoteUpstreamEntry(canonicalName, "1.0.0"));
+      const fetchSpy = vi
+        .spyOn(globalThis, "fetch")
+        .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 201 }));
+
+      const res = await installApp().request("/install/preflight", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ registryName: canonicalName }),
+      });
+
+      expect(res.status).toBe(201);
+      const body = PreflightReadySchema.parse(await res.json());
+      expect((await testAdapter.get(body.server_id))?.status).toBe("ready");
+      expect(mockRunDoctor).not.toHaveBeenCalled();
+      // Annotation suppresses dynamic Link provider synthesis — no Link call.
+      expect(fetchSpy).not.toHaveBeenCalled();
+      fetchSpy.mockRestore();
+    });
+
     it("fast path: surfaces a warning when Link provider creation fails", async () => {
       const canonicalName = "io.github.test/preflight-link-fail";
       mockFetchLatest.mockResolvedValue(createNpmStdioUpstreamEntryWithEnv(canonicalName, "1.0.0"));

--- a/apps/atlasd/routes/mcp-registry.ts
+++ b/apps/atlasd/routes/mcp-registry.ts
@@ -544,8 +544,7 @@ export const mcpRegistryRouter = daemonFactory
       upstreamEntry.server.packages?.some((p) => (p.environmentVariables?.length ?? 0) > 0) ??
       false;
     const hasCuratedProvider = Boolean(getAnnotation(upstreamEntry.server.name)?.providerId);
-    const needsDoctor =
-      !hasDeclaredEnvs && !translateResult.linkProvider && !hasCuratedProvider;
+    const needsDoctor = !hasDeclaredEnvs && !translateResult.linkProvider && !hasCuratedProvider;
 
     if (!needsDoctor) {
       // Fast path — no LLM call. Fetch the README synchronously, persist ready.

--- a/apps/atlasd/routes/mcp-registry.ts
+++ b/apps/atlasd/routes/mcp-registry.ts
@@ -533,15 +533,19 @@ export const mcpRegistryRouter = daemonFactory
       );
     }
 
-    // Fast path vs. doctor path. The doctor only runs for a *bare* entry — one
-    // where the registry declared no env vars and translation synthesized no
-    // Link provider either (e.g. an HTTP-remote OAuth server). When the
-    // registry told us what the server needs, or translation did, install
-    // finishes inline with no LLM call.
+    // Fast path vs. doctor path. The doctor only runs for a *bare* entry —
+    // one where we have no signal about what the server needs: the registry
+    // declared no env vars, translation synthesized no Link provider, and no
+    // curator annotation routes credentials to an existing Link provider.
+    // A curated `providerId` means the translator has already wired the
+    // configTemplate to an existing provider, so there is nothing left for the
+    // LLM to analyze.
     const hasDeclaredEnvs =
       upstreamEntry.server.packages?.some((p) => (p.environmentVariables?.length ?? 0) > 0) ??
       false;
-    const needsDoctor = !hasDeclaredEnvs && !translateResult.linkProvider;
+    const hasCuratedProvider = Boolean(getAnnotation(upstreamEntry.server.name)?.providerId);
+    const needsDoctor =
+      !hasDeclaredEnvs && !translateResult.linkProvider && !hasCuratedProvider;
 
     if (!needsDoctor) {
       // Fast path — no LLM call. Fetch the README synchronously, persist ready.

--- a/packages/system/agents/workspace-chat/tools/enable-mcp-server.test.ts
+++ b/packages/system/agents/workspace-chat/tools/enable-mcp-server.test.ts
@@ -104,6 +104,46 @@ describe("createEnableMcpServerTool", () => {
     expect(result).toEqual({ success: false, error: 'Server "github" not found in catalog.' });
   });
 
+  // The server-side handler at apps/atlasd/routes/workspaces/mcp.ts:282 returns
+  // `{ success: false, error: "needs_manual_config", serverId }` with NO `message`
+  // field. Reading only `errorBody.message` collapses it to the generic
+  // "Conflict enabling MCP server." string — exactly the misleading wording that
+  // sent Friday hunting for a credential-binding fix during the Notion incident.
+  it("returns server's structured error code on 409 when no message field", async () => {
+    setupMock("ws-1");
+    mockPut.mockResolvedValueOnce({
+      status: 409,
+      json: () =>
+        Promise.resolve({ success: false, error: "needs_manual_config", serverId: "com-notion-mcp" }),
+    });
+
+    const tools = createEnableMcpServerTool("ws-1", logger);
+    const result = await tools.enable_mcp_server!.execute!(
+      { serverId: "com-notion-mcp" },
+      TOOL_CALL_OPTS,
+    );
+
+    expect(result).toEqual({ success: false, error: "needs_manual_config" });
+  });
+
+  it("prefers server's message field on 409 when both are present", async () => {
+    setupMock("ws-1");
+    mockPut.mockResolvedValueOnce({
+      status: 409,
+      json: () =>
+        Promise.resolve({
+          success: false,
+          error: "conflict",
+          message: "Operation conflicts with existing entity",
+        }),
+    });
+
+    const tools = createEnableMcpServerTool("ws-1", logger);
+    const result = await tools.enable_mcp_server!.execute!({ serverId: "github" }, TOOL_CALL_OPTS);
+
+    expect(result).toEqual({ success: false, error: "Operation conflicts with existing entity" });
+  });
+
   it("returns error on 422 blueprint", async () => {
     setupMock("ws-1");
     mockPut.mockResolvedValueOnce({

--- a/packages/system/agents/workspace-chat/tools/enable-mcp-server.test.ts
+++ b/packages/system/agents/workspace-chat/tools/enable-mcp-server.test.ts
@@ -114,7 +114,11 @@ describe("createEnableMcpServerTool", () => {
     mockPut.mockResolvedValueOnce({
       status: 409,
       json: () =>
-        Promise.resolve({ success: false, error: "needs_manual_config", serverId: "com-notion-mcp" }),
+        Promise.resolve({
+          success: false,
+          error: "needs_manual_config",
+          serverId: "com-notion-mcp",
+        }),
     });
 
     const tools = createEnableMcpServerTool("ws-1", logger);

--- a/packages/system/agents/workspace-chat/tools/enable-mcp-server.test.ts
+++ b/packages/system/agents/workspace-chat/tools/enable-mcp-server.test.ts
@@ -180,6 +180,36 @@ describe("createEnableMcpServerTool", () => {
     expect(result).toEqual({ success: false, error: "Internal server error" });
   });
 
+  // Gateways (502/504) and misconfigured proxies routinely return HTML or
+  // empty bodies. Before, `res.json()` threw and bubbled to the outer catch,
+  // producing "Enable failed: Unexpected non-whitespace character..." — useless
+  // to the agent. Now the per-status default reaches the caller.
+  it("falls back to per-status default when body is not JSON", async () => {
+    setupMock("ws-1");
+    mockPut.mockResolvedValueOnce({
+      status: 502,
+      json: () => Promise.reject(new SyntaxError("Unexpected token '<' at position 0")),
+    });
+
+    const tools = createEnableMcpServerTool("ws-1", logger);
+    const result = await tools.enable_mcp_server!.execute!({ serverId: "github" }, TOOL_CALL_OPTS);
+
+    expect(result).toEqual({ success: false, error: "Enable failed: 502" });
+  });
+
+  it("falls back to status-specific default on 409 with non-JSON body", async () => {
+    setupMock("ws-1");
+    mockPut.mockResolvedValueOnce({
+      status: 409,
+      json: () => Promise.reject(new SyntaxError("Unexpected end of JSON input")),
+    });
+
+    const tools = createEnableMcpServerTool("ws-1", logger);
+    const result = await tools.enable_mcp_server!.execute!({ serverId: "github" }, TOOL_CALL_OPTS);
+
+    expect(result).toEqual({ success: false, error: "Conflict enabling MCP server." });
+  });
+
   it("returns error when fetch throws", async () => {
     setupMock("ws-1");
     mockPut.mockRejectedValueOnce(new Error("Network failure"));

--- a/packages/system/agents/workspace-chat/tools/enable-mcp-server.ts
+++ b/packages/system/agents/workspace-chat/tools/enable-mcp-server.ts
@@ -78,10 +78,18 @@ export function createEnableMcpServerTool(workspaceId: string, logger: Logger): 
             };
           }
 
+          // The server returns one of two shapes:
+          //   - { success: false, error: "<tag>", message?: "<sentence>", ... }  (most paths)
+          //   - { success: false, error: "<tag>", serverId }                     (e.g. needs_manual_config)
+          // Prefer `message` (human-readable), fall back to the `error` tag so the
+          // agent gets a specific signal instead of a generic per-status fallback.
+          // Without this, `needs_manual_config` collapsed to "Conflict enabling
+          // MCP server." — the wording that sent the agent guessing during the
+          // Notion incident.
           if (res.status === 404) {
             const errorBody = body as Record<string, unknown>;
             const errorMsg = String(
-              errorBody.message ?? `Server "${serverId}" not found in catalog.`,
+              errorBody.message ?? errorBody.error ?? `Server "${serverId}" not found in catalog.`,
             );
             logger.info("enable_mcp_server: not found", {
               workspaceId: effectiveWorkspaceId,
@@ -92,7 +100,9 @@ export function createEnableMcpServerTool(workspaceId: string, logger: Logger): 
 
           if (res.status === 409) {
             const errorBody = body as Record<string, unknown>;
-            const errorMsg = String(errorBody.message ?? "Conflict enabling MCP server.");
+            const errorMsg = String(
+              errorBody.message ?? errorBody.error ?? "Conflict enabling MCP server.",
+            );
             logger.info("enable_mcp_server: conflict", {
               workspaceId: effectiveWorkspaceId,
               serverId,
@@ -105,6 +115,7 @@ export function createEnableMcpServerTool(workspaceId: string, logger: Logger): 
             const errorBody = body as Record<string, unknown>;
             const errorMsg = String(
               errorBody.message ??
+                errorBody.error ??
                 "This workspace uses a blueprint — direct config mutations are not supported.",
             );
             logger.info("enable_mcp_server: blueprint rejected", {

--- a/packages/system/agents/workspace-chat/tools/enable-mcp-server.ts
+++ b/packages/system/agents/workspace-chat/tools/enable-mcp-server.ts
@@ -54,7 +54,12 @@ export function createEnableMcpServerTool(workspaceId: string, logger: Logger): 
           const res = await client
             .workspaceMcp(effectiveWorkspaceId)
             [":serverId"].$put({ param: { serverId } });
-          const body = await res.json();
+          // The status branches below read structured fields off `body`, but the
+          // response isn't always JSON — gateways and proxies surface HTML or
+          // empty payloads on 502/504, and the daemon could regress. Swallow
+          // parse errors so the per-status default text reaches the agent
+          // instead of "Enable failed: Unexpected non-whitespace character...".
+          const body: unknown = await res.json().catch(() => ({}));
 
           if (res.status === 200) {
             const parsed = z


### PR DESCRIPTION
🪷

```
Doctor analyzes
a server that needs no help —
who heals the healer?
```

## Summary

Two bugs surfaced by the Notion install incident, both downstream of one mistaken predicate:

- **Doctor was running for fully-specified MCP entries.** The install fast-path used `!translateResult.linkProvider` as a proxy for "this server needs the doctor." But the translator deliberately suppresses `linkProvider` when `REGISTRY_ANNOTATIONS` provides a `providerId` — to avoid creating a duplicate dynamic Link provider when a curated one already exists. The skip predicate mistook that suppression for "no auth info" and ran the doctor on Notion, Linear, Atlassian, and PostHog — all of which have complete `streamable-http` registry entries and need no LLM analysis. Added a `hasCuratedProvider` clause so annotated entries take the fast path.

- **`enable_mcp_server` collapsed structured 409s into "Conflict enabling MCP server."** The server returns two shapes: most paths carry both `error` (machine tag) and `message` (sentence), but `needs_manual_config` returns only `error` + `serverId`. The tool only read `message`, so the most diagnostic 409 became the most opaque one — exactly the wording that sent the agent guessing about credential rebinding during the Notion incident. Added `errorBody.error` as a middle fallback in 404 / 409 / 422 branches.

The cascade Notion hit: install ran the doctor → doctor returned `verdict: unknown` (HTTP remotes have nothing to enumerate) → enable 409'd with `needs_manual_config` → agent saw "Conflict enabling MCP server." and re-attempted `connect_service`, which is unrelated to the underlying block.

Out of scope: backfill for already-broken installs (Eric directed to skip it — bounded user surface today, the canonical-name set is ≤4).

## Test Plan

- New parameterized test in `apps/atlasd/routes/mcp-registry.test.ts` over all four annotated canonical names (`com.notion/mcp`, `app.linear/linear`, `com.atlassian/atlassian-mcp-server`, `io.github.PostHog/mcp`) — asserts `status: ready`, doctor not invoked, Link fetch not called. Verified RED before the fix.
- Two new tests in `enable-mcp-server.test.ts`: structured-error pass-through when no `message`, and `message`-preferred behavior preserved when both fields present. First test verified RED before the fix.
- Full suite results post-fix:
  - `apps/atlasd/routes/mcp-registry.test.ts`: 103/103 (+4)
  - `enable-mcp-server.test.ts`: 12/12 (+2)
  - `apps/atlasd/routes/workspaces/mcp.test.ts`: 36/36 (server-side handler unchanged, sanity)
- `deno check` clean on both modified source files.