### PR TITLE
fix(llm): drop hardcoded Groq from labels default chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`labels` role default is anthropic-only; Groq is opt-in via `models.labels`.** The default chain in `packages/llm/src/platform-models.ts` previously led with `groq:openai/gpt-oss-120b`, so any environment with `GROQ_API_KEY` set silently routed session titles (and every other `smallLLM` caller) through Groq — including in regions where Groq is geo-blocked, where the call surfaced as a 403 on every session title. Default is now `anthropic:claude-haiku-4-5` across all four roles; opting back into Groq for sub-second titles is a one-line addition: `models.labels: "groq:openai/gpt-oss-120b"` in `friday.yml`. User-configured `models.labels` was always honored and is unchanged. (#412)
 
 ## [0.1.11] - 2026-05-20
 

--- a/apps/atlasd/daemon-startup.test.ts
+++ b/apps/atlasd/daemon-startup.test.ts
@@ -14,8 +14,18 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
+import type { PlatformModels } from "@atlas/llm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AtlasDaemon } from "./src/atlas-daemon.ts";
+
+/**
+ * `getPlatformModels` is a daemon-internal accessor not exposed on the
+ * public type — narrow through the daemon's known interface so test
+ * assertions can read `.provider` / `.modelId` without resorting to `any`.
+ */
+function getPlatformModels(daemon: AtlasDaemon): PlatformModels {
+  return (daemon as unknown as { getPlatformModels: () => PlatformModels }).getPlatformModels();
+}
 
 // daemon.initialize() spawns NATS, ensures multiple JetStream streams,
 // runs chat + memory migrations in the background. The default 5s vitest
@@ -116,8 +126,8 @@ describe("daemon startup platform models", () => {
     it(
       "boots successfully and resolves labels from the anthropic default even when GROQ_API_KEY is set",
       async () => {
-        // Default labels chain leads with anthropic — a stray GROQ_API_KEY in
-        // the environment must NOT silently hijack the labels role.
+        // Regression guard: a stray GROQ_API_KEY in the environment must NOT
+        // silently hijack the labels role. Default chain leads with anthropic.
         setCredential("GROQ_API_KEY", "test-groq-key");
         setCredential("ANTHROPIC_API_KEY", "test-anthropic-key");
 
@@ -125,11 +135,9 @@ describe("daemon startup platform models", () => {
         activeDaemon = daemon;
         await daemon.initialize();
 
-        const platformModels = (
-          daemon as unknown as { getPlatformModels: () => { get: (role: string) => unknown } }
-        ).getPlatformModels();
-        const labelsModel = platformModels.get("labels");
-        expect(labelsModel).toBeDefined();
+        const labels = getPlatformModels(daemon).get("labels");
+        expect(labels.provider).toContain("anthropic");
+        expect(labels.modelId).toBe("claude-haiku-4-5");
 
         await daemon.shutdown();
       },
@@ -241,12 +249,12 @@ describe("daemon startup platform models", () => {
         activeDaemon = daemon;
         await daemon.initialize();
 
-        const platformModels = (
-          daemon as unknown as { getPlatformModels: () => { get: (role: string) => unknown } }
-        ).getPlatformModels();
-        // Labels should resolve to the anthropic default — groq is opt-in via
-        // `models.labels` in friday.yml / settings, not the env var alone.
-        expect(platformModels.get("labels")).toBeDefined();
+        // Groq is opt-in via `models.labels` in friday.yml / settings — env
+        // var alone is not enough. Assert the resolved identity, not just
+        // that something resolved (toBeDefined would pass for groq too).
+        const labels = getPlatformModels(daemon).get("labels");
+        expect(labels.provider).toContain("anthropic");
+        expect(labels.modelId).toBe("claude-haiku-4-5");
 
         await daemon.shutdown();
       },

--- a/apps/atlasd/daemon-startup.test.ts
+++ b/apps/atlasd/daemon-startup.test.ts
@@ -114,11 +114,11 @@ describe("daemon startup platform models", () => {
     );
 
     it(
-      "boots successfully with groq credentials and resolves labels from groq",
+      "boots successfully and resolves labels from the anthropic default even when GROQ_API_KEY is set",
       async () => {
-        // Groq wins the labels role when credentialed
+        // Default labels chain leads with anthropic — a stray GROQ_API_KEY in
+        // the environment must NOT silently hijack the labels role.
         setCredential("GROQ_API_KEY", "test-groq-key");
-        // Also need anthropic for other roles (classifier, planner, conversational)
         setCredential("ANTHROPIC_API_KEY", "test-anthropic-key");
 
         const daemon = new AtlasDaemon({ port: 0 });
@@ -232,7 +232,7 @@ describe("daemon startup platform models", () => {
     );
 
     it(
-      "prefers groq for labels when both groq and anthropic are credentialed",
+      "uses anthropic for labels by default even when both groq and anthropic are credentialed",
       async () => {
         setCredential("GROQ_API_KEY", "test-groq-key");
         setCredential("ANTHROPIC_API_KEY", "test-anthropic-key");
@@ -244,7 +244,8 @@ describe("daemon startup platform models", () => {
         const platformModels = (
           daemon as unknown as { getPlatformModels: () => { get: (role: string) => unknown } }
         ).getPlatformModels();
-        // Labels should resolve (to groq in the default chain)
+        // Labels should resolve to the anthropic default — groq is opt-in via
+        // `models.labels` in friday.yml / settings, not the env var alone.
         expect(platformModels.get("labels")).toBeDefined();
 
         await daemon.shutdown();

--- a/apps/atlasd/daemon-startup.test.ts
+++ b/apps/atlasd/daemon-startup.test.ts
@@ -14,18 +14,8 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import process from "node:process";
-import type { PlatformModels } from "@atlas/llm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { AtlasDaemon } from "./src/atlas-daemon.ts";
-
-/**
- * `getPlatformModels` is a daemon-internal accessor not exposed on the
- * public type — narrow through the daemon's known interface so test
- * assertions can read `.provider` / `.modelId` without resorting to `any`.
- */
-function getPlatformModels(daemon: AtlasDaemon): PlatformModels {
-  return (daemon as unknown as { getPlatformModels: () => PlatformModels }).getPlatformModels();
-}
 
 // daemon.initialize() spawns NATS, ensures multiple JetStream streams,
 // runs chat + memory migrations in the background. The default 5s vitest
@@ -135,7 +125,7 @@ describe("daemon startup platform models", () => {
         activeDaemon = daemon;
         await daemon.initialize();
 
-        const labels = getPlatformModels(daemon).get("labels");
+        const labels = daemon.getPlatformModels().get("labels");
         expect(labels.provider).toContain("anthropic");
         expect(labels.modelId).toBe("claude-haiku-4-5");
 
@@ -252,7 +242,7 @@ describe("daemon startup platform models", () => {
         // Groq is opt-in via `models.labels` in friday.yml / settings — env
         // var alone is not enough. Assert the resolved identity, not just
         // that something resolved (toBeDefined would pass for groq too).
-        const labels = getPlatformModels(daemon).get("labels");
+        const labels = daemon.getPlatformModels().get("labels");
         expect(labels.provider).toContain("anthropic");
         expect(labels.modelId).toBe("claude-haiku-4-5");
 

--- a/packages/llm/src/platform-models.ts
+++ b/packages/llm/src/platform-models.ts
@@ -51,11 +51,12 @@ export interface PlatformModels {
 
 /**
  * Per-role ordered default chains. The factory walks each chain and picks
- * the first entry whose credentials are present. Preserves zero-config
- * Anthropic behavior while preferring Groq for labels when available.
+ * the first entry whose credentials are present. Zero-config behavior is
+ * Anthropic across every role; users who want Groq (or any other provider)
+ * for a role must opt in via `models.<role>` in friday.yml / settings.
  */
 export const DEFAULT_PLATFORM_MODELS: Record<PlatformRole, readonly string[]> = {
-  labels: ["groq:openai/gpt-oss-120b", "anthropic:claude-haiku-4-5"],
+  labels: ["anthropic:claude-haiku-4-5"],
   classifier: ["anthropic:claude-haiku-4-5"],
   planner: ["anthropic:claude-sonnet-4-6"],
   conversational: ["anthropic:claude-sonnet-4-6"],

--- a/packages/llm/src/small.ts
+++ b/packages/llm/src/small.ts
@@ -26,9 +26,9 @@ export async function smallLLM(params: {
 
     return result.text;
   } catch (e) {
-    // 400s from the LiteLLM proxy or upstream providers (budget exceeded, model not
-    // found, parameter rejection, gpt-oss tool hallucination, etc.) are logged at
-    // warn. Call sites must handle errors with fallbacks.
+    // 400s from the LiteLLM proxy or upstream providers (budget exceeded, model
+    // not found, parameter rejection, model-specific tool-call quirks, etc.)
+    // are logged at warn. Call sites must handle errors with fallbacks.
     if (APICallError.isInstance(e) && e.statusCode === 400) {
       logger.warn("Small LLM request rejected (400)", { error: e });
       throw e;

--- a/packages/llm/src/tests/platform-models.test.ts
+++ b/packages/llm/src/tests/platform-models.test.ts
@@ -68,16 +68,17 @@ describe("createPlatformModels", () => {
     expect(models.get("conversational")).toBeDefined();
   });
 
-  it("walks the labels default chain and picks Groq when GROQ_API_KEY is set", () => {
+  it("uses anthropic for labels by default — groq is opt-in even when GROQ_API_KEY is set", () => {
     setEnv({ GROQ_API_KEY: "gsk-test", ANTHROPIC_API_KEY: "sk-ant-test" });
 
-    // groq:openai/gpt-oss-120b is first in chain; both creds present — groq wins
-    expect(DEFAULT_PLATFORM_MODELS.labels[0]).toContain("groq:");
+    // Default chain leads with anthropic. Groq presence should NOT silently
+    // hijack the labels role — users opt in via `models.labels` in settings.
+    expect(DEFAULT_PLATFORM_MODELS.labels[0]).toContain("anthropic:");
     const models = createPlatformModels(null);
     expect(models.get("labels")).toBeDefined();
   });
 
-  it("falls through labels chain to anthropic when GROQ_API_KEY is missing", () => {
+  it("resolves labels from anthropic default when only ANTHROPIC_API_KEY is set", () => {
     setEnv({ ANTHROPIC_API_KEY: "sk-ant-test" });
 
     const models = createPlatformModels(null);

--- a/packages/llm/src/tests/platform-models.test.ts
+++ b/packages/llm/src/tests/platform-models.test.ts
@@ -12,11 +12,7 @@ vi.mock("../tracing.ts", async () => {
   return { ...actual, traceModel: traceModelMock };
 });
 
-import {
-  createPlatformModels,
-  DEFAULT_PLATFORM_MODELS,
-  PlatformModelsConfigError,
-} from "../platform-models.ts";
+import { createPlatformModels, PlatformModelsConfigError } from "../platform-models.ts";
 
 /**
  * Snapshot and restore the env vars the resolver reads so each test starts
@@ -71,18 +67,20 @@ describe("createPlatformModels", () => {
   it("uses anthropic for labels by default — groq is opt-in even when GROQ_API_KEY is set", () => {
     setEnv({ GROQ_API_KEY: "gsk-test", ANTHROPIC_API_KEY: "sk-ant-test" });
 
-    // Default chain leads with anthropic. Groq presence should NOT silently
-    // hijack the labels role — users opt in via `models.labels` in settings.
-    expect(DEFAULT_PLATFORM_MODELS.labels[0]).toContain("anthropic:");
+    // Regression guard: a stray GROQ_API_KEY must NOT silently hijack the
+    // labels role. Users opt into groq via `models.labels` in settings.
     const models = createPlatformModels(null);
-    expect(models.get("labels")).toBeDefined();
+    const labels = models.get("labels");
+    expect(labels.provider).toContain("anthropic");
+    expect(labels.modelId).toBe("claude-haiku-4-5");
   });
 
   it("resolves labels from anthropic default when only ANTHROPIC_API_KEY is set", () => {
     setEnv({ ANTHROPIC_API_KEY: "sk-ant-test" });
 
-    const models = createPlatformModels(null);
-    expect(models.get("labels")).toBeDefined();
+    const labels = createPlatformModels(null).get("labels");
+    expect(labels.provider).toContain("anthropic");
+    expect(labels.modelId).toBe("claude-haiku-4-5");
   });
 
   it("accepts LITELLM_API_KEY as universal credential for every provider", () => {

--- a/packages/system/skills/workspace-api/references/platform-friday-yml.md
+++ b/packages/system/skills/workspace-api/references/platform-friday-yml.md
@@ -28,7 +28,7 @@ independently. Id format: `provider:model`. Known providers: `anthropic`,
 
 ```yaml
 models:
-  labels: "groq:openai/gpt-oss-120b"            # short plain-text (session titles, quick summaries)
+  labels: "anthropic:claude-haiku-4-5"          # short plain-text (session titles, quick summaries)
   classifier: "anthropic:claude-haiku-4-5"      # structured-output routing decisions
   planner: "anthropic:claude-sonnet-4-6"        # multi-step synthesis (workspace planner, plan DAG)
   conversational: "anthropic:claude-sonnet-4-6" # streaming chat with tools (workspace chat)
@@ -38,8 +38,9 @@ models:
 
 - **`labels`** — short plain-text, latency matters, quality ceiling is low.
   Session titles, snap summaries, anything on a user-blocking path under
-  ~100 output tokens. Default: `groq:openai/gpt-oss-120b` → falls back to
-  `anthropic:claude-haiku-4-5` if no Groq key.
+  ~100 output tokens. Default: `anthropic:claude-haiku-4-5`. A common
+  override is `groq:openai/gpt-oss-120b` for sub-second titles when
+  `GROQ_API_KEY` is reachable from your region.
 - **`classifier`** — `generateObject` over small enums / discriminated
   unions. Schema-compliance matters most. Default:
   `anthropic:claude-haiku-4-5`.
@@ -98,14 +99,14 @@ credential is missing.
 
 ## Default chains (what happens when `models` is absent)
 
-- `labels` → try `groq:openai/gpt-oss-120b`; fall back to
-  `anthropic:claude-haiku-4-5` if no Groq key.
+- `labels` → `anthropic:claude-haiku-4-5`.
 - `classifier` → `anthropic:claude-haiku-4-5`.
 - `planner` → `anthropic:claude-sonnet-4-6`.
 - `conversational` → `anthropic:claude-sonnet-4-6`.
 
-So with just `ANTHROPIC_API_KEY` set, the whole platform runs. Add
-`GROQ_API_KEY` and labels-path latency improves automatically.
+So with just `ANTHROPIC_API_KEY` set, the whole platform runs. Switching
+labels to a faster provider (e.g. Groq) is a deliberate `models.labels`
+override — env-var presence alone does not change the default.
 
 ## Extended `server.mcp` (friday.yml only)
 


### PR DESCRIPTION
## Summary

- Title-generator (and any other `smallLLM` caller) resolves through `platformModels.get("labels")`. The default chain led with `groq:openai/gpt-oss-120b`, so any env where `GROQ_API_KEY` happened to be set silently routed to Groq — overriding what the user configured-or-defaulted. From Groq-blocked regions (Canada) this surfaced as a 403 on every session title.
- Default chain is now anthropic-only across all four roles. Groq is strictly opt-in via `models.labels` in friday.yml / settings.
- User-configured `models.labels` was already honored; that path is unchanged.

## Test plan

- [x] `packages/llm/src/tests/platform-models.test.ts` — 25 tests pass; updated the two assertions that previously expected groq-first
- [x] `packages/llm/src/tests/platform-models-integration.test.ts` — 8 tests pass; wizard fixtures still resolve correctly
- [ ] `apps/atlasd/daemon-startup.test.ts` — assertion logic flipped to match new default; not run locally (spawns nats-server, needs full env)
- [ ] Manual: verify session-title generation in playground with no `models.labels` set picks anthropic, and that setting `models.labels` to any provider is honored