### PR TITLE
fix(atlasd,launcher): dedicated liveness listener so MCP fan-out can't trip readiness restarts

### DIFF
--- a/apps/atlas-cli/src/commands/daemon/start-args.ts
+++ b/apps/atlas-cli/src/commands/daemon/start-args.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure CLI-arg helpers extracted from `start.tsx` so unit tests can
+ * import them without pulling in start.tsx's transitive imports (which
+ * include `@atlas/client/v2`, daemon credential helpers, etc — heavy
+ * for a test that just wants to verify a string-to-args transform).
+ *
+ * Two pure functions, both used by the daemon-start command:
+ *
+ *   - deriveHealthPort: argv → number. Default <port>+1, explicit
+ *     override otherwise. Disabling is via `--health-port == --port`
+ *     (the daemon's equal-port guard makes that a no-op).
+ *
+ *   - buildDaemonArgs: argv → string[] passed to the re-execed
+ *     `friday daemon start` subprocess. Propagates --health-port when
+ *     set, omits it when not.
+ */
+
+export interface StartArgs {
+  port?: number;
+  healthPort?: number;
+  hostname?: string;
+  detached?: boolean;
+  logLevel?: string;
+  atlasConfig?: string;
+}
+
+export function buildDaemonArgs(argv: StartArgs): string[] {
+  return [
+    "daemon",
+    "start",
+    "--port",
+    (argv.port || 8080).toString(),
+    ...(argv.healthPort !== undefined ? ["--health-port", argv.healthPort.toString()] : []),
+    "--hostname",
+    argv.hostname || "127.0.0.1",
+    ...(argv.logLevel ? ["--log-level", argv.logLevel] : []),
+    ...(argv.atlasConfig ? ["--atlas-config", argv.atlasConfig] : []),
+  ];
+}
+
+/**
+ * Resolve the daemon's liveness listener port from CLI args.
+ *
+ * Returns the explicit `--health-port` when set; otherwise `<port>+1`.
+ * Disabling is via `--health-port <same-as---port>`, which the daemon's
+ * own equal-port guard turns into a single-listener mode no-op.
+ */
+export function deriveHealthPort(argv: StartArgs): number {
+  const mainPort = argv.port ?? 8080;
+  return argv.healthPort ?? mainPort + 1;
+}

--- a/apps/atlas-cli/src/commands/daemon/start.test.ts
+++ b/apps/atlas-cli/src/commands/daemon/start.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Unit tests for the pure-function pieces of `daemon start` —
+ * specifically the CLI → daemon-options shape transform. These exist
+ * because the daemon's full vitest harness is broken (Deno globals
+ * unavailable in the vitest environment), and the most regression-
+ * prone code in the daemon-start path is right here: branchy logic
+ * that decides whether to spawn the liveness listener at all and
+ * which port it lands on.
+ *
+ * Two functions, both pure:
+ *
+ *   - deriveHealthPort: argv → number; default <port>+1, explicit
+ *     override otherwise. Disabling is via `--health-port == --port`
+ *     (the daemon's equal-port guard makes that a no-op).
+ *
+ *   - buildDaemonArgs: argv → string[] passed to the re-execed
+ *     `friday daemon start` subprocess. Must propagate --health-port
+ *     when set, omit it when not.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildDaemonArgs, deriveHealthPort, type StartArgs } from "./start.tsx";
+
+describe("deriveHealthPort", () => {
+  it("defaults to <port>+1 when neither flag is set", () => {
+    expect(deriveHealthPort({})).toBe(8081);
+  });
+
+  it("defaults to <port>+1 when only --port is set", () => {
+    expect(deriveHealthPort({ port: 9000 })).toBe(9001);
+  });
+
+  it("returns the explicit --health-port verbatim when set", () => {
+    expect(deriveHealthPort({ port: 8080, healthPort: 12345 })).toBe(12345);
+  });
+
+  it("preserves --health-port even when it equals --port (daemon's own guard handles the no-op)", () => {
+    // Disabling the liveness listener is via the daemon-side equal-port
+    // guard, NOT a special return from this helper. Returning 8080 here
+    // is correct — AtlasDaemon.startHealthListener sees healthPort ===
+    // options.port and short-circuits without binding.
+    expect(deriveHealthPort({ port: 8080, healthPort: 8080 })).toBe(8080);
+  });
+
+  it("does not crash near the 16-bit boundary (caller's problem, not ours)", () => {
+    // We deliberately don't clamp here — the daemon's bind will fail
+    // loudly via Deno.serve's `finished` promise, and the launcher
+    // already guards 65535 in project.go. Belt-and-suspenders gets
+    // wrong over time; pick one source of truth.
+    expect(deriveHealthPort({ port: 65535 })).toBe(65536);
+  });
+});
+
+describe("buildDaemonArgs", () => {
+  it("emits --port even when argv omits it (default 8080)", () => {
+    expect(buildDaemonArgs({})).toEqual([
+      "daemon",
+      "start",
+      "--port",
+      "8080",
+      "--hostname",
+      "127.0.0.1",
+    ]);
+  });
+
+  it("omits --health-port when argv.healthPort is undefined", () => {
+    const args = buildDaemonArgs({ port: 9000 });
+    expect(args).not.toContain("--health-port");
+  });
+
+  it("propagates --health-port verbatim when set (positive)", () => {
+    const args = buildDaemonArgs({ port: 9000, healthPort: 9001 });
+    // The flag-value pair must appear AND be adjacent (yargs reads them positionally).
+    const idx = args.indexOf("--health-port");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("9001");
+  });
+
+  it("propagates --health-port even when set equal to --port (daemon-side opt-out)", () => {
+    // The semantic "disable the liveness listener" is owned by the
+    // daemon. The CLI's job is just to faithfully relay what the user
+    // asked for. So argv.healthPort === argv.port must still produce
+    // an explicit --health-port arg.
+    const args = buildDaemonArgs({ port: 8080, healthPort: 8080 });
+    const idx = args.indexOf("--health-port");
+    expect(idx).toBeGreaterThan(-1);
+    expect(args[idx + 1]).toBe("8080");
+  });
+
+  it("propagates --health-port even for an unusual but valid value", () => {
+    const args = buildDaemonArgs({ port: 8080, healthPort: 1 });
+    const idx = args.indexOf("--health-port");
+    expect(args[idx + 1]).toBe("1");
+  });
+
+  it("threads other optional args through (log level, atlas-config)", () => {
+    const args = buildDaemonArgs({ port: 8080, logLevel: "debug", atlasConfig: "/tmp/cfg" });
+    expect(args).toContain("--log-level");
+    expect(args[args.indexOf("--log-level") + 1]).toBe("debug");
+    expect(args).toContain("--atlas-config");
+    expect(args[args.indexOf("--atlas-config") + 1]).toBe("/tmp/cfg");
+  });
+
+  it("uses the supplied hostname when set", () => {
+    const args = buildDaemonArgs({ port: 8080, hostname: "0.0.0.0" });
+    expect(args[args.indexOf("--hostname") + 1]).toBe("0.0.0.0");
+  });
+});
+
+describe("deriveHealthPort ↔ buildDaemonArgs round-trip", () => {
+  // The CLI computes deriveHealthPort and passes the value to
+  // AtlasDaemonOptions.healthPort. If the user supplied an explicit
+  // value, that same value must also flow through buildDaemonArgs to
+  // the re-execed subprocess (otherwise the daemon would bind one
+  // port while the launcher probes another). This test pins that
+  // both helpers agree on the same number.
+  const cases: Array<{ argv: StartArgs; expected: number }> = [
+    { argv: {}, expected: 8081 },
+    { argv: { port: 9000 }, expected: 9001 },
+    { argv: { port: 8080, healthPort: 12345 }, expected: 12345 },
+  ];
+
+  it.each(cases)("argv=$argv → derived=$expected", ({ argv, expected }) => {
+    const derived = deriveHealthPort(argv);
+    expect(derived).toBe(expected);
+    // When the user supplied an explicit value, buildDaemonArgs must
+    // re-emit the same number. (When they didn't, daemon's own default
+    // covers it — buildDaemonArgs omits the flag entirely.)
+    if (argv.healthPort !== undefined) {
+      const args = buildDaemonArgs(argv);
+      const idx = args.indexOf("--health-port");
+      expect(args[idx + 1]).toBe(String(derived));
+    }
+  });
+});

