### PR TITLE
fix(atlasd): kill orphan MCP probe subprocesses on client abort (#344)

### DIFF
--- a/apps/atlasd/routes/mcp-registry.subprocess-kill.test.ts
+++ b/apps/atlasd/routes/mcp-registry.subprocess-kill.test.ts
@@ -1,0 +1,185 @@
+// End-to-end verification for issue #344. A real `Deno.serve` hosts the
+// MCP-registry router; a real Node `fetch` with `AbortController` calls
+// `GET /:id/tools`; the route spawns a real slow stdio MCP server; we
+// abort the client; we assert the spawned subprocess is gone within ~2s.
+//
+// Unlike `apps/atlasd/routes/mcp-registry.test.ts`, this file intentionally
+// does NOT mock `@atlas/mcp` — proving the abort path actually reaches the
+// spawned child and kills it is the whole point. Living in its own file
+// keeps `vi.mock` scope from polluting either suite.
+//
+// PID capture uses the `pgrep -P <test-pid>` baseline-then-diff pattern
+// established by `packages/mcp/src/create-mcp-tools.subprocess-kill.test.ts`
+// (Vitest's frozen ESM namespaces make `vi.spyOn(child_process, "spawn")`
+// throw "Cannot redefine property", so we read the OS process tree instead).
+
+import { execFileSync } from "node:child_process";
+import process from "node:process";
+import { mcpServersRegistry } from "@atlas/core/mcp-registry/registry-consolidated";
+import { getMCPRegistryAdapter } from "@atlas/core/mcp-registry/storage";
+import { Hono } from "hono";
+import { afterEach, beforeEach, describe, it } from "vitest";
+import { mcpRegistryRouter } from "./mcp-registry.ts";
+import { _resetCacheForTest } from "./mcp-tool-cache.ts";
+
+// Same slow MCP server used by `create-mcp-tools.subprocess-kill.test.ts`:
+// keeps the event loop alive (setInterval), holds stdin open, and never
+// responds to the MCP `initialize` handshake — so `experimental_createMCPClient`
+// hangs until the transport's AbortController fires SIGTERM.
+const SLOW_SERVER_SCRIPT = "setInterval(() => {}, 1000); process.stdin.resume();";
+
+function listChildren(parent: number): number[] {
+  try {
+    const out = execFileSync("pgrep", ["-P", String(parent)], { encoding: "utf8" });
+    return out
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map(Number)
+      .filter((n) => Number.isFinite(n));
+  } catch (err) {
+    const e = err as { status?: number };
+    if (e.status === 1) return [];
+    throw err;
+  }
+}
+
+async function waitForNewChild(baseline: Set<number>, timeoutMs: number): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    for (const pid of listChildren(process.pid)) {
+      if (!baseline.has(pid)) return pid;
+    }
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error("timed out waiting for spawned child to appear");
+}
+
+async function expectPidGone(pid: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ESRCH") return;
+      throw err;
+    }
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(`pid ${pid} still alive after ${timeoutMs}ms`);
+}
+
+// POSIX-only — same skip rationale as `create-mcp-tools.subprocess-kill.test.ts`.
+// The daemon doesn't run on Windows; `pgrep` and `process.kill(pid, 0)` ESRCH
+// semantics aren't portable.
+describe.skipIf(process.platform === "win32")(
+  "GET /:id/tools — client abort kills spawned stdio subprocess (#344)",
+  () => {
+    let server: Deno.HttpServer<Deno.NetAddr> | undefined;
+    let baseUrl: string | undefined;
+    const trackedPids = new Set<number>();
+    const seededIds = new Set<string>();
+
+    beforeEach(async () => {
+      _resetCacheForTest();
+
+      // Build a Hono app that mounts the registry router under "/". The
+      // production daemon mounts at "/api/mcp-registry"; the prefix doesn't
+      // affect what we're testing (abort propagation through the handler),
+      // and a flat mount keeps URLs short.
+      const app = new Hono();
+      app.use("*", async (c, next) => {
+        // @ts-expect-error - the registry route never reads `app` context.
+        c.set("app", {});
+        // @ts-expect-error - userId Variables not typed on bare Hono app
+        c.set("userId", "test-user");
+        await next();
+      });
+      app.route("/", mcpRegistryRouter);
+
+      // Port 0 → OS picks a free port. Bind to loopback so the test doesn't
+      // need network permissions beyond localhost.
+      const ready = Promise.withResolvers<void>();
+      server = Deno.serve(
+        {
+          port: 0,
+          hostname: "127.0.0.1",
+          onListen: ({ hostname, port }) => {
+            baseUrl = `http://${hostname}:${port}`;
+            ready.resolve();
+          },
+        },
+        app.fetch,
+      );
+      await ready.promise;
+    });
+
+    afterEach(async () => {
+      // Kill any subprocess the test failed to clean up — otherwise the
+      // next test's `pgrep -P` baseline picks it up as a stray.
+      for (const pid of trackedPids) {
+        try {
+          process.kill(pid, "SIGKILL");
+        } catch {
+          // already gone
+        }
+      }
+      trackedPids.clear();
+
+      // Drop dynamic registry entries so the JetStream KV bucket (shared
+      // across the worker) doesn't accumulate test fixtures.
+      if (seededIds.size > 0) {
+        const adapter = await getMCPRegistryAdapter();
+        for (const id of seededIds) {
+          await adapter.delete(id).catch(() => {});
+        }
+        seededIds.clear();
+      }
+
+      if (server) {
+        await server.shutdown();
+        server = undefined;
+        baseUrl = undefined;
+      }
+    });
+
+    it("aborts the request → SIGTERMs the stdio child within ~2s", async () => {
+      if (!baseUrl) throw new Error("server did not start");
+
+      // Random suffix because the JetStream KV bucket is shared across the
+      // worker and prior runs may have leaked. Also guards against any
+      // accidental overlap with a blessed-registry id.
+      const serverId = `subprocess-kill-test-${crypto.randomUUID().slice(0, 8)}`;
+      if (mcpServersRegistry.servers[serverId]) {
+        throw new Error(`unexpected blessed-registry collision on ${serverId}`);
+      }
+
+      const adapter = await getMCPRegistryAdapter();
+      await adapter.add({
+        id: serverId,
+        name: "Subprocess kill test",
+        source: "web",
+        securityRating: "medium",
+        status: "ready",
+        configTemplate: {
+          transport: { type: "stdio", command: "node", args: ["-e", SLOW_SERVER_SCRIPT] },
+        },
+      });
+      seededIds.add(serverId);
+
+      const baseline = new Set(listChildren(process.pid));
+      const controller = new AbortController();
+      const fetchPromise = fetch(`${baseUrl}/${serverId}/tools`, { signal: controller.signal });
+      // Swallow the rejection that lands when we abort — we assert on the
+      // subprocess PID, not the fetch promise.
+      fetchPromise.catch(() => {});
+
+      const pid = await waitForNewChild(baseline, 3000);
+      trackedPids.add(pid);
+
+      controller.abort();
+      await expectPidGone(pid, 2000);
+      trackedPids.delete(pid);
+    }, 15_000);
+  },
+);

--- a/apps/atlasd/routes/mcp-registry.subprocess-kill.test.ts
+++ b/apps/atlasd/routes/mcp-registry.subprocess-kill.test.ts
@@ -44,11 +44,30 @@ function listChildren(parent: number): number[] {
   }
 }
 
