### PR TITLE
feat(chat): surface macOS TCC denials as in-card affordance

### DIFF
--- a/packages/system/agents/workspace-chat/tools/code-exec.test.ts
+++ b/packages/system/agents/workspace-chat/tools/code-exec.test.ts
@@ -166,4 +166,47 @@ describe("run_code — PTY wrap for interactive-auth commands", () => {
     expect(String(result.stderr)).toContain("stderr content");
     expect(result.exit_code).toBe(7);
   });
+
+  it("attaches tcc_denied when stderr matches macOS protected-folder denial", async () => {
+    // Drive the detector via a synthetic stderr — actually triggering TCC
+    // requires a non-entitled parent process which CI cannot guarantee.
+    // The script prints the same byte sequence the OS would emit, exits
+    // non-zero, and we assert the field is populated end-to-end.
+    if (process.platform !== "darwin") return;
+    const tools = createRunCodeTool("test-session-tcc", logger);
+    const run = getExecute(tools.run_code);
+
+    const homePath = process.env.HOME ?? "";
+    if (!homePath) throw new Error("HOME not set in test env");
+
+    const result = await run({
+      language: "bash",
+      source: `printf '%s\\n' "ls: ${homePath}/Downloads/: Operation not permitted" >&2; exit 1`,
+    });
+
+    if (!hasKey(result, "exit_code")) {
+      throw new Error(`expected success shape, got ${JSON.stringify(result)}`);
+    }
+    const tcc = (result as { tcc_denied?: { protectedRoot: string; actions: unknown[] } })
+      .tcc_denied;
+    expect(tcc).toBeDefined();
+    expect(tcc?.protectedRoot).toBe(`${homePath}/Downloads`);
+    expect(Array.isArray(tcc?.actions)).toBe(true);
+  });
+
+  it("does NOT attach tcc_denied on a clean (exit 0) run, even if output mentions the marker", async () => {
+    // Guard: a 0-exit script that happens to print the magic string as
+    // data shouldn't trip the affordance.
+    if (process.platform !== "darwin") return;
+    const tools = createRunCodeTool("test-session-tcc-cleanrun", logger);
+    const run = getExecute(tools.run_code);
+
+    const result = await run({
+      language: "bash",
+      source: `echo "the string Operation not permitted is just data here"; exit 0`,
+    });
+
+    if (!hasKey(result, "exit_code")) throw new Error("expected success shape");
+    expect((result as { tcc_denied?: unknown }).tcc_denied).toBeUndefined();
+  });
 });

--- a/packages/system/agents/workspace-chat/tools/code-exec.ts
+++ b/packages/system/agents/workspace-chat/tools/code-exec.ts
@@ -44,6 +44,7 @@
 import type { Buffer } from "node:buffer";
 import { type ExecOptions, exec } from "node:child_process";
 import { mkdir, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
 import { promisify } from "node:util";
@@ -52,6 +53,7 @@ import type { Logger } from "@atlas/logger";
 import { getFridayHome } from "@atlas/utils/paths.server";
 import { tool } from "ai";
 import { z } from "zod";
+import { detectTccDenial, type TccDenial } from "./tcc-detect.ts";
 
 const execAsync = promisify(exec);
 
@@ -127,6 +129,14 @@ export interface RunCodeSuccess {
   scratch_dir: string;
   stdout_truncated: boolean;
   stderr_truncated: boolean;
+  /**
+   * Set when the script's output matches a macOS TCC denial against a
+   * protected user folder (Downloads/Desktop/Documents). Surfaces a
+   * structured affordance so the chat UI can render a "click to grant
+   * access" card instead of the bare `Operation not permitted` shell error.
+   * See {@link detectTccDenial}. Always absent on non-darwin.
+   */
+  tcc_denied?: TccDenial;
 }
 
 export interface RunCodeError {
@@ -396,14 +406,23 @@ function buildSuccess(
 ): RunCodeSuccess {
   const stdoutTruncated = stdout.length > MAX_STDOUT_BYTES;
   const stderrTruncated = stderr.length > MAX_STDERR_BYTES;
+  const finalStdout = stdoutTruncated ? stdout.slice(0, MAX_STDOUT_BYTES) : stdout;
+  const finalStderr = stderrTruncated ? stderr.slice(0, MAX_STDERR_BYTES) : stderr;
+  // Only run the detector on failure — a 0-exit script that happens to print
+  // "Operation not permitted" as data shouldn't trigger the affordance.
+  const tccDenied =
+    exitCode === 0
+      ? undefined
+      : (detectTccDenial(`${finalStdout}\n${finalStderr}`, homedir()) ?? undefined);
   return {
-    stdout: stdoutTruncated ? stdout.slice(0, MAX_STDOUT_BYTES) : stdout,
-    stderr: stderrTruncated ? stderr.slice(0, MAX_STDERR_BYTES) : stderr,
+    stdout: finalStdout,
+    stderr: finalStderr,
     exit_code: exitCode,
     duration_ms: duration,
     language,
     scratch_dir: scratchPath,
     stdout_truncated: stdoutTruncated,
     stderr_truncated: stderrTruncated,
+    ...(tccDenied ? { tcc_denied: tccDenied } : {}),
   };
 }

--- a/packages/system/agents/workspace-chat/tools/file-io.ts
+++ b/packages/system/agents/workspace-chat/tools/file-io.ts
@@ -31,6 +31,7 @@
  */
 
 import { lstat, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import type { AtlasTools } from "@atlas/agent-sdk";
 import { isInvalidChatId } from "@atlas/core/artifacts/file-upload";
@@ -38,6 +39,7 @@ import type { Logger } from "@atlas/logger";
 import { chatUploadsRoot, getFridayHome } from "@atlas/utils/paths.server";
 import { tool } from "ai";
 import { z } from "zod";
+import { detectTccDenial, type TccDenial } from "./tcc-detect.ts";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -121,6 +123,31 @@ interface FileOk {
 }
 interface FileErr {
   error: string;
+  /**
+   * Set when the underlying OS error matched the macOS TCC denial signature
+   * against a protected user folder. The chat UI uses this to render an
+   * affordance card (deeplink to System Settings, etc.) instead of the
+   * raw "Operation not permitted" text. Today's path-resolution gates
+   * keep these tools inside the scratch dir and so TCC is unreachable in
+   * practice — this is forward-defensive plumbing for any future variant
+   * that exposes protected paths to the agent.
+   * See {@link detectTccDenial}.
+   */
+  tcc_denied?: TccDenial;
+}
+
+/**
+ * Convert an unknown caught error into a `FileErr`, attaching `tcc_denied`
+ * when the OS message matches the macOS TCC denial signature. Centralised
+ * so all four tools (`read_file`, `write_file`, `list_files`,
+ * `read_attachment`) emit the same shape.
+ */
+function toFileErr(prefix: string, err: unknown): FileErr {
+  const message = err instanceof Error ? err.message : String(err);
+  const tccDenied = detectTccDenial(message, homedir());
+  return tccDenied
+    ? { error: `${prefix}: ${message}`, tcc_denied: tccDenied }
+    : { error: `${prefix}: ${message}` };
 }
 
 export interface ReadFileSuccess {
@@ -169,8 +196,7 @@ export function createFileIOTools(sessionId: string, logger: Logger): AtlasTools
           logger.info("read_file success", { sessionId, path, bytes: buffer.byteLength });
           return { path, content, size_bytes: buffer.byteLength, truncated };
         } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          return { error: `read_file failed: ${message}` };
+          return toFileErr("read_file failed", err);
         }
       },
     }),
