### PR TITLE
fix(playground): daemon-gate wedges on hidden-tab first mount

### DIFF
--- a/tools/agent-playground/src/lib/daemon-health.svelte.ts
+++ b/tools/agent-playground/src/lib/daemon-health.svelte.ts
@@ -83,15 +83,15 @@ function scheduleNext(): void {
 
 async function tick(): Promise<void> {
   scheduled = null;
-  // Skip the probe while the tab is hidden — a backgrounded playground
-  // has nothing to display anyway, and Chrome throttles network in
-  // hidden tabs hard enough that a probe is more likely to time out
-  // than report ground truth. We re-arm immediately so a quick toggle
-  // back to visible still gets a probe at the next scheduled tick.
-  if (typeof document !== "undefined" && document.visibilityState !== "visible") {
-    scheduleNext();
-    return;
-  }
+  // Previous version bailed when `document.visibilityState !== "visible"` to
+  // avoid probing in backgrounded tabs. It silently wedged the daemon-gate
+  // on any tab that mounted while hidden (background-opened tabs,
+  // DevTools-Protocol-driven tabs, headless test harnesses) because
+  // `state.loading` only flips inside `check()`'s `finally` — no probe, no
+  // flip, gate stuck on "CONNECTING…" forever. The bail's stated rationale
+  // (Chrome throttles fetch on hidden tabs) doesn't apply at the cadence
+  // we use: one local fetch per 30s when steady-connected is negligible,
+  // and Chrome throttles timers, not fetch. Probe unconditionally.
   try {
     await check();
   } finally {


### PR DESCRIPTION
🪷 Koan

The tab opens.
No one is looking.
The probe never runs.

## Summary

`tick()` bailed when `document.visibilityState !== "visible"`, leaving the daemon-gate's loading branch mounted forever on any tab that mounted while hidden: `state.loading` only flips inside `check()`'s `finally`, so no probe → no flip → gate stuck on "CONNECTING…" indefinitely.

**Affected tabs:**
- Background-opened tabs — 5s+ visible wedge until the next scheduled tick lands on a visible state.
- DevTools-Protocol-driven tabs (Claude in Chrome, headless test harnesses) where \`visibilityState\` never transitions to \`\"visible\"\` — **permanent wedge** with the daemon perfectly healthy.

## Fix

**Drop the bail.** That's it. One \`if\` block + a comment removed.

The bail's stated rationale (\"Chrome throttles network in hidden tabs hard enough that a probe is more likely to time out\") doesn't survive close inspection: Chrome throttles **timers**, not fetch; the steady cadence is 30s; the daemon is \`localhost\`, not a metered network. One extra \`/api/daemon/health\` request per 30s on a hidden tab is negligible.

### Why not the visibilitychange-listener approach

An earlier version of this PR (`f6e41fb1`, force-pushed) preserved the bail and compensated with an unconditional first-probe path plus a `visibilitychange` listener (~40 lines). That worked but introduced a real race in `scheduleNext` — two `check().finally(scheduleNext)` chains could overlap and leak `setTimeout` handles. Reviewer (#404 review doc) called out that dropping the bail collapses the patch and eliminates the race surface entirely. This version is that collapse.

## Test plan

Verified in MCP-driven Chrome (\`visibilityState === \"hidden\"\`):

- [x] Page renders the workspace inspector within ~600ms of first mount. Sidebar shows Online. \`.gate-state\` opacity transitions to 0 immediately after first probe lands.
- [x] Run-button flow completes end-to-end (modal opens, trigger fires, navigation to spawned session view).
- [x] \`deno task typecheck\` — 0 errors, 33 pre-existing warnings unchanged.

Without the fix, the same MCP tab wedges on \`CONNECTING…\` indefinitely (reproducible across hard reloads).

Independent of and orthogonal to PR #402 (Run-button \`?nowait=true\`); together they make MCP-driven QA of any signal-trigger feature actually feasible.