### PR TITLE
fix(playground): keep mic listening until user stops it

### DIFF
--- a/tools/agent-playground/src/lib/components/chat/chat-input.svelte
+++ b/tools/agent-playground/src/lib/components/chat/chat-input.svelte
@@ -113,7 +113,7 @@
     if (!SpeechRecognitionCtor) return;
 
     const sr = new SpeechRecognitionCtor();
-    sr.continuous = false;
+    sr.continuous = true;
     sr.interimResults = true;
     sr.lang = navigator.language || "en-US";
 


### PR DESCRIPTION
## Summary
- Flip `SpeechRecognition.continuous` from `false` to `true` in the chat input mic toggle so the browser stops auto-ending the session on the first detected pause.
- Mic now records until the user clicks the button again — matches the ChatGPT-style "manual start/stop" behavior the issue asks for.

Closes #351

## Background
The Web Speech API exposes no silence-duration / VAD-timeout tunables (verified against MDN and the W3C spec), so there's no middle ground between "auto-stop on pause" and "manual stop". Going manual matches the literal request in the issue.

## Test plan
- [ ] Open the playground chat, click the mic icon, talk with multi-second pauses — the session should not end on a pause.
- [ ] Click the mic icon again — recording stops and the final transcript lands in the textarea.
- [ ] Confirm interim results still stream into the textarea while talking.

## Follow-ups (not in this PR)
- Chrome has a known ~60s internal session limit even with `continuous = true`. If users hit that in practice, add a restart-on-`end` handler that distinguishes user-initiated stops from browser-ended sessions.