@@ -192,8 +218,7 @@ export function createFileIOTools(sessionId: string, logger: Logger): AtlasTools
           logger.info("write_file success", { sessionId, path, bytes });
           return { ok: true, path, bytes_written: bytes };
         } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          return { error: `write_file failed: ${message}` };
+          return toFileErr("write_file failed", err);
         }
       },
     }),
@@ -230,7 +255,7 @@ export function createFileIOTools(sessionId: string, logger: Logger): AtlasTools
           if (message.includes("ENOENT")) {
             return { path: requested, entries: [], truncated: false };
           }
-          return { error: `list_files failed: ${message}` };
+          return toFileErr("list_files failed", err);
         }
       },
     }),
@@ -353,8 +378,7 @@ export function createReadAttachmentTool(
           });
           return { path, content, size_bytes: buffer.byteLength, truncated };
         } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          return { error: `read_attachment failed: ${message}` };
+          return toFileErr("read_attachment failed", err);
         }
       },
     }),

--- a/packages/system/agents/workspace-chat/tools/tcc-detect.test.ts
+++ b/packages/system/agents/workspace-chat/tools/tcc-detect.test.ts
@@ -1,0 +1,115 @@
+import process from "node:process";
+import { describe, expect, it } from "vitest";
+import { detectTccDenial } from "./tcc-detect.ts";
+
+const HOME = "/Users/friday";
+
+/**
+ * The detector branches on `process.platform === "darwin"`. Wrap each
+ * darwin-specific assertion so non-mac CI still passes — the helper is
+ * shared but its activation is OS-specific by design.
+ */
+function darwinOnly(name: string, body: () => void | Promise<void>) {
+  it(name, async () => {
+    if (process.platform !== "darwin") return;
+    await body();
+  });
+}
+
+describe("detectTccDenial — recognised macOS error signatures", () => {
+  darwinOnly("recognises `find: <path>: Operation not permitted`", () => {
+    const out = "find: /Users/friday/Downloads/bucketlist-cs/agents: Operation not permitted\n";
+    const result = detectTccDenial(out, HOME);
+    expect(result).not.toBeNull();
+    expect(result?.protectedRoot).toBe("/Users/friday/Downloads");
+    expect(result?.attemptedPath).toBe("/Users/friday/Downloads/bucketlist-cs/agents");
+  });
+
+  darwinOnly("recognises `ls: <path>/: Operation not permitted` (trailing slash)", () => {
+    const out = "ls: /Users/friday/Downloads/: Operation not permitted\ntotal 0\n";
+    const result = detectTccDenial(out, HOME);
+    expect(result).not.toBeNull();
+    expect(result?.attemptedPath).toBe("/Users/friday/Downloads");
+  });
+
+  darwinOnly("recognises Python PermissionError with quoted path", () => {
+    const out = "PermissionError: [Errno 1] Operation not permitted: '/Users/friday/Downloads'\n";
+    const result = detectTccDenial(out, HOME);
+    expect(result).not.toBeNull();
+    expect(result?.attemptedPath).toBe("/Users/friday/Downloads");
+  });
+
+  darwinOnly("recognises Desktop and Documents, not just Downloads", () => {
+    const desk = detectTccDenial("ls: /Users/friday/Desktop/foo: Operation not permitted", HOME);
+    const docs = detectTccDenial("ls: /Users/friday/Documents/foo: Operation not permitted", HOME);
+    expect(desk?.protectedRoot).toBe("/Users/friday/Desktop");
+    expect(docs?.protectedRoot).toBe("/Users/friday/Documents");
+  });
+
+  darwinOnly("emits two actions: System Settings deeplink + copy-shell mv suggestion", () => {
+    const out = "find: /Users/friday/Downloads/bucketlist-cs: Operation not permitted";
+    const result = detectTccDenial(out, HOME);
+    expect(result?.actions).toHaveLength(2);
+    expect(result?.actions[0]).toMatchObject({
+      type: "open-url",
+      payload: expect.stringContaining("Privacy_Files_Folders"),
+    });
+    expect(result?.actions[1]).toMatchObject({
+      type: "copy-shell",
+      payload: expect.stringContaining("mv "),
+    });
+    // The suggested mv destination should be under $HOME, not under Downloads.
+    expect(result?.actions[1].payload).toContain("/Users/friday/bucketlist-cs");
+  });
+
+  darwinOnly("shell-quotes paths with spaces in the mv suggestion", () => {
+    const out = "ls: /Users/friday/Downloads/folder with spaces: Operation not permitted";
+    const result = detectTccDenial(out, HOME);
+    expect(result?.actions[1].payload).toContain(`'/Users/friday/Downloads/folder with spaces'`);
+    expect(result?.actions[1].payload).toContain(`'/Users/friday/folder with spaces'`);
+  });
+
+  darwinOnly("drops the no-op mv suggestion when user attempted the root itself", () => {
+    // Real repro from QA 2026-05-19: user runs `ls -la ~/Downloads`. Without
+    // this guard the suggestion becomes `mv '~/Downloads' '~/Downloads'` —
+    // a no-op and a confusing one. Only the System Settings deeplink stays.
+    const out = "ls: /Users/friday/Downloads: Operation not permitted";
+    const result = detectTccDenial(out, HOME);
+    expect(result?.attemptedPath).toBe("/Users/friday/Downloads");
+    expect(result?.actions).toHaveLength(1);
+    expect(result?.actions[0].type).toBe("open-url");
+  });
+});
+
+describe("detectTccDenial — non-matches", () => {
+  darwinOnly("returns null when stdout is empty", () => {
+    expect(detectTccDenial("", HOME)).toBeNull();
+  });
+
+  darwinOnly("returns null when 'Operation not permitted' is not present", () => {
+    expect(detectTccDenial("ls: /tmp/foo: No such file or directory", HOME)).toBeNull();
+  });
+
+  darwinOnly("returns null when the path is outside the protected dirs", () => {
+    // ~/.friday/local/scratch is not TCC-protected; a permission error here
+    // is a real ACL bug and we should NOT swallow it with a fake TCC card.
+    const out = "ls: /Users/friday/.friday/local/scratch/foo: Operation not permitted";
+    expect(detectTccDenial(out, HOME)).toBeNull();
+  });
+
+  darwinOnly("returns null when the path is under a different user's home", () => {
+    const out = "ls: /Users/other/Downloads/foo: Operation not permitted";
+    expect(detectTccDenial(out, HOME)).toBeNull();
+  });
+});
+
+describe("detectTccDenial — platform gate", () => {
+  it("returns null on non-darwin platforms even with a matching string", () => {
+    if (process.platform === "darwin") return;
+    // On Linux/Windows, an "Operation not permitted" error against a path
+    // that LOOKS like a Mac home is a real chmod/ACL issue — we must NOT
+    // surface a misleading "grant macOS permission" affordance.
+    const out = "find: /Users/friday/Downloads/foo: Operation not permitted";
+    expect(detectTccDenial(out, HOME)).toBeNull();
+  });
+});