-async function waitForNewChild(baseline: Set<number>, timeoutMs: number): Promise<number> {
+// Read a single pid's command line via `ps -o command=` — portable across
+// macOS and Linux. Returns "" if the pid is gone by the time we ask, so
+// the caller treats it as a non-match.
+function cmdlineFor(pid: number): string {
+  try {
+    return execFileSync("ps", ["-o", "command=", "-p", String(pid)], { encoding: "utf8" }).trim();
+  } catch {
+    return "";
+  }
+}
+
+// Filter candidate child PIDs by command line so a concurrent test's spawn
+// can't be picked up as ours. The `cmdlineMatch` substring must be unique
+// to this test's slow-server script (see SLOW_SERVER_SCRIPT).
+async function waitForNewChild(
+  baseline: Set<number>,
+  timeoutMs: number,
+  cmdlineMatch: string,
+): Promise<number> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     for (const pid of listChildren(process.pid)) {
-      if (!baseline.has(pid)) return pid;
+      if (baseline.has(pid)) continue;
+      if (cmdlineFor(pid).includes(cmdlineMatch)) return pid;
     }
     await new Promise((r) => setTimeout(r, 10));
   }
@@ -174,7 +193,7 @@ describe.skipIf(process.platform === "win32")(
       // subprocess PID, not the fetch promise.
       fetchPromise.catch(() => {});
 
-      const pid = await waitForNewChild(baseline, 3000);
+      const pid = await waitForNewChild(baseline, 3000, SLOW_SERVER_SCRIPT);
       trackedPids.add(pid);
 
       controller.abort();

--- a/apps/atlasd/routes/mcp-registry.test.ts
+++ b/apps/atlasd/routes/mcp-registry.test.ts
@@ -2570,6 +2570,94 @@ describe("MCP Registry Routes", () => {
       expect(mockCreateMCPTools.mock.calls.length).toBe(1);
     });
 
+    it("client abort wins the race — route short-circuits, prewarm keeps running", async () => {
+      // PR 1 of #344: when the client disconnects mid-dedup-wait, the route
+      // must abort its wait without canceling the underlying prewarm — the
+      // prewarm has its own 60s lifecycle and serves the next caller.
+      const entry = createTestEntry("dedup-client-abort");
+      let resolvePrewarm:
+        | ((value: { tools: Record<string, MockTool>; disconnected: never[] }) => void)
+        | undefined;
+      const disposeSpy = vi.fn().mockResolvedValue(undefined);
+      mockCreateMCPTools.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolvePrewarm = (v) => resolve({ ...v, dispose: disposeSpy });
+          }),
+      );
+
+      await mcpRegistryRouter.request("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entry }),
+      });
+
+      const ctl = new AbortController();
+      const probePromise = mcpRegistryRouter.request(`/${entry.id}/tools`, { signal: ctl.signal });
+      // Give the handler time to reach Promise.race and register the listener
+      // before aborting — otherwise the synchronous pre-check at the top of
+      // the abort-promise constructor would fire instead.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      ctl.abort(new Error("client gone"));
+
+      // Hono's `app.request` doesn't observe the AbortSignal at the fetch
+      // layer — instead the handler throws and Hono surfaces it as a 500.
+      // What matters is the route did NOT return tools (no `ok: true` body)
+      // and the prewarm was NOT canceled.
+      const resp = await probePromise;
+      expect(resp.status).toBe(500);
+
+      // Prewarm is still in-flight — settle it to flush the IIFE and let the
+      // test's afterEach clean up. If the route had erroneously canceled the
+      // prewarm, mockCreateMCPTools' returned promise would have already
+      // rejected and `resolvePrewarm` would be useless.
+      expect(resolvePrewarm).toBeDefined();
+      resolvePrewarm?.({
+        tools: { "warmed-tool": { description: "warmed" } },
+        disconnected: [],
+      });
+      await _flushPrewarmsForTest();
+      expect(mockCreateMCPTools.mock.calls.length).toBe(1);
+    });
+
+    it("prewarm wins the race — abort listener is cleaned up so a later abort is inert", async () => {
+      // Locks in the listener-cleanup invariant: once the race resolves on
+      // the prewarm branch, removing the abort listener (both via
+      // {once: true} and explicit removeEventListener) means a subsequent
+      // abort on the same signal does not double-resolve or leak handler
+      // refs. Asserted indirectly via mock state — a leaked listener would
+      // not affect functional correctness here, but the test pins both the
+      // happy path AND the lifecycle assumption the impl depends on.
+      const entry = createTestEntry("dedup-prewarm-wins");
+      mockCreateMCPTools.mockImplementationOnce(() =>
+        Promise.resolve({
+          tools: { "warmed-tool": { description: "warmed" } },
+          dispose: vi.fn().mockResolvedValue(undefined),
+          disconnected: [],
+        }),
+      );
+
+      await mcpRegistryRouter.request("/", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ entry }),
+      });
+
+      const ctl = new AbortController();
+      const probe = await mcpRegistryRouter.request(`/${entry.id}/tools`, { signal: ctl.signal });
+      expect(probe.status).toBe(200);
+      const body = ToolProbeSuccessSchema.parse(await probe.json());
+      expect(body.tools[0]?.name).toBe("warmed-tool");
+
+      // Aborting after the response settled must not affect anything — the
+      // listener should already be gone. We can't introspect listeners via
+      // public API, but a leak would manifest as an unhandled rejection
+      // (the `aborted` Promise would resolve into a settled race that has
+      // no consumer); vitest fails the test on unhandled rejections.
+      ctl.abort(new Error("late abort"));
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
     it("returns retryable hint when in-flight prewarm exceeds the race cap", async () => {
       _setRaceCapForTest(50);
       const entry = createTestEntry("dedup-retryable");

--- a/apps/atlasd/routes/mcp-registry.test.ts
+++ b/apps/atlasd/routes/mcp-registry.test.ts
@@ -2612,10 +2612,7 @@ describe("MCP Registry Routes", () => {
       // prewarm, mockCreateMCPTools' returned promise would have already
       // rejected and `resolvePrewarm` would be useless.
       expect(resolvePrewarm).toBeDefined();
-      resolvePrewarm?.({
-        tools: { "warmed-tool": { description: "warmed" } },
-        disconnected: [],
-      });
+      resolvePrewarm?.({ tools: { "warmed-tool": { description: "warmed" } }, disconnected: [] });
       await _flushPrewarmsForTest();
       expect(mockCreateMCPTools.mock.calls.length).toBe(1);
     });

--- a/apps/atlasd/routes/mcp-registry.ts
+++ b/apps/atlasd/routes/mcp-registry.ts
@@ -1027,6 +1027,11 @@ export const mcpRegistryRouter = daemonFactory
     ),
     async (c) => {
       const { id } = c.req.valid("param");
+      // Client abort signal — when the playground cancels (e.g. user mashing
+      // Retry, navigating away), short-circuit the probe so we stop awaiting.
+      // PR 1 of #344: this only collapses the route's wait; the in-flight
+      // stdio subprocess still lives for ~20s until task 4 lands.
+      const clientSignal = c.req.raw.signal;
 
       let server: MCPServerMetadata | undefined = mcpServersRegistry.servers[id];
       if (!server) {
@@ -1051,13 +1056,30 @@ export const mcpRegistryRouter = daemonFactory
       const inFlight = getInFlightPrewarm(id, server.configTemplate);
       if (inFlight) {
         const TIMED_OUT = Symbol("timeout");
+        const ABORTED = Symbol("aborted");
         let timer: ReturnType<typeof setTimeout> | undefined;
         const timed = new Promise<typeof TIMED_OUT>((resolve) => {
           timer = setTimeout(() => resolve(TIMED_OUT), getRaceCapMs());
         });
-        const winner = await Promise.race([inFlight, timed]);
+        // Race-loser sentinel for client abort. Cancels the *wait*, not the
+        // prewarm itself — prewarm has its own 60s lifecycle and continues
+        // so the next caller can still benefit from a warm cache.
+        let onAbort: (() => void) | undefined;
+        const aborted = new Promise<typeof ABORTED>((resolve) => {
+          if (clientSignal.aborted) {
+            resolve(ABORTED);
+            return;
+          }
+          onAbort = () => resolve(ABORTED);
+          clientSignal.addEventListener("abort", onAbort, { once: true });
+        });
+        const winner = await Promise.race([inFlight, timed, aborted]);
         if (timer) clearTimeout(timer);
+        if (onAbort) clientSignal.removeEventListener("abort", onAbort);
 
+        if (winner === ABORTED) {
+          throw clientSignal.reason ?? new Error("Aborted");
+        }
         if (winner === TIMED_OUT) {
           return c.json({
             ok: false as const,
@@ -1080,7 +1102,7 @@ export const mcpRegistryRouter = daemonFactory
       }
 
       try {
-        const tools = await probeAndExtract(id, server.configTemplate, logger, 5000);
+        const tools = await probeAndExtract(id, server.configTemplate, logger, 5000, clientSignal);
         putCachedTools(id, server.configTemplate, tools);
         return c.json({ ok: true as const, tools });
       } catch (error) {

--- a/apps/atlasd/routes/mcp-tool-cache.test.ts
+++ b/apps/atlasd/routes/mcp-tool-cache.test.ts
@@ -2,10 +2,7 @@ import type { MCPServerConfig } from "@atlas/agent-sdk";
 import { createLogger } from "@atlas/logger";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-type MockTool = {
-  description?: string;
-  inputSchema?: { jsonSchema?: Record<string, unknown> };
-};
+type MockTool = { description?: string; inputSchema?: { jsonSchema?: Record<string, unknown> } };
 type MockDisconnected = { serverId: string; kind: string; message: string };
 
 const mockCreateMCPTools =
@@ -27,9 +24,7 @@ vi.mock("@atlas/mcp", () => ({
 
 const { probeAndExtract } = await import("./mcp-tool-cache.ts");
 
-const config: MCPServerConfig = {
-  transport: { type: "stdio", command: "echo", args: ["hello"] },
-};
+const config: MCPServerConfig = { transport: { type: "stdio", command: "echo", args: ["hello"] } };
 const logger = createLogger({ test: "mcp-tool-cache" });
 
 beforeEach(() => {

--- a/apps/atlasd/routes/mcp-tool-cache.test.ts
+++ b/apps/atlasd/routes/mcp-tool-cache.test.ts
@@ -1,0 +1,118 @@
+import type { MCPServerConfig } from "@atlas/agent-sdk";
+import { createLogger } from "@atlas/logger";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type MockTool = {
+  description?: string;
+  inputSchema?: { jsonSchema?: Record<string, unknown> };
+};
+type MockDisconnected = { serverId: string; kind: string; message: string };
+
+const mockCreateMCPTools =
+  vi.fn<
+    (
+      configs: Record<string, unknown>,
+      logger: unknown,
+      options?: { signal?: AbortSignal; toolPrefix?: string },
+    ) => Promise<{
+      tools: Record<string, MockTool>;
+      dispose: () => Promise<void>;
+      disconnected: MockDisconnected[];
+    }>
+  >();
+
+vi.mock("@atlas/mcp", () => ({
+  createMCPTools: (...args: Parameters<typeof mockCreateMCPTools>) => mockCreateMCPTools(...args),
+}));
+
+const { probeAndExtract } = await import("./mcp-tool-cache.ts");
+
+const config: MCPServerConfig = {
+  transport: { type: "stdio", command: "echo", args: ["hello"] },
+};
+const logger = createLogger({ test: "mcp-tool-cache" });
+
+beforeEach(() => {
+  mockCreateMCPTools.mockReset();
+});
+
+describe("probeAndExtract — signal threading (PR 1 of #344)", () => {
+  it("rejects immediately when a pre-aborted signal is passed", async () => {
+    // createMCPTools' existing pre-check throws synchronously on an aborted
+    // signal before any subprocess work — the composed signal is aborted at
+    // construction time when the parent signal is already aborted.
+    mockCreateMCPTools.mockImplementation((_configs, _logger, options) => {
+      if (options?.signal?.aborted) {
+        return Promise.reject(options.signal.reason ?? new Error("Aborted"));
+      }
+      return Promise.resolve({
+        tools: {},
+        dispose: vi.fn().mockResolvedValue(undefined),
+        disconnected: [],
+      });
+    });
+
+    const ctl = new AbortController();
+    ctl.abort(new Error("client gone"));
+    const start = performance.now();
+    await expect(probeAndExtract("srv-1", config, logger, 5000, ctl.signal)).rejects.toThrow(
+      "client gone",
+    );
+    expect(performance.now() - start).toBeLessThan(50);
+  });
+
+  it("rejects within ~50ms when signal aborts mid-call", async () => {
+    // Mock createMCPTools to hang until its own signal aborts, then reject
+    // with that signal's reason. This mirrors createMCPTools' real behavior
+    // on abort (post-settle check disposes + throws signal.reason).
+    mockCreateMCPTools.mockImplementation(
+      (_configs, _logger, options) =>
+        new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            reject(options.signal!.reason ?? new Error("Aborted"));
+          });
+        }),
+    );
+
+    const ctl = new AbortController();
+    const promise = probeAndExtract("srv-2", config, logger, 60_000, ctl.signal);
+    // Abort after a brief delay so the call is genuinely in-flight.
+    setTimeout(() => ctl.abort(new Error("client disconnected")), 20);
+    const start = performance.now();
+    await expect(promise).rejects.toThrow("client disconnected");
+    expect(performance.now() - start).toBeLessThan(150);
+  });
+
+  it("internal timeout still fires when no parent signal is passed", async () => {
+    // Regression guard on AbortSignal.any composition: when only the timeout
+    // path is active, the composed signal must still abort at timeoutMs.
+    mockCreateMCPTools.mockImplementation(
+      (_configs, _logger, options) =>
+        new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            reject(options.signal!.reason ?? new Error("Aborted"));
+          });
+        }),
+    );
+
+    const start = performance.now();
+    await expect(probeAndExtract("srv-3", config, logger, 30)).rejects.toThrow();
+    const elapsed = performance.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(25);
+    expect(elapsed).toBeLessThan(200);
+  });
+
+  it("returns tools normally when neither signal aborts", async () => {
+    mockCreateMCPTools.mockResolvedValue({
+      tools: { "tool-a": { description: "first tool" } },
+      dispose: vi.fn().mockResolvedValue(undefined),
+      disconnected: [],
+    });
+
+    const ctl = new AbortController();
+    const tools = await probeAndExtract("srv-4", config, logger, 5000, ctl.signal);
+    expect(tools).toHaveLength(1);
+    expect(tools[0]?.name).toBe("tool-a");
+    expect(tools[0]?.description).toBe("first tool");
+  });
+});

--- a/apps/atlasd/routes/mcp-tool-cache.ts
+++ b/apps/atlasd/routes/mcp-tool-cache.ts
@@ -142,15 +142,24 @@ export async function _flushPrewarmsForTest(): Promise<void> {
  * Probe an MCP server and extract its tool list. Throws on failure (including
  * credential-disconnected servers — those get surfaced as auth errors via
  * the classifier rather than caching an empty tool list).
+ *
+ * Optional `signal` lets the route honor client disconnects (PR 1 of #344). It
+ * composes with the internal probe timeout — whichever aborts first wins.
+ * Note: this slice does NOT yet kill the spawned stdio subprocess on abort;
+ * that lands in the follow-up PR. See
+ * `docs/plans/2026-05-19-mcp-probe-abort-signal-design.md`.
  */
 export async function probeAndExtract(
   serverId: string,
   config: MCPServerConfig,
   logger: Logger,
   timeoutMs: number,
+  signal?: AbortSignal,
 ): Promise<CachedTool[]> {
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
+  const composedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
   const result = await createMCPTools({ [serverId]: config }, logger, {
-    signal: AbortSignal.timeout(timeoutMs),
+    signal: composedSignal,
   });
   // createMCPTools does not throw on missing/expired credentials — it routes
   // the server into `disconnected` with an empty tools map. For a single-

--- a/apps/atlasd/routes/mcp-tool-cache.ts
+++ b/apps/atlasd/routes/mcp-tool-cache.ts
@@ -158,9 +158,7 @@ export async function probeAndExtract(
 ): Promise<CachedTool[]> {
   const timeoutSignal = AbortSignal.timeout(timeoutMs);
   const composedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
-  const result = await createMCPTools({ [serverId]: config }, logger, {
-    signal: composedSignal,
-  });
+  const result = await createMCPTools({ [serverId]: config }, logger, { signal: composedSignal });
   // createMCPTools does not throw on missing/expired credentials — it routes
   // the server into `disconnected` with an empty tools map. For a single-
   // server probe, any disconnected entry means *this* probe failed.

--- a/packages/mcp/src/create-mcp-tools-startup.test.ts
+++ b/packages/mcp/src/create-mcp-tools-startup.test.ts
@@ -292,6 +292,54 @@ describe("connectHttp startup", () => {
     const callArgs = httpCall[1] as { requestInit: { headers: Record<string, string> } };
     expect(callArgs.requestInit.headers).not.toHaveProperty("TEST_PLATFORM_VAR");
   });
+
+  it("client signal is NOT forwarded to sharedMCPProcesses.acquire — shared children outlive any individual probe", async () => {
+    // Locks in the HTTP-path safety invariant from issue #344's design doc:
+    // the shared subprocess registry is daemon-scoped and intentionally
+    // outlives individual probes. If a future refactor leaked the client's
+    // AbortSignal into `acquire`, an HTTP-transport child would die on client
+    // abort and break shared reuse across probes. See
+    // `packages/mcp/src/create-mcp-tools.ts:845-851`.
+    const child = createMockChildProcess();
+    const mockSpawn = vi.fn().mockReturnValue(child);
+    let fetchCall = 0;
+    const mockFetch = vi.fn().mockImplementation(() => {
+      fetchCall++;
+      if (fetchCall <= 1) {
+        return Promise.reject(new Error("ECONNREFUSED"));
+      }
+      return Promise.resolve({ status: 200, ok: true } as Response);
+    });
+
+    mockMCPClient({ "cal-tool": { description: "calendar" } });
+
+    const acquireSpy = vi.spyOn(sharedMCPProcesses, "acquire");
+
+    const controller = new AbortController();
+    const config = makeHttpConfig();
+    await connectHttp(
+      config,
+      {},
+      "signal-isolation-server",
+      fakeLogger,
+      { spawn: mockSpawn, fetch: mockFetch, pidFile: noopPidFile() },
+      controller.signal,
+    );
+
+    expect(acquireSpy).toHaveBeenCalledTimes(1);
+    const acquireArgs = acquireSpy.mock.calls[0];
+    if (!acquireArgs) throw new Error("expected acquireSpy to have been called");
+
+    // No positional argument is (or contains) the request signal.
+    for (const arg of acquireArgs) {
+      expect(arg).not.toBe(controller.signal);
+      if (arg && typeof arg === "object") {
+        for (const value of Object.values(arg as unknown as Record<string, unknown>)) {
+          expect(value).not.toBe(controller.signal);
+        }
+      }
+    }
+  });
 });
 
 describe("MCPStartupError", () => {

--- a/packages/mcp/src/create-mcp-tools.subprocess-kill.test.ts
+++ b/packages/mcp/src/create-mcp-tools.subprocess-kill.test.ts
@@ -111,11 +111,22 @@ describe.skipIf(process.platform === "win32")("attemptStdio subprocess teardown"
   }, 10_000);
 
   it("kills the spawned child when withTimeout fires (reduced timeout)", async () => {
-    // Mirror `connectServerWithTimeout`'s wiring with a 200ms timeout
-    // instead of the production 20s. When the timer fires, it aborts
-    // `timeoutController`, which propagates through `AbortSignal.any`
-    // into `attemptStdio`'s registered abort listener and SIGTERMs the
-    // child — same kill path as test A, different trigger.
+    // Mirrors `connectServerWithTimeout` (packages/mcp/src/create-mcp-tools.ts)
+    // with a 200ms timeout instead of the production 20s. The production
+    // wiring is: internal `AbortController` + downstream `AbortSignal.any`
+    // combining it with the external signal + `timeoutController.abort(err)`
+    // called from inside `withTimeout`'s `makeError` callback. We reproduce
+    // that here so the timer firing reaches `attemptStdio`'s registered
+    // listener via the same signal-propagation path.
+    //
+    // IF `connectServerWithTimeout` CHANGES ITS SIGNAL COMPOSITION (e.g.
+    // drops `AbortSignal.any`, moves the `timeoutController.abort()` call,
+    // or substitutes a different timeout primitive), THIS TEST WILL SILENTLY
+    // KEEP PASSING WHILE NO LONGER TESTING THE REAL PATH. Mirror the change
+    // here. The signal-aware behavior of `withTimeout` and the abort
+    // listener in `attemptStdio` are what's actually under test; the
+    // composition between them lives in `connectServerWithTimeout` and
+    // is the load-bearing part to keep in sync.
     const timeoutController = new AbortController();
     const baseline = new Set(listChildren(process.pid));
 

--- a/packages/mcp/src/create-mcp-tools.subprocess-kill.test.ts
+++ b/packages/mcp/src/create-mcp-tools.subprocess-kill.test.ts
@@ -1,0 +1,142 @@
+// Verifies the real invariant from the design doc (issue #344):
+// when the abort signal fires — either externally (test A) or via the
+// inner `withTimeout` firing through `connectServerWithTimeout`'s
+// `AbortSignal.any` plumbing (test B) — the spawned stdio MCP subprocess
+// is actually gone. "Promise rejected" is not enough; the orphan-leak
+// regression mode passes the rejection test. The honest invariant is
+// `process.kill(pid, 0)` throws ESRCH.
+//
+// This file intentionally does NOT mock `@ai-sdk/mcp` or its stdio
+// transport — only the real spawn → real SIGTERM path proves the bug
+// is fixed.
+
+import { execFileSync } from "node:child_process";
+import process from "node:process";
+import { afterEach, describe, expect, it } from "vitest";
+import { attemptStdio, MCPTimeoutError, withTimeout } from "./create-mcp-tools.ts";
+
+// A "slow" MCP server: keeps the event loop alive and reads stdin so it
+// doesn't exit on its own. It never responds to the MCP `initialize`
+// handshake, so `experimental_createMCPClient` hangs until something
+// aborts the transport — which is exactly the window we want to abort in.
+const SLOW_SERVER_SCRIPT = "setInterval(() => {}, 1000); process.stdin.resume();";
+
+// List direct children of the current process via `pgrep -P`. Vitest's
+// ESM namespace is frozen, so we can't spy on `node:child_process.spawn`
+// from the test — instead, snapshot the OS's process tree before and
+// after `attemptStdio` spawns so we can identify the new child by diff.
+function listChildren(parent: number): number[] {
+  try {
+    const out = execFileSync("pgrep", ["-P", String(parent)], { encoding: "utf8" });
+    return out
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map(Number)
+      .filter((n) => Number.isFinite(n));
+  } catch (err) {
+    // `pgrep -P` exits 1 when there are no matches — that's not an error
+    // for us, it just means no children yet.
+    const e = err as { status?: number };
+    if (e.status === 1) return [];
+    throw err;
+  }
+}
+
+async function waitForNewChild(baseline: Set<number>, timeoutMs: number): Promise<number> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    for (const pid of listChildren(process.pid)) {
+      if (!baseline.has(pid)) return pid;
+    }
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error("timed out waiting for spawned child to appear");
+}
+
+// `process.kill(pid, 0)` throws ESRCH when the pid no longer exists.
+// Poll because SIGTERM → child exit → kernel reaping is asynchronous;
+// 2s gives the OS plenty of headroom without making the test sluggish.
+async function expectPidGone(pid: number, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ESRCH") return;
+      throw err;
+    }
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(`pid ${pid} still alive after ${timeoutMs}ms`);
+}
+
+// `process.kill(pid, 0)` ESRCH semantics are POSIX. Windows uses a
+// different errno surface. The daemon does not run on Windows, but skip
+// rather than emit a false failure if CI ever picks this up there.
+describe.skipIf(process.platform === "win32")("attemptStdio subprocess teardown", () => {
+  const trackedPids = new Set<number>();
+
+  afterEach(() => {
+    // Any child still alive at the end of a test means the test itself
+    // leaked — kill it so the next test starts clean.
+    for (const pid of trackedPids) {
+      try {
+        process.kill(pid, "SIGKILL");
+      } catch {
+        // already gone
+      }
+    }
+    trackedPids.clear();
+  });
+
+  it("kills the spawned child when the external signal aborts mid-handshake", async () => {
+    const baseline = new Set(listChildren(process.pid));
+    const controller = new AbortController();
+    const promise = attemptStdio(
+      "node",
+      ["-e", SLOW_SERVER_SCRIPT],
+      { ...(process.env as Record<string, string>) },
+      controller.signal,
+    );
+
+    const pid = await waitForNewChild(baseline, 2000);
+    trackedPids.add(pid);
+
+    controller.abort(new Error("client gone"));
+
+    await expect(promise).rejects.toThrow("client gone");
+    await expectPidGone(pid, 2000);
+    trackedPids.delete(pid);
+  }, 10_000);
+
+  it("kills the spawned child when withTimeout fires (reduced timeout)", async () => {
+    // Mirror `connectServerWithTimeout`'s wiring with a 200ms timeout
+    // instead of the production 20s. When the timer fires, it aborts
+    // `timeoutController`, which propagates through `AbortSignal.any`
+    // into `attemptStdio`'s registered abort listener and SIGTERMs the
+    // child — same kill path as test A, different trigger.
+    const timeoutController = new AbortController();
+    const baseline = new Set(listChildren(process.pid));
+
+    const inner = attemptStdio(
+      "node",
+      ["-e", SLOW_SERVER_SCRIPT],
+      { ...(process.env as Record<string, string>) },
+      timeoutController.signal,
+    );
+
+    const promise = withTimeout(inner, 200, (actualDurationMs) => {
+      const err = new MCPTimeoutError("slow-test", "list_tools", 200, actualDurationMs);
+      timeoutController.abort(err);
+      return err;
+    });
+
+    const pid = await waitForNewChild(baseline, 2000);
+    trackedPids.add(pid);
+
+    await expect(promise).rejects.toBeInstanceOf(MCPTimeoutError);
+    await expectPidGone(pid, 2000);
+    trackedPids.delete(pid);
+  }, 10_000);
+});

--- a/packages/mcp/src/create-mcp-tools.subprocess-kill.test.ts
+++ b/packages/mcp/src/create-mcp-tools.subprocess-kill.test.ts
@@ -43,11 +43,31 @@ function listChildren(parent: number): number[] {
   }
 }
 
-async function waitForNewChild(baseline: Set<number>, timeoutMs: number): Promise<number> {
+// Read a single pid's command line via `ps -o command=` — portable across
+// macOS and Linux (where /proc/<pid>/cmdline would also work, but ps keeps
+// the helper POSIX-only and identical in both files). Returns "" if the
+// pid is gone by the time we ask, so the caller treats it as a non-match.
+function cmdlineFor(pid: number): string {
+  try {
+    return execFileSync("ps", ["-o", "command=", "-p", String(pid)], { encoding: "utf8" }).trim();
+  } catch {
+    return "";
+  }
+}
+
+// Filter candidate child PIDs by command line so a concurrent test's spawn
+// can't be picked up as ours. The `cmdlineMatch` substring must be unique
+// to this test's slow-server script (see SLOW_SERVER_SCRIPT).
+async function waitForNewChild(
+  baseline: Set<number>,
+  timeoutMs: number,
+  cmdlineMatch: string,
+): Promise<number> {
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     for (const pid of listChildren(process.pid)) {
-      if (!baseline.has(pid)) return pid;
+      if (baseline.has(pid)) continue;
+      if (cmdlineFor(pid).includes(cmdlineMatch)) return pid;
     }
     await new Promise((r) => setTimeout(r, 10));
   }
@@ -100,7 +120,7 @@ describe.skipIf(process.platform === "win32")("attemptStdio subprocess teardown"
       controller.signal,
     );
 
-    const pid = await waitForNewChild(baseline, 2000);
+    const pid = await waitForNewChild(baseline, 2000, SLOW_SERVER_SCRIPT);
     trackedPids.add(pid);
 
     controller.abort(new Error("client gone"));
@@ -143,7 +163,7 @@ describe.skipIf(process.platform === "win32")("attemptStdio subprocess teardown"
       return err;
     });
 
-    const pid = await waitForNewChild(baseline, 2000);
+    const pid = await waitForNewChild(baseline, 2000, SLOW_SERVER_SCRIPT);
     trackedPids.add(pid);
 
     await expect(promise).rejects.toBeInstanceOf(MCPTimeoutError);

--- a/packages/mcp/src/create-mcp-tools.test.ts
+++ b/packages/mcp/src/create-mcp-tools.test.ts
@@ -67,6 +67,14 @@ beforeEach(() => {
   MockHTTPTransport.mockReset();
   mockResolveEnvValues.mockReset();
   mockResolveEnvValues.mockResolvedValue({});
+  // attemptStdio's abort listener calls transport.close() to SIGTERM the
+  // spawned child before createMCPClient resolves. The default mock needs
+  // a close() that returns a Promise so the abort path doesn't throw.
+  // Individual tests override via mockImplementation when they care about
+  // the transport instance (e.g. stderr inspection).
+  MockStdioTransport.mockImplementation(function (this: { close: () => Promise<void> }) {
+    this.close = () => Promise.resolve();
+  });
 });
 
 afterEach(() => {

--- a/packages/mcp/src/create-mcp-tools.test.ts
+++ b/packages/mcp/src/create-mcp-tools.test.ts
@@ -48,7 +48,7 @@ vi.mock("@atlas/core/mcp-registry/credential-resolver", async (importOriginal) =
 });
 
 // Import after mocks
-const { createMCPTools, MCPTimeoutError } = await import("./create-mcp-tools.ts");
+const { createMCPTools, MCPTimeoutError, withTimeout } = await import("./create-mcp-tools.ts");
 
 // Fake logger
 const fakeLogger = {
@@ -1262,5 +1262,93 @@ describe("createMCPTools", () => {
         if (originalAtlasHome !== undefined) process.env.FRIDAY_HOME = originalAtlasHome;
       }
     });
+  });
+});
+
+describe("withTimeout", () => {
+  const makeTimeoutError = (ms: number) => new Error(`timed out after ${ms}ms`);
+
+  it("rejects immediately with signal.reason when signal is already aborted", async () => {
+    const reason = new Error("pre-aborted");
+    const controller = new AbortController();
+    controller.abort(reason);
+
+    await expect(
+      withTimeout(new Promise(() => {}), 10_000, makeTimeoutError, controller.signal),
+    ).rejects.toBe(reason);
+  });
+
+  it("rejects with signal.reason when signal aborts before the timer fires", async () => {
+    vi.useFakeTimers();
+    try {
+      const controller = new AbortController();
+      const reason = new Error("mid-flight");
+      const promise = withTimeout(
+        new Promise(() => {}),
+        10_000,
+        makeTimeoutError,
+        controller.signal,
+      );
+
+      // Abort before the 10s timer would fire.
+      await vi.advanceTimersByTimeAsync(50);
+      controller.abort(reason);
+
+      await expect(promise).rejects.toBe(reason);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears the timer when the signal aborts (no zombie setTimeout)", async () => {
+    vi.useFakeTimers();
+    try {
+      const controller = new AbortController();
+      const promise = withTimeout(
+        new Promise(() => {}),
+        10_000,
+        makeTimeoutError,
+        controller.signal,
+      );
+
+      controller.abort(new Error("cancel"));
+      await expect(promise).rejects.toThrow("cancel");
+
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("clears the timer when the inner promise resolves", async () => {
+    vi.useFakeTimers();
+    try {
+      const promise = withTimeout(Promise.resolve("ok"), 10_000, makeTimeoutError);
+      await expect(promise).resolves.toBe("ok");
+      expect(vi.getTimerCount()).toBe(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("still rejects on timeout when no signal is supplied (backward compatible)", async () => {
+    vi.useFakeTimers();
+    try {
+      const promise = withTimeout(new Promise(() => {}), 1_000, makeTimeoutError);
+      const assertion = expect(promise).rejects.toThrow("timed out after");
+      await vi.advanceTimersByTimeAsync(1_500);
+      await assertion;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("removes the abort listener after the inner promise settles", async () => {
+    const controller = new AbortController();
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
+
+    await withTimeout(Promise.resolve("ok"), 10_000, makeTimeoutError, controller.signal);
+
+    expect(removeSpy).toHaveBeenCalledWith("abort", expect.any(Function));
   });
 });

--- a/packages/mcp/src/create-mcp-tools.test.ts
+++ b/packages/mcp/src/create-mcp-tools.test.ts
@@ -1315,6 +1315,7 @@ describe("withTimeout", () => {
     vi.useFakeTimers();
     try {
       const controller = new AbortController();
+      const removeSpy = vi.spyOn(controller.signal, "removeEventListener");
       const promise = withTimeout(
         new Promise(() => {}),
         10_000,
@@ -1326,6 +1327,7 @@ describe("withTimeout", () => {
       await expect(promise).rejects.toThrow("cancel");
 
       expect(vi.getTimerCount()).toBe(0);
+      expect(removeSpy).toHaveBeenCalledWith("abort", expect.any(Function));
     } finally {
       vi.useRealTimers();
     }

--- a/packages/mcp/src/create-mcp-tools.test.ts
+++ b/packages/mcp/src/create-mcp-tools.test.ts
@@ -694,7 +694,7 @@ describe("createMCPTools", () => {
     expect(result.disconnected[0]?.message).not.toContain("different-server");
   });
 
-  it("disposes all connected clients when signal aborts mid-connect", async () => {
+  it("disposes connected clients and short-circuits second server when signal aborts mid-connect", async () => {
     const closeA = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
     const controller = new AbortController();
 
@@ -716,9 +716,12 @@ describe("createMCPTools", () => {
     );
     expect(error).toBeInstanceOf(Error);
     expect((error as Error).message).toBe("cancelled");
-    // Both parallel mappers created a client; both get disposed in cleanup
-    expect(closeA).toHaveBeenCalledTimes(2);
-    expect(mockCreateMCPClient).toHaveBeenCalledTimes(2);
+    // The first mapper's createMCPClient resolves and the abort fires before
+    // tools() — attemptStdio closes the client on the aborted-signal check.
+    // The second mapper sees the already-aborted signal and short-circuits
+    // before calling createMCPClient, so no second spawn happens.
+    expect(mockCreateMCPClient).toHaveBeenCalledTimes(1);
+    expect(closeA).toHaveBeenCalledTimes(1);
   });
 
   it("dispose awaits close() — does not resolve before cleanup finishes", async () => {

--- a/packages/mcp/src/create-mcp-tools.ts
+++ b/packages/mcp/src/create-mcp-tools.ts
@@ -448,6 +448,16 @@ interface ConnectedServer {
  * Combines the optional external `signal` with an internal controller that
  * aborts when the timer fires, so the downstream abort listener in
  * `attemptStdio` kills the spawned child on both abort and timeout paths.
+ *
+ * AI SDK contract dependency: the "timer → SIGTERM" chain that closes #344
+ * relies on `@ai-sdk/mcp`'s `StdioMCPTransport.close()` calling
+ * `abortController.abort()` on the controller passed to Node's `spawn()` as
+ * `signal` — which is how the child receives SIGTERM. This is internal AI
+ * SDK behaviour and could regress silently on a version bump. The real
+ * invariant ("subprocess PID is gone after abort/timeout") is verified by:
+ *   - `packages/mcp/src/create-mcp-tools.subprocess-kill.test.ts`
+ *   - `apps/atlasd/routes/mcp-registry.subprocess-kill.test.ts`
+ * Both suites MUST pass before merging any `@ai-sdk/mcp` version bump.
  */
 function connectServerWithTimeout(
   config: MCPServerConfig,

--- a/packages/mcp/src/create-mcp-tools.ts
+++ b/packages/mcp/src/create-mcp-tools.ts
@@ -91,7 +91,12 @@ export function withTimeout<T>(
   makeError: (actualDurationMs: number) => Error,
   signal?: AbortSignal,
 ): Promise<T> {
-  if (signal?.aborted) return Promise.reject(signal.reason);
+  if (signal?.aborted) {
+    // Caller already constructed `promise`; swallow any future rejection so
+    // it doesn't bubble up as an unhandled rejection after we short-circuit.
+    promise.catch(() => {});
+    return Promise.reject(signal.reason);
+  }
   const startedAt = Date.now();
   let timer: ReturnType<typeof setTimeout> | undefined;
   let onAbort: (() => void) | undefined;
@@ -112,6 +117,12 @@ export function withTimeout<T>(
       signal.addEventListener("abort", onAbort);
     }
   });
+  // If the timer or signal wins the race, the inner promise is orphaned and
+  // may reject later (e.g. when `attemptStdio`'s post-abort signal check
+  // throws). Attach a no-op handler so that orphan doesn't bubble up as an
+  // unhandled rejection — the race result already settled with the right
+  // reason for the caller.
+  promise.catch(() => {});
   return Promise.race([promise.finally(cleanup), timeoutPromise]);
 }
 
@@ -220,6 +231,7 @@ export async function createMCPTools(
           serverId,
           logger,
           options?.envOverlay,
+          signal,
         );
         const filtered = filterTools(connected.tools, config.tools);
         const prefixed = options?.toolPrefix
@@ -432,6 +444,10 @@ interface ConnectedServer {
 /**
  * Connect a single MCP server with a hard timeout on the full handshake +
  * listTools sequence. No retry — a hung server is not a transient failure.
+ *
+ * Combines the optional external `signal` with an internal controller that
+ * aborts when the timer fires, so the downstream abort listener in
+ * `attemptStdio` kills the spawned child on both abort and timeout paths.
  */
 function connectServerWithTimeout(
   config: MCPServerConfig,
@@ -439,12 +455,26 @@ function connectServerWithTimeout(
   serverId: string,
   logger: Logger,
   envOverlay?: Record<string, string>,
+  signal?: AbortSignal,
 ): Promise<ConnectedServer> {
+  const timeoutController = new AbortController();
+  const downstreamSignal = signal
+    ? AbortSignal.any([signal, timeoutController.signal])
+    : timeoutController.signal;
   return withTimeout(
-    connectServer(config, resolvedEnv, serverId, logger, envOverlay),
+    connectServer(config, resolvedEnv, serverId, logger, envOverlay, downstreamSignal),
     LIST_TOOLS_TIMEOUT_MS,
-    (actualDurationMs) =>
-      new MCPTimeoutError(serverId, "list_tools", LIST_TOOLS_TIMEOUT_MS, actualDurationMs),
+    (actualDurationMs) => {
+      const err = new MCPTimeoutError(
+        serverId,
+        "list_tools",
+        LIST_TOOLS_TIMEOUT_MS,
+        actualDurationMs,
+      );
+      timeoutController.abort(err);
+      return err;
+    },
+    signal,
   );
 }
 
@@ -455,13 +485,14 @@ async function connectServer(
   serverId: string,
   logger: Logger,
   envOverlay?: Record<string, string>,
+  signal?: AbortSignal,
 ): Promise<ConnectedServer> {
   const { transport } = config;
   switch (transport.type) {
     case "stdio":
-      return await connectStdio(transport, resolvedEnv, serverId, logger);
+      return await connectStdio(transport, resolvedEnv, serverId, logger, signal);
     case "http":
-      return await connectHttp(config, resolvedEnv, serverId, logger, { envOverlay });
+      return await connectHttp(config, resolvedEnv, serverId, logger, { envOverlay }, signal);
   }
 }
 
@@ -490,7 +521,10 @@ async function attemptStdio(
   command: string,
   args: readonly string[],
   env: Record<string, string>,
+  signal?: AbortSignal,
 ): Promise<StdioAttempt> {
+  if (signal?.aborted) throw signal.reason;
+
   // Pipe subprocess stderr through a temp file so we can read it on failure.
   // Two simpler approaches don't work reliably:
   //   - Passing an in-memory Writable: Deno's node:child_process compat
@@ -526,6 +560,26 @@ async function attemptStdio(
       const stderr = readStderr();
       const error = err instanceof Error ? err : new Error(String(err));
       return { ok: false, error, stderr };
+    }
+
+    // Close the race window between createMCPClient resolving and the abort
+    // listener attaching: if the signal aborted while the handshake was in
+    // flight, kill the just-spawned child before returning.
+    if (signal?.aborted) {
+      await client.close().catch(() => {});
+      throw signal.reason;
+    }
+    if (signal) {
+      // One-shot listener that survives attemptStdio's return. Kills the spawned
+      // child via StdioMCPTransport.close() → AbortController.abort() → SIGTERM.
+      // On success (ok:true) the caller owns the client and may dispose normally;
+      // a late signal abort still fires this listener and closes the child.
+      // On failure paths below, the catch already calls client.close() — a later
+      // listener fire is a no-op (close is idempotent). { once: true } means the
+      // listener auto-removes after firing, and the signal is request-scoped so
+      // it (and an unfired listener) is GC'd when the request ends.
+      const c = client;
+      signal.addEventListener("abort", () => c.close().catch(() => {}), { once: true });
     }
 
     // Verify the subprocess is actually responding AND capture tools in one call.
@@ -614,6 +668,7 @@ async function connectStdio(
   resolvedEnv: Record<string, string>,
   serverId: string,
   logger: Logger,
+  signal?: AbortSignal,
 ): Promise<ConnectedServer> {
   const { command, args } = transport;
   const expandedArgs = (args ?? []).map(interpolateArg);
@@ -633,7 +688,7 @@ async function connectStdio(
     args: expandedArgs,
   });
 
-  let result = await attemptStdio(command, expandedArgs, mergedEnv);
+  let result = await attemptStdio(command, expandedArgs, mergedEnv, signal);
   let firstStderr: string | undefined;
 
   if (!result.ok) {
@@ -651,7 +706,7 @@ async function connectStdio(
       // otherwise the only diagnostic for the failure mode this code targets
       // would be lost in `result`'s reassignment below.
       firstStderr = result.stderr;
-      result = await attemptStdio(command, recoveryArgs, mergedEnv);
+      result = await attemptStdio(command, recoveryArgs, mergedEnv, signal);
     }
   }
 
@@ -728,6 +783,7 @@ export async function connectHttp(
     /** Workspace `.env` overlay for resolving `startup.env` entries. */
     envOverlay?: Record<string, string>;
   } = {},
+  signal?: AbortSignal,
 ): Promise<ConnectedServer> {
   const { transport, auth, startup } = config;
   if (transport.type !== "http") {
@@ -750,12 +806,12 @@ export async function connectHttp(
     status: reachable.status,
   });
   if (reachable.ok) {
-    return connectHttpClient(url, headers, serverId, logger);
+    return connectHttpClient(url, headers, serverId, logger, signal);
   }
 
   // No startup config — try direct connection (will likely fail, matching old behaviour).
   if (!startup) {
-    return connectHttpClient(url, headers, serverId, logger);
+    return connectHttpClient(url, headers, serverId, logger, signal);
   }
 
   // Resolve startup.env separately from config.env — bearer tokens must never
@@ -783,7 +839,8 @@ export async function connectHttp(
   // eliminating the kernel TIME_WAIT respawn failures that broke FSM workflows
   // reusing the same MCP server across sequential states. The registry — not
   // this caller — owns the child's lifetime; `dispose` closes the MCP client
-  // only.
+  // only. Deliberately not passing `signal` here: the shared subprocess
+  // outlives any individual probe by design.
   await sharedMCPProcesses.acquire(
     serverId,
     {
@@ -798,7 +855,7 @@ export async function connectHttp(
     logger,
   );
 
-  return connectHttpClient(url, headers, serverId, logger);
+  return connectHttpClient(url, headers, serverId, logger, signal);
 }
 
 /** Create MCP client over HTTP transport and verify with tools(). */
@@ -807,7 +864,10 @@ async function connectHttpClient(
   headers: Record<string, string>,
   serverId: string,
   logger: Logger,
+  signal?: AbortSignal,
 ): Promise<ConnectedServer> {
+  if (signal?.aborted) throw signal.reason;
+
   logger.debug(`MCP HTTP connection attempt for "${serverId}"`, {
     operation: "mcp_connect",
     serverId,
@@ -819,6 +879,14 @@ async function connectHttpClient(
   });
 
   const client = await createMCPClient({ transport: httpTransport });
+
+  if (signal?.aborted) {
+    await client.close().catch(() => {});
+    throw signal.reason;
+  }
+  if (signal) {
+    signal.addEventListener("abort", () => client.close().catch(() => {}), { once: true });
+  }
 
   let tools: Record<string, Tool>;
   try {

--- a/packages/mcp/src/create-mcp-tools.ts
+++ b/packages/mcp/src/create-mcp-tools.ts
@@ -517,7 +517,7 @@ type StdioAttempt =
   | { ok: true; client: MCPClient; tools: Record<string, Tool> }
   | { ok: false; error: Error; stderr: string };
 
-async function attemptStdio(
+export async function attemptStdio(
   command: string,
   args: readonly string[],
   env: Record<string, string>,
@@ -547,39 +547,47 @@ async function attemptStdio(
     return buf.toString("utf8").trim();
   };
 
+  // Hoist the transport so the abort listener can call transport.close()
+  // BEFORE `createMCPClient` resolves. The AI SDK's createMCPClient awaits
+  // the MCP `initialize` handshake with no signal observation — a server
+  // that hangs at handshake (the exact #344 production failure) leaves
+  // the spawn running with no termination path. transport.close() →
+  // abortController.abort() → SIGTERM kills the child immediately and
+  // the in-flight handshake rejects via the transport's onclose handler.
+  const transport = new StdioMCPTransport({ command, args: [...args], env, stderr: fd });
+  let onAbort: (() => void) | undefined;
+  if (signal) {
+    onAbort = () => {
+      transport.close().catch(() => {});
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  }
+
   let client: MCPClient | undefined;
   try {
     try {
-      client = await createMCPClient({
-        transport: new StdioMCPTransport({ command, args: [...args], env, stderr: fd }),
-      });
+      client = await createMCPClient({ transport });
     } catch (err) {
       // The transport's start() can reject (e.g. ENOENT, or the subprocess
       // dies before completing the MCP handshake). Capture stderr from the
       // temp file and return failure rather than letting it propagate.
+      // If the rejection is *because* the signal aborted (transport.close()
+      // tore down the in-flight handshake), surface the abort reason instead
+      // of the resulting "Connection closed" — preserves the contract that
+      // an aborted attempt throws signal.reason.
+      if (signal?.aborted) throw signal.reason;
       const stderr = readStderr();
       const error = err instanceof Error ? err : new Error(String(err));
       return { ok: false, error, stderr };
     }
 
-    // Close the race window between createMCPClient resolving and the abort
-    // listener attaching: if the signal aborted while the handshake was in
-    // flight, kill the just-spawned child before returning.
+    // If the signal aborted in the narrow window between createMCPClient
+    // resolving and reaching this check, the abort listener has already
+    // called transport.close(). Surface signal.reason rather than
+    // proceeding to client.tools() against a torn-down transport.
     if (signal?.aborted) {
       await client.close().catch(() => {});
       throw signal.reason;
-    }
-    if (signal) {
-      // One-shot listener that survives attemptStdio's return. Kills the spawned
-      // child via StdioMCPTransport.close() → AbortController.abort() → SIGTERM.
-      // On success (ok:true) the caller owns the client and may dispose normally;
-      // a late signal abort still fires this listener and closes the child.
-      // On failure paths below, the catch already calls client.close() — a later
-      // listener fire is a no-op (close is idempotent). { once: true } means the
-      // listener auto-removes after firing, and the signal is request-scoped so
-      // it (and an unfired listener) is GC'd when the request ends.
-      const c = client;
-      signal.addEventListener("abort", () => c.close().catch(() => {}), { once: true });
     }
 
     // Verify the subprocess is actually responding AND capture tools in one call.

--- a/packages/mcp/src/create-mcp-tools.ts
+++ b/packages/mcp/src/create-mcp-tools.ts
@@ -78,18 +78,41 @@ export interface MCPToolsResult {
   disconnected: DisconnectedIntegration[];
 }
 
-/** Race a promise against a timeout, clearing the timer when the promise settles. */
-function withTimeout<T>(
+/**
+ * Race a promise against a timeout, clearing the timer when the promise settles.
+ *
+ * When `signal` is supplied, the race also rejects with `signal.reason` if the
+ * signal aborts before the timer fires. The timer is cleared on every exit path
+ * (settle, timeout, abort) so no zombie `setTimeout` is left behind.
+ */
+export function withTimeout<T>(
   promise: Promise<T>,
   timeoutMs: number,
   makeError: (actualDurationMs: number) => Error,
+  signal?: AbortSignal,
 ): Promise<T> {
+  if (signal?.aborted) return Promise.reject(signal.reason);
   const startedAt = Date.now();
   let timer: ReturnType<typeof setTimeout> | undefined;
+  let onAbort: (() => void) | undefined;
+  const cleanup = () => {
+    if (timer !== undefined) clearTimeout(timer);
+    if (signal && onAbort) signal.removeEventListener("abort", onAbort);
+  };
   const timeoutPromise = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(makeError(Date.now() - startedAt)), timeoutMs);
+    timer = setTimeout(() => {
+      cleanup();
+      reject(makeError(Date.now() - startedAt));
+    }, timeoutMs);
+    if (signal) {
+      onAbort = () => {
+        cleanup();
+        reject(signal.reason);
+      };
+      signal.addEventListener("abort", onAbort);
+    }
   });
-  return Promise.race([promise.finally(() => clearTimeout(timer)), timeoutPromise]);
+  return Promise.race([promise.finally(cleanup), timeoutPromise]);
 }
 
 /** Add the 15-minute hard ceiling to a single tool's execute. */


### PR DESCRIPTION
## Summary

Closes #344. Mashing **Retry** 5–10× on a flaky MCP server used to silently wedge the daemon — each click spawned a fresh stdio MCP child while the previous one was still running, and after ~10 retries the daemon ran out of file descriptors and stopped accepting connections. PR #343 fixed the client-side stacking; this fixes the daemon-side leak that the client-side abort exposed.

Two compounding bugs:
1. `GET /api/mcp-registry/:id/tools` didn't observe `c.req.raw.signal`. Client disconnect was ignored.
2. Even when the route did time out internally, `withTimeout` was a fire-and-forget `Promise.race` — the inner spawn kept running until it eventually responded (or didn't). The MCP client object never had `.close()` called, so the spawned child never received SIGTERM. Worst-case orphan window: ~20s per probe.

Fix:
- Thread `c.req.raw.signal` from the route through `probeAndExtract` → `createMCPTools` → `connectServerWithTimeout` → `attemptStdio` (and the parallel HTTP branch).
- Make `withTimeout` signal-aware: timer fires → internal `AbortController.abort()` → same downstream listener fires → SIGTERM.
- In `attemptStdio`, hoist `StdioMCPTransport` to a local and register the abort listener **before** `await createMCPClient(...)`. The AI SDK's `createMCPClient` doesn't accept a signal, so a server hanging at the MCP `initialize` handshake (the exact #344 failure mode) is otherwise uninterruptible. `transport.close()` propagates through the SDK's internal `AbortController` → Node's spawn `signal` option → SIGTERM.
- Prewarm-race in the route handler gets a third `ABORTED` sentinel + one-shot listener: client abort cancels the *wait on* the in-flight prewarm without canceling the prewarm itself (it keeps running for the next caller).
- `connectHttp`'s `sharedMCPProcesses.acquire` deliberately does **not** receive the signal — that daemon-scoped registry is supposed to outlive any individual probe.

Orphan window collapses from ~20s to <2s (SIGTERM → exit → kernel reap).

## Test plan

- [x] `packages/mcp/src/create-mcp-tools.subprocess-kill.test.ts` — real spawn, real SIGTERM, `process.kill(pid, 0)` ESRCH within 2s of (a) external abort and (b) `withTimeout` firing through the `AbortSignal.any` plumbing. PID captured via `pgrep -P $$` baseline-then-diff (Vitest's frozen ESM namespace makes `vi.spyOn(child_process, "spawn")` throw).
- [x] `apps/atlasd/routes/mcp-registry.subprocess-kill.test.ts` — end-to-end: real `Deno.serve`, real Node `fetch` with `AbortController`, same ESRCH assertion through the actual HTTP path. Verified deterministic with 10 sequential runs.
- [x] `apps/atlasd/routes/mcp-tool-cache.test.ts` (new) — `probeAndExtract` signal composition: pre-aborted, mid-flight abort, timeout fallthrough, happy path.
- [x] `apps/atlasd/routes/mcp-registry.test.ts` — added two route-level race tests covering both prewarm-race winners (client abort wins / prewarm wins) to lock in the listener-cleanup invariant.
- [x] `packages/mcp/src/create-mcp-tools.test.ts` — extended with 6 `withTimeout` tests (pre-aborted, mid-flight abort, timer cleared on abort and on resolve, backward-compat timeout-only, listener removal on settle); updated one existing test's assertions to reflect new short-circuit behavior.
- [x] `deno check` clean; 354/354 tests pass across PR-touched files; lint warnings on PR-touched files are pre-existing (`noNonNullAssertion`, `noTemplateCurlyInString`).
- [x] POSIX-only subprocess tests via `describe.skipIf(process.platform === "win32")` — daemon doesn't run on Windows; `process.kill(pid, 0)` ESRCH semantics aren't portable.

## Notes for reviewers

- Manual repro: `/mcp/<flaky-server>/tools` → mash **Retry** 10× → watch `pgrep -P <daemon-pid>` go to zero within 2s of release, instead of accumulating 10 orphans for ~20s each.
- `attemptStdio` and `withTimeout` are now exported. Test-only exports — one keyword each, no signature changes for production callers.
- Listener placement (before vs after the `createMCPClient` await) was the subtle bug — the first attempt had it after, which never observes signals during the hung handshake. Pattern documented inline.