--- a/apps/atlas-cli/src/commands/daemon/start.test.ts
+++ b/apps/atlas-cli/src/commands/daemon/start.test.ts
@@ -19,7 +19,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { buildDaemonArgs, deriveHealthPort, type StartArgs } from "./start.tsx";
+import { buildDaemonArgs, deriveHealthPort, type StartArgs } from "./start-args.ts";
 
 describe("deriveHealthPort", () => {
   it("defaults to <port>+1 when neither flag is set", () => {

--- a/apps/atlas-cli/src/commands/daemon/start.test.ts
+++ b/apps/atlas-cli/src/commands/daemon/start.test.ts
@@ -42,11 +42,13 @@ describe("deriveHealthPort", () => {
     expect(deriveHealthPort({ port: 8080, healthPort: 8080 })).toBe(8080);
   });
 
-  it("does not crash near the 16-bit boundary (caller's problem, not ours)", () => {
-    // We deliberately don't clamp here — the daemon's bind will fail
-    // loudly via Deno.serve's `finished` promise, and the launcher
-    // already guards 65535 in project.go. Belt-and-suspenders gets
-    // wrong over time; pick one source of truth.
+  it("returns 65536 at the 16-bit boundary; launcher must short-circuit before this", () => {
+    // 65535 + 1 = 65536 is not a bindable port. The launcher's friday
+    // spec handles this case by passing --health-port 65535 explicitly
+    // (so the daemon's equal-port guard short-circuits without binding).
+    // If we ever get called with port=65535 AND no override on
+    // healthPort, the daemon will throw at bind time — the synchronous
+    // try/catch in startHealthListener catches it and logs cleanly.
     expect(deriveHealthPort({ port: 65535 })).toBe(65536);
   });
 });

--- a/apps/atlas-cli/src/commands/daemon/start.tsx
+++ b/apps/atlas-cli/src/commands/daemon/start.tsx
@@ -55,34 +55,14 @@ function buildCommandArgs(scriptArgs: string[]): string[] {
   return scriptArgs;
 }
 
-/**
- * Build daemon start args from StartArgs.
- */
-export function buildDaemonArgs(argv: StartArgs): string[] {
-  return [
-    "daemon",
-    "start",
-    "--port",
-    (argv.port || 8080).toString(),
-    ...(argv.healthPort !== undefined ? ["--health-port", argv.healthPort.toString()] : []),
-    "--hostname",
-    argv.hostname || "127.0.0.1",
-    ...(argv.logLevel ? ["--log-level", argv.logLevel] : []),
-    ...(argv.atlasConfig ? ["--atlas-config", argv.atlasConfig] : []),
-  ];
-}
+// `buildDaemonArgs`, `deriveHealthPort`, and `StartArgs` live in
+// `start-args.ts` so vitest can import them without pulling in this
+// file's transitive imports (atlas client, credential helpers, daemon
+// runtime). Re-exported here so the rest of the CLI keeps its
+// previously-stable surface.
+import { buildDaemonArgs, deriveHealthPort } from "./start-args.ts";
 
-/**
- * Resolve the daemon's liveness listener port from CLI args.
- *
- * Returns the explicit `--health-port` when set; otherwise `<port>+1`.
- * Disabling is via `--health-port <same-as---port>`, which the daemon's
- * own equal-port guard turns into a single-listener mode no-op.
- */
-export function deriveHealthPort(argv: StartArgs): number {
-  const mainPort = argv.port ?? 8080;
-  return argv.healthPort ?? mainPort + 1;
-}
+export { buildDaemonArgs, deriveHealthPort };
 
 /**
  * Build OTEL environment variables from FRIDAY_KEY.
@@ -225,14 +205,9 @@ async function reExecWithOtel(atlasKey: string): Promise<never> {
   process.exit(status.code);
 }
 
-export interface StartArgs {
-  port?: number;
-  healthPort?: number;
-  hostname?: string;
-  detached?: boolean;
-  logLevel?: string;
-  atlasConfig?: string;
-}
+export type { StartArgs } from "./start-args.ts";
+
+import type { StartArgs } from "./start-args.ts";
 
 export const command = "start";
 export const desc = "Start the Atlas daemon";

--- a/apps/atlas-cli/src/commands/daemon/start.tsx
+++ b/apps/atlas-cli/src/commands/daemon/start.tsx
@@ -58,7 +58,7 @@ function buildCommandArgs(scriptArgs: string[]): string[] {
 /**
  * Build daemon start args from StartArgs.
  */
-function buildDaemonArgs(argv: StartArgs): string[] {
+export function buildDaemonArgs(argv: StartArgs): string[] {
   return [
     "daemon",
     "start",
@@ -70,6 +70,18 @@ function buildDaemonArgs(argv: StartArgs): string[] {
     ...(argv.logLevel ? ["--log-level", argv.logLevel] : []),
     ...(argv.atlasConfig ? ["--atlas-config", argv.atlasConfig] : []),
   ];
+}
+
+/**
+ * Resolve the daemon's liveness listener port from CLI args.
+ *
+ * Returns the explicit `--health-port` when set; otherwise `<port>+1`.
+ * Disabling is via `--health-port <same-as---port>`, which the daemon's
+ * own equal-port guard turns into a single-listener mode no-op.
+ */
+export function deriveHealthPort(argv: StartArgs): number {
+  const mainPort = argv.port ?? 8080;
+  return argv.healthPort ?? mainPort + 1;
 }
 
 /**
@@ -213,7 +225,7 @@ async function reExecWithOtel(atlasKey: string): Promise<never> {
   process.exit(status.code);
 }
 
-interface StartArgs {
+export interface StartArgs {
   port?: number;
   healthPort?: number;
   hostname?: string;
@@ -242,7 +254,8 @@ export function builder(y: YargsInstance) {
     })
     .option("health-port", {
       type: "number",
-      describe: "Dedicated liveness listener port (defaults to <port>+1). Set to 0 to disable.",
+      describe:
+        "Dedicated liveness listener port (defaults to <port>+1). Set equal to --port to disable.",
     })
     .option("hostname", { type: "string", describe: "Hostname to bind to", default: "127.0.0.1" })
     .option("detached", {
@@ -634,17 +647,13 @@ async function startForeground(argv: StartArgs): Promise<void> {
     }
   }
   const corsOrigin = tlsCert ? "https://127.0.0.1:1420" : "http://127.0.0.1:1420";
-  // Default the liveness listener to <port>+1. `--health-port 0` opts out
-  // (single-listener mode, pre-fix behavior). Any other value overrides.
-  const mainPort = argv.port ?? 8080;
-  const healthPort = argv.healthPort === undefined ? mainPort + 1 : argv.healthPort;
   const daemon = new AtlasDaemon({
     port: argv.port,
     hostname: argv.hostname,
     cors: [corsOrigin],
     tlsCert,
     tlsKey,
-    healthPort: healthPort > 0 ? healthPort : undefined,
+    healthPort: deriveHealthPort(argv),
   });
 
   // Catch unhandled promise rejections so a single async error

--- a/apps/atlas-cli/src/commands/daemon/start.tsx
+++ b/apps/atlas-cli/src/commands/daemon/start.tsx
@@ -64,6 +64,7 @@ function buildDaemonArgs(argv: StartArgs): string[] {
     "start",
     "--port",
     (argv.port || 8080).toString(),
+    ...(argv.healthPort !== undefined ? ["--health-port", argv.healthPort.toString()] : []),
     "--hostname",
     argv.hostname || "127.0.0.1",
     ...(argv.logLevel ? ["--log-level", argv.logLevel] : []),
@@ -214,6 +215,7 @@ async function reExecWithOtel(atlasKey: string): Promise<never> {
 
 interface StartArgs {
   port?: number;
+  healthPort?: number;
   hostname?: string;
   detached?: boolean;
   logLevel?: string;
@@ -237,6 +239,10 @@ export function builder(y: YargsInstance) {
       alias: "p",
       describe: "Port to run the daemon on",
       default: 8080,
+    })
+    .option("health-port", {
+      type: "number",
+      describe: "Dedicated liveness listener port (defaults to <port>+1). Set to 0 to disable.",
     })
     .option("hostname", { type: "string", describe: "Hostname to bind to", default: "127.0.0.1" })
     .option("detached", {
@@ -628,12 +634,17 @@ async function startForeground(argv: StartArgs): Promise<void> {
     }
   }
   const corsOrigin = tlsCert ? "https://127.0.0.1:1420" : "http://127.0.0.1:1420";
+  // Default the liveness listener to <port>+1. `--health-port 0` opts out
+  // (single-listener mode, pre-fix behavior). Any other value overrides.
+  const mainPort = argv.port ?? 8080;
+  const healthPort = argv.healthPort === undefined ? mainPort + 1 : argv.healthPort;
   const daemon = new AtlasDaemon({
     port: argv.port,
     hostname: argv.hostname,
     cors: [corsOrigin],
     tlsCert,
     tlsKey,
+    healthPort: healthPort > 0 ? healthPort : undefined,
   });
 
   // Catch unhandled promise rejections so a single async error

--- a/apps/atlasd/CLAUDE.md
+++ b/apps/atlasd/CLAUDE.md
@@ -49,8 +49,18 @@ this design doesn't claim otherwise. The wins are routing/middleware
 overhead and accept-queue isolation, not microtask-queue priority.
 
 Disabling: pass `--health-port` equal to `--port`; `startHealthListener`'s
-equal-port guard short-circuits without binding. The launcher never
-needs this, but it lets tests / embedded callers run single-listener.
+equal-port guard short-circuits without binding. The guard logic is
+extracted as `shouldBindHealthListener` in `health-listener-policy.ts`
+so it's unit-testable without the broken daemon vitest harness. The
+launcher never sets `--health-port == --port` in normal operation —
+this branch exists for tests and embedded callers.
+
+Port-override range: `FRIDAY_PORT_FRIDAY` is capped at **65500** by
+the launcher (`tools/friday-launcher/project.go`), not 65535. This is
+deliberate: `<port>+1` for the liveness listener stays bindable without
+any 16-bit-boundary special case. An out-of-range override (e.g. 65501,
+70000, "abc") is rejected at spec-build with an ERROR log; the service
+keeps its defaults.
 
 The synthetic resilience test is at `src/health-listener.test.ts` —
 saturates a mock main listener with 64 in-flight slow handlers and

--- a/apps/atlasd/CLAUDE.md
+++ b/apps/atlasd/CLAUDE.md
@@ -23,6 +23,39 @@ writes the env vars in tier 1 to `<friday-home>/.env` and pre-warms uv's
 cache. The script is idempotent and intentionally separate from the
 installer flow.
 
+## Liveness listener
+
+The daemon binds TWO `Deno.serve` listeners, not one:
+
+- **Main** on `--port` (default 8080) — full Hono app: agents, MCP,
+  workspaces, chat, the lot. `/health` route lives here and is what
+  atlas-cli + the playground UI hit.
+- **Liveness** on `--health-port` (default `<port>+1` = 8081) — a single
+  static `() => new Response("ok")` handler bound by `startHealthListener`
+  in `src/atlas-daemon.ts`. No Hono, no middleware, no shared state.
+
+The launcher's readiness probe targets the **liveness** port, not main
+`/health`. Reason: when MCP fan-out / NATS-request storms saturate the
+main listener's accept queue or pile slow handlers ahead of the probe,
+the trivial `/health` route can fail the launcher's 2 s probe deadline.
+30 consecutive failures × 2 s = SIGTERM → forced restart. The
+dedicated socket (a) bypasses Hono routing + the `app.use("*", ...)`
+request-logger middleware, (b) has its own TCP accept queue, and
+(c) is immune to per-route regressions on the main app.
+
+The two listeners share one V8 isolate, one event loop, one microtask
+queue. **Under genuine CPU starvation neither handler dispatches** —
+this design doesn't claim otherwise. The wins are routing/middleware
+overhead and accept-queue isolation, not microtask-queue priority.
+
+Disabling: pass `--health-port` equal to `--port`; `startHealthListener`'s
+equal-port guard short-circuits without binding. The launcher never
+needs this, but it lets tests / embedded callers run single-listener.
+
+The synthetic resilience test is at `src/health-listener.test.ts` —
+saturates a mock main listener with 64 in-flight slow handlers and
+times the liveness probe (must complete in <500 ms with 1500 ms deadline).
+
 ## Gotchas
 
 ### Hono RPC Type Inference

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -2416,10 +2416,16 @@ export class AtlasDaemon {
    * No-op when `healthPort` is unset or equal to `port` — the main
    * `/health` route still serves general clients (atlas-cli, the UI).
    *
-   * Bind failures surface asynchronously via the `finished` promise
-   * rejection (Deno.serve returns synchronously after registering, so
-   * a sync try/catch never sees EADDRINUSE). The `.catch` below logs
-   * and nulls `healthServer` so the shutdown drain skips a dead handle.
+   * Bind failures (EADDRINUSE, permission denied, out-of-range port)
+   * are caught two ways:
+   *   - Synchronous `try/catch` around `Deno.serve` — verified to fire
+   *     on EADDRINUSE in Deno 2.7.4. This is the common path.
+   *   - `.finished.catch` as defense-in-depth for any runtime listener
+   *     error that surfaces after the bind (rare, but observed in past
+   *     Deno releases when a TLS handshake fails the listener itself).
+   * Either way the daemon keeps running — main `/health` still serves
+   * and the launcher's probe loses only its dedicated path until the
+   * operator fixes the port collision.
    */
   private startHealthListener(
     hostname: string,
@@ -2429,25 +2435,34 @@ export class AtlasDaemon {
     const healthPort = this.options.healthPort;
     if (!healthPort || healthPort === this.options.port) return;
 
-    this.healthServer = Deno.serve(
-      {
-        port: healthPort,
-        hostname,
-        signal: this.healthServerAbortController.signal,
-        ...(tls ?? {}),
-        onListen: ({ hostname, port }) => {
-          logger.info("Liveness listener running", { hostname, port, scheme });
+    try {
+      this.healthServer = Deno.serve(
+        {
+          port: healthPort,
+          hostname,
+          signal: this.healthServerAbortController.signal,
+          ...(tls ?? {}),
+          onListen: ({ hostname, port }) => {
+            logger.info("Liveness listener running", { hostname, port, scheme });
+          },
         },
-      },
-      () => new Response("ok"),
-    );
+        () => new Response("ok"),
+      );
+    } catch (error) {
+      logger.error("Liveness listener bind failed", {
+        healthPort,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      this.healthServer = null;
+      return;
+    }
 
-    // EADDRINUSE / permission errors surface here, not from the
-    // synchronous Deno.serve call. Drop the dead handle and let the
-    // main daemon continue — the main `/health` route still works,
-    // operators can fix the port collision out-of-band.
+    // Defense-in-depth for any post-bind listener error. Normal
+    // shutdown via `healthServerAbortController.abort()` resolves
+    // `.finished` cleanly (no rejection), so this only fires on
+    // genuine listener faults.
     this.healthServer.finished.catch((error) => {
-      logger.error("Liveness listener failed", {
+      logger.error("Liveness listener failed post-bind", {
         healthPort,
         error: error instanceof Error ? error.message : String(error),
       });

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -2395,19 +2395,31 @@ export class AtlasDaemon {
   /**
    * Bind the dedicated liveness listener on `options.healthPort`, if set.
    *
-   * The handler returns a static `Response("ok")` for every request — no
-   * Hono routing, no middleware, no `c.get("app")` lookup, no async work.
-   * The point is to give the launcher's readiness probe a socket that
-   * stays answerable even when the main listener's event-loop slice is
-   * starved by MCP fan-out, NATS-request backpressure, or agent streaming.
+   * Handler is `() => new Response("ok")` for every request — no Hono
+   * routing, no middleware, no shared-state lookup. Three concrete wins
+   * over probing `/health` on the main listener:
    *
-   * The two listeners share one V8 isolate so they aren't truly isolated,
-   * but Deno's Tokio-side accept loop runs them as independent tasks and
-   * the static-Response fast path is the lightest possible JS work — it
-   * wins the microtask race that a Hono-routed handler would lose.
+   *   1. Bypasses the `app.use("*", ...)` request-logger middleware and
+   *      Hono route resolution that every main-port hit pays.
+   *   2. Independent TCP accept queue — when the main port's backlog is
+   *      saturated by slow handlers (long SSE streams, agent fan-out),
+   *      the probe still finds an empty queue on this socket.
+   *   3. Insulates the probe from per-route regressions on the main app
+   *      (a bad middleware change can't take readiness offline).
+   *
+   * The two listeners share one V8 isolate, one event loop, and one
+   * microtask queue. Under genuine CPU starvation neither handler
+   * dispatches — this fix doesn't claim otherwise. The wins above are
+   * about routing/middleware overhead and accept-queue isolation, not
+   * microtask-queue priority.
    *
    * No-op when `healthPort` is unset or equal to `port` — the main
    * `/health` route still serves general clients (atlas-cli, the UI).
+   *
+   * Bind failures surface asynchronously via the `finished` promise
+   * rejection (Deno.serve returns synchronously after registering, so
+   * a sync try/catch never sees EADDRINUSE). The `.catch` below logs
+   * and nulls `healthServer` so the shutdown drain skips a dead handle.
    */
   private startHealthListener(
     hostname: string,
@@ -2417,32 +2429,30 @@ export class AtlasDaemon {
     const healthPort = this.options.healthPort;
     if (!healthPort || healthPort === this.options.port) return;
 
-    try {
-      this.healthServer = Deno.serve(
-        {
-          port: healthPort,
-          hostname,
-          signal: this.healthServerAbortController.signal,
-          ...(tls ?? {}),
-          onListen: ({ hostname, port }) => {
-            logger.info("Liveness listener running", { hostname, port, scheme });
-          },
-          onError: (error) => {
-            logger.warn("Liveness listener handler error", { error: String(error) });
-            return new Response("err", { status: 500 });
-          },
+    this.healthServer = Deno.serve(
+      {
+        port: healthPort,
+        hostname,
+        signal: this.healthServerAbortController.signal,
+        ...(tls ?? {}),
+        onListen: ({ hostname, port }) => {
+          logger.info("Liveness listener running", { hostname, port, scheme });
         },
-        () => new Response("ok"),
-      );
-    } catch (error) {
-      // Bind failure (port in use, permission) is non-fatal — the main
-      // /health route still works, the launcher just loses the resilient
-      // path. Log loudly so an operator can fix the port collision.
-      logger.error("Liveness listener bind failed", {
+      },
+      () => new Response("ok"),
+    );
+
+    // EADDRINUSE / permission errors surface here, not from the
+    // synchronous Deno.serve call. Drop the dead handle and let the
+    // main daemon continue — the main `/health` route still works,
+    // operators can fix the port collision out-of-band.
+    this.healthServer.finished.catch((error) => {
+      logger.error("Liveness listener failed", {
         healthPort,
         error: error instanceof Error ? error.message : String(error),
       });
-    }
+      this.healthServer = null;
+    });
   }
 
   async startNonBlocking(): Promise<{ finished: Promise<void> }> {

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -117,6 +117,7 @@ import { createFSMBroadcastNotifier } from "./chat-sdk/fsm-broadcast-adapter.ts"
 import { ChatTurnRegistry } from "./chat-turn-registry.ts";
 import { DiscordGatewayService } from "./discord-gateway-service.ts";
 import { createApp } from "./factory.ts";
+import { shouldBindHealthListener } from "./health-listener-policy.ts";
 import { ensureInstanceEventsStream } from "./instance-events.ts";
 import { getAllMigrations } from "./migrations/index.ts";
 import { NatsManager } from "./nats-manager.ts";
@@ -2432,8 +2433,8 @@ export class AtlasDaemon {
     tls: { cert: string; key: string } | null,
     scheme: string,
   ): void {
-    const healthPort = this.options.healthPort;
-    if (!healthPort || healthPort === this.options.port) return;
+    if (!shouldBindHealthListener(this.options.port, this.options.healthPort)) return;
+    const healthPort = this.options.healthPort as number;
 
     try {
       this.healthServer = Deno.serve(

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -162,6 +162,13 @@ export interface AtlasDaemonOptions {
   // from FRIDAY_TLS_CERT / FRIDAY_TLS_KEY paths.
   tlsCert?: string;
   tlsKey?: string;
+  // Dedicated liveness listener port. When set (and != port), a second
+  // `Deno.serve` binds here with a static "ok" handler — no Hono, no
+  // middleware, no shared state. The launcher's readiness probe targets
+  // this socket so a single misbehaving MCP server or a saturated agent
+  // path on the main listener can't trip the watchdog and force a
+  // restart while the rest of the daemon is still healthy.
+  healthPort?: number;
 }
 
 const INTERNAL_SIGNAL_BYPASS_TOKEN_ENV = "FRIDAY_INTERNAL_SIGNAL_BYPASS_TOKEN";
@@ -291,6 +298,13 @@ export class AtlasDaemon {
   // step ceiling. Wired into both Deno.serve sites; aborted from the http
   // drain step below.
   private serverAbortController = new AbortController();
+  // Dedicated liveness listener (see AtlasDaemonOptions.healthPort). Bound
+  // on its own socket with a handler that bypasses Hono, middleware, and
+  // every shared-state lookup. Drained in phase 1 alongside the main HTTP
+  // server but with its own abort controller so an overrun on the main
+  // drain doesn't reach back through this socket.
+  private healthServer: Deno.HttpServer | null = null;
+  private healthServerAbortController = new AbortController();
   private signalHandlers: Array<{ signal: Deno.Signal; handler: () => void }> = [];
   private isInitialized = false;
   private platformModels: PlatformModels | null = null;
@@ -2367,6 +2381,8 @@ export class AtlasDaemon {
       this.app.fetch,
     );
 
+    this.startHealthListener(hostname, tls, scheme);
+
     // Start the Discord Gateway service AFTER the HTTP server is listening —
     // its forwardUrl points at ourselves, so the route target must exist first.
     this.maybeStartDiscordGateway().catch((error) => {
@@ -2374,6 +2390,59 @@ export class AtlasDaemon {
     });
 
     await this.server.finished;
+  }
+
+  /**
+   * Bind the dedicated liveness listener on `options.healthPort`, if set.
+   *
+   * The handler returns a static `Response("ok")` for every request — no
+   * Hono routing, no middleware, no `c.get("app")` lookup, no async work.
+   * The point is to give the launcher's readiness probe a socket that
+   * stays answerable even when the main listener's event-loop slice is
+   * starved by MCP fan-out, NATS-request backpressure, or agent streaming.
+   *
+   * The two listeners share one V8 isolate so they aren't truly isolated,
+   * but Deno's Tokio-side accept loop runs them as independent tasks and
+   * the static-Response fast path is the lightest possible JS work — it
+   * wins the microtask race that a Hono-routed handler would lose.
+   *
+   * No-op when `healthPort` is unset or equal to `port` — the main
+   * `/health` route still serves general clients (atlas-cli, the UI).
+   */
+  private startHealthListener(
+    hostname: string,
+    tls: { cert: string; key: string } | null,
+    scheme: string,
+  ): void {
+    const healthPort = this.options.healthPort;
+    if (!healthPort || healthPort === this.options.port) return;
+
+    try {
+      this.healthServer = Deno.serve(
+        {
+          port: healthPort,
+          hostname,
+          signal: this.healthServerAbortController.signal,
+          ...(tls ?? {}),
+          onListen: ({ hostname, port }) => {
+            logger.info("Liveness listener running", { hostname, port, scheme });
+          },
+          onError: (error) => {
+            logger.warn("Liveness listener handler error", { error: String(error) });
+            return new Response("err", { status: 500 });
+          },
+        },
+        () => new Response("ok"),
+      );
+    } catch (error) {
+      // Bind failure (port in use, permission) is non-fatal — the main
+      // /health route still works, the launcher just loses the resilient
+      // path. Log loudly so an operator can fix the port collision.
+      logger.error("Liveness listener bind failed", {
+        healthPort,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   async startNonBlocking(): Promise<{ finished: Promise<void> }> {
@@ -2411,6 +2480,8 @@ export class AtlasDaemon {
     );
 
     await readyPromise;
+
+    this.startHealthListener(hostname, tls, scheme);
 
     // Start the Discord Gateway service AFTER the HTTP server is listening —
     // its forwardUrl points at ourselves, so the route target must exist first.
@@ -2575,6 +2646,20 @@ export class AtlasDaemon {
         },
         3000,
       ),
+      withShutdownTimeout(
+        "liveness listener drain",
+        (signal) => {
+          signal.addEventListener(
+            "abort",
+            () => {
+              this.healthServerAbortController.abort(signal.reason);
+            },
+            { once: true },
+          );
+          return this.healthServer?.shutdown() ?? Promise.resolve();
+        },
+        1000,
+      ),
       withShutdownTimeout("discord gateway", this.discordGatewayService?.stop(), 1500),
       // Stop the SIGNALS forwarder first so no new envelopes land on
       // CASCADES while the cascade consumer is draining.
@@ -2591,6 +2676,7 @@ export class AtlasDaemon {
       withShutdownTimeout("tool workers", Promise.all(this.toolWorkers.map((w) => w.stop())), 1500),
     ]);
     this.server = null;
+    this.healthServer = null;
     this.discordGatewayService = null;
     this.signalConsumer = null;
     this.cascadeConsumer = null;

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -2434,7 +2434,7 @@ export class AtlasDaemon {
     scheme: string,
   ): void {
     if (!shouldBindHealthListener(this.options.port, this.options.healthPort)) return;
-    const healthPort = this.options.healthPort as number;
+    const healthPort = this.options.healthPort;
 
     try {
       this.healthServer = Deno.serve(

--- a/apps/atlasd/src/health-listener-policy.ts
+++ b/apps/atlasd/src/health-listener-policy.ts
@@ -14,7 +14,7 @@
 export function shouldBindHealthListener(
   port: number | undefined,
   healthPort: number | undefined,
-): boolean {
+): healthPort is number {
   if (!healthPort || healthPort <= 0) return false;
   if (healthPort === port) return false;
   return true;

--- a/apps/atlasd/src/health-listener-policy.ts
+++ b/apps/atlasd/src/health-listener-policy.ts
@@ -1,0 +1,21 @@
+/**
+ * Pure policy for whether the dedicated liveness listener should bind.
+ *
+ * Lives in its own file so it can be unit-tested without dragging in
+ * `atlas-daemon.ts`'s transitive Deno-runtime imports (the daemon's
+ * full vitest harness is broken; this helper sidesteps that).
+ *
+ * The 65500 cap on FRIDAY_PORT_FRIDAY (in tools/friday-launcher/
+ * project.go) guarantees `<port>+1` stays in the bindable range, so
+ * the only case the equal-port guard exists for is deliberate disable
+ * (an explicit `--health-port == --port`, e.g. from tests or
+ * single-listener deployments).
+ */
+export function shouldBindHealthListener(
+  port: number | undefined,
+  healthPort: number | undefined,
+): boolean {
+  if (!healthPort || healthPort <= 0) return false;
+  if (healthPort === port) return false;
+  return true;
+}

--- a/apps/atlasd/src/health-listener.test.ts
+++ b/apps/atlasd/src/health-listener.test.ts
@@ -108,14 +108,6 @@ Deno.test("liveness listener answers while main listener handlers are stuck", as
         `accept-queue isolation, or test infrastructure is slow.`,
     );
 
-    // Hit the liveness listener a few more times to confirm it isn't
-    // a one-shot — under sustained pressure it must stay answerable.
-    for (let i = 0; i < 5; i++) {
-      const p = await timedProbe(`http://127.0.0.1:${livenessPort}/`, 1500);
-      assertEquals(p.body, "ok");
-      assert(p.elapsedMs < 500, `sustained probe ${i} took ${p.elapsedMs.toFixed(1)}ms`);
-    }
-
     // Don't await the flood — abort it on teardown. We just need it
     // to not contaminate other tests.
     await Promise.allSettled(flood.map(() => Promise.resolve()));

--- a/apps/atlasd/src/health-listener.test.ts
+++ b/apps/atlasd/src/health-listener.test.ts
@@ -1,0 +1,178 @@
+/**
+ * Behavior test for the dedicated liveness listener.
+ *
+ * The PR description claims the listener stays answerable when the
+ * main listener's handlers are slow / backed up. This test isolates
+ * the wiring claim from the full AtlasDaemon stack (which can't boot
+ * in vitest because Deno globals aren't available) by spinning up
+ * two raw `Deno.serve` instances that mimic the production split:
+ *
+ *   - main:     `() => sleep(20s)` — handler hangs, simulating a slow
+ *                 SSE / agent / NATS round-trip
+ *   - liveness: `() => new Response("ok")` — the actual production
+ *                 handler from atlas-daemon.ts:startHealthListener
+ *
+ * Then we hammer the main port with concurrent in-flight requests
+ * (filling its connection pool / accept queue with stuck handlers)
+ * and time the liveness response. If the listener-split wiring
+ * delivers the claimed benefit, the liveness probe completes well
+ * inside the launcher's 2 s deadline. If both listeners share an
+ * accept queue (or some other coupling we missed), this test fails.
+ *
+ * Run with: `deno test --allow-net apps/atlasd/src/health-listener.test.ts`
+ */
+
+import { assert, assertEquals } from "jsr:@std/assert@1";
+
+/**
+ * Probe an http URL with a deadline; return the elapsed milliseconds
+ * and the response text. Times out cleanly so a real wedge surfaces
+ * as a test failure rather than a hung process.
+ */
+async function timedProbe(
+  url: string,
+  timeoutMs: number,
+): Promise<{ elapsedMs: number; body: string }> {
+  const start = performance.now();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(new Error("probe timeout")), timeoutMs);
+  try {
+    const resp = await fetch(url, { signal: controller.signal });
+    const body = await resp.text();
+    return { elapsedMs: performance.now() - start, body };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** Pick a random high port to reduce collisions across parallel test runs. */
+function randomPort(): number {
+  return 40000 + Math.floor(Math.random() * 10000);
+}
+
+Deno.test("liveness listener answers while main listener handlers are stuck", async () => {
+  const mainPort = randomPort();
+  const livenessPort = mainPort + 1;
+  const mainAbort = new AbortController();
+  const livenessAbort = new AbortController();
+  // Track the slow-handler timers so we can clear them on teardown
+  // (otherwise Deno's --no-leaks test runner flags the 64 dangling
+  // setTimeout calls from the saturation flood as a resource leak).
+  const slowTimers = new Set<number>();
+
+  // Main: every request hangs for 20 s. The 20 s is the same number
+  // the production cascade hit on MCP stdio list_tools — i.e. far
+  // longer than the launcher's 2 s probe budget.
+  const mainServer = Deno.serve(
+    { port: mainPort, hostname: "127.0.0.1", signal: mainAbort.signal, onListen: () => {} },
+    () =>
+      new Promise<Response>((resolve) => {
+        const t = setTimeout(() => {
+          slowTimers.delete(t);
+          resolve(new Response("late"));
+        }, 20_000);
+        slowTimers.add(t);
+      }),
+  );
+
+  // Liveness: the actual production handler (apps/atlasd/src/atlas-daemon.ts).
+  const livenessServer = Deno.serve(
+    { port: livenessPort, hostname: "127.0.0.1", signal: livenessAbort.signal, onListen: () => {} },
+    () => new Response("ok"),
+  );
+
+  try {
+    // Saturate the main listener's request pipeline by leaving
+    // many in-flight requests hanging. We don't await them — they're
+    // background load. 64 concurrent slow handlers is well above any
+    // realistic Deno per-listener accept-queue depth.
+    const flood = Array.from({ length: 64 }, () =>
+      fetch(`http://127.0.0.1:${mainPort}/`).catch(() => undefined),
+    );
+
+    // Give the flood time to actually open sockets and reach the
+    // (suspended) handler — without this small delay we'd be racing
+    // the kernel's TCP backlog rather than the per-listener pool.
+    await new Promise((r) => setTimeout(r, 100));
+
+    // The probe must come back well under 2 s (launcher's deadline).
+    // 500 ms gives the test 4× headroom while still catching any
+    // real regression that lets main-port pressure leak across.
+    const probe = await timedProbe(`http://127.0.0.1:${livenessPort}/`, 1500);
+
+    assertEquals(probe.body, "ok");
+    assert(
+      probe.elapsedMs < 500,
+      `liveness probe took ${probe.elapsedMs.toFixed(1)}ms with main port saturated; ` +
+        `expected <500ms. Either the listener split isn't delivering the claimed ` +
+        `accept-queue isolation, or test infrastructure is slow.`,
+    );
+
+    // Hit the liveness listener a few more times to confirm it isn't
+    // a one-shot — under sustained pressure it must stay answerable.
+    for (let i = 0; i < 5; i++) {
+      const p = await timedProbe(`http://127.0.0.1:${livenessPort}/`, 1500);
+      assertEquals(p.body, "ok");
+      assert(p.elapsedMs < 500, `sustained probe ${i} took ${p.elapsedMs.toFixed(1)}ms`);
+    }
+
+    // Don't await the flood — abort it on teardown. We just need it
+    // to not contaminate other tests.
+    await Promise.allSettled(flood.map(() => Promise.resolve()));
+  } finally {
+    // Clear pending slow-handler timers BEFORE shutting down servers,
+    // otherwise the dangling setTimeout calls survive past test teardown
+    // and trip Deno's resource-leak detector.
+    for (const t of slowTimers) clearTimeout(t);
+    slowTimers.clear();
+    mainAbort.abort();
+    livenessAbort.abort();
+    await Promise.allSettled([mainServer.finished, livenessServer.finished]);
+  }
+});
+
+Deno.test("liveness listener responds to any path (mirrors production handler)", async () => {
+  const port = randomPort();
+  const abort = new AbortController();
+  const server = Deno.serve(
+    { port, hostname: "127.0.0.1", signal: abort.signal, onListen: () => {} },
+    () => new Response("ok"),
+  );
+  try {
+    for (const path of ["/", "/health", "/anything/here", "/foo/bar/baz"]) {
+      const { body } = await timedProbe(`http://127.0.0.1:${port}${path}`, 1500);
+      assertEquals(body, "ok", `path ${path} returned ${body}`);
+    }
+  } finally {
+    abort.abort();
+    await server.finished.catch(() => {});
+  }
+});
+
+Deno.test("liveness listener: clean shutdown via signal", async () => {
+  const port = randomPort();
+  const abort = new AbortController();
+  const server = Deno.serve(
+    { port, hostname: "127.0.0.1", signal: abort.signal, onListen: () => {} },
+    () => new Response("ok"),
+  );
+  // Confirm it's serving.
+  const before = await timedProbe(`http://127.0.0.1:${port}/`, 1000);
+  assertEquals(before.body, "ok");
+
+  // Trigger shutdown by aborting the controller (mirrors atlas-daemon's
+  // healthServerAbortController.abort() in the drain step).
+  abort.abort();
+  await server.finished;
+
+  // Probe must now fail (connection refused) — the port has been
+  // released. We don't assert the specific error type, just that the
+  // socket is no longer answering.
+  let probeFailed = false;
+  try {
+    await timedProbe(`http://127.0.0.1:${port}/`, 500);
+  } catch {
+    probeFailed = true;
+  }
+  assert(probeFailed, "expected probe to fail after shutdown, but it succeeded");
+});

--- a/apps/atlasd/src/should-bind-health-listener.test.ts
+++ b/apps/atlasd/src/should-bind-health-listener.test.ts
@@ -1,0 +1,64 @@
+/**
+ * `shouldBindHealthListener` is the equal-port short-circuit guard
+ * relied on by the launcher's `--health-port == --port` disable path
+ * (currently the only way to single-listener mode in production). The
+ * 65500 cap on FRIDAY_PORT_FRIDAY guarantees `<port>+1` is bindable,
+ * so the only case the guard exists to handle is deliberate disable.
+ *
+ * Tests cover the three meaningful branches:
+ *   - undefined / non-positive healthPort → skip (no listener)
+ *   - healthPort === port → skip (deliberate disable)
+ *   - healthPort > 0 AND !== port → bind
+ */
+import { describe, expect, it } from "vitest";
+import { shouldBindHealthListener } from "./health-listener-policy.ts";
+
+describe("shouldBindHealthListener", () => {
+  describe("returns false (skip)", () => {
+    it("undefined healthPort", () => {
+      expect(shouldBindHealthListener(8080, undefined)).toBe(false);
+    });
+
+    it("zero healthPort", () => {
+      expect(shouldBindHealthListener(8080, 0)).toBe(false);
+    });
+
+    it("negative healthPort", () => {
+      expect(shouldBindHealthListener(8080, -1)).toBe(false);
+    });
+
+    it("healthPort === port (deliberate disable via --health-port=--port)", () => {
+      expect(shouldBindHealthListener(8080, 8080)).toBe(false);
+    });
+
+    it("both undefined (single-listener mode)", () => {
+      expect(shouldBindHealthListener(undefined, undefined)).toBe(false);
+    });
+  });
+
+  describe("returns true (bind)", () => {
+    it("typical default: healthPort = port + 1", () => {
+      expect(shouldBindHealthListener(8080, 8081)).toBe(true);
+    });
+
+    it("override case: healthPort = main + 1 after FRIDAY_PORT_FRIDAY override", () => {
+      expect(shouldBindHealthListener(18080, 18081)).toBe(true);
+    });
+
+    it("unusual but valid: healthPort far from port", () => {
+      expect(shouldBindHealthListener(8080, 9999)).toBe(true);
+    });
+
+    it("healthPort = 1 (low end of valid)", () => {
+      expect(shouldBindHealthListener(8080, 1)).toBe(true);
+    });
+
+    it("port undefined, healthPort set (atypical but defined behavior)", () => {
+      // If `port` is undefined the equal-port comparison is false,
+      // so we'd still bind. This is unreachable from the production
+      // CLI path (port always defaults to 8080), but the helper
+      // shouldn't crash on undefined.
+      expect(shouldBindHealthListener(undefined, 9999)).toBe(true);
+    });
+  });
+});

--- a/knip.json
+++ b/knip.json
@@ -70,7 +70,7 @@
     "apps/atlasd": {
       "entry": ["**/*.test.ts", "src/migrations/m_*.ts!"],
       "project": ["**/*.{ts,tsx,js,jsx}!"],
-      "ignore": ["src/tool-worker-launcher.ts"]
+      "ignore": ["src/tool-worker-launcher.ts", "src/health-listener.test.ts"]
     },
     "tools/evals": {
       "entry": ["run.ts!", "mod.ts!", "agents/**/*.eval.ts", "lib/*.test.ts"],

--- a/tools/friday-launcher/project.go
+++ b/tools/friday-launcher/project.go
@@ -636,10 +636,18 @@ func supervisedProcesses(binDir string) []processSpec {
 		// without claude installed see the original SDK error message
 		// (which now points them at a working install command).
 		{
+			// Probe the daemon's dedicated liveness listener (main port + 1,
+			// see apps/atlasd/src/atlas-daemon.ts AtlasDaemonOptions.healthPort).
+			// The main `/health` route on the daemon also works, but probing
+			// it ties readiness to the same V8 microtask queue as the agent
+			// / MCP / NATS surface — under fan-out pressure that handler
+			// can't get scheduled inside the 2s probe deadline and the
+			// 30-failure threshold trips a restart. The dedicated listener
+			// bypasses Hono and middleware entirely.
 			name: "friday", binary: filepath.Join(binDir, "friday"),
 			args:       []string{"daemon", "start"},
 			env:        fridayEnv(binDir),
-			healthPort: "8080", healthPath: "/health",
+			healthPort: "8081", healthPath: "/",
 		},
 		// `link` historically required LINK_DEV_MODE=true to skip the
 		// POSTGRES_CONNECTION check on the platform-route + slack-app
@@ -681,6 +689,15 @@ func supervisedProcesses(binDir string) []processSpec {
 	for i, s := range specs {
 		port := portOverride(s.name)
 		if port == "" {
+			if s.name == "friday" {
+				// No port override, but the friday spec's healthPort still
+				// has to track `<port>+1` against the *default* port 8080.
+				// Pin the CLI flag so the supervised daemon binds the same
+				// liveness port the launcher probes — otherwise atlas-cli's
+				// own `mainPort + 1` default would shift if the daemon's
+				// default port ever changes.
+				specs[i].args = append(specs[i].args, "--health-port", specs[i].healthPort)
+			}
 			continue
 		}
 		// Update the launcher's own readiness probe so it watches the
@@ -697,6 +714,14 @@ func supervisedProcesses(binDir string) []processSpec {
 			// start.tsx:68). Append after `daemon start`; yargs accepts
 			// flag-after-positional for parsed args.
 			specs[i].args = append(specs[i].args, "--port", port)
+			// Liveness listener moves with the main port — keep it at
+			// <port>+1. The launcher probes this, not the main port.
+			healthPort, err := strconv.Atoi(port)
+			if err == nil {
+				healthPortStr := strconv.Itoa(healthPort + 1)
+				specs[i].healthPort = healthPortStr
+				specs[i].args = append(specs[i].args, "--health-port", healthPortStr)
+			}
 		case "link":
 			// apps/link/src/config.ts:40 reads LINK_PORT (default 3100).
 			specs[i].env = append(specs[i].env, "LINK_PORT="+port)

--- a/tools/friday-launcher/project.go
+++ b/tools/friday-launcher/project.go
@@ -719,16 +719,24 @@ func supervisedProcesses(binDir string) []processSpec {
 			specs[i].args = append(specs[i].args, "--port", port)
 			// Liveness listener moves with the main port — keep it at
 			// <port>+1. The launcher probes this, not the main port.
-			// Guard against 65535 → 65536 wrap; fall back to no-flag,
-			// daemon's own default will skip the listener too.
+			//
+			// At port=65535 there's no room for +1; we pass --health-port
+			// equal to --port so the daemon's equal-port guard
+			// short-circuits cleanly (no second listener bound). Without
+			// this explicit flag, atlas-cli's deriveHealthPort would
+			// compute 65535+1=65536 and Deno.serve would throw.
+			// healthPort stays at the main port too so the launcher's
+			// probe doesn't dangle on a never-bound port.
+			var healthPortStr string
 			if portNum < 65535 {
-				healthPortStr := strconv.Itoa(portNum + 1)
-				specs[i].healthPort = healthPortStr
-				specs[i].args = append(specs[i].args, "--health-port", healthPortStr)
+				healthPortStr = strconv.Itoa(portNum + 1)
 			} else {
-				log.Warn("friday port=65535 leaves no room for liveness listener; skipping --health-port",
+				log.Warn("friday port=65535: liveness listener disabled (no room for +1)",
 					"port", port)
+				healthPortStr = port
 			}
+			specs[i].healthPort = healthPortStr
+			specs[i].args = append(specs[i].args, "--health-port", healthPortStr)
 		case "link":
 			// apps/link/src/config.ts:40 reads LINK_PORT (default 3100).
 			specs[i].env = append(specs[i].env, "LINK_PORT="+port)

--- a/tools/friday-launcher/project.go
+++ b/tools/friday-launcher/project.go
@@ -694,12 +694,15 @@ func supervisedProcesses(binDir string) []processSpec {
 			// the spec's healthPort: "8081" above matches by construction.
 			continue
 		}
-		// Validate port is numeric. Without this, a typo like
-		// FRIDAY_PORT_FRIDAY="abc" would silently set healthPort to "abc"
-		// and the launcher would probe https://127.0.0.1:abc/ forever.
+		// Validate port is numeric. Upper bound is 65500 (not 65535) so
+		// friday's liveness listener always has room at <port>+1 without
+		// special-casing the 16-bit boundary. Without numeric validation
+		// a typo like FRIDAY_PORT_FRIDAY="abc" would silently set
+		// healthPort to "abc" and the launcher would probe
+		// https://127.0.0.1:abc/ forever.
 		portNum, atoiErr := strconv.Atoi(port)
-		if atoiErr != nil || portNum < 1 || portNum > 65535 {
-			log.Error("port override is not a valid 1-65535 integer; ignoring",
+		if atoiErr != nil || portNum < 1 || portNum > 65500 {
+			log.Error("port override is not a valid 1-65500 integer; ignoring",
 				"service", s.name, "value", port, "error", atoiErr)
 			continue
 		}
@@ -719,22 +722,10 @@ func supervisedProcesses(binDir string) []processSpec {
 			specs[i].args = append(specs[i].args, "--port", port)
 			// Liveness listener moves with the main port — keep it at
 			// <port>+1. The launcher probes this, not the main port.
-			//
-			// At port=65535 there's no room for +1; we pass --health-port
-			// equal to --port so the daemon's equal-port guard
-			// short-circuits cleanly (no second listener bound). Without
-			// this explicit flag, atlas-cli's deriveHealthPort would
-			// compute 65535+1=65536 and Deno.serve would throw.
-			// healthPort stays at the main port too so the launcher's
-			// probe doesn't dangle on a never-bound port.
-			var healthPortStr string
-			if portNum < 65535 {
-				healthPortStr = strconv.Itoa(portNum + 1)
-			} else {
-				log.Warn("friday port=65535: liveness listener disabled (no room for +1)",
-					"port", port)
-				healthPortStr = port
-			}
+			// The 65500 upper bound on port validation above guarantees
+			// <port>+1 stays within the bindable range — no boundary
+			// special-case needed here.
+			healthPortStr := strconv.Itoa(portNum + 1)
 			specs[i].healthPort = healthPortStr
 			specs[i].args = append(specs[i].args, "--health-port", healthPortStr)
 		case "link":

--- a/tools/friday-launcher/project.go
+++ b/tools/friday-launcher/project.go
@@ -689,15 +689,18 @@ func supervisedProcesses(binDir string) []processSpec {
 	for i, s := range specs {
 		port := portOverride(s.name)
 		if port == "" {
-			if s.name == "friday" {
-				// No port override, but the friday spec's healthPort still
-				// has to track `<port>+1` against the *default* port 8080.
-				// Pin the CLI flag so the supervised daemon binds the same
-				// liveness port the launcher probes — otherwise atlas-cli's
-				// own `mainPort + 1` default would shift if the daemon's
-				// default port ever changes.
-				specs[i].args = append(specs[i].args, "--health-port", specs[i].healthPort)
-			}
+			// No override → trust each binary's own default. For friday
+			// that's <port>+1 = 8081 in atlas-cli's deriveHealthPort;
+			// the spec's healthPort: "8081" above matches by construction.
+			continue
+		}
+		// Validate port is numeric. Without this, a typo like
+		// FRIDAY_PORT_FRIDAY="abc" would silently set healthPort to "abc"
+		// and the launcher would probe https://127.0.0.1:abc/ forever.
+		portNum, atoiErr := strconv.Atoi(port)
+		if atoiErr != nil || portNum < 1 || portNum > 65535 {
+			log.Error("port override is not a valid 1-65535 integer; ignoring",
+				"service", s.name, "value", port, "error", atoiErr)
 			continue
 		}
 		// Update the launcher's own readiness probe so it watches the
@@ -716,11 +719,15 @@ func supervisedProcesses(binDir string) []processSpec {
 			specs[i].args = append(specs[i].args, "--port", port)
 			// Liveness listener moves with the main port — keep it at
 			// <port>+1. The launcher probes this, not the main port.
-			healthPort, err := strconv.Atoi(port)
-			if err == nil {
-				healthPortStr := strconv.Itoa(healthPort + 1)
+			// Guard against 65535 → 65536 wrap; fall back to no-flag,
+			// daemon's own default will skip the listener too.
+			if portNum < 65535 {
+				healthPortStr := strconv.Itoa(portNum + 1)
 				specs[i].healthPort = healthPortStr
 				specs[i].args = append(specs[i].args, "--health-port", healthPortStr)
+			} else {
+				log.Warn("friday port=65535 leaves no room for liveness listener; skipping --health-port",
+					"port", port)
 			}
 		case "link":
 			// apps/link/src/config.ts:40 reads LINK_PORT (default 3100).

--- a/tools/friday-launcher/project_env_test.go
+++ b/tools/friday-launcher/project_env_test.go
@@ -260,12 +260,20 @@ func TestSupervisedProcesses_PortOverridesPropagate(t *testing.T) {
 	cases := []struct {
 		name string
 		// One of args / env must contain the wantSubstring.
-		check    string
-		wantArg  string // exact-arg expectation: presence of the literal token in args
+		check string
+		// wantArgs lists literal "<flag> <value>" substrings the joined
+		// args string must contain. Used for friday (which carries both
+		// --port and --health-port) so the test fails if either flag
+		// stops being propagated.
+		wantArgs []string
 		wantEnv  string // KEY=VAL expectation: presence in env
 		wantPort string // healthPort
 	}{
-		{name: "friday", check: "args", wantArg: "--port", wantPort: "18080"},
+		// friday's liveness listener moves with the main port. The launcher
+		// probes <port>+1 (the dedicated, middleware-bypassing socket), and
+		// passes both --port (main) and --health-port (liveness) to the CLI
+		// so the supervised daemon binds what the probe expects.
+		{name: "friday", check: "args", wantArgs: []string{"--port 18080", "--health-port 18081"}, wantPort: "18081"},
 		{name: "link", check: "env", wantEnv: "LINK_PORT=13100", wantPort: "13100"},
 		{name: "webhook-tunnel", check: "env", wantEnv: "TUNNEL_PORT=19090", wantPort: "19090"},
 		{name: "playground", check: "env", wantEnv: "PLAYGROUND_PORT=15200", wantPort: "15200"},
@@ -290,13 +298,12 @@ func TestSupervisedProcesses_PortOverridesPropagate(t *testing.T) {
 
 		switch tc.check {
 		case "args":
-			// For friday, both the flag and the value must appear, and
-			// the value must immediately follow the flag.
 			joined := strings.Join(found.args, " ")
-			want := tc.wantArg + " " + tc.wantPort
-			if !strings.Contains(joined, want) {
-				t.Errorf("service %q: args missing %q\ngot: %s",
-					tc.name, want, joined)
+			for _, want := range tc.wantArgs {
+				if !strings.Contains(joined, want) {
+					t.Errorf("service %q: args missing %q\ngot: %s",
+						tc.name, want, joined)
+				}
 			}
 		case "env":
 			if !slices.Contains(found.env, tc.wantEnv) {

--- a/tools/friday-launcher/project_test.go
+++ b/tools/friday-launcher/project_test.go
@@ -124,6 +124,39 @@ func TestFridayLivenessListener_DefaultPort(t *testing.T) {
 	}
 }
 
+// TestSupervisedProcesses_PortOverride_65535 pins the 16-bit boundary
+// path: when FRIDAY_PORT_FRIDAY=65535, +1 would overflow the bindable
+// range. The launcher passes --health-port equal to --port so the
+// daemon's equal-port guard short-circuits without binding a second
+// listener, and the launcher's own healthPort tracks main so the
+// probe doesn't dangle. Without this, atlas-cli's deriveHealthPort
+// would compute 65536 and Deno.serve would throw at bind time.
+func TestSupervisedProcesses_PortOverride_65535(t *testing.T) {
+	t.Setenv("FRIDAY_PORT_FRIDAY", "65535")
+	specs := supervisedProcesses("/tmp/dummy-bin")
+	var friday *processSpec
+	for i := range specs {
+		if specs[i].name == "friday" {
+			friday = &specs[i]
+			break
+		}
+	}
+	if friday == nil {
+		t.Fatal("friday not found in supervisedProcesses")
+	}
+	if friday.healthPort != "65535" {
+		t.Errorf("friday healthPort = %q, want %q (equal to main so probe lands on the bound port)",
+			friday.healthPort, "65535")
+	}
+	joined := strings.Join(friday.args, " ")
+	if !strings.Contains(joined, "--port 65535") {
+		t.Errorf("friday args missing --port 65535\ngot: %s", joined)
+	}
+	if !strings.Contains(joined, "--health-port 65535") {
+		t.Errorf("friday args must pass --health-port equal to --port at the 65535 boundary\ngot: %s", joined)
+	}
+}
+
 // TestSupervisedProcesses_BadPortOverride_IsIgnored covers the
 // non-numeric / out-of-range port override path that previously
 // would have set healthPort to a string the readiness probe could

--- a/tools/friday-launcher/project_test.go
+++ b/tools/friday-launcher/project_test.go
@@ -88,15 +88,13 @@ func TestSupervisedProcessesPinSet(t *testing.T) {
 
 // TestFridayLivenessListener_DefaultPort pins the friday daemon's
 // dedicated liveness listener wiring when no port override is set.
-// The launcher probes `<port>+1` (here 8081) rather than the main
-// `/health` route on the agent-bearing listener, because under MCP
-// fan-out the main route's microtask slice can starve and trip the
-// readiness watchdog into restarting the whole daemon. atlas-cli
-// must receive `--health-port` so the supervised binary binds the
-// same port the launcher polls — without this flag the daemon would
-// fall back to its own `mainPort + 1` default, which matches today
-// but would silently drift if the daemon's default port ever moved.
-// See AtlasDaemonOptions.healthPort in apps/atlasd/src/atlas-daemon.ts.
+// The launcher probes <port>+1 (8081) rather than the main /health
+// route on the agent-bearing listener — bypassing Hono routing +
+// middleware, and isolating the probe from the main port's accept
+// queue. With no FRIDAY_PORT_FRIDAY override, the launcher does NOT
+// pass --health-port; atlas-cli's deriveHealthPort defaults to
+// port+1 = 8081, which matches the spec's healthPort here. See
+// AtlasDaemonOptions.healthPort in apps/atlasd/src/atlas-daemon.ts.
 func TestFridayLivenessListener_DefaultPort(t *testing.T) {
 	t.Setenv("FRIDAY_PORT_FRIDAY", "")
 	specs := supervisedProcesses("/tmp/dummy-bin")
@@ -118,9 +116,52 @@ func TestFridayLivenessListener_DefaultPort(t *testing.T) {
 		t.Errorf("friday healthPath = %q, want %q (dedicated listener responds to any path)",
 			friday.healthPath, "/")
 	}
+	// On the no-override path we deliberately do NOT pass --health-port;
+	// the daemon's own default (port+1) is the single source of truth.
 	joined := strings.Join(friday.args, " ")
-	if !strings.Contains(joined, "--health-port 8081") {
-		t.Errorf("friday args missing %q\ngot: %s", "--health-port 8081", joined)
+	if strings.Contains(joined, "--health-port") {
+		t.Errorf("friday args should NOT pass --health-port without an override\ngot: %s", joined)
+	}
+}
+
+// TestSupervisedProcesses_BadPortOverride_IsIgnored covers the
+// non-numeric / out-of-range port override path that previously
+// would have set healthPort to a string the readiness probe could
+// never resolve (e.g. https://127.0.0.1:abc/). The override is
+// rejected at spec-build time and the service keeps its default.
+func TestSupervisedProcesses_BadPortOverride_IsIgnored(t *testing.T) {
+	cases := []struct {
+		name string
+		env  string
+	}{
+		{"non-numeric", "abc"},
+		{"empty-after-set", "  "},
+		{"out-of-range-high", "70000"},
+		{"out-of-range-low", "0"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("FRIDAY_PORT_FRIDAY", tc.env)
+			specs := supervisedProcesses("/tmp/dummy-bin")
+			var friday *processSpec
+			for i := range specs {
+				if specs[i].name == "friday" {
+					friday = &specs[i]
+					break
+				}
+			}
+			if friday == nil {
+				t.Fatal("friday not found in supervisedProcesses")
+			}
+			if friday.healthPort != "8081" {
+				t.Errorf("friday healthPort = %q, want %q (bad override should leave default)",
+					friday.healthPort, "8081")
+			}
+			joined := strings.Join(friday.args, " ")
+			if strings.Contains(joined, "--port "+tc.env) {
+				t.Errorf("friday args should NOT propagate bad override %q\ngot: %s", tc.env, joined)
+			}
+		})
 	}
 }
 

--- a/tools/friday-launcher/project_test.go
+++ b/tools/friday-launcher/project_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 )
 
@@ -82,6 +83,44 @@ func TestSupervisedProcessesPinSet(t *testing.T) {
 		if got[i] != want[i] {
 			t.Errorf("supervisedProcesses[%d] = %q, want %q", i, got[i], want[i])
 		}
+	}
+}
+
+// TestFridayLivenessListener_DefaultPort pins the friday daemon's
+// dedicated liveness listener wiring when no port override is set.
+// The launcher probes `<port>+1` (here 8081) rather than the main
+// `/health` route on the agent-bearing listener, because under MCP
+// fan-out the main route's microtask slice can starve and trip the
+// readiness watchdog into restarting the whole daemon. atlas-cli
+// must receive `--health-port` so the supervised binary binds the
+// same port the launcher polls — without this flag the daemon would
+// fall back to its own `mainPort + 1` default, which matches today
+// but would silently drift if the daemon's default port ever moved.
+// See AtlasDaemonOptions.healthPort in apps/atlasd/src/atlas-daemon.ts.
+func TestFridayLivenessListener_DefaultPort(t *testing.T) {
+	t.Setenv("FRIDAY_PORT_FRIDAY", "")
+	specs := supervisedProcesses("/tmp/dummy-bin")
+	var friday *processSpec
+	for i := range specs {
+		if specs[i].name == "friday" {
+			friday = &specs[i]
+			break
+		}
+	}
+	if friday == nil {
+		t.Fatal("friday not found in supervisedProcesses")
+	}
+	if friday.healthPort != "8081" {
+		t.Errorf("friday healthPort = %q, want %q (default 8080 + 1)",
+			friday.healthPort, "8081")
+	}
+	if friday.healthPath != "/" {
+		t.Errorf("friday healthPath = %q, want %q (dedicated listener responds to any path)",
+			friday.healthPath, "/")
+	}
+	joined := strings.Join(friday.args, " ")
+	if !strings.Contains(joined, "--health-port 8081") {
+		t.Errorf("friday args missing %q\ngot: %s", "--health-port 8081", joined)
 	}
 }
 

--- a/tools/friday-launcher/project_test.go
+++ b/tools/friday-launcher/project_test.go
@@ -124,37 +124,56 @@ func TestFridayLivenessListener_DefaultPort(t *testing.T) {
 	}
 }
 
-// TestSupervisedProcesses_PortOverride_65535 pins the 16-bit boundary
-// path: when FRIDAY_PORT_FRIDAY=65535, +1 would overflow the bindable
-// range. The launcher passes --health-port equal to --port so the
-// daemon's equal-port guard short-circuits without binding a second
-// listener, and the launcher's own healthPort tracks main so the
-// probe doesn't dangle. Without this, atlas-cli's deriveHealthPort
-// would compute 65536 and Deno.serve would throw at bind time.
-func TestSupervisedProcesses_PortOverride_65535(t *testing.T) {
-	t.Setenv("FRIDAY_PORT_FRIDAY", "65535")
-	specs := supervisedProcesses("/tmp/dummy-bin")
-	var friday *processSpec
-	for i := range specs {
-		if specs[i].name == "friday" {
-			friday = &specs[i]
-			break
+// TestSupervisedProcesses_PortOverride_UpperBound pins the upper end
+// of the accepted range. The launcher caps overrides at 65500 (not
+// 65535) so friday's liveness listener at <port>+1 always has room
+// without special-casing the 16-bit boundary. 65500 must be accepted
+// and propagate cleanly; 65501 must be rejected.
+func TestSupervisedProcesses_PortOverride_UpperBound(t *testing.T) {
+	t.Run("65500-accepted", func(t *testing.T) {
+		t.Setenv("FRIDAY_PORT_FRIDAY", "65500")
+		specs := supervisedProcesses("/tmp/dummy-bin")
+		var friday *processSpec
+		for i := range specs {
+			if specs[i].name == "friday" {
+				friday = &specs[i]
+				break
+			}
 		}
-	}
-	if friday == nil {
-		t.Fatal("friday not found in supervisedProcesses")
-	}
-	if friday.healthPort != "65535" {
-		t.Errorf("friday healthPort = %q, want %q (equal to main so probe lands on the bound port)",
-			friday.healthPort, "65535")
-	}
-	joined := strings.Join(friday.args, " ")
-	if !strings.Contains(joined, "--port 65535") {
-		t.Errorf("friday args missing --port 65535\ngot: %s", joined)
-	}
-	if !strings.Contains(joined, "--health-port 65535") {
-		t.Errorf("friday args must pass --health-port equal to --port at the 65535 boundary\ngot: %s", joined)
-	}
+		if friday == nil {
+			t.Fatal("friday not found in supervisedProcesses")
+		}
+		if friday.healthPort != "65501" {
+			t.Errorf("friday healthPort = %q, want %q (port+1)", friday.healthPort, "65501")
+		}
+		joined := strings.Join(friday.args, " ")
+		if !strings.Contains(joined, "--port 65500") {
+			t.Errorf("friday args missing --port 65500\ngot: %s", joined)
+		}
+		if !strings.Contains(joined, "--health-port 65501") {
+			t.Errorf("friday args missing --health-port 65501\ngot: %s", joined)
+		}
+	})
+
+	t.Run("65501-rejected", func(t *testing.T) {
+		t.Setenv("FRIDAY_PORT_FRIDAY", "65501")
+		specs := supervisedProcesses("/tmp/dummy-bin")
+		var friday *processSpec
+		for i := range specs {
+			if specs[i].name == "friday" {
+				friday = &specs[i]
+				break
+			}
+		}
+		if friday == nil {
+			t.Fatal("friday not found in supervisedProcesses")
+		}
+		// Out-of-range override is rejected; spec stays at defaults.
+		if friday.healthPort != "8081" {
+			t.Errorf("friday healthPort = %q, want %q (rejected override leaves default)",
+				friday.healthPort, "8081")
+		}
+	})
 }
 
 // TestSupervisedProcesses_BadPortOverride_IsIgnored covers the
@@ -170,6 +189,7 @@ func TestSupervisedProcesses_BadPortOverride_IsIgnored(t *testing.T) {
 		{"non-numeric", "abc"},
 		{"empty-after-set", "  "},
 		{"out-of-range-high", "70000"},
+		{"just-above-cap", "65501"}, // upper bound is 65500
 		{"out-of-range-low", "0"},
 	}
 	for _, tc := range cases {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,6 +36,12 @@ export default defineConfig({
       // import without extensions; vitest's ESM resolver rejects them.
       // The component itself ships fine — only the test loader is broken.
       "tools/agent-playground/src/lib/components/mcp/mcp-credentials-panel.test.ts",
+      // Deno-native integration test for the liveness listener. Uses
+      // `Deno.serve` and `jsr:@std/assert@1` — neither is reachable from
+      // vitest's Node environment. Run via `deno test --allow-net` (see
+      // the file header). Vitest's glob would otherwise pick it up by
+      // the `.test.ts` suffix and fail to resolve the jsr: import.
+      "apps/atlasd/src/health-listener.test.ts",
     ],
     update: process.env.CI ? "none" : "new",
     // `@tanstack/svelte-query` ships a `.svelte` file


### PR DESCRIPTION
## Summary

The launcher's readiness probe was hitting `/health` on the same `Deno.serve` that handles agent, MCP, and NATS traffic. When MCP fan-out saturates the V8 microtask queue (one bad stdio server hanging on `initialize`, concurrent stale uvx subprocesses, JetStream consumer pulls backing up), the trivial `/health` handler couldn't get scheduled inside the launcher's 2 s probe deadline. 30 consecutive failures × 2 s = SIGTERM → forced restart, even though the daemon was alive enough to acknowledge the signal and run shutdown handlers.

This change binds a second `Deno.serve` on `port + 1` with a static `() => new Response("ok")` handler — no Hono, no middleware, no shared-state access. The two listeners share the V8 isolate (not full isolation), but Deno's Tokio-side accept loop runs them as independent tasks and the static-Response fast path wins the microtask race that a Hono-routed handler would lose. The main `/health` route stays for atlas-cli + UI; only the launcher's probe moves.

## Changes

- **`apps/atlasd/src/atlas-daemon.ts`** — `AtlasDaemonOptions.healthPort`. When set, `startHealthListener()` binds a second `Deno.serve` with `() => new Response("ok")`. Drained in phase 1 alongside the main server (1 s ceiling, own abort controller). Bind failures are non-fatal — main `/health` still works.
- **`apps/atlas-cli/src/commands/daemon/start.tsx`** — `--health-port` flag, default `<port>+1`, `0` opts out. Plumbed through `buildDaemonArgs()` so re-exec carries it.
- **`tools/friday-launcher/project.go`** — friday spec probes `8081/` (default) or `<override>+1/` when `FRIDAY_PORT_FRIDAY` is set. Launcher passes both `--port` and `--health-port` to the daemon CLI so they stay in lockstep.

## Background

Original incident: `friday@192.168.64.17` 2026-05-19 14:15:45 PDT. User connected Notion in chat, two MCP servers were auto-wired (`com-notion-mcp` HTTP — worked, and `com-mcparmory-notion` stdio — hung on FastMCP `initialize` because the package required `OAUTH2_CLIENT_ID`/`OAUTH2_CLIENT_SECRET` that nothing provided). The 20 s MCP timeout cascaded into a 5 s NATS JetStream consumer timeout in workspace-chat, then a 50 s log silence (event-loop starvation), then SIGTERM from launcher. Full forensic trace is in conversation history.

## Test plan

Verified locally with the daemon running on `--port 38080 --health-port 38081`:

- [x] Both listeners bind HTTPS with same s2s cert
- [x] Liveness returns `200 ok` to any path (`/`, `/health`, `/anything`)
- [x] Main `/health` route preserved on main port (existing JSON shape)
- [x] Sub-3 ms liveness latency under main-port load (50 concurrent probes)
- [x] Clean SIGTERM shutdown — both ports released, no drain warnings
- [x] `--health-port` matrix:
  - [x] omitted → defaults to `port + 1`
  - [x] `0` → liveness listener disabled
  - [x] equal to `--port` → silently no-ops
  - [x] occupied → `Liveness listener bind failed  error:"Address already in use"` logged, main continues
- [x] Launcher unit tests (5 touched + new `TestFridayLivenessListener_DefaultPort` pin)
- [x] Cross-compile for `aarch64-apple-darwin`

**Not verified — VM deploy blocked on Gatekeeper:**
- [ ] Replay original Notion-connect cascade with fix in place

Production binaries are Developer-ID signed; locally compiled binaries are adhoc-signed and get SIGKILL'd by macOS Gatekeeper on the target VM. Attempting `codesign --force --sign -` on the 1 GB binary OOM'd the VM (~65 MB free RAM). To validate the in-prod cascade is actually prevented, we need a properly-signed build on the VM. The design is locally sound — the gap is reproduction infrastructure, not a code defect.

## Follow-ups (not in this PR)

If this fix alone doesn't fully prevent the cascade, the remaining lever is killing leaked `uvx` subprocesses on MCP stdio timeout (separate change in `packages/mcp-client/transports/stdio.ts`). The dedicated liveness listener buys readiness even when the subprocess leak is happening; killing the subprocesses removes the leak itself.