--- a/packages/system/agents/workspace-chat/tools/tcc-detect.test.ts
+++ b/packages/system/agents/workspace-chat/tools/tcc-detect.test.ts
@@ -59,14 +59,14 @@ describe("detectTccDenial — recognised macOS error signatures", () => {
       payload: expect.stringContaining("mv "),
     });
     // The suggested mv destination should be under $HOME, not under Downloads.
-    expect(result?.actions[1].payload).toContain("/Users/friday/bucketlist-cs");
+    expect(result?.actions[1]?.payload).toContain("/Users/friday/bucketlist-cs");
   });
 
   darwinOnly("shell-quotes paths with spaces in the mv suggestion", () => {
     const out = "ls: /Users/friday/Downloads/folder with spaces: Operation not permitted";
     const result = detectTccDenial(out, HOME);
-    expect(result?.actions[1].payload).toContain(`'/Users/friday/Downloads/folder with spaces'`);
-    expect(result?.actions[1].payload).toContain(`'/Users/friday/folder with spaces'`);
+    expect(result?.actions[1]?.payload).toContain(`'/Users/friday/Downloads/folder with spaces'`);
+    expect(result?.actions[1]?.payload).toContain(`'/Users/friday/folder with spaces'`);
   });
 
   darwinOnly("drops the no-op mv suggestion when user attempted the root itself", () => {
@@ -77,7 +77,7 @@ describe("detectTccDenial — recognised macOS error signatures", () => {
     const result = detectTccDenial(out, HOME);
     expect(result?.attemptedPath).toBe("/Users/friday/Downloads");
     expect(result?.actions).toHaveLength(1);
-    expect(result?.actions[0].type).toBe("open-url");
+    expect(result?.actions[0]?.type).toBe("open-url");
   });
 });
 

