### PR TITLE
fix(playground): use PageLayout.Breadcrumbs on job, edit, and memory pages

### DIFF
--- a/tools/agent-playground/src/routes/memory/[workspaceId]/[memoryName]/+page.svelte
+++ b/tools/agent-playground/src/routes/memory/[workspaceId]/[memoryName]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { PageLayout } from "@atlas/ui";
   import { createQuery } from "@tanstack/svelte-query";
   import { page } from "$app/state";
   import MemoryEntryTable from "$lib/components/MemoryEntryTable.svelte";
@@ -55,6 +56,12 @@
   const isFetchingEntries = $derived(entriesQuery.isFetching);
   const entriesError = $derived(entriesQuery.error);
 
+  const crumbs = $derived([
+    { label: "Memory", href: "/memory" },
+    { label: workspaceName, href: `/memory/${encodeURIComponent(workspaceId)}` },
+    { label: memoryName },
+  ]);
+
   function handleKeydown(e: KeyboardEvent) {
     const target = e.target;
     if (target instanceof HTMLInputElement) return;
@@ -71,53 +78,49 @@
 
 <svelte:window onkeydown={handleKeydown} />
 
-<div class="memory-detail">
-  <header class="page-header">
-    <nav class="breadcrumb">
-      <a href="/memory">Memory</a>
-      <span class="sep">/</span>
-      <a href="/memory/{encodeURIComponent(workspaceId)}">{workspaceName}</a>
-      <span class="sep">/</span>
-      <span>{memoryName}</span>
-    </nav>
+<PageLayout.Root>
+  <PageLayout.Breadcrumbs {crumbs} />
 
-    <div class="title-row">
-      <h1>{memoryName}</h1>
-      {#if isFetchingEntries}
-        <span class="live-dot" title="Refreshing…"></span>
-        <span class="live-label">Live</span>
-      {/if}
-    </div>
-
-    <div class="meta-row">
-      {#if lastUpdated}
-        <span class="updated">Updated: {lastUpdated}</span>
-      {/if}
-      <span class="updated">
-        {entries.length} {showAllHistory ? "raw" : "unique"} entries
-        {#if !showAllHistory && duplicateCount > 0}
-          <span class="hint">({duplicateCount} shadowed)</span>
+  <div class="memory-detail">
+    <header class="page-header">
+      <div class="title-row">
+        <h1>{memoryName}</h1>
+        {#if isFetchingEntries}
+          <span class="live-dot" title="Refreshing…"></span>
+          <span class="live-label">Live</span>
         {/if}
-      </span>
-      <label class="history-toggle">
-        <input type="checkbox" bind:checked={showAllHistory} />
-        Show all history
-      </label>
-      <span class="hint">Press R to refresh</span>
-    </div>
-  </header>
+      </div>
 
-  {#if entriesError && entries.length === 0}
-    <div class="error-banner">
-      <span>{entriesQuery.error?.message}</span>
-      <button class="dismiss" onclick={() => entriesQuery.refetch()}>Retry</button>
-    </div>
-  {/if}
+      <div class="meta-row">
+        {#if lastUpdated}
+          <span class="updated">Updated: {lastUpdated}</span>
+        {/if}
+        <span class="updated">
+          {entries.length} {showAllHistory ? "raw" : "unique"} entries
+          {#if !showAllHistory && duplicateCount > 0}
+            <span class="hint">({duplicateCount} shadowed)</span>
+          {/if}
+        </span>
+        <label class="history-toggle">
+          <input type="checkbox" bind:checked={showAllHistory} />
+          Show all history
+        </label>
+        <span class="hint">Press R to refresh</span>
+      </div>
+    </header>
 
-  <div class="table-container">
-    <MemoryEntryTable {entries} loading={isEntriesLoading} />
+    {#if entriesError && entries.length === 0}
+      <div class="error-banner">
+        <span>{entriesQuery.error?.message}</span>
+        <button class="dismiss" onclick={() => entriesQuery.refetch()}>Retry</button>
+      </div>
+    {/if}
+
+    <div class="table-container">
+      <MemoryEntryTable {entries} loading={isEntriesLoading} />
+    </div>
   </div>
-</div>
+</PageLayout.Root>
 
 <style>
   .memory-detail {
@@ -132,26 +135,7 @@
     flex-direction: column;
     flex-shrink: 0;
     gap: var(--size-1);
-    padding: var(--size-5) var(--size-6) var(--size-3);
-  }
-
-  .breadcrumb {
-    color: color-mix(in srgb, var(--color-text), transparent 40%);
-    font-size: var(--font-size-1);
-  }
-
-  .breadcrumb a {
-    color: inherit;
-    text-decoration: underline;
-    text-underline-offset: 2px;
-
-    &:hover {
-      color: var(--color-text);
-    }
-  }
-
-  .sep {
-    margin-inline: var(--size-1);
+    padding: var(--size-16) var(--size-6) var(--size-3);
   }
 
   .title-row {

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/edit/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/edit/+page.svelte
@@ -27,27 +27,14 @@
   const client = getDaemonClient();
 
   const workspaceName = $derived(configQuery.data?.config?.workspace?.name ?? workspaceId ?? "");
-  const editPath = $derived(page.url.searchParams.get("path"));
-  const SECTION_ROUTES = new Set(["agents", "jobs", "skills"]);
-  const SECTION_LABELS: Record<string, string> = {
-    agents: "Agents",
-    jobs: "Jobs",
-    skills: "Skills",
-  };
-  const crumbs = $derived.by(() => {
-    if (!workspaceId) return [{ label: "Edit" }];
-    const base = [{ label: workspaceName, href: `/platform/${workspaceId}` }];
-    if (!editPath) return [...base, { label: "Edit" }];
-    const segments = editPath.split(".");
-    const first = segments[0];
-    const rest = segments.slice(1);
-    if (SECTION_ROUTES.has(first)) {
-      const middle = { label: SECTION_LABELS[first], href: `/platform/${workspaceId}/${first}` };
-      if (rest.length === 0) return [...base, middle];
-      return [...base, middle, { label: rest.join(".") }];
-    }
-    return [...base, { label: editPath }];
-  });
+  const crumbs = $derived(
+    workspaceId
+      ? [
+          { label: workspaceName, href: `/platform/${workspaceId}` },
+          { label: "Edit Configuration" },
+        ]
+      : [{ label: "Edit Configuration" }],
+  );
 
   // Line highlight effect for jump-to-path — shows a flash on the target line
   const highlightLineEffect = StateEffect.define<number>();

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/edit/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/edit/+page.svelte
@@ -8,13 +8,12 @@
 -->
 
 <script lang="ts">
-  import { Button } from "@atlas/ui";
+  import { Button, PageLayout } from "@atlas/ui";
   import { yaml as yamlLang } from "@codemirror/lang-yaml";
   import { EditorState, StateEffect, StateField } from "@codemirror/state";
   import { Decoration, EditorView, keymap } from "@codemirror/view";
   import { createQuery, useQueryClient } from "@tanstack/svelte-query";
   import { page } from "$app/state";
-  import WorkspaceBreadcrumb from "$lib/components/workspace/workspace-breadcrumb.svelte";
   import { getDaemonClient } from "$lib/daemon-client.ts";
   import { atlasTheme } from "$lib/editor/atlas-theme";
   import { workspaceQueries } from "$lib/queries";
@@ -26,6 +25,29 @@
   const configQuery = createQuery(() => workspaceQueries.config(workspaceId));
   const queryClient = useQueryClient();
   const client = getDaemonClient();
+
+  const workspaceName = $derived(configQuery.data?.config?.workspace?.name ?? workspaceId ?? "");
+  const editPath = $derived(page.url.searchParams.get("path"));
+  const SECTION_ROUTES = new Set(["agents", "jobs", "skills"]);
+  const SECTION_LABELS: Record<string, string> = {
+    agents: "Agents",
+    jobs: "Jobs",
+    skills: "Skills",
+  };
+  const crumbs = $derived.by(() => {
+    if (!workspaceId) return [{ label: "Edit" }];
+    const base = [{ label: workspaceName, href: `/platform/${workspaceId}` }];
+    if (!editPath) return [...base, { label: "Edit" }];
+    const segments = editPath.split(".");
+    const first = segments[0];
+    const rest = segments.slice(1);
+    if (SECTION_ROUTES.has(first)) {
+      const middle = { label: SECTION_LABELS[first], href: `/platform/${workspaceId}/${first}` };
+      if (rest.length === 0) return [...base, middle];
+      return [...base, middle, { label: rest.join(".") }];
+    }
+    return [...base, { label: editPath }];
+  });
 
   // Line highlight effect for jump-to-path — shows a flash on the target line
   const highlightLineEffect = StateEffect.define<number>();
@@ -183,9 +205,7 @@
 </script>
 
 <div class="edit-page">
-  {#if workspaceId}
-    <WorkspaceBreadcrumb {workspaceId} />
-  {/if}
+  <PageLayout.Breadcrumbs {crumbs} />
 
   <div class="edit-content">
     <div class="title-row">

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/jobs/[jobName]/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/jobs/[jobName]/+page.svelte
@@ -15,10 +15,9 @@
 -->
 
 <script lang="ts">
-  import { markdownToHTMLSafe, toast } from "@atlas/ui";
+  import { markdownToHTMLSafe, PageLayout, toast } from "@atlas/ui";
   import { createQuery, queryOptions, skipToken } from "@tanstack/svelte-query";
   import { page } from "$app/state";
-  import WorkspaceBreadcrumb from "$lib/components/workspace/workspace-breadcrumb.svelte";
   import { skillQueries, workspaceQueries } from "$lib/queries";
   import {
     searchSkillsSh,
@@ -55,6 +54,17 @@
     const job = (cfg.jobs as Record<string, { title?: string }> | undefined)?.[jobName];
     return job?.title ?? jobName;
   });
+
+  const workspaceName = $derived(configQuery.data?.config?.workspace?.name ?? workspaceId ?? "");
+  const crumbs = $derived(
+    workspaceId
+      ? [
+          { label: workspaceName, href: `/platform/${workspaceId}` },
+          { label: "Jobs", href: `/platform/${workspaceId}/jobs` },
+          { label: jobTitle },
+        ]
+      : [{ label: "Jobs" }, { label: jobTitle }],
+  );
 
   const jobDescription = $derived.by(() => {
     const cfg = configQuery.data?.config;
@@ -305,10 +315,11 @@
   }
 </script>
 
-<div class="page">
-  {#if workspaceId}
-    <WorkspaceBreadcrumb {workspaceId} />
-  {/if}
+<PageLayout.Root>
+  <PageLayout.Breadcrumbs {crumbs} />
+  <PageLayout.Body>
+    <PageLayout.Content>
+      <div class="stack">
 
   <header class="page-header">
     <div class="title-row">
@@ -531,7 +542,10 @@
       {/if}
     </section>
   {/if}
-</div>
+      </div>
+    </PageLayout.Content>
+  </PageLayout.Body>
+</PageLayout.Root>
 
 {#if selected}
   {@const sel = selected}
@@ -571,11 +585,10 @@
 {/if}
 
 <style>
-  .page {
+  .stack {
     display: flex;
     flex-direction: column;
     gap: var(--size-5);
-    padding: var(--size-6) var(--size-8);
   }
 
   .page-header {
@@ -623,7 +636,9 @@
   .skills-section {
     border: 1px solid var(--color-border-1);
     border-radius: var(--radius-3);
-    overflow: hidden;
+    overflow: auto;
+    overscroll-behavior: none;
+    scrollbar-width: thin;
     background: var(--color-surface-1);
   }
 


### PR DESCRIPTION
## Summary
- Migrates the single-job, YAML-edit, and memory-detail headers to the shared `PageLayout.Breadcrumbs` component so nav looks the same across the app (workspace / section / detail).
- Wraps memory-detail in `PageLayout.Root` so the absolute breadcrumb anchors to the content area instead of escaping to the page edge; bumps the header's top padding so the title clears the overlaid bar.
- Makes the job page's skill list scrollable (`overflow: auto`, `overscroll-behavior: none`, `scrollbar-width: thin`).
- Edit page derives crumbs from `?path=<segments>`: known sections (`agents`, `jobs`, `skills`) link to their list page; the remaining segments render as the leaf label.

## Test plan
- [ ] `/platform/<ws>/jobs/<jobName>` shows `Workspace / Jobs / <jobName>`; skill list scrolls.
- [ ] `/platform/<ws>/edit?path=agents.<id>` shows `Workspace / Agents / <id>`; `?path=jobs.<id>` shows `Workspace / Jobs / <id>`; no `?path=` shows `Workspace / Edit`.
- [ ] `/memory/<ws>/<memoryName>` shows `Memory / <workspaceName> / <memoryName>`, breadcrumb is aligned with the content (not the page edge), and the title isn't clipped underneath.