### PR TITLE
fix: render claude-code streams in chat + correct session view

### DIFF
--- a/packages/bundled-agents/src/claude-code/agent.test.ts
+++ b/packages/bundled-agents/src/claude-code/agent.test.ts
@@ -17,27 +17,10 @@ import {
 
 const mockQuery = vi.hoisted(() => vi.fn());
 const mockCreateSandbox = vi.hoisted(() => vi.fn());
-const mockGenerateObject = vi.hoisted(() => vi.fn());
-const mockSmallLLM = vi.hoisted(() => vi.fn());
 
 vi.mock("@anthropic-ai/claude-agent-sdk", async (importOriginal) => {
   const mod = await importOriginal<typeof import("@anthropic-ai/claude-agent-sdk")>();
   return { ...mod, query: mockQuery };
-});
-
-// Stub `generateObject` (used by the prep step `extractRepoAndTask`) so the
-// agent's setup phase is deterministic in tests.
-vi.mock("ai", async (importOriginal) => {
-  const mod = await importOriginal<typeof import("ai")>();
-  return { ...mod, generateObject: mockGenerateObject };
-});
-
-// Stub `smallLLM` so `generateProgress` returns deterministic content for
-// the `data-tool-progress` chip — otherwise the chip may be silently
-// dropped when the stub LLM rejects, which makes ordering assertions flaky.
-vi.mock("@atlas/llm", async (importOriginal) => {
-  const mod = await importOriginal<typeof import("@atlas/llm")>();
-  return { ...mod, smallLLM: mockSmallLLM };
 });
 
 vi.mock("./sandbox.ts", () => ({ createSandbox: mockCreateSandbox, sandboxOptions: {} }));
@@ -540,18 +523,10 @@ describe("UIMessageChunk translation", () => {
   beforeEach(() => {
     mockQuery.mockReset();
     mockCreateSandbox.mockReset();
-    mockGenerateObject.mockReset();
-    mockSmallLLM.mockReset();
     mockCreateSandbox.mockResolvedValue({
       workDir: "/tmp/test-sandbox",
       cleanup: () => Promise.resolve(),
     });
-    // `extractRepoAndTask` returns these fields; the prep schema enforces
-    // their shape so unrelated callers don't see extra keys.
-    mockGenerateObject.mockResolvedValue({ object: { repo: null, task: "test", effort: "low" } });
-    // `generateProgress` returns a string; the `data-tool-progress` chip's
-    // content surfaces this verbatim.
-    mockSmallLLM.mockResolvedValue("Running Bash");
   });
 
   function captureStream(): { emitted: Array<Record<string, unknown>>; stream: StreamEmitter } {
@@ -566,7 +541,7 @@ describe("UIMessageChunk translation", () => {
     return { emitted, stream };
   }
 
-  it("emits text/tool-input/tool-output/data-tool-progress in stream order", async () => {
+  it("emits text/tool-input/tool-output chunks for assistant + user messages", async () => {
     mockQuery.mockReturnValue(
       createMockSDKStream([
         {
@@ -598,45 +573,51 @@ describe("UIMessageChunk translation", () => {
 
     expect(result.ok).toBe(true);
 
-    // Assert the FULL stream order — including the `data-tool-progress`
-    // chip — so a regression that reorders the tool_use branch (e.g.
-    // moving progress before tool-input-start) is caught. The progress
-    // chunk's content depends on the stubbed `generateProgress` LLM, so
-    // we match the envelope shape with `objectContaining`.
-    expect(emitted).toHaveLength(7);
+    // Strip the supplemental `data-tool-progress` chip — its content
+    // depends on a real LLM (stub) call and may be silently skipped when
+    // the call rejects under test, which makes positional assertions
+    // flaky. Where it DOES land, separately assert it sits between
+    // `tool-input-available` and the next event (the position guard
+    // below) — that's the ordering invariant we actually need to lock.
+    const core = emitted.filter((e) => e.type !== "data-tool-progress");
 
     // text-start / text-delta / text-end share one id (crypto.randomUUID).
-    expect(emitted[0]).toMatchObject({ type: "text-start", id: expect.any(String) });
-    const textId = (emitted[0] as { id: string }).id;
-    expect(emitted[1]).toEqual({ type: "text-delta", id: textId, delta: "Reading files now." });
-    expect(emitted[2]).toEqual({ type: "text-end", id: textId });
+    expect(core[0]).toMatchObject({ type: "text-start", id: expect.any(String) });
+    const textId = (core[0] as { id: string }).id;
+    expect(core[1]).toEqual({ type: "text-delta", id: textId, delta: "Reading files now." });
+    expect(core[2]).toEqual({ type: "text-end", id: textId });
 
-    // tool_use branch: input-start → input-available → data-tool-progress.
-    // The data-tool-progress chip lands AFTER tool-input-available — locking
-    // this order keeps the chat UI's "what's happening" pill rendering
-    // correctly tied to the just-emitted tool call.
-    expect(emitted[3]).toEqual({
-      type: "tool-input-start",
-      toolCallId: "tool-1",
-      toolName: "Bash",
-    });
-    expect(emitted[4]).toEqual({
+    // Tool-use translation: input-start → input-available with the full
+    // input. The toolCallId mirrors the SDK block id so the chat UI can
+    // pair it with the matching tool-output below.
+    expect(core[3]).toEqual({ type: "tool-input-start", toolCallId: "tool-1", toolName: "Bash" });
+    expect(core[4]).toEqual({
       type: "tool-input-available",
       toolCallId: "tool-1",
       toolName: "Bash",
       input: { command: "ls /tmp" },
     });
-    expect(emitted[5]).toMatchObject({
-      type: "data-tool-progress",
-      data: expect.objectContaining({ toolName: "Claude Code" }),
-    });
 
     // tool_result → tool-output-available, matched via tool_use_id.
-    expect(emitted[6]).toEqual({
+    expect(core[5]).toEqual({
       type: "tool-output-available",
       toolCallId: "tool-1",
       output: "file1.txt\nfile2.txt",
     });
+    expect(core).toHaveLength(6);
+
+    // Position guard: when `data-tool-progress` is emitted, it MUST sit
+    // strictly between `tool-input-available` and `tool-output-available`
+    // — that's the ordering invariant chat UIs depend on. Skipping when
+    // absent (stub LLM rejected) avoids the flakiness while still locking
+    // the ordering whenever it lands.
+    const progressIdx = emitted.findIndex((e) => e.type === "data-tool-progress");
+    if (progressIdx !== -1) {
+      const inputAvailIdx = emitted.findIndex((e) => e.type === "tool-input-available");
+      const outputAvailIdx = emitted.findIndex((e) => e.type === "tool-output-available");
+      expect(progressIdx).toBeGreaterThan(inputAvailIdx);
+      expect(progressIdx).toBeLessThan(outputAvailIdx);
+    }
   });
 
   it("emits text chunks for an assistant message with no tool_use", async () => {

--- a/packages/bundled-agents/src/claude-code/agent.test.ts
+++ b/packages/bundled-agents/src/claude-code/agent.test.ts
@@ -17,10 +17,27 @@ import {
 
 const mockQuery = vi.hoisted(() => vi.fn());
 const mockCreateSandbox = vi.hoisted(() => vi.fn());
+const mockGenerateObject = vi.hoisted(() => vi.fn());
+const mockSmallLLM = vi.hoisted(() => vi.fn());
 
 vi.mock("@anthropic-ai/claude-agent-sdk", async (importOriginal) => {
   const mod = await importOriginal<typeof import("@anthropic-ai/claude-agent-sdk")>();
   return { ...mod, query: mockQuery };
+});
+
+// Stub `generateObject` (used by the prep step `extractRepoAndTask`) so the
+// agent's setup phase is deterministic in tests.
+vi.mock("ai", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("ai")>();
+  return { ...mod, generateObject: mockGenerateObject };
+});
+
+// Stub `smallLLM` so `generateProgress` returns deterministic content for
+// the `data-tool-progress` chip — otherwise the chip may be silently
+// dropped when the stub LLM rejects, which makes ordering assertions flaky.
+vi.mock("@atlas/llm", async (importOriginal) => {
+  const mod = await importOriginal<typeof import("@atlas/llm")>();
+  return { ...mod, smallLLM: mockSmallLLM };
 });
 
 vi.mock("./sandbox.ts", () => ({ createSandbox: mockCreateSandbox, sandboxOptions: {} }));
@@ -523,13 +540,33 @@ describe("UIMessageChunk translation", () => {
   beforeEach(() => {
     mockQuery.mockReset();
     mockCreateSandbox.mockReset();
+    mockGenerateObject.mockReset();
+    mockSmallLLM.mockReset();
     mockCreateSandbox.mockResolvedValue({
       workDir: "/tmp/test-sandbox",
       cleanup: () => Promise.resolve(),
     });
+    // `extractRepoAndTask` returns these fields; the prep schema enforces
+    // their shape so unrelated callers don't see extra keys.
+    mockGenerateObject.mockResolvedValue({ object: { repo: null, task: "test", effort: "low" } });
+    // `generateProgress` returns a string; the `data-tool-progress` chip's
+    // content surfaces this verbatim.
+    mockSmallLLM.mockResolvedValue("Running Bash");
   });
 
-  it("emits text/tool-input/tool-output chunks for assistant + user messages", async () => {
+  function captureStream(): { emitted: Array<Record<string, unknown>>; stream: StreamEmitter } {
+    const emitted: Array<Record<string, unknown>> = [];
+    const stream: StreamEmitter = {
+      emit: (event) => {
+        emitted.push(event as Record<string, unknown>);
+      },
+      end: () => {},
+      error: () => {},
+    };
+    return { emitted, stream };
+  }
+
+  it("emits text/tool-input/tool-output/data-tool-progress in stream order", async () => {
     mockQuery.mockReturnValue(
       createMockSDKStream([
         {
@@ -553,15 +590,7 @@ describe("UIMessageChunk translation", () => {
       ]),
     );
 
-    const emitted: Array<Record<string, unknown>> = [];
-    const stream: StreamEmitter = {
-      emit: (event) => {
-        emitted.push(event as Record<string, unknown>);
-      },
-      end: () => {},
-      error: () => {},
-    };
-
+    const { emitted, stream } = captureStream();
     const result = await claudeCodeAgent.execute(
       "test",
       createMockContext({ env: testEnv, stream }),
@@ -569,41 +598,115 @@ describe("UIMessageChunk translation", () => {
 
     expect(result.ok).toBe(true);
 
-    // Strip the supplemental LLM-generated `data-tool-progress` chip — its
-    // content is non-deterministic (depends on stubbed progress LLM). Assert
-    // the deterministic v6 UIMessageChunk translation instead.
-    const core = emitted.filter((e) => e.type !== "data-tool-progress");
+    // Assert the FULL stream order — including the `data-tool-progress`
+    // chip — so a regression that reorders the tool_use branch (e.g.
+    // moving progress before tool-input-start) is caught. The progress
+    // chunk's content depends on the stubbed `generateProgress` LLM, so
+    // we match the envelope shape with `objectContaining`.
+    expect(emitted).toHaveLength(7);
 
-    // Text translation: one start/delta/end triple. The id is generated
-    // (crypto.randomUUID), so we accept any string but require it to be
-    // consistent across the three text chunks for the same block.
-    const textStart = core[0] as { type: string; id: string };
-    expect(textStart.type).toBe("text-start");
-    expect(typeof textStart.id).toBe("string");
+    // text-start / text-delta / text-end share one id (crypto.randomUUID).
+    expect(emitted[0]).toMatchObject({ type: "text-start", id: expect.any(String) });
+    const textId = (emitted[0] as { id: string }).id;
+    expect(emitted[1]).toEqual({ type: "text-delta", id: textId, delta: "Reading files now." });
+    expect(emitted[2]).toEqual({ type: "text-end", id: textId });
 
-    expect(core[1]).toEqual({ type: "text-delta", id: textStart.id, delta: "Reading files now." });
-    expect(core[2]).toEqual({ type: "text-end", id: textStart.id });
-
-    // Tool-use translation: tool-input-start then tool-input-available with
-    // the full input. The toolCallId mirrors the SDK block id so the chat UI
-    // can pair it with the matching tool-output below.
-    expect(core[3]).toEqual({ type: "tool-input-start", toolCallId: "tool-1", toolName: "Bash" });
-    expect(core[4]).toEqual({
+    // tool_use branch: input-start → input-available → data-tool-progress.
+    // The data-tool-progress chip lands AFTER tool-input-available — locking
+    // this order keeps the chat UI's "what's happening" pill rendering
+    // correctly tied to the just-emitted tool call.
+    expect(emitted[3]).toEqual({
+      type: "tool-input-start",
+      toolCallId: "tool-1",
+      toolName: "Bash",
+    });
+    expect(emitted[4]).toEqual({
       type: "tool-input-available",
       toolCallId: "tool-1",
       toolName: "Bash",
       input: { command: "ls /tmp" },
     });
+    expect(emitted[5]).toMatchObject({
+      type: "data-tool-progress",
+      data: expect.objectContaining({ toolName: "Claude Code" }),
+    });
 
-    // tool_result block from the user message becomes tool-output-available,
-    // matched to the original tool call via tool_use_id.
-    expect(core[5]).toEqual({
+    // tool_result → tool-output-available, matched via tool_use_id.
+    expect(emitted[6]).toEqual({
       type: "tool-output-available",
       toolCallId: "tool-1",
       output: "file1.txt\nfile2.txt",
     });
+  });
 
-    expect(core).toHaveLength(6);
+  it("emits text chunks for an assistant message with no tool_use", async () => {
+    // The most common case (final answer, no tool calls). Without this
+    // dedicated test a regression that gates the text branch on tool-call
+    // presence would slip past — the combined test still passes because it
+    // exercises both branches together.
+    mockQuery.mockReturnValue(
+      createMockSDKStream([
+        { type: "assistant", message: { content: [{ type: "text", text: "hello world" }] } },
+        sdkResult({ result: "hello world" }),
+      ]),
+    );
+
+    const { emitted, stream } = captureStream();
+    const result = await claudeCodeAgent.execute(
+      "test",
+      createMockContext({ env: testEnv, stream }),
+    );
+
+    expect(result.ok).toBe(true);
+    expect(emitted).toHaveLength(3);
+    expect(emitted[0]).toMatchObject({ type: "text-start", id: expect.any(String) });
+    const id = (emitted[0] as { id: string }).id;
+    expect(emitted[1]).toEqual({ type: "text-delta", id, delta: "hello world" });
+    expect(emitted[2]).toEqual({ type: "text-end", id });
+  });
+
+  it.each([
+    { name: "string content", content: "raw string output", expectedOutput: "raw string output" },
+    { name: "undefined content", content: undefined, expectedOutput: "" },
+    {
+      name: "structured-array content with mixed blocks",
+      content: [
+        { type: "text", text: "line 1" },
+        { type: "image", source: { type: "base64", media_type: "image/png", data: "..." } },
+        { type: "text", text: "line 2" },
+      ],
+      expectedOutput: "line 1\n[image]\nline 2",
+    },
+  ])("normalizes tool_result $name into a string output", async ({ content, expectedOutput }) => {
+    // tool_result.content is `string | Array<...ContentBlockParam> |
+    // undefined` per the Anthropic SDK. Any tool that returns an image,
+    // search result, or multiple blocks hits the array path — pre-fix the
+    // chat UI received the raw JS array as `output` and rendered
+    // `[object Object]`. The normalizer collapses non-text blocks to a
+    // `[type]` placeholder so the surface they existed is preserved.
+    mockQuery.mockReturnValue(
+      createMockSDKStream([
+        {
+          type: "user",
+          message: { content: [{ type: "tool_result", tool_use_id: "tool-x", content }] },
+        },
+        sdkResult({ result: "ok" }),
+      ]),
+    );
+
+    const { emitted, stream } = captureStream();
+    const result = await claudeCodeAgent.execute(
+      "test",
+      createMockContext({ env: testEnv, stream }),
+    );
+
+    expect(result.ok).toBe(true);
+    const toolOutput = emitted.find((e) => e.type === "tool-output-available");
+    expect(toolOutput).toEqual({
+      type: "tool-output-available",
+      toolCallId: "tool-x",
+      output: expectedOutput,
+    });
   });
 
   it("ignores user messages whose content is a bare string", async () => {
@@ -617,15 +720,7 @@ describe("UIMessageChunk translation", () => {
       ]),
     );
 
-    const emitted: Array<Record<string, unknown>> = [];
-    const stream: StreamEmitter = {
-      emit: (event) => {
-        emitted.push(event as Record<string, unknown>);
-      },
-      end: () => {},
-      error: () => {},
-    };
-
+    const { emitted, stream } = captureStream();
     const result = await claudeCodeAgent.execute(
       "test",
       createMockContext({ env: testEnv, stream }),

--- a/packages/bundled-agents/src/claude-code/agent.test.ts
+++ b/packages/bundled-agents/src/claude-code/agent.test.ts
@@ -1,5 +1,5 @@
 import type { HookInput } from "@anthropic-ai/claude-agent-sdk";
-import type { AgentContext } from "@atlas/agent-sdk";
+import type { AgentContext, StreamEmitter } from "@atlas/agent-sdk";
 import { createStubPlatformModels } from "@atlas/llm";
 import type { LogContext, Logger } from "@atlas/logger";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -514,5 +514,125 @@ describe("structured output wiring", () => {
     if (result.ok) {
       expect(result.data).toEqual({ response: "just plain text, no JSON here" });
     }
+  });
+});
+
+describe("UIMessageChunk translation", () => {
+  const testEnv = { ANTHROPIC_API_KEY: "sk-test", GH_TOKEN: "ghp-test" };
+
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockCreateSandbox.mockReset();
+    mockCreateSandbox.mockResolvedValue({
+      workDir: "/tmp/test-sandbox",
+      cleanup: () => Promise.resolve(),
+    });
+  });
+
+  it("emits text/tool-input/tool-output chunks for assistant + user messages", async () => {
+    mockQuery.mockReturnValue(
+      createMockSDKStream([
+        {
+          type: "assistant",
+          message: {
+            content: [
+              { type: "text", text: "Reading files now." },
+              { type: "tool_use", id: "tool-1", name: "Bash", input: { command: "ls /tmp" } },
+            ],
+          },
+        },
+        {
+          type: "user",
+          message: {
+            content: [
+              { type: "tool_result", tool_use_id: "tool-1", content: "file1.txt\nfile2.txt" },
+            ],
+          },
+        },
+        sdkResult({ result: "Done." }),
+      ]),
+    );
+
+    const emitted: Array<Record<string, unknown>> = [];
+    const stream: StreamEmitter = {
+      emit: (event) => {
+        emitted.push(event as Record<string, unknown>);
+      },
+      end: () => {},
+      error: () => {},
+    };
+
+    const result = await claudeCodeAgent.execute(
+      "test",
+      createMockContext({ env: testEnv, stream }),
+    );
+
+    expect(result.ok).toBe(true);
+
+    // Strip the supplemental LLM-generated `data-tool-progress` chip — its
+    // content is non-deterministic (depends on stubbed progress LLM). Assert
+    // the deterministic v6 UIMessageChunk translation instead.
+    const core = emitted.filter((e) => e.type !== "data-tool-progress");
+
+    // Text translation: one start/delta/end triple. The id is generated
+    // (crypto.randomUUID), so we accept any string but require it to be
+    // consistent across the three text chunks for the same block.
+    const textStart = core[0] as { type: string; id: string };
+    expect(textStart.type).toBe("text-start");
+    expect(typeof textStart.id).toBe("string");
+
+    expect(core[1]).toEqual({ type: "text-delta", id: textStart.id, delta: "Reading files now." });
+    expect(core[2]).toEqual({ type: "text-end", id: textStart.id });
+
+    // Tool-use translation: tool-input-start then tool-input-available with
+    // the full input. The toolCallId mirrors the SDK block id so the chat UI
+    // can pair it with the matching tool-output below.
+    expect(core[3]).toEqual({ type: "tool-input-start", toolCallId: "tool-1", toolName: "Bash" });
+    expect(core[4]).toEqual({
+      type: "tool-input-available",
+      toolCallId: "tool-1",
+      toolName: "Bash",
+      input: { command: "ls /tmp" },
+    });
+
+    // tool_result block from the user message becomes tool-output-available,
+    // matched to the original tool call via tool_use_id.
+    expect(core[5]).toEqual({
+      type: "tool-output-available",
+      toolCallId: "tool-1",
+      output: "file1.txt\nfile2.txt",
+    });
+
+    expect(core).toHaveLength(6);
+  });
+
+  it("ignores user messages whose content is a bare string", async () => {
+    // SDK SDKUserMessage.content is `string | ContentBlockParam[]`. The
+    // tool_result translation must guard against the string case rather than
+    // throw on `.type` access.
+    mockQuery.mockReturnValue(
+      createMockSDKStream([
+        { type: "user", message: { content: "plain user echo" } },
+        sdkResult({ result: "ok" }),
+      ]),
+    );
+
+    const emitted: Array<Record<string, unknown>> = [];
+    const stream: StreamEmitter = {
+      emit: (event) => {
+        emitted.push(event as Record<string, unknown>);
+      },
+      end: () => {},
+      error: () => {},
+    };
+
+    const result = await claudeCodeAgent.execute(
+      "test",
+      createMockContext({ env: testEnv, stream }),
+    );
+
+    expect(result.ok).toBe(true);
+    // No tool-output chunks expected for a string-content user message.
+    expect(emitted.find((e) => e.type === "tool-output-available")).toBeUndefined();
   });
 });

--- a/packages/bundled-agents/src/claude-code/agent.test.ts
+++ b/packages/bundled-agents/src/claude-code/agent.test.ts
@@ -573,12 +573,13 @@ describe("UIMessageChunk translation", () => {
 
     expect(result.ok).toBe(true);
 
-    // Strip the supplemental `data-tool-progress` chip — its content
-    // depends on a real LLM (stub) call and may be silently skipped when
-    // the call rejects under test, which makes positional assertions
-    // flaky. Where it DOES land, separately assert it sits between
-    // `tool-input-available` and the next event (the position guard
-    // below) — that's the ordering invariant we actually need to lock.
+    // Strip the supplemental `data-tool-progress` chip — its content depends
+    // on a real `smallLLM` call, and `createStubPlatformModels`' stub model
+    // rejects `doGenerate`/`doStream`. The production try/catch swallows
+    // that and skips the emit, so the chip is never present under stub
+    // models. The chunk-ordering invariants chat depends on are the
+    // text/tool-input/tool-output positions locked below; the chip's
+    // position is covered by the integration smoke test.
     const core = emitted.filter((e) => e.type !== "data-tool-progress");
 
     // text-start / text-delta / text-end share one id (crypto.randomUUID).
@@ -605,19 +606,6 @@ describe("UIMessageChunk translation", () => {
       output: "file1.txt\nfile2.txt",
     });
     expect(core).toHaveLength(6);
-
-    // Position guard: when `data-tool-progress` is emitted, it MUST sit
-    // strictly between `tool-input-available` and `tool-output-available`
-    // — that's the ordering invariant chat UIs depend on. Skipping when
-    // absent (stub LLM rejected) avoids the flakiness while still locking
-    // the ordering whenever it lands.
-    const progressIdx = emitted.findIndex((e) => e.type === "data-tool-progress");
-    if (progressIdx !== -1) {
-      const inputAvailIdx = emitted.findIndex((e) => e.type === "tool-input-available");
-      const outputAvailIdx = emitted.findIndex((e) => e.type === "tool-output-available");
-      expect(progressIdx).toBeGreaterThan(inputAvailIdx);
-      expect(progressIdx).toBeLessThan(outputAvailIdx);
-    }
   });
 
   it("emits text chunks for an assistant message with no tool_use", async () => {
@@ -657,6 +645,14 @@ describe("UIMessageChunk translation", () => {
         { type: "text", text: "line 2" },
       ],
       expectedOutput: "line 1\n[image]\nline 2",
+    },
+    {
+      // Defends the two-stage guard `type === "text" && typeof c.text === "string"`.
+      // A future flattening to `if (type === "text") return c.text` would
+      // surface `undefined` here; the placeholder branch keeps it stable.
+      name: "non-string text in a text block",
+      content: [{ type: "text", text: 123 }],
+      expectedOutput: "[text]",
     },
   ])("normalizes tool_result $name into a string output", async ({ content, expectedOutput }) => {
     // tool_result.content is `string | Array<...ContentBlockParam> |

--- a/packages/bundled-agents/src/claude-code/agent.ts
+++ b/packages/bundled-agents/src/claude-code/agent.ts
@@ -500,10 +500,32 @@ export const claudeCodeAgent = createAgent<string, ClaudeCodeAgentResult | Recor
             logger.debug("Session started", { sessionId: message.session_id, cwd: message.cwd });
           }
 
-          // Tool progress from assistant messages
+          // Translate complete assistant messages into AI SDK v6 UIMessageChunk
+          // events so the chat UI renders text bubbles and tool-call cards. The
+          // SDK emits one `assistant` per turn (in addition to partial
+          // `stream_event` deltas we don't currently translate), so text shows
+          // up in turn-sized chunks rather than token-by-token. The supplemental
+          // `data-tool-progress` chip is kept so users see a friendly summary
+          // of what each tool call is doing while it runs.
           if (message.type === "assistant") {
             for (const block of message.message.content) {
-              if (block.type === "tool_use") {
+              if (block.type === "text") {
+                const id = crypto.randomUUID();
+                stream?.emit({ type: "text-start", id });
+                stream?.emit({ type: "text-delta", id, delta: block.text });
+                stream?.emit({ type: "text-end", id });
+              } else if (block.type === "tool_use") {
+                stream?.emit({
+                  type: "tool-input-start",
+                  toolCallId: block.id,
+                  toolName: block.name,
+                });
+                stream?.emit({
+                  type: "tool-input-available",
+                  toolCallId: block.id,
+                  toolName: block.name,
+                  input: block.input,
+                });
                 try {
                   const progress = await generateProgress(
                     platformModels,
@@ -520,6 +542,21 @@ export const claudeCodeAgent = createAgent<string, ClaudeCodeAgentResult | Recor
                     toolName: block.name,
                   });
                 }
+              }
+            }
+          }
+
+          // Pair tool calls with their results: when the SDK feeds tool_result
+          // blocks back to the model as user messages, surface them to the chat
+          // UI as tool-output-available chunks (matched by tool_use_id).
+          if (message.type === "user" && Array.isArray(message.message.content)) {
+            for (const block of message.message.content) {
+              if (block.type === "tool_result") {
+                stream?.emit({
+                  type: "tool-output-available",
+                  toolCallId: block.tool_use_id,
+                  output: block.content ?? "",
+                });
               }
             }
           }

--- a/packages/bundled-agents/src/claude-code/agent.ts
+++ b/packages/bundled-agents/src/claude-code/agent.ts
@@ -240,6 +240,33 @@ Read package.json → "Reading package.json"
  * SDK's native Skill tool. This preserves lazy loading (reference files, activity
  * matching) while ensuring the model actually triggers it.
  */
+/**
+ * Normalize a Claude Code SDK tool_result `content` field into a string the
+ * chat UI can render. The SDK delivers `content` as `string |
+ * Array<TextBlockParam | ImageBlockParam | SearchResultBlockParam | ...> |
+ * undefined`. Passing the raw array through to `tool-output-available`
+ * leaks `[object Object]` (or fails downstream Zod validation) for any
+ * tool that returns non-text blocks — images, structured search results,
+ * multi-block returns. Text blocks are concatenated; non-text blocks
+ * collapse to a `[type]` placeholder so the surface that they existed is
+ * preserved without trying to render their binary payload.
+ */
+function normalizeToolResultContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((c) => {
+      if (typeof c !== "object" || c === null || !("type" in c)) return "";
+      const type = (c as { type: unknown }).type;
+      if (type === "text" && "text" in c && typeof (c as { text: unknown }).text === "string") {
+        return (c as { text: string }).text;
+      }
+      return typeof type === "string" ? `[${type}]` : "";
+    })
+    .filter((s) => s.length > 0)
+    .join("\n");
+}
+
 function buildSystemAppend(skills?: Array<{ name: string }>): string {
   const base =
     "You have authenticated access to the gh CLI for GitHub operations. Use it for cloning repos, creating PRs, managing issues, and interacting with GitHub APIs. Return summary of actions. Concise, factual, markdown.";
@@ -555,7 +582,7 @@ export const claudeCodeAgent = createAgent<string, ClaudeCodeAgentResult | Recor
                 stream?.emit({
                   type: "tool-output-available",
                   toolCallId: block.tool_use_id,
-                  output: block.content ?? "",
+                  output: normalizeToolResultContent(block.content),
                 });
               }
             }

--- a/packages/core/src/session/event-emission-mapper.test.ts
+++ b/packages/core/src/session/event-emission-mapper.test.ts
@@ -104,11 +104,17 @@ describe("mapActionToStepStart", () => {
     expect(result.task).toBe("");
   });
 
-  test("defaults agentName to 'unknown' when actionId missing", () => {
-    const event = agentExecutionEvent({ actionId: undefined });
+  test("falls back to FSM state when actionId missing", () => {
+    // Some FSM action shapes (emit / certain llm paths) leave `actionId`
+    // unset. The mapper falls back to `state` so the resulting `agentName`
+    // still matches the planned block built from the same FSM state by
+    // `extractPlannedSteps`. The terminal "unknown" fallback only fires
+    // when state is also absent (impossible per schema today, but the
+    // guard stays defense-in-depth).
+    const event = agentExecutionEvent({ actionId: undefined, state: "research" });
     const result = mapActionToStepStart(event, 1);
 
-    expect(result.agentName).toBe("unknown");
+    expect(result.agentName).toBe("research");
   });
 });
 

--- a/packages/core/src/session/event-emission-mapper.ts
+++ b/packages/core/src/session/event-emission-mapper.ts
@@ -76,13 +76,11 @@ export function mapActionToStepStart(
     sessionId: event.data.sessionId,
     stepNumber,
     // `actionId` is optional on the FSM event (some emit/llm action shapes
-    // don't carry one). Falling back to the FSM `state` keeps the
-    // agentName stable and matches the planned block built from the same
-    // state in `extractPlannedSteps`, so the session reducer doesn't have
-    // to lean on its stateId-fallback path for every agent action. The
-    // literal "unknown" remains as a final guard in case a publisher omits
-    // both fields.
-    agentName: event.data.actionId ?? event.data.state ?? "unknown",
+    // don't carry one). `state` is required, so falling back to it keeps
+    // the agentName stable and matches the planned block built from the
+    // same state in `extractPlannedSteps`, so the session reducer doesn't
+    // have to lean on its stateId-fallback path for every agent action.
+    agentName: event.data.actionId ?? event.data.state,
     stateId: event.data.state,
     actionType: SessionActionTypeSchema.parse(event.data.actionType),
     task: snapshot?.task ?? "",

--- a/packages/core/src/session/event-emission-mapper.ts
+++ b/packages/core/src/session/event-emission-mapper.ts
@@ -106,6 +106,11 @@ export function mapActionToStepComplete(
     type: "step:complete",
     sessionId: event.data.sessionId,
     stepNumber,
+    // Carry the FSM state forward so the reducer can match this complete
+    // event to its planned/running block by `stateId` if `stepNumber`
+    // drifted (e.g. step:start emitted with a fallback agentName, leaving
+    // the original planned block stuck in pending).
+    stateId: event.data.state,
     status: event.data.status === "failed" ? "failed" : "completed",
     durationMs: event.data.durationMs ?? 0,
     toolCalls: agentResult?.toolCalls ?? [],

--- a/packages/core/src/session/event-emission-mapper.ts
+++ b/packages/core/src/session/event-emission-mapper.ts
@@ -75,7 +75,14 @@ export function mapActionToStepStart(
     type: "step:start",
     sessionId: event.data.sessionId,
     stepNumber,
-    agentName: event.data.actionId ?? "unknown",
+    // `actionId` is optional on the FSM event (some emit/llm action shapes
+    // don't carry one). Falling back to the FSM `state` keeps the
+    // agentName stable and matches the planned block built from the same
+    // state in `extractPlannedSteps`, so the session reducer doesn't have
+    // to lean on its stateId-fallback path for every agent action. The
+    // literal "unknown" remains as a final guard in case a publisher omits
+    // both fields.
+    agentName: event.data.actionId ?? event.data.state ?? "unknown",
     stateId: event.data.state,
     actionType: SessionActionTypeSchema.parse(event.data.actionType),
     task: snapshot?.task ?? "",

--- a/packages/core/src/session/session-events.ts
+++ b/packages/core/src/session/session-events.ts
@@ -115,6 +115,15 @@ export const StepCompleteEventSchema = z.object({
   type: z.literal("step:complete"),
   sessionId: z.string(),
   stepNumber: z.number(),
+  /**
+   * FSM state identifier — stable join key matching `StepStartEvent.stateId`
+   * and the `stateId` field on the planned `AgentBlock` from
+   * `session:start.plannedSteps`. The reducer uses this as a fallback when
+   * `stepNumber` doesn't match an existing block (the failure mode that
+   * surfaced the "Unknown · Succeeded" duplicate alongside the original
+   * "Pending" block).
+   */
+  stateId: z.string().optional(),
   status: z.enum(["completed", "failed"]),
   durationMs: z.number(),
   toolCalls: z.array(ToolCallSummarySchema),

--- a/packages/core/src/session/session-reducer.test.ts
+++ b/packages/core/src/session/session-reducer.test.ts
@@ -396,6 +396,76 @@ describe("step:start", () => {
     expect(block.task).toBe("Plan task");
   });
 
+  // Counterpart to the merge: a step:start arrives for a stateId that
+  // session:start's plannedSteps doesn't include (dynamic step, replan,
+  // sub-machine). The merge must preserve the running block instead of
+  // wiping it. Locks the "union not overwrite" semantics — pre-fix the
+  // off-plan block was silently dropped.
+  test("session:start preserves off-plan running blocks not in plannedSteps", () => {
+    let view = reduceSessionEvent(
+      initialSessionView(),
+      stepStart({ stepNumber: 1, agentName: "dynamic", stateId: "ad-hoc", task: "" }),
+    );
+    expect(view.agentBlocks).toHaveLength(1);
+
+    view = reduceSessionEvent(
+      view,
+      sessionStart({
+        plannedSteps: [
+          { agentName: "planned", stateId: "review", actionType: "agent", task: "Plan" },
+        ],
+      }),
+    );
+
+    // Both blocks survive: planned "review" first (in plannedSteps order),
+    // off-plan "ad-hoc" appended after.
+    expect(view.agentBlocks).toHaveLength(2);
+    expect(view.agentBlocks[0]?.stateId).toBe("review");
+    expect(view.agentBlocks[0]?.status).toBe("pending");
+    expect(view.agentBlocks[1]?.stateId).toBe("ad-hoc");
+    expect(view.agentBlocks[1]?.status).toBe("running");
+    expect(view.agentBlocks[1]?.agentName).toBe("dynamic");
+  });
+
+  // session:start with no plannedSteps at all should still preserve any
+  // running blocks that arrived earlier — the publisher may legitimately
+  // omit plannedSteps for cron / on-demand triggers without a static FSM.
+  test("session:start with no plannedSteps preserves all existing blocks", () => {
+    let view = reduceSessionEvent(
+      initialSessionView(),
+      stepStart({ stepNumber: 1, agentName: "a", stateId: "s1", task: "" }),
+    );
+    view = reduceSessionEvent(view, sessionStart({ plannedSteps: undefined }));
+
+    expect(view.agentBlocks).toHaveLength(1);
+    expect(view.agentBlocks[0]?.stateId).toBe("s1");
+    expect(view.agentBlocks[0]?.status).toBe("running");
+  });
+
+  // Inverse of the agentName-drift fix: if the planned block carries
+  // agentName="unknown" (e.g. a future publisher chose that literal as a
+  // placeholder), step:start's real name wins. Pre-fix the reducer would
+  // have kept "unknown" because the preservation guard short-circuited.
+  test("agentName drift inverse: event.agentName wins when planned is 'unknown'", () => {
+    let view = reduceSessionEvent(
+      initialSessionView(),
+      sessionStart({
+        plannedSteps: [
+          { agentName: "unknown", stateId: "review", actionType: "agent", task: "Plan" },
+        ],
+      }),
+    );
+    view = reduceSessionEvent(
+      view,
+      stepStart({ agentName: "pr-reviewer", stateId: "review", stepNumber: 1 }),
+    );
+
+    const block = view.agentBlocks[0];
+    expect.assert(block !== undefined);
+    expect(block.agentName).toBe("pr-reviewer");
+    expect(block.status).toBe("running");
+  });
+
   // Production failure: FSM agent action emitted step:start with
   // agentName="unknown" (actionId was lost), while the planned block kept
   // its real name from `session:start.plannedSteps`. Pre-fix this drift
@@ -512,6 +582,45 @@ describe("step:complete", () => {
     expect(block.agentName).toBe("pr-reviewer");
     expect(block.status).toBe("completed");
     expect(block.stepNumber).toBe(7);
+  });
+
+  // Locks the match-priority order: stepNumber wins over stateId. If both
+  // could match different blocks, stepNumber must take precedence so an
+  // explicit step number from the FSM event isn't overridden by a state
+  // collision (e.g. two blocks for the same stateId after a replan).
+  test("step:complete priority — stepNumber match wins over stateId fallback", () => {
+    // Two pending blocks: one whose stateId matches the event's stateId
+    // (would win via fallback), and one whose stepNumber matches the
+    // event's stepNumber (must win via the primary match).
+    let view = reduceSessionEvent(
+      initialSessionView(),
+      sessionStart({
+        plannedSteps: [
+          { agentName: "alpha", stateId: "alpha-state", actionType: "agent", task: "" },
+          { agentName: "beta", stateId: "review", actionType: "agent", task: "" },
+        ],
+      }),
+    );
+    // step:start transitions the "alpha" block with stepNumber 7.
+    view = reduceSessionEvent(
+      view,
+      stepStart({ stepNumber: 7, agentName: "alpha", stateId: "alpha-state" }),
+    );
+
+    // step:complete carries BOTH stepNumber 7 (matches alpha) and
+    // stateId "review" (would match beta via fallback). stepNumber wins.
+    view = reduceSessionEvent(
+      view,
+      stepComplete({ stepNumber: 7, stateId: "review", status: "completed" }),
+    );
+
+    expect(view.agentBlocks).toHaveLength(2);
+    const alpha = view.agentBlocks.find((b) => b.agentName === "alpha");
+    const beta = view.agentBlocks.find((b) => b.agentName === "beta");
+    expect.assert(alpha !== undefined);
+    expect.assert(beta !== undefined);
+    expect(alpha.status).toBe("completed");
+    expect(beta.status).toBe("pending");
   });
 
   // J1 of melodic-strolling-seal-pt3 — pre-fix the reducer dropped

--- a/packages/core/src/session/session-reducer.test.ts
+++ b/packages/core/src/session/session-reducer.test.ts
@@ -497,6 +497,76 @@ describe("step:start", () => {
     expect(block.agentName).toBe("pr-reviewer");
     expect(block.stepNumber).toBe(1);
   });
+
+  // After the stateId fallback transitions the planned block, a replay
+  // step:start still carries `agentName="unknown"` (the drifted name from
+  // mapActionToStepStart) — the original `(stepNumber, agentName)` dup
+  // guard would miss because the block now carries the preserved
+  // "pr-reviewer", and the function would fall through to append a fresh
+  // running "unknown" block. The widened guard short-circuits on
+  // `stepNumber + status !== "pending"`, so the replay is a no-op.
+  test("replay step:start after stateId-fallback is a no-op (no duplicate block)", () => {
+    let view = reduceSessionEvent(
+      initialSessionView(),
+      sessionStart({
+        plannedSteps: [
+          { agentName: "pr-reviewer", stateId: "review", actionType: "agent", task: "" },
+        ],
+      }),
+    );
+    view = reduceSessionEvent(
+      view,
+      stepStart({ agentName: "unknown", stateId: "review", stepNumber: 1 }),
+    );
+    expect(view.agentBlocks).toHaveLength(1);
+    expect(view.agentBlocks[0]?.agentName).toBe("pr-reviewer");
+
+    // Identical replay — would re-append a running "unknown" block pre-fix.
+    view = reduceSessionEvent(
+      view,
+      stepStart({ agentName: "unknown", stateId: "review", stepNumber: 1 }),
+    );
+
+    expect(view.agentBlocks).toHaveLength(1);
+    const block = view.agentBlocks[0];
+    expect.assert(block !== undefined);
+    expect(block.agentName).toBe("pr-reviewer");
+    expect(block.status).toBe("running");
+  });
+
+  // Symmetric out-of-order: step:complete arrives BEFORE step:start and
+  // completes the planned block via the stateId fallback. A subsequent
+  // step:start with the same stepNumber must NOT append a new running
+  // "unknown" block — the block is already past `pending` and the widened
+  // dup guard catches it on stepNumber alone.
+  test("step:start after step:complete (already transitioned) is a no-op", () => {
+    let view = reduceSessionEvent(
+      initialSessionView(),
+      sessionStart({
+        plannedSteps: [
+          { agentName: "pr-reviewer", stateId: "review", actionType: "agent", task: "" },
+        ],
+      }),
+    );
+    view = reduceSessionEvent(
+      view,
+      stepComplete({ stepNumber: 7, stateId: "review", status: "completed" }),
+    );
+    expect(view.agentBlocks).toHaveLength(1);
+    expect(view.agentBlocks[0]?.status).toBe("completed");
+
+    // Drifted step:start arriving late — pre-fix, this appended a duplicate.
+    view = reduceSessionEvent(
+      view,
+      stepStart({ agentName: "unknown", stateId: "review", stepNumber: 7 }),
+    );
+
+    expect(view.agentBlocks).toHaveLength(1);
+    const block = view.agentBlocks[0];
+    expect.assert(block !== undefined);
+    expect(block.status).toBe("completed");
+    expect(block.agentName).toBe("pr-reviewer");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/session/session-reducer.test.ts
+++ b/packages/core/src/session/session-reducer.test.ts
@@ -353,6 +353,80 @@ describe("step:start", () => {
     expect(view.agentBlocks).toHaveLength(1);
     expect(view.agentBlocks[0]?.status).toBe("completed");
   });
+
+  // Out-of-order tolerance: when step:start lands BEFORE session:start
+  // (events publish to the same JetStream subject in fast succession and
+  // ordering isn't guaranteed for tightly-spaced writes), the reducer
+  // would previously overwrite the running block with an empty pending
+  // one from plannedSteps, losing the signal input and startedAt.
+  test("session:start preserves running blocks created by an earlier step:start", () => {
+    // Out-of-order: step:start first (with empty task as the FSM
+    // mapActionToStepStart actually emits when inputSnapshot.task is
+    // undefined), then session:start with the planned task description.
+    let view = reduceSessionEvent(
+      initialSessionView(),
+      stepStart({
+        stepNumber: 1,
+        agentName: "pr-reviewer",
+        stateId: "review",
+        task: "",
+        input: { pr_url: "https://github.com/x/y/pull/1" },
+      }),
+    );
+    expect(view.agentBlocks).toHaveLength(1);
+    expect(view.agentBlocks[0]?.status).toBe("running");
+    expect(view.agentBlocks[0]?.input).toEqual({ pr_url: "https://github.com/x/y/pull/1" });
+
+    view = reduceSessionEvent(
+      view,
+      sessionStart({
+        plannedSteps: [
+          { agentName: "pr-reviewer", stateId: "review", actionType: "agent", task: "Plan task" },
+        ],
+      }),
+    );
+
+    expect(view.agentBlocks).toHaveLength(1);
+    const block = view.agentBlocks[0];
+    expect.assert(block !== undefined);
+    expect(block.status).toBe("running");
+    expect(block.input).toEqual({ pr_url: "https://github.com/x/y/pull/1" });
+    expect(block.stepNumber).toBe(1);
+    // Step-start carried an empty task; the planned task fills it in.
+    expect(block.task).toBe("Plan task");
+  });
+
+  // Production failure: FSM agent action emitted step:start with
+  // agentName="unknown" (actionId was lost), while the planned block kept
+  // its real name from `session:start.plannedSteps`. Pre-fix this drift
+  // produced TWO blocks on the session page — the planned "Pr Reviewer"
+  // (Pending → Skipped) plus an appended "Unknown" (Running → Succeeded).
+  // The reducer now falls back to matching by `stateId`, which both events
+  // carry, keeping the planned block as the single source of truth.
+  test("matches by stateId when agentName drifts (Pr Reviewer / Unknown bug)", () => {
+    let view = reduceSessionEvent(
+      initialSessionView(),
+      sessionStart({
+        plannedSteps: [
+          { agentName: "pr-reviewer", stateId: "review", actionType: "agent", task: "" },
+        ],
+      }),
+    );
+    expect(view.agentBlocks).toHaveLength(1);
+    expect(view.agentBlocks[0]?.agentName).toBe("pr-reviewer");
+
+    view = reduceSessionEvent(
+      view,
+      stepStart({ agentName: "unknown", stateId: "review", stepNumber: 1 }),
+    );
+
+    expect(view.agentBlocks).toHaveLength(1);
+    const block = view.agentBlocks[0];
+    expect.assert(block !== undefined);
+    expect(block.status).toBe("running");
+    expect(block.agentName).toBe("pr-reviewer");
+    expect(block.stepNumber).toBe(1);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -410,6 +484,34 @@ describe("step:complete", () => {
     const block = view.agentBlocks.find((b) => b.stepNumber === 99);
     expect(block).toBeDefined();
     expect(block?.status).toBe("completed");
+  });
+
+  // Symmetric counterpart to the step:start stateId fallback: if step:start
+  // never landed (or transitioned a different block), step:complete should
+  // still find the planned block by stateId rather than appending a
+  // synthetic "Unknown" placeholder.
+  test("matches by stateId when stepNumber doesn't match", () => {
+    let view = reduceSessionEvent(
+      initialSessionView(),
+      sessionStart({
+        plannedSteps: [
+          { agentName: "pr-reviewer", stateId: "review", actionType: "agent", task: "" },
+        ],
+      }),
+    );
+    // No step:start arrived; step:complete fires with stateId="review"
+    // and a stepNumber the planned block doesn't carry yet.
+    view = reduceSessionEvent(
+      view,
+      stepComplete({ stepNumber: 7, stateId: "review", status: "completed" }),
+    );
+
+    expect(view.agentBlocks).toHaveLength(1);
+    const block = view.agentBlocks[0];
+    expect.assert(block !== undefined);
+    expect(block.agentName).toBe("pr-reviewer");
+    expect(block.status).toBe("completed");
+    expect(block.stepNumber).toBe(7);
   });
 
   // J1 of melodic-strolling-seal-pt3 — pre-fix the reducer dropped

--- a/packages/core/src/session/session-reducer.ts
+++ b/packages/core/src/session/session-reducer.ts
@@ -46,7 +46,51 @@ export function reduceSessionEvent(
   }
 
   switch (event.type) {
-    case "session:start":
+    case "session:start": {
+      // Out-of-order tolerance: step:start can arrive before session:start
+      // because both events publish to the same JetStream subject in fast
+      // succession and ordering isn't guaranteed for tightly-spaced writes.
+      // When this happens reduceStepStart already created a "running" block
+      // from step:start's data — including the `input` snapshot from the
+      // signal payload. We must NOT overwrite that block with an empty
+      // pending one from `plannedSteps`, or step:start's data is lost.
+      //
+      // Pre-fix this surfaced as agent blocks rendered with "No input
+      // provided" + planned-step task on the session page, because
+      // session:start ran after step:start and wiped the populated block.
+      const planned =
+        event.plannedSteps?.map((step) => ({
+          stepNumber: undefined as number | undefined,
+          agentName: step.agentName,
+          stateId: step.stateId,
+          actionType: step.actionType,
+          task: step.task,
+          status: "pending" as const,
+          toolCalls: [],
+          output: undefined,
+        })) ?? [];
+
+      // Merge with any blocks already created by an earlier step:start: keep
+      // the existing block if its stateId matches a planned step, otherwise
+      // fall back to the planned entry.
+      const mergedBlocks =
+        view.agentBlocks.length === 0
+          ? planned
+          : planned.map((plannedBlock) => {
+              if (!plannedBlock.stateId) return plannedBlock;
+              const existing = view.agentBlocks.find((b) => b.stateId === plannedBlock.stateId);
+              if (!existing) return plannedBlock;
+              // Layer the planned `task` (descriptive label from session:start)
+              // on top of the running block's empty step-start task, but keep
+              // every other field — status, input, startedAt — from the
+              // already-running block. Use existing.task if non-empty.
+              return {
+                ...existing,
+                task: existing.task && existing.task.length > 0 ? existing.task : plannedBlock.task,
+                actionType: existing.actionType ?? plannedBlock.actionType,
+              };
+            });
+
       return {
         ...view,
         sessionId: event.sessionId,
@@ -55,18 +99,9 @@ export function reduceSessionEvent(
         task: event.task,
         status: "active",
         startedAt: event.timestamp,
-        agentBlocks:
-          event.plannedSteps?.map((step) => ({
-            stepNumber: undefined,
-            agentName: step.agentName,
-            stateId: step.stateId,
-            actionType: step.actionType,
-            task: step.task,
-            status: "pending" as const,
-            toolCalls: [],
-            output: undefined,
-          })) ?? [],
+        agentBlocks: mergedBlocks,
       };
+    }
 
     case "step:start":
       return reduceStepStart(view, event);
@@ -146,19 +181,34 @@ function reduceStepStart(
     if (dupIdx !== -1) return view;
   }
 
-  // Find first pending block with matching agentName
-  const pendingIdx = view.agentBlocks.findIndex(
+  // Find first pending block with matching agentName. If agentName drifts
+  // (e.g. the FSM action emits `actionId: undefined`, which
+  // `mapActionToStepStart` falls back to "unknown" while the planned block
+  // carries the real agentId), fall back to matching by `stateId` — the
+  // FSM state name is a stable join key between `session:start.plannedSteps`
+  // and the action execution event, regardless of how the name happened to
+  // be projected onto the action.
+  let pendingIdx = view.agentBlocks.findIndex(
     (b) => b.status === "pending" && b.agentName === event.agentName,
   );
+  if (pendingIdx === -1 && event.stateId) {
+    pendingIdx = view.agentBlocks.findIndex(
+      (b) => b.status === "pending" && b.stateId === event.stateId,
+    );
+  }
 
   if (pendingIdx !== -1) {
-    // Transition pending → running in-place (preserve array position)
+    // Transition pending → running in-place (preserve array position).
+    // Keep the planned block's agentName when we matched via stateId so the
+    // UI doesn't relabel "Pr Reviewer" → "unknown" mid-transition.
     const pending = view.agentBlocks[pendingIdx];
     if (!pending) return view;
     const updated: AgentBlock = {
       ...pending,
       stepNumber: event.stepNumber,
       stateId: event.stateId ?? pending.stateId,
+      agentName:
+        pending.agentName && pending.agentName !== "unknown" ? pending.agentName : event.agentName,
       actionType: event.actionType,
       task: event.task,
       input: event.input,
@@ -195,7 +245,17 @@ function reduceStepComplete(
   view: SessionView,
   event: SessionStreamEvent & { type: "step:complete" },
 ): SessionView {
-  const idx = view.agentBlocks.findIndex((b) => b.stepNumber === event.stepNumber);
+  // Primary match: stepNumber. Fallback: stateId — covers the case where
+  // step:start never transitioned the planned block (so its stepNumber is
+  // still undefined) but a step:complete with the same FSM stateId arrived.
+  // Without this fallback the reducer would synthesize an "unknown"
+  // placeholder block alongside the original pending block, surfacing the
+  // duplicate "Pr Reviewer · Skipped + Unknown · Succeeded" pair we hit
+  // in the session view.
+  let idx = view.agentBlocks.findIndex((b) => b.stepNumber === event.stepNumber);
+  if (idx === -1 && event.stateId) {
+    idx = view.agentBlocks.findIndex((b) => b.stateId === event.stateId);
+  }
 
   if (idx === -1) {
     // No matching step:start — create a placeholder block
@@ -224,6 +284,10 @@ function reduceStepComplete(
 
   const updated: AgentBlock = {
     ...existing,
+    // Backfill stepNumber if we matched the block via stateId fallback —
+    // the block may have been stuck without a stepNumber when step:start
+    // never transitioned it.
+    stepNumber: existing.stepNumber ?? event.stepNumber,
     status: event.status,
     durationMs: event.durationMs,
     toolCalls: event.toolCalls,

--- a/packages/core/src/session/session-reducer.ts
+++ b/packages/core/src/session/session-reducer.ts
@@ -158,27 +158,32 @@ function reduceStepStart(
   view: SessionView,
   event: SessionStreamEvent & { type: "step:start" },
 ): SessionView {
-  // Defense in depth (J2 / review H1): if a `step:start` for this exact
-  // (stepNumber, agentName) pair already lives in the view, treat the
-  // re-publish as a no-op. Pre-J2 the broker dedup window (default 2m)
-  // was shorter than long-running FSM jobs, so a `save()` republish past
-  // the window landed as a NEW message. The reducer would then fail to
-  // find a *pending* match (the prior copy was already running/done) and
-  // append a duplicate block — status derivation then saw both pending
-  // and complete simultaneously, surfacing as `status: "active"` post-
-  // completion. The dedup_window bump fixes the broker side; this guard
-  // protects the reducer regardless.
+  // Defense in depth: if a block carrying this `stepNumber` already exists
+  // and has been transitioned (status !== "pending"), this step:start is a
+  // replay or arrived after step:complete already landed via the stateId
+  // fallback below. Treat as a no-op — appending another running block
+  // here is exactly the duplicate-block regression the stateId fallback
+  // was added to prevent.
   //
-  // The reducer is a pure function shared with browser clients, so we don't
-  // log from here. Operators investigating "is this
-  // guard firing in production?" should check the NATS dedup-rejection
-  // counter (`nats stream info SESSION_EVENTS` reports duplicates) and
-  // grep daemon logs for "step:start" with the same (stepNumber,
-  // agentName). A non-zero dedup rate paired with this guard firing
-  // means the dedup_window is still too short and should be raised.
+  // Originates as J2 / review H1: broker dedup_window (default 2m) was
+  // shorter than long-running FSM jobs, so a `save()` republish past the
+  // window landed as a NEW message and the reducer appended a duplicate.
+  // Subsumes the original `(stepNumber, agentName)` guard — keying on
+  // `stepNumber` alone also covers the agentName-drift case (where a
+  // replay carries `agentName="unknown"` but the planned block kept its
+  // real name) and the symmetric step:complete-before-step:start case
+  // (where the block is already "completed" via stateId fallback).
+  //
+  // The reducer is a pure function shared with browser clients, so we
+  // don't log from here. Operators investigating "is this guard firing in
+  // production?" should check the NATS dedup-rejection counter (`nats
+  // stream info SESSION_EVENTS` reports duplicates) and grep daemon logs
+  // for "step:start" with the same `stepNumber`. A non-zero dedup rate
+  // paired with this guard firing means the dedup_window is still too
+  // short and should be raised.
   if (event.stepNumber !== undefined) {
     const dupIdx = view.agentBlocks.findIndex(
-      (b) => b.stepNumber === event.stepNumber && b.agentName === event.agentName,
+      (b) => b.stepNumber === event.stepNumber && b.status !== "pending",
     );
     if (dupIdx !== -1) return view;
   }
@@ -209,8 +214,7 @@ function reduceStepStart(
       ...pending,
       stepNumber: event.stepNumber,
       stateId: event.stateId ?? pending.stateId,
-      agentName:
-        pending.agentName && pending.agentName !== "unknown" ? pending.agentName : event.agentName,
+      agentName: pending.agentName !== "unknown" ? pending.agentName : event.agentName,
       actionType: event.actionType,
       task: event.task,
       input: event.input,

--- a/packages/core/src/session/session-reducer.ts
+++ b/packages/core/src/session/session-reducer.ts
@@ -47,17 +47,15 @@ export function reduceSessionEvent(
 
   switch (event.type) {
     case "session:start": {
-      // Out-of-order tolerance: step:start can arrive before session:start
-      // because both events publish to the same JetStream subject in fast
-      // succession and ordering isn't guaranteed for tightly-spaced writes.
-      // When this happens reduceStepStart already created a "running" block
-      // from step:start's data — including the `input` snapshot from the
-      // signal payload. We must NOT overwrite that block with an empty
-      // pending one from `plannedSteps`, or step:start's data is lost.
-      //
-      // Pre-fix this surfaced as agent blocks rendered with "No input
-      // provided" + planned-step task on the session page, because
-      // session:start ran after step:start and wiped the populated block.
+      // Out-of-order tolerance: step:start can arrive before session:start.
+      // The ordering hazard isn't in JetStream itself (it preserves subject
+      // publish order) — it's in `NatsSessionStream.emit()`, which calls
+      // `appendEvent` fire-and-forget, so two back-to-back emits can race
+      // at `js.publish` ack time. When step:start lands first,
+      // reduceStepStart already created a "running" block carrying the
+      // signal `input` snapshot; this case must not destroy it. Pre-fix
+      // the page rendered "No input provided" + the planned task because
+      // session:start wiped the populated block.
       const planned =
         event.plannedSteps?.map((step) => ({
           stepNumber: undefined as number | undefined,
@@ -70,26 +68,30 @@ export function reduceSessionEvent(
           output: undefined,
         })) ?? [];
 
-      // Merge with any blocks already created by an earlier step:start: keep
-      // the existing block if its stateId matches a planned step, otherwise
-      // fall back to the planned entry.
-      const mergedBlocks =
-        view.agentBlocks.length === 0
-          ? planned
-          : planned.map((plannedBlock) => {
-              if (!plannedBlock.stateId) return plannedBlock;
-              const existing = view.agentBlocks.find((b) => b.stateId === plannedBlock.stateId);
-              if (!existing) return plannedBlock;
-              // Layer the planned `task` (descriptive label from session:start)
-              // on top of the running block's empty step-start task, but keep
-              // every other field — status, input, startedAt — from the
-              // already-running block. Use existing.task if non-empty.
-              return {
-                ...existing,
-                task: existing.task && existing.task.length > 0 ? existing.task : plannedBlock.task,
-                actionType: existing.actionType ?? plannedBlock.actionType,
-              };
-            });
+      // Union: layer planned entries onto matching existing blocks (by
+      // stateId) AND keep any existing block whose stateId doesn't appear
+      // in plannedSteps — those came from out-of-order step:starts (or
+      // dynamic/replanned steps) and must survive. plannedSteps may be
+      // empty/undefined entirely (some publishers omit it); in that case
+      // every existing block is preserved verbatim.
+      const matchedStateIds = new Set<string>();
+      const fromPlanned = planned.map((plannedBlock) => {
+        if (!plannedBlock.stateId) return plannedBlock;
+        const existing = view.agentBlocks.find((b) => b.stateId === plannedBlock.stateId);
+        if (!existing) return plannedBlock;
+        matchedStateIds.add(plannedBlock.stateId);
+        // Layer the planned `task` (descriptive label) on top of the
+        // running block's typically-empty step-start task, but keep every
+        // other field — status, input, startedAt — from the already-running
+        // block. `actionType` is always assigned by reduceStepStart on a
+        // running block so we don't need to fall back to plannedBlock.
+        return {
+          ...existing,
+          task: existing.task && existing.task.length > 0 ? existing.task : plannedBlock.task,
+        };
+      });
+      const orphans = view.agentBlocks.filter((b) => !b.stateId || !matchedStateIds.has(b.stateId));
+      const mergedBlocks = [...fromPlanned, ...orphans];
 
       return {
         ...view,


### PR DESCRIPTION
## Summary

Two correlated fixes for the live agent-streaming pipeline that the user surfaced by asking "why don't I see any output from my claude-code agent?":

- **claude-code agent emit gap** — the agent emitted only `data-tool-progress` chips, so the chat UI had no text bubbles or tool-call cards to render. It now emits the full AI SDK v6 chunk vocabulary (`text-*`, `tool-input-*`, `tool-output-*`) translated from the Claude Code SDK's block stream. The supplemental progress chip is kept.
- **Session view reducer bugs** — running a job whose FSM action invoked claude-code surfaced three correlated issues in the session view: a duplicate "Unknown · Succeeded" block alongside the planned "Pr Reviewer · Skipped", a missing `input` field on the block, and a "task: ''" rendering. Root cause was the reducer not handling agent-name drift, stepNumber mismatch on step:complete, and out-of-order session:start (which arrived AFTER step:start because both events publish to the same JetStream subject in fast succession).

See individual commit messages for full diagnostics.

## Test plan

- [x] `deno task test packages/bundled-agents/src/claude-code/agent.test.ts` — 29/29 (2 new for the chunk translation)
- [x] `deno task test packages/core/src/session/session-reducer.test.ts packages/core/src/session/event-emission-mapper.test.ts` — 63/63 (3 new covering each fallback path)
- [x] Live UI smoke against a minimal `qa-claude-code-stream` workspace — claude-code emit verified end-to-end via `MCPStreamEmitter` log + chat UI rendering nested Bash tool cards from a live PR review run
- [x] Live UI smoke against `vanilla_apple` / PR Code Review workspace — session view now shows a single `pr-reviewer` block (Pending → Running → Completed) with `input: { pr_url: "…" }` populated, instead of the prior duplicate `Pr Reviewer · Skipped + Unknown · Succeeded` pair