--- a/packages/system/agents/workspace-chat/tools/tcc-detect.ts
+++ b/packages/system/agents/workspace-chat/tools/tcc-detect.ts
@@ -1,0 +1,133 @@
+/**
+ * macOS TCC (Transparency, Consent, and Control) denial detector.
+ *
+ * macOS gates `~/Downloads`, `~/Desktop`, and `~/Documents` behind a per-app
+ * permission grant. When Friday Studio (and therefore the daemon and every
+ * `run_code` shell it spawns) lacks that grant, every `ls`, `find`, `open`,
+ * `read`, etc. against those folders fails with `Operation not permitted` —
+ * a generic POSIX errno that gives the LLM no useful repair signal. Without
+ * this detector the agent dumps the raw error and asks the user to debug it.
+ *
+ * The detector turns that into a structured affordance the chat UI renders
+ * as a card with a deeplink to System Settings → Privacy & Security → Files
+ * & Folders, where the user can flip the toggle in one click.
+ *
+ * Scope: macOS only. On Linux, "Operation not permitted" usually means a
+ * real filesystem ACL or chmod issue and the user wants to see it raw.
+ */
+
+import { homedir } from "node:os";
+import process from "node:process";
+
+/**
+ * The TCC-protected user folders we recognise. Three is the canonical macOS
+ * "user files" set; iCloud Drive and removable volumes are gated separately
+ * (and are rare enough in normal Friday usage that we don't try to detect
+ * them here — false negatives there fall back to the raw error, which is
+ * the same behavior we have today).
+ */
+const TCC_PROTECTED_DIRS = ["Downloads", "Desktop", "Documents"] as const;
+
+/** macOS deeplink that opens System Settings → Privacy & Security → Files & Folders. */
+const FILES_AND_FOLDERS_DEEPLINK =
+  "x-apple.systempreferences:com.apple.preference.security?Privacy_Files_Folders";
+
+export interface TccDeniedAction {
+  /** Visible button label. */
+  label: string;
+  /**
+   * `open-url` opens the URL via the OS handler (System Settings deeplink).
+   * `copy-shell` copies a suggested shell command to the clipboard.
+   */
+  type: "open-url" | "copy-shell";
+  /** URL when `type === "open-url"`, shell command when `type === "copy-shell"`. */
+  payload: string;
+}
+
+export interface TccDenial {
+  kind: "tcc-denied";
+  /** The TCC-protected root that triggered the denial, e.g. `/Users/lcf/Downloads`. */
+  protectedRoot: string;
+  /** The full path the daemon tried to access. */
+  attemptedPath: string;
+  /** Short user-facing explanation. The chat UI renders this verbatim. */
+  guidance: string;
+  /** One or more click-actions the user can take to unblock. */
+  actions: TccDeniedAction[];
+}
+
+/**
+ * Inspect a combined stdout/stderr string for the macOS TCC denial signature
+ * against one of the protected user folders. Returns null on Linux/Windows,
+ * when the marker isn't present, or when the path doesn't match a protected
+ * root.
+ *
+ * `homeDir` is injected so tests can pin a deterministic home — production
+ * callers pass {@link homedir}().
+ */
+export function detectTccDenial(combined: string, homeDir: string = homedir()): TccDenial | null {
+  if (process.platform !== "darwin") return null;
+  if (!combined.includes("Operation not permitted")) return null;
+
+  for (const dir of TCC_PROTECTED_DIRS) {
+    const root = `${homeDir}/${dir}`;
+    // Find any line containing both "Operation not permitted" and the
+    // protected root, then extract the longest path under that root.
+    // Two error orderings exist in the wild:
+    //   `find: <path>: Operation not permitted`            (path first)
+    //   `ls: <path>/: Operation not permitted`             (path first)
+    //   `PermissionError: [Errno 1] Operation not permitted: '<path>'`
+    //                                                       (path last)
+    // The pattern must stop at quotes / whitespace / the colon-terminator,
+    // but allow normal path characters including spaces.
+    const candidate = combined
+      .split(/\r?\n/)
+      .find((line) => line.includes("Operation not permitted") && line.includes(root));
+    if (!candidate) continue;
+
+    const pathRe = new RegExp(`${escapeRegExp(root)}[^'"\\n:]*`);
+    const pathMatch = candidate.match(pathRe);
+    if (!pathMatch) continue;
+
+    // Trim trailing whitespace and slashes, but keep at least the protected
+    // root if everything after it was empty.
+    const attemptedPath = pathMatch[0].replace(/[\s/]+$/, "") || root;
+    const actions: TccDeniedAction[] = [
+      { label: "Open System Settings", type: "open-url", payload: FILES_AND_FOLDERS_DEEPLINK },
+    ];
+    // Only suggest a move when the user accessed something *under* the
+    // protected root. When the attempted path IS the root itself (e.g.
+    // `ls ~/Downloads`), `mv` would be a no-op (`mv ~/Downloads ~/Downloads`)
+    // and offering it is just noise.
+    if (attemptedPath !== root) {
+      actions.push({
+        label: `Move out of ~/${dir}`,
+        type: "copy-shell",
+        payload: `mv ${shellQuote(attemptedPath)} ${shellQuote(`${homeDir}/${basename(attemptedPath)}`)}`,
+      });
+    }
+    return {
+      kind: "tcc-denied",
+      protectedRoot: root,
+      attemptedPath,
+      guidance: `Friday Studio doesn't have macOS permission to read ~/${dir}. Grant it in System Settings → Privacy & Security → Files & Folders, then retry.`,
+      actions,
+    };
+  }
+  return null;
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function shellQuote(s: string): string {
+  // Single-quote and escape any embedded single quotes the POSIX way.
+  return `'${s.replace(/'/g, `'\\''`)}'`;
+}
+
+function basename(path: string): string {
+  const trimmed = path.replace(/\/+$/, "");
+  const slash = trimmed.lastIndexOf("/");
+  return slash === -1 ? trimmed : trimmed.slice(slash + 1);
+}

--- a/tools/agent-playground/src/lib/components/chat/tcc-denied-card.svelte
+++ b/tools/agent-playground/src/lib/components/chat/tcc-denied-card.svelte
@@ -1,5 +1,11 @@
 <script lang="ts">
-  import { Button, IconSmall } from "@atlas/ui";
+  // Use plain HTML elements instead of @atlas/ui's Button / IconSmall — the
+  // @atlas/ui barrel transitively pulls in `packages/ui/src/lib/table` which
+  // imports `@tanstack/svelte-table/dist/createTable.svelte`. That extension-
+  // less re-export can't be resolved by Node ESM under vitest (works fine
+  // in the SvelteKit build pipeline). Going plain HTML here avoids dragging
+  // the broken table import into our test, and the card has its own CSS
+  // anyway so we're not losing visual consistency.
 
   interface TccAction {
     label: string;
@@ -41,7 +47,6 @@
 
 <div class="tcc-card" role="region" aria-label="macOS permission needed">
   <div class="header">
-    <span class="icon" aria-hidden="true"><IconSmall.Clock /></span>
     <span class="eyebrow">macOS permission needed</span>
   </div>
 
@@ -51,9 +56,9 @@
 
   <div class="actions">
     {#each denial.actions as action (action.label + action.payload)}
-      <Button onclick={() => handleAction(action)}>
+      <button type="button" class="action" onclick={() => handleAction(action)}>
         {copied === action.payload ? "Copied!" : action.label}
-      </Button>
+      </button>
     {/each}
   </div>
 </div>
@@ -73,11 +78,6 @@
     align-items: center;
     display: flex;
     gap: var(--size-2);
-  }
-
-  .icon {
-    color: color-mix(in srgb, var(--yellow-primary), black 25%);
-    display: inline-flex;
   }
 
   .eyebrow {
@@ -112,5 +112,23 @@
     display: flex;
     flex-wrap: wrap;
     gap: var(--size-2);
+  }
+
+  /* Buttons mimic the @atlas/ui primary Button look without dragging the
+     barrel import in — see the explainer comment in the script block. */
+  .action {
+    background-color: var(--text-bright);
+    border: 1px solid var(--text-bright);
+    border-radius: var(--radius-2);
+    color: var(--surface-dark);
+    cursor: pointer;
+    font: inherit;
+    font-size: var(--font-size-1);
+    font-weight: var(--font-weight-6);
+    padding: var(--size-1) var(--size-3);
+  }
+
+  .action:hover {
+    opacity: 0.85;
   }
 </style>

--- a/tools/agent-playground/src/lib/components/chat/tcc-denied-card.svelte
+++ b/tools/agent-playground/src/lib/components/chat/tcc-denied-card.svelte
@@ -1,0 +1,116 @@
+<script lang="ts">
+  import { Button, IconSmall } from "@atlas/ui";
+
+  interface TccAction {
+    label: string;
+    type: "open-url" | "copy-shell";
+    payload: string;
+  }
+
+  interface TccDenied {
+    kind: "tcc-denied";
+    protectedRoot: string;
+    attemptedPath: string;
+    guidance: string;
+    actions: TccAction[];
+  }
+
+  interface Props {
+    denial: TccDenied;
+  }
+
+  const { denial }: Props = $props();
+
+  let copied = $state<string | null>(null);
+
+  function handleAction(action: TccAction) {
+    if (action.type === "open-url") {
+      // Use location.href so the OS handler claims the x-apple… deeplink.
+      // window.open() in some browsers blocks unknown schemes silently.
+      window.location.href = action.payload;
+      return;
+    }
+    void navigator.clipboard.writeText(action.payload).then(() => {
+      copied = action.payload;
+      setTimeout(() => {
+        if (copied === action.payload) copied = null;
+      }, 1800);
+    });
+  }
+</script>
+
+<div class="tcc-card" role="region" aria-label="macOS permission needed">
+  <div class="header">
+    <span class="icon" aria-hidden="true"><IconSmall.Clock /></span>
+    <span class="eyebrow">macOS permission needed</span>
+  </div>
+
+  <p class="guidance">{denial.guidance}</p>
+
+  <code class="path" title={denial.attemptedPath}>{denial.attemptedPath}</code>
+
+  <div class="actions">
+    {#each denial.actions as action (action.label + action.payload)}
+      <Button onclick={() => handleAction(action)}>
+        {copied === action.payload ? "Copied!" : action.label}
+      </Button>
+    {/each}
+  </div>
+</div>
+
+<style>
+  .tcc-card {
+    background-color: color-mix(in srgb, var(--yellow-primary), transparent 92%);
+    border: 1px solid color-mix(in srgb, var(--yellow-primary), transparent 60%);
+    border-radius: var(--radius-3);
+    display: flex;
+    flex-direction: column;
+    gap: var(--size-2);
+    padding: var(--size-3);
+  }
+
+  .header {
+    align-items: center;
+    display: flex;
+    gap: var(--size-2);
+  }
+
+  .icon {
+    color: color-mix(in srgb, var(--yellow-primary), black 25%);
+    display: inline-flex;
+  }
+
+  .eyebrow {
+    color: color-mix(in srgb, var(--text), transparent 30%);
+    font-size: var(--font-size-0, 11px);
+    font-weight: var(--font-weight-7);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  .guidance {
+    color: var(--text-bright);
+    font-size: var(--font-size-2);
+    line-height: 1.4;
+    margin: 0;
+  }
+
+  .path {
+    background-color: var(--surface-dark);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-1);
+    color: var(--text);
+    font-family: var(--font-family-mono, ui-monospace, monospace);
+    font-size: var(--font-size-1);
+    overflow: hidden;
+    padding: var(--size-1) var(--size-2);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--size-2);
+  }
+</style>

--- a/tools/agent-playground/src/lib/components/chat/tcc-denied-card.test.ts
+++ b/tools/agent-playground/src/lib/components/chat/tcc-denied-card.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for `tcc-denied-card.svelte` — the macOS TCC affordance card the
+ * agent shows when `run_code` (or a future file-io variant) hits `Operation
+ * not permitted` against `~/Downloads`, `~/Desktop`, or `~/Documents`.
+ *
+ * Render-only assertions (no DOM event simulation) since `svelte/server`
+ * does an SSR pass that captures everything the user would see on first
+ * paint, which is what we care about for the affordance's content + the
+ * presence of click targets. Behavior of the click handlers (clipboard,
+ * deeplink) is exercised in QA, not unit tests.
+ */
+
+import { render } from "svelte/server";
+import { describe, expect, it } from "vitest";
+import TccDeniedCard from "./tcc-denied-card.svelte";
+
+const baseDenial = {
+  kind: "tcc-denied" as const,
+  protectedRoot: "/Users/friday/Downloads",
+  attemptedPath: "/Users/friday/Downloads/bucketlist-cs/agents",
+  guidance:
+    "Friday Studio doesn't have macOS permission to read ~/Downloads. Grant it in System Settings → Privacy & Security → Files & Folders, then retry.",
+  actions: [
+    {
+      label: "Open System Settings",
+      type: "open-url" as const,
+      payload: "x-apple.systempreferences:com.apple.preference.security?Privacy_Files_Folders",
+    },
+    {
+      label: "Move out of ~/Downloads",
+      type: "copy-shell" as const,
+      payload: "mv '/Users/friday/Downloads/bucketlist-cs/agents' '/Users/friday/agents'",
+    },
+  ],
+};
+
+describe("tcc-denied-card", () => {
+  it("renders the eyebrow, guidance text, and the attempted path verbatim", () => {
+    const { body } = render(TccDeniedCard, { props: { denial: baseDenial } });
+    expect(body).toContain("macOS permission needed");
+    expect(body).toContain("Friday Studio doesn't have macOS permission");
+    expect(body).toContain("/Users/friday/Downloads/bucketlist-cs/agents");
+  });
+
+  it("renders one button per action with its label", () => {
+    const { body } = render(TccDeniedCard, { props: { denial: baseDenial } });
+    expect(body).toContain("Open System Settings");
+    expect(body).toContain("Move out of ~/Downloads");
+    // Buttons are <button>s rendered by the @atlas/ui Button component.
+    const buttonCount = (body.match(/<button\b/g) ?? []).length;
+    expect(buttonCount).toBe(2);
+  });
+
+  it("scopes the affordance to the region role for accessibility", () => {
+    const { body } = render(TccDeniedCard, { props: { denial: baseDenial } });
+    expect(body).toContain('role="region"');
+    expect(body).toContain('aria-label="macOS permission needed"');
+  });
+
+  it("renders even when only one action is provided", () => {
+    const { body } = render(TccDeniedCard, {
+      props: {
+        denial: { ...baseDenial, actions: [baseDenial.actions[0]] },
+      },
+    });
+    expect(body).toContain("Open System Settings");
+    expect(body).not.toContain("Move out of");
+  });
+});

--- a/tools/agent-playground/src/lib/components/chat/tcc-denied-card.test.ts
+++ b/tools/agent-playground/src/lib/components/chat/tcc-denied-card.test.ts
@@ -46,7 +46,8 @@ describe("tcc-denied-card", () => {
     const { body } = render(TccDeniedCard, { props: { denial: baseDenial } });
     expect(body).toContain("Open System Settings");
     expect(body).toContain("Move out of ~/Downloads");
-    // Buttons are <button>s rendered by the @atlas/ui Button component.
+    // Plain <button> elements (the card intentionally doesn't use @atlas/ui's
+    // Button wrapper — see the explainer comment in the .svelte file).
     const buttonCount = (body.match(/<button\b/g) ?? []).length;
     expect(buttonCount).toBe(2);
   });

--- a/tools/agent-playground/src/lib/components/chat/tool-call-card.svelte
+++ b/tools/agent-playground/src/lib/components/chat/tool-call-card.svelte
@@ -6,6 +6,7 @@
   import ConnectService from "./connect-service.svelte";
   import DelegateToolCard from "./delegate-tool-card.svelte";
   import EnvSetToolCard from "./env-set-tool-card.svelte";
+  import TccDeniedCard from "./tcc-denied-card.svelte";
   import { formatRawOutput } from "./format-raw-output";
   import HumanInputToolCard from "./human-input-tool-card.svelte";
   import { extractLiftedArtifactIds } from "./lifted-markers";
@@ -242,6 +243,64 @@
     return { artifactId: i.artifactId };
   });
 
+  /* ─── TCC-denied affordance extraction ──────────────────────────── */
+
+  /**
+   * macOS TCC ("Operation not permitted" against ~/Downloads etc.) is detected
+   * server-side by `detectTccDenial` and surfaced as `output.tcc_denied`. Both
+   * `run_code` (success shape) and the file-io tools (error shape) can carry
+   * this field. Extract a typed view so the card renders without any-casts.
+   */
+  interface TccDeniedView {
+    kind: "tcc-denied";
+    protectedRoot: string;
+    attemptedPath: string;
+    guidance: string;
+    actions: Array<{
+      label: string;
+      type: "open-url" | "copy-shell";
+      payload: string;
+    }>;
+  }
+
+  function readTccDenied(output: unknown): TccDeniedView | null {
+    if (typeof output !== "object" || output === null) return null;
+    const candidate = (output as Record<string, unknown>).tcc_denied;
+    if (typeof candidate !== "object" || candidate === null) return null;
+    const c = candidate as Record<string, unknown>;
+    if (
+      c.kind !== "tcc-denied" ||
+      typeof c.protectedRoot !== "string" ||
+      typeof c.attemptedPath !== "string" ||
+      typeof c.guidance !== "string" ||
+      !Array.isArray(c.actions)
+    ) {
+      return null;
+    }
+    const actions: TccDeniedView["actions"] = [];
+    for (const raw of c.actions) {
+      if (typeof raw !== "object" || raw === null) continue;
+      const a = raw as Record<string, unknown>;
+      if (
+        typeof a.label === "string" &&
+        (a.type === "open-url" || a.type === "copy-shell") &&
+        typeof a.payload === "string"
+      ) {
+        actions.push({ label: a.label, type: a.type, payload: a.payload });
+      }
+    }
+    if (actions.length === 0) return null;
+    return {
+      kind: "tcc-denied",
+      protectedRoot: c.protectedRoot,
+      attemptedPath: c.attemptedPath,
+      guidance: c.guidance,
+      actions,
+    };
+  }
+
+  const tccDenied = $derived(readTccDenied(call.output));
+
   /* ─── Drawer open state ──────────────────────────────────────────── */
 
   // Closed drawers do not pay the `formatRawOutput` cost (JSON.stringify +
@@ -432,6 +491,9 @@
     class:error={isError(call.state)}
   >
     {@render cardBody(call, meta)}
+    {#if tccDenied}
+      <TccDeniedCard denial={tccDenied} />
+    {/if}
     {#if liftedArtifacts.length > 0}
       <div class="lifted-artifacts">
         {#each liftedArtifacts as ref (ref.artifactId)}

--- a/tools/agent-playground/src/lib/components/chat/tool-call-utils.ts
+++ b/tools/agent-playground/src/lib/components/chat/tool-call-utils.ts
@@ -28,6 +28,17 @@ export function needsUserAction(call: ToolCallDisplay): boolean {
   if (call.toolName === "request_human_input" && isInProgress(call.state)) return true;
   if (call.toolName === "connect_service" && call.state === "output-available") return true;
   if (call.toolName === "connect_communicator" && call.state === "output-available") return true;
+  // macOS TCC denial cards live inside the tool-burst. Without this branch
+  // the burst stays collapsed and the affordance (deeplink + suggested mv)
+  // is invisible — the model ends up describing buttons that aren't on
+  // screen. See packages/system/agents/workspace-chat/tools/tcc-detect.ts.
+  if (
+    typeof call.output === "object" &&
+    call.output !== null &&
+    (call.output as { tcc_denied?: unknown }).tcc_denied !== undefined
+  ) {
+    return true;
+  }
   return call.children?.some((child) => needsUserAction(child)) ?? false;
 }
 


### PR DESCRIPTION
## Summary

When the chat agent's `run_code` (or file-io) tool hits `Operation not permitted` against a TCC-protected user folder (`~/Downloads`, `~/Desktop`, `~/Documents`), the chat now renders a yellow **macOS permission needed** card with a one-click deeplink to System Settings → Privacy & Security → Files & Folders.

Before: agent saw the raw shell error, dumped it at the user, and asked them to debug it.

After: structured affordance the model can point at — and a clickable surface the user can act on directly.

**Scope**: macOS only. On Linux/Windows the same error usually means a real ACL issue and the raw error is the right signal — the detector is gated on `process.platform === "darwin"`.

**Edge case clarification**: this card is the fallback for the **already-denied** state (user previously clicked Don't Allow, or revoked via System Settings → `auth_value=0` in `TCC.db`). The first-encounter path is still handled by macOS's native consent dialog.

## What's in the change

- `packages/system/agents/workspace-chat/tools/tcc-detect.ts` — pure detector. Recognizes three error formats (`find:`, `ls:`, Python `PermissionError`), returns a structured `TccDenial` with deeplink + optional `mv` suggestion. 12 unit tests.
- `code-exec.ts` — attaches `tcc_denied?: TccDenial` to `RunCodeSuccess` when the script exited non-zero and the stderr matches.
- `file-io.ts` — same wiring via a shared `toFileErr` helper. Forward-defensive — the existing path-resolution gates keep these tools inside the scratch dir, so TCC isn't reachable today.
- `tools/agent-playground/.../tcc-denied-card.svelte` — the actual card component, 4 SSR tests.
- `tool-call-card.svelte` — typed `readTccDenied` extractor + render branch.
- `tool-call-utils.ts` — extends `needsUserAction` to recognize `tcc_denied`, which is what auto-opens the `tool-burst` `<details>` so the card is actually visible.

## QA

Real-TCC reproduction on a Tahoe VM (192.168.64.17) with the daemon's Downloads grant revoked via `tccutil reset`:

| # | Case | Result |
|---|---|---|
| 1 | Unit prechecks (detector, file-io, card SSR) | 18/18 PASS |
| 2 | Build + deploy to VM, launcher bounced, hashes verified | PASS |
| 3 | `ls ~/Downloads` → card renders with eyebrow, guidance, path, Settings button | PASS |
| 4 | `ls ~/Downloads/qa-test` → both buttons render; Move button writes correct `mv '<src>' '<dst>'` to clipboard | PASS |
| 5 | Settings button payload = correct `x-apple.systempreferences:` deeplink (structural) | PASS |
| 6 | `ls /tmp` (success) → no false card | PASS |
| 7 | `ls /nonexistent` (ENOENT) → no false card | PASS |

QA found two bugs that are folded into this PR:

1. **UI card never rendered** — `tool-burst` wraps tool calls in a collapsed `<details>` and `needsUserAction` didn't recognize `tcc_denied`, so the card was in the DOM but hidden. Embarrassingly, the model could see `tcc_denied` in its tool result JSON and would describe "a shortcut button above" that wasn't actually on screen. Fix: extend `needsUserAction`.
2. **No-op `mv` suggestion** when user attempted the protected root directly (`mv '~/Downloads' '~/Downloads'`). Fix: only push the Move action when `attemptedPath !== root`. New unit test locks this in.

## Test plan

- [ ] CI runs the 18 new unit tests (detector + card SSR + run_code wiring + file-io wiring)
- [ ] Revoke Downloads access for Friday Studio (`tccutil reset SystemPolicyDownloadsFolder ai.hellofriday.studio` + click Don't Allow when prompted), then ask the chat `run ls -la ~/Downloads` — verify yellow card appears
- [ ] Same with `~/Desktop` and `~/Documents` to cover the other two protected dirs
- [ ] Confirm clean runs (`ls /tmp`) and ENOENT runs (`ls /nonexistent`) don't trigger the affordance