### PR TITLE
feat(session): thread correlationId onto SessionSummary

### DIFF
--- a/apps/atlasd/routes/sessions/index.ts
+++ b/apps/atlasd/routes/sessions/index.ts
@@ -11,7 +11,16 @@ import { daemonFactory } from "../../src/factory.ts";
 import { publishSessionCancel } from "../../src/session-dispatch-registry.ts";
 import { getAccessibleWorkspaceIds, requireWorkspaceMember } from "../../src/workspace-authz.ts";
 
-const ListQuery = z.object({ workspaceId: z.string().optional() });
+const ListQuery = z.object({
+  workspaceId: z.string().optional(),
+  /**
+   * Filter to sessions whose `SessionSummary.correlationId` matches.
+   * Lets a `?nowait=true` signal-trigger caller redeem the 202's
+   * correlationId for the spawned sessionId without polling for a
+   * generic "newest non-snapshot" guess.
+   */
+  correlationId: z.string().optional(),
+});
 
 /**
  * Build a SessionSummary from a SessionView (for active sessions
@@ -30,6 +39,7 @@ function viewToSummary(view: SessionView): SessionSummary {
     stepCount: view.agentBlocks.length,
     agentNames: view.agentBlocks.map((b) => b.agentName),
     aiSummary: view.aiSummary,
+    ...(view.correlationId && { correlationId: view.correlationId }),
   };
 }
 
@@ -45,7 +55,7 @@ const sessionsRoutes = daemonFactory
     const userId = c.get("userId");
     if (!userId) return c.json({ error: "Unauthorized" }, 401);
 
-    const { workspaceId } = c.req.valid("query");
+    const { workspaceId, correlationId } = c.req.valid("query");
     if (workspaceId !== undefined) {
       await requireWorkspaceMember(c, workspaceId);
     }
@@ -70,9 +80,19 @@ const sessionsRoutes = daemonFactory
     }
 
     // Merge and sort by startedAt descending
-    const sessions = [...activeSummaries, ...completedSummaries].sort(
+    let sessions = [...activeSummaries, ...completedSummaries].sort(
       (a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
     );
+
+    // correlationId filter — applied after the workspace filter so a
+    // nowait caller can look up its spawned session without knowing
+    // the workspaceId (though typically it does). Returns at most one
+    // session in practice (correlationId is per-signal-trigger), but
+    // we don't enforce that here — callers should treat results as
+    // "all sessions tagged with this correlationId".
+    if (correlationId !== undefined) {
+      sessions = sessions.filter((s) => s.correlationId === correlationId);
+    }
 
     return c.json({ sessions }, 200);
   })

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -822,6 +822,12 @@ export class AtlasDaemon {
               // consumed — Phase 11 makes it carry across into
               // `SessionSummary.parentSessionId`.
               parentSessionId: envelope.sourceSessionId,
+              // Carry the HTTP trigger's correlationId through to the
+              // spawned session so a `?nowait=true` caller can redeem the
+              // 202's correlationId for this sessionId via
+              // `GET /api/sessions?correlationId=…`. Absent on
+              // non-correlated envelopes (cron, fs-watch).
+              correlationId: envelope.correlationId,
               webhookContext: envelopeToWebhookContext(envelope),
             },
           );

--- a/packages/core/src/session/session-events.ts
+++ b/packages/core/src/session/session-events.ts
@@ -60,6 +60,14 @@ export const SessionStartEventSchema = z.object({
    * inflight-marker writer to let listers filter without a join.
    */
   signalId: z.string().optional(),
+  /**
+   * Correlation id from the HTTP envelope that triggered this session.
+   * Carried so the SessionView reducer can surface it on active
+   * sessions (the durable `SessionSummary.correlationId` only exists
+   * after finalization). Optional — absent for non-HTTP triggers or
+   * historical events that predate the field.
+   */
+  correlationId: z.string().optional(),
   plannedSteps: z
     .array(
       z.object({
@@ -255,6 +263,14 @@ export const SessionViewSchema = z.object({
   error: z.string().optional(),
   /** AI-generated summary produced at session finalization */
   aiSummary: SessionAISummarySchema.optional(),
+  /**
+   * Correlation id from the HTTP envelope that triggered this session.
+   * Captured from the `session:start` event by the reducer. Lets the
+   * list endpoint surface correlationId for *active* sessions too —
+   * the durable `SessionSummary.correlationId` only exists post-
+   * finalization.
+   */
+  correlationId: z.string().optional(),
 });
 export type SessionView = z.infer<typeof SessionViewSchema>;
 
@@ -290,5 +306,16 @@ export const SessionSummarySchema = z.object({
    * pure session-level linkage works without it.
    */
   parentEventId: z.string().optional(),
+  /**
+   * Correlation id assigned by the signal trigger that spawned this
+   * session. Carried on the cascade envelope, threaded through to the
+   * session at creation. Lets a `?nowait=true` HTTP caller redeem the
+   * correlationId from the 202 response for the spawned sessionId via
+   * `GET /api/sessions?correlationId=…`, without polling for a generic
+   * "newest non-snapshot" guess. Absent for sessions spawned without a
+   * correlated envelope (chat-tools that call `bypassConcurrency`,
+   * cron signals, fs-watch signals).
+   */
+  correlationId: z.string().optional(),
 });
 export type SessionSummary = z.infer<typeof SessionSummarySchema>;

--- a/packages/core/src/session/session-reducer.ts
+++ b/packages/core/src/session/session-reducer.ts
@@ -55,6 +55,7 @@ export function reduceSessionEvent(
         task: event.task,
         status: "active",
         startedAt: event.timestamp,
+        ...(event.correlationId && { correlationId: event.correlationId }),
         agentBlocks:
           event.plannedSteps?.map((step) => ({
             stepNumber: undefined,

--- a/packages/workspace/src/runtime.ts
+++ b/packages/workspace/src/runtime.ts
@@ -243,6 +243,15 @@ interface WorkspaceRuntimeSignal {
    */
   parentSessionId?: string;
   /**
+   * Correlation id assigned by the HTTP signal trigger that produced
+   * this envelope. Forwarded to `SessionSummary.correlationId` at
+   * finalization so a `?nowait=true` caller can redeem its 202's
+   * correlationId for the spawned sessionId via
+   * `GET /api/sessions?correlationId=…`. Absent for non-correlated
+   * triggers (cron, fs-watch, bypassConcurrency chat tools).
+   */
+  correlationId?: string;
+  /**
    * Base64-encoded original webhook request body. Only set for signals
    * fired through Friday's webhook-tunnel (the byte-for-byte HTTP proxy).
    * Surfaces to the agent as `ctx.input.raw["body"]` so HMAC verification
@@ -277,6 +286,13 @@ export interface TriggerSignalOpts {
    * session records its parent. Phase 11 provenance.
    */
   parentSessionId?: string;
+  /**
+   * Correlation id from the HTTP envelope that triggered this signal.
+   * Threads through to `SessionSummary.correlationId` so the spawned
+   * session is discoverable from the 202's `{ correlationId }` via
+   * `GET /api/sessions?correlationId=…`. Absent for non-HTTP triggers.
+   */
+  correlationId?: string;
   /**
    * Webhook-only context (base64 body + lowercased headers) preserved
    * byte-for-byte from the upstream HTTP request when the signal was
@@ -2049,6 +2065,7 @@ export class WorkspaceRuntime {
           task: typeof signal.data?.task === "string" ? signal.data.task : job.name,
           plannedSteps,
           timestamp: session.startedAt.toISOString(),
+          ...(signal.correlationId && { correlationId: signal.correlationId }),
         });
 
         // Emit session-start to the client's SSE stream so the UI can display
@@ -2429,6 +2446,10 @@ export class WorkspaceRuntime {
               // field on the wire — keeps existing SESSION_METADATA entries
               // and round-trip schema parses unchanged.
               ...(signal.parentSessionId && { parentSessionId: signal.parentSessionId }),
+              // Correlation id from the HTTP envelope. Lets nowait callers
+              // redeem their 202's correlationId for this sessionId via
+              // GET /api/sessions?correlationId=…
+              ...(signal.correlationId && { correlationId: signal.correlationId }),
             };
 
             await sessionStream.finalize(summaryV2).catch((err) => {
@@ -3446,8 +3467,15 @@ export class WorkspaceRuntime {
     payload?: Record<string, unknown>,
     opts: TriggerSignalOpts = {},
   ): Promise<WorkspaceSignalRunResult> {
-    const { streamId, onStreamEvent, skipStates, abortSignal, parentSessionId, webhookContext } =
-      opts;
+    const {
+      streamId,
+      onStreamEvent,
+      skipStates,
+      abortSignal,
+      parentSessionId,
+      correlationId,
+      webhookContext,
+    } = opts;
     // Top-level `streamId` opt wins over any payload.streamId. The runtime
     // reads the merged value via `signal.data.streamId` (see processSignalForJob
     // ~line 1595 where streamId is derived). Both surfaces stay supported so
@@ -3462,6 +3490,7 @@ export class WorkspaceRuntime {
       data,
       timestamp: new Date(),
       parentSessionId,
+      correlationId,
       body: webhookContext?.body,
       headers: webhookContext?.headers,
     };

--- a/tools/agent-playground/src/lib/components/workspace/run-job-dialog.svelte
+++ b/tools/agent-playground/src/lib/components/workspace/run-job-dialog.svelte
@@ -14,7 +14,7 @@
 <script lang="ts">
   import { Button, Dialog } from "@atlas/ui";
   import { goto } from "$app/navigation";
-  import { getDaemonClient } from "$lib/daemon-client";
+  import { getDaemonClient, PROXY_BASE } from "$lib/daemon-client";
   import {
     getFieldRendering,
     humanizeFieldName,
@@ -35,9 +35,25 @@
   let { workspaceId, jobId, jobTitle, signals, triggers }: Props = $props();
 
   let error = $state<string | null>(null);
+  let submitting = $state(false);
 
   let selectedSignalId = $state("");
   let formData = $state<Record<string, unknown>>({});
+
+  /**
+   * Held in component scope so unmount cleanup and Cancel can abort an
+   * in-flight trigger+poll cycle. Without it, a poll that outlives the
+   * dialog would happily fire `goto()` on whatever page the user
+   * navigated to next.
+   */
+  let pollController: AbortController | null = null;
+
+  $effect(() => {
+    return () => {
+      pollController?.abort();
+      pollController = null;
+    };
+  });
 
   const triggerSignals = $derived(
     triggers
@@ -70,9 +86,12 @@
   });
 
   function resetForm() {
+    pollController?.abort();
+    pollController = null;
     selectedSignalId = "";
     formData = {};
     error = null;
+    submitting = false;
   }
 
   function handleSignalChange(signalId: string) {
@@ -82,6 +101,8 @@
   }
 
   async function handleSubmit(open: { set: (v: boolean) => void }) {
+    if (submitting) return;
+
     if (!activeSignalId) {
       error = "Please select a signal to trigger";
       return;
@@ -103,33 +124,127 @@
     const payload = hasSchema ? { ...formData } : undefined;
 
     error = null;
+    submitting = true;
 
-    // Fire-and-forget: dismiss modal immediately, navigate on success
-    open.set(false);
-    resetForm();
+    // Use `?nowait=true` so the inbound HTTP request returns 202 as soon
+    // as the signal is published to JetStream. The cascade runs decoupled
+    // from this browser tab's lifetime — closing the modal, navigating
+    // away, or refreshing won't abort the spawned session. The sync path
+    // (no nowait) held the fetch open for the full cascade and cancelled
+    // the run on any navigation; long jobs (minutes-plus) always lost
+    // that race.
+    //
+    // Direct fetch instead of the typed RPC client: the daemon route has
+    // no `zValidator("query")`, so the Hono RPC input type doesn't
+    // expose a `query` field. Adding one upstream would force every
+    // other caller (CLI, MCP server, workspace-chat job tools, the
+    // platform client) to pass `query: {}` boilerplate — not worth the
+    // churn for a single optional flag.
+    //
+    // Auto-navigation: nowait's 202 carries a `correlationId`. The
+    // daemon threads it onto `SessionSummary.correlationId` (see
+    // `SessionSummarySchema` in @atlas/core), and `GET /api/sessions`
+    // accepts a `correlationId` filter. Poll the filter until our
+    // session appears, then navigate — deterministic match, no race
+    // even when two tabs fire the same job at once (each gets its
+    // own correlationId server-side).
+    //
+    // Modal stays open showing "Starting…" until we either land on
+    // the spawned session view or the poll budget runs out — closing
+    // on click before the session existed gave the user "nothing
+    // happened" for up to half a second on the happy path.
+    pollController?.abort();
+    const controller = new AbortController();
+    pollController = controller;
+    const { signal } = controller;
 
-    const client = getDaemonClient();
-    client.workspace[":workspaceId"].signals[":signalId"]
-      .$post({
-        param: { workspaceId, signalId },
-        json: { payload },
-      })
-      .then(async (res) => {
-        if (!res.ok) {
-          console.error("Trigger failed:", res.status);
-          return;
-        }
-        const data = await res.json();
-        // Response can be {status:"completed",sessionId,...} (default sync)
-        // or {status:"accepted",correlationId,...} (?nowait=true). This
-        // dialog uses sync mode (no nowait), so navigate to the session.
-        if (data.status === "completed" && data.sessionId) {
-          goto(`/platform/${workspaceId}/sessions/${data.sessionId}`);
-        }
-      })
-      .catch((err) => {
-        console.error("Failed to trigger signal:", err);
+    try {
+      const url = `${PROXY_BASE}/api/workspaces/${encodeURIComponent(
+        workspaceId,
+      )}/signals/${encodeURIComponent(signalId)}?nowait=true`;
+      const triggerRes = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ payload }),
+        signal,
       });
+      if (!triggerRes.ok) {
+        error = `Trigger failed (HTTP ${triggerRes.status})`;
+        submitting = false;
+        return;
+      }
+      const triggerBody = (await triggerRes.json()) as { correlationId?: string };
+      const correlationId = triggerBody.correlationId;
+      if (!correlationId) {
+        error = "Trigger accepted but the daemon didn't return a correlation id.";
+        submitting = false;
+        return;
+      }
+
+      const sessionId = await findSessionByCorrelationId(workspaceId, correlationId, signal);
+      if (signal.aborted) return;
+
+      if (sessionId) {
+        // Route change unmounts the dialog; the $effect cleanup aborts
+        // the controller automatically, so no separate teardown here.
+        open.set(false);
+        resetForm();
+        goto(`/platform/${workspaceId}/sessions/${sessionId}`);
+      } else {
+        error = "Couldn't find the spawned session — check Recent Runs.";
+        submitting = false;
+      }
+    } catch (err) {
+      if ((err as Error | undefined)?.name === "AbortError") return;
+      console.error("Failed to trigger signal:", err);
+      error = "Failed to trigger signal.";
+      submitting = false;
+    }
+  }
+
+  /**
+   * Poll `GET /api/sessions?workspaceId=…&correlationId=…` until the
+   * cascade consumer has spawned the session and tagged it with our
+   * correlationId. Deterministic match — correlationId is unique per
+   * signal trigger, so we cannot race with another tab or with cron.
+   *
+   * Budget: first poll fires immediately, then 150ms cadence for the
+   * first 5 attempts (user is staring at "Starting…"; tighten the
+   * loop), then 400ms for the remaining 12 attempts (~5s tail). Total
+   * ~5.5s before we give up and surface an inline error.
+   */
+  async function findSessionByCorrelationId(
+    workspaceId: string,
+    correlationId: string,
+    signal: AbortSignal,
+  ): Promise<string | null> {
+    const fastInterval = 150;
+    const fastAttempts = 5;
+    const slowInterval = 400;
+    const slowAttempts = 12;
+    const totalAttempts = fastAttempts + slowAttempts;
+    const client = getDaemonClient();
+    for (let attempt = 0; attempt < totalAttempts; attempt++) {
+      if (signal.aborted) return null;
+      try {
+        const res = await client.sessions.index.$get(
+          { query: { workspaceId, correlationId } },
+          { init: { signal } },
+        );
+        if (res.ok) {
+          const data = await res.json();
+          const match = data.sessions[0];
+          if (match?.sessionId) return match.sessionId;
+        }
+      } catch (err) {
+        if ((err as Error | undefined)?.name === "AbortError") return null;
+        console.warn("Session poll failed:", err);
+      }
+      if (signal.aborted) return null;
+      const intervalMs = attempt < fastAttempts ? fastInterval : slowInterval;
+      await new Promise<void>((resolve) => setTimeout(resolve, intervalMs));
+    }
+    return null;
   }
 </script>
 
@@ -243,8 +358,8 @@
           {/if}
 
           <div class="buttons">
-            <Dialog.Button type="submit" closeOnClick={false}>
-              Run
+            <Dialog.Button type="submit" closeOnClick={false} disabled={submitting}>
+              {submitting ? "Starting…" : "Run"}
             </Dialog.Button>
             <Dialog.Cancel onclick={resetForm}>Cancel</Dialog.Cancel>
           </div>

--- a/tools/agent-playground/src/lib/daemon-client.ts
+++ b/tools/agent-playground/src/lib/daemon-client.ts
@@ -17,8 +17,12 @@ import { hc } from "hono/client";
 /**
  * Proxy base — all daemon requests route through the SvelteKit proxy
  * at `/api/daemon/`, which strips the prefix and forwards to the daemon.
+ *
+ * Exported so callers that need to bypass the typed Hono RPC client
+ * (e.g. to append a query param the route doesn't validate) can build
+ * a URL against the same proxy base instead of hard-coding the prefix.
  */
-const PROXY_BASE = "/api/daemon";
+export const PROXY_BASE = "/api/daemon";
 
 /**
  * Creates a typed Hono RPC client for the local daemon, routed through the


### PR DESCRIPTION
📖 Six-word memoir

Receive correlation id. Now use it.

## Summary

Closes the gap PR #402's \`run-job-dialog\` had to work around: nowait gives the caller a \`correlationId\` in the 202, but there was no API that accepted it as input — so the dialog snapshotted sessions pre-POST and picked \"newest non-snapshot for this jobName\" post-POST, which races when two tabs (or cron + a manual click) fire the same job at the same time.

This makes correlationId a first-class attribute of a session, end to end:

- **\`SessionSummarySchema\` / \`SessionViewSchema\`** get an optional \`correlationId\` field (\`@atlas/core\`)
- **\`SessionStartEventSchema\`** gets the same field, and the reducer surfaces it on the live \`SessionView\` so *active* sessions (whose summary isn't persisted yet) are also discoverable
- **Runtime** threads correlationId from \`TriggerSignalOpts\` → \`WorkspaceRuntimeSignal\` → emitted \`session:start\` event → conditionally-spread \`summaryV2\` at finalization
- **atlasd cascade consumer** passes \`envelope.correlationId\` into \`triggerWorkspaceSignal\` (mirroring how \`parentSessionId\` is already plumbed). The envelope already carries correlationId from the JetStream publish path; this PR just makes the consumer forward it instead of dropping it.
- **\`GET /api/sessions\`** accepts a new optional \`?correlationId=…\` query that filters the merged active+completed list

\`run-job-dialog\` is rewritten to use it: read \`correlationId\` from the 202 body, poll \`/api/sessions?workspaceId=…&correlationId=…\` with that filter, navigate when a match appears. Snapshot-then-diff is gone (~50 lines deleted). **Deterministic match** means two tabs firing the same job can no longer mis-attribute each other's runs — each tab's trigger gets its own server-generated correlationId.

## Relationship to #402

Same dialog file. This PR's dialog supersedes #402's snapshot-diff approach. Suggested merge order: close #402 in favor of this, OR merge #402 first and then this PR's rebase deletes the snapshot code added by #402. Either works.

## Test plan

Verified end-to-end via curl against \`deno task dev:playground\`:

\`\`\`
$ curl -sk -X POST https://localhost:8080/api/workspaces/braised_oregano/signals/count-and-sleep?nowait=true \\
    -H 'Content-Type: application/json' -d '{\"payload\":{}}'
{\"message\":\"Signal accepted\",\"status\":\"accepted\",\"workspaceId\":\"braised_oregano\",\"signalId\":\"count-and-sleep\",\"correlationId\":\"738f65c0-b819-47a8-9238-049d74aeb0d4\"}

$ curl -sk https://localhost:8080/api/sessions?correlationId=738f65c0-b819-47a8-9238-049d74aeb0d4
{\"sessions\":[{\"sessionId\":\"0d151072-…\",\"workspaceId\":\"braised_oregano\",\"jobName\":\"count-and-sleep\",\"status\":\"active\",\"correlationId\":\"738f65c0-b819-47a8-9238-049d74aeb0d4\",…}]}

$ curl -sk https://localhost:8080/api/sessions?correlationId=nonexistent
{\"sessions\":[]}
\`\`\`

- [x] \`deno task typecheck\` — 0 errors, 33 pre-existing warnings unchanged
- [x] Server side verified via curl (above)
- [ ] UI flow in Chrome MCP — currently blocked on this branch by the hidden-tab daemon-gate wedge (orthogonal fix in #404). Once #404 lands or this PR rebases on top, the dialog QA can be driven via the same MCP harness as the prior PRs.