### PR TITLE
feat(ui): add HotkeyRegistry and DragDropContext

### DIFF
--- a/deno.lock
+++ b/deno.lock
@@ -6655,6 +6655,7 @@
             "npm:eslint-plugin-svelte@^3.17.1",
             "npm:eslint@^10.3.0",
             "npm:globals@^17.6.0",
+            "npm:happy-dom@^20.9.0",
             "npm:isomorphic-dompurify@^2.16.0",
             "npm:marked@^18.0.3",
             "npm:prettier-plugin-svelte@^3.5.2",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -70,6 +70,7 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-svelte": "^3.17.1",
     "globals": "^17.6.0",
+    "happy-dom": "^20.9.0",
     "prettier": "^3.8.3",
     "prettier-plugin-svelte": "^3.5.2",
     "publint": "^0.3.18",

--- a/packages/ui/src/lib/drag-drop-zone.svelte
+++ b/packages/ui/src/lib/drag-drop-zone.svelte
@@ -8,6 +8,12 @@
   layout, positioning, and scoped-CSS context. Override with `class`
   or `style` if a real layout box is needed.
 
+  Callers that overlay absolutely-positioned children inside the zone
+  must set `position: relative` on the child themselves — `display:
+  contents` on the wrapper removes it as a containing block, so the
+  overlay would otherwise anchor to the nearest positioned ancestor
+  outside the zone.
+
   Multiple zones can coexist on the same page; each is scoped to its
   own subtree, so a drop on one never fires the other.
 

--- a/packages/ui/src/lib/drag-drop-zone.svelte
+++ b/packages/ui/src/lib/drag-drop-zone.svelte
@@ -1,0 +1,46 @@
+<!--
+  Element-scoped file drop zone.
+
+  Wraps a region with dragenter/over/leave/drop handlers and exposes a
+  live `dragOver` flag through the children snippet. The wrapping
+  `<div>` defaults to `display: contents` so it adds drop listeners
+  without introducing a layout box — children keep their existing
+  layout, positioning, and scoped-CSS context. Override with `class`
+  or `style` if a real layout box is needed.
+
+  Multiple zones can coexist on the same page; each is scoped to its
+  own subtree, so a drop on one never fires the other.
+
+  `onFiles` is read through the props proxy on every drop, so callers
+  can pass a fresh arrow each render without losing the latest closure.
+-->
+<script lang="ts">
+  import type { Snippet } from "svelte";
+  import { createDragDropState } from "./drag-drop.svelte.ts";
+
+  interface Props {
+    /** Called with dropped files. Filtering is the caller's job. */
+    onFiles: (files: File[]) => void;
+    /** Optional class on the wrapper element. */
+    class?: string;
+    /** Inline style override. Appended after the default `display: contents`. */
+    style?: string;
+    /** Children receive the live `dragOver` state. */
+    children: Snippet<[{ dragOver: boolean }]>;
+  }
+
+  const props: Props = $props();
+  const state = createDragDropState((files) => props.onFiles(files));
+</script>
+
+<div
+  class={props.class}
+  style="display: contents;{props.style ? ` ${props.style}` : ''}"
+  ondragenter={state.onDragEnter}
+  ondragover={state.onDragOver}
+  ondragleave={state.onDragLeave}
+  ondrop={state.onDrop}
+  role="presentation"
+>
+  {@render props.children({ dragOver: state.dragOver })}
+</div>

--- a/packages/ui/src/lib/drag-drop.svelte.ts
+++ b/packages/ui/src/lib/drag-drop.svelte.ts
@@ -1,0 +1,142 @@
+/**
+ * Global drag-and-drop file context.
+ *
+ * Owns body-level dragenter/dragover/dragleave/drop listeners. Consumers
+ * register an `onFiles` callback; the top of the stack receives drops.
+ * Listeners attach lazily — present only while at least one handler is
+ * registered — so navigating off a drop-enabled route leaves the document
+ * inert. Lifecycle drives gating: a route component that wants drops
+ * registers in a `$effect`; unmounting disposes automatically.
+ *
+ * Filtering (image-only, size limits, MIME checks, etc.) is the call
+ * site's job — the context forwards every dropped file as a `File[]`.
+ *
+ * @module
+ */
+
+import { getContext, setContext } from "svelte";
+
+const CONTEXT_KEY = Symbol("drag-drop-context");
+
+export interface DragDropHandler {
+  onFiles: (files: File[]) => void;
+}
+
+export interface DragDropContext {
+  /** True while a file drag is hovering anywhere in the document. */
+  readonly dragOver: boolean;
+  /**
+   * Push a handler onto the stack. Top of the stack receives drops.
+   * Returns a disposer; call it (or return it from a `$effect`) to pop.
+   */
+  register(handler: DragDropHandler): () => void;
+}
+
+export function createDragDropContext(): DragDropContext {
+  const handlers: DragDropHandler[] = [];
+  let dragOver = $state(false);
+  let attached = false;
+  // Counter for nested dragenter/leave events. Dragging over a child
+  // element fires dragleave on the parent and dragenter on the child;
+  // a counter that increments on enter and decrements on leave only
+  // returns to zero when the cursor exits the document entirely.
+  let dragCounter = 0;
+
+  function activeHandler(): DragDropHandler | null {
+    return handlers[handlers.length - 1] ?? null;
+  }
+
+  function hasFiles(e: DragEvent): boolean {
+    const types = e.dataTransfer?.types;
+    if (!types) return false;
+    for (const t of types) {
+      if (t === "Files") return true;
+    }
+    return false;
+  }
+
+  function onEnter(e: DragEvent) {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    dragCounter++;
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+    dragOver = true;
+  }
+
+  function onOver(e: DragEvent) {
+    if (!hasFiles(e)) return;
+    // preventDefault on dragover is REQUIRED — without it the browser
+    // rejects the drop and `drop` never fires.
+    e.preventDefault();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
+  }
+
+  function onLeave(_e: DragEvent) {
+    dragCounter = Math.max(0, dragCounter - 1);
+    if (dragCounter === 0) dragOver = false;
+  }
+
+  function onDrop(e: DragEvent) {
+    if (!hasFiles(e)) return;
+    e.preventDefault();
+    dragCounter = 0;
+    dragOver = false;
+    const handler = activeHandler();
+    const files = e.dataTransfer?.files;
+    if (!handler || !files || files.length === 0) return;
+    handler.onFiles(Array.from(files));
+  }
+
+  function ensureAttached() {
+    if (attached || typeof document === "undefined") return;
+    document.body.addEventListener("dragenter", onEnter);
+    document.body.addEventListener("dragover", onOver);
+    document.body.addEventListener("dragleave", onLeave);
+    document.body.addEventListener("drop", onDrop);
+    attached = true;
+  }
+
+  function detach() {
+    if (!attached || typeof document === "undefined") return;
+    document.body.removeEventListener("dragenter", onEnter);
+    document.body.removeEventListener("dragover", onOver);
+    document.body.removeEventListener("dragleave", onLeave);
+    document.body.removeEventListener("drop", onDrop);
+    attached = false;
+    dragCounter = 0;
+    dragOver = false;
+  }
+
+  function register(handler: DragDropHandler): () => void {
+    handlers.push(handler);
+    ensureAttached();
+    return () => {
+      const idx = handlers.lastIndexOf(handler);
+      if (idx >= 0) handlers.splice(idx, 1);
+      if (handlers.length === 0) detach();
+    };
+  }
+
+  return {
+    get dragOver() {
+      return dragOver;
+    },
+    register,
+  };
+}
+
+export function setDragDropContext(): DragDropContext {
+  const ctx = createDragDropContext();
+  setContext(CONTEXT_KEY, ctx);
+  return ctx;
+}
+
+export function getDragDropContext(): DragDropContext {
+  const ctx = getContext<DragDropContext | undefined>(CONTEXT_KEY);
+  if (!ctx) {
+    throw new Error(
+      "DragDropContext not found. Call setDragDropContext() in the root layout.",
+    );
+  }
+  return ctx;
+}

--- a/packages/ui/src/lib/drag-drop.svelte.ts
+++ b/packages/ui/src/lib/drag-drop.svelte.ts
@@ -1,50 +1,40 @@
 /**
- * Global drag-and-drop file context.
+ * Element-scoped drag-and-drop state machine.
  *
- * Owns body-level dragenter/dragover/dragleave/drop listeners. Consumers
- * register an `onFiles` callback; the top of the stack receives drops.
- * Listeners attach lazily — present only while at least one handler is
- * registered — so navigating off a drop-enabled route leaves the document
- * inert. Lifecycle drives gating: a route component that wants drops
- * registers in a `$effect`; unmounting disposes automatically.
+ * Factory returns a reactive `dragOver` flag and the four event
+ * handlers a component wires to its root element. No global document
+ * listeners — drops fire only inside the element that owns the
+ * handlers, so multiple zones on the same page cannot collide.
  *
- * Filtering (image-only, size limits, MIME checks, etc.) is the call
- * site's job — the context forwards every dropped file as a `File[]`.
+ * Filtering (image-only, size limits, MIME checks, etc.) is the
+ * caller's job — the state machine forwards every dropped file as a
+ * `File[]`. The only filter built in is "must be a file drag" — drags
+ * that don't carry files (text, URLs from another tab) are ignored so
+ * the zone doesn't visually react to them.
+ *
+ * For component usage, prefer `<DragDropZone>`, which wraps this.
  *
  * @module
  */
 
-import { getContext, setContext } from "svelte";
-
-const CONTEXT_KEY = Symbol("drag-drop-context");
-
-export interface DragDropHandler {
-  onFiles: (files: File[]) => void;
-}
-
-export interface DragDropContext {
-  /** True while a file drag is hovering anywhere in the document. */
+export interface DragDropState {
+  /** True while a file drag is hovering inside the owning element. */
   readonly dragOver: boolean;
-  /**
-   * Push a handler onto the stack. Top of the stack receives drops.
-   * Returns a disposer; call it (or return it from a `$effect`) to pop.
-   */
-  register(handler: DragDropHandler): () => void;
+  onDragEnter(e: DragEvent): void;
+  onDragOver(e: DragEvent): void;
+  onDragLeave(e: DragEvent): void;
+  onDrop(e: DragEvent): void;
 }
 
-export function createDragDropContext(): DragDropContext {
-  const handlers: DragDropHandler[] = [];
+export function createDragDropState(
+  onFiles: (files: File[]) => void,
+): DragDropState {
   let dragOver = $state(false);
-  let attached = false;
-  // Counter for nested dragenter/leave events. Dragging over a child
-  // element fires dragleave on the parent and dragenter on the child;
-  // a counter that increments on enter and decrements on leave only
-  // returns to zero when the cursor exits the document entirely.
+  // Nested children fire dragleave on the parent and dragenter on the
+  // child as the cursor crosses element boundaries. A counter that
+  // increments on enter and decrements on leave only returns to zero
+  // when the cursor exits the owning element entirely.
   let dragCounter = 0;
-
-  function activeHandler(): DragDropHandler | null {
-    return handlers[handlers.length - 1] ?? null;
-  }
 
   function hasFiles(e: DragEvent): boolean {
     const types = e.dataTransfer?.types;
@@ -55,7 +45,7 @@ export function createDragDropContext(): DragDropContext {
     return false;
   }
 
-  function onEnter(e: DragEvent) {
+  function onDragEnter(e: DragEvent) {
     if (!hasFiles(e)) return;
     e.preventDefault();
     dragCounter++;
@@ -63,7 +53,7 @@ export function createDragDropContext(): DragDropContext {
     dragOver = true;
   }
 
-  function onOver(e: DragEvent) {
+  function onDragOver(e: DragEvent) {
     if (!hasFiles(e)) return;
     // preventDefault on dragover is REQUIRED — without it the browser
     // rejects the drop and `drop` never fires.
@@ -71,7 +61,7 @@ export function createDragDropContext(): DragDropContext {
     if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
   }
 
-  function onLeave(_e: DragEvent) {
+  function onDragLeave(_e: DragEvent) {
     dragCounter = Math.max(0, dragCounter - 1);
     if (dragCounter === 0) dragOver = false;
   }
@@ -81,62 +71,18 @@ export function createDragDropContext(): DragDropContext {
     e.preventDefault();
     dragCounter = 0;
     dragOver = false;
-    const handler = activeHandler();
     const files = e.dataTransfer?.files;
-    if (!handler || !files || files.length === 0) return;
-    handler.onFiles(Array.from(files));
-  }
-
-  function ensureAttached() {
-    if (attached || typeof document === "undefined") return;
-    document.body.addEventListener("dragenter", onEnter);
-    document.body.addEventListener("dragover", onOver);
-    document.body.addEventListener("dragleave", onLeave);
-    document.body.addEventListener("drop", onDrop);
-    attached = true;
-  }
-
-  function detach() {
-    if (!attached || typeof document === "undefined") return;
-    document.body.removeEventListener("dragenter", onEnter);
-    document.body.removeEventListener("dragover", onOver);
-    document.body.removeEventListener("dragleave", onLeave);
-    document.body.removeEventListener("drop", onDrop);
-    attached = false;
-    dragCounter = 0;
-    dragOver = false;
-  }
-
-  function register(handler: DragDropHandler): () => void {
-    handlers.push(handler);
-    ensureAttached();
-    return () => {
-      const idx = handlers.lastIndexOf(handler);
-      if (idx >= 0) handlers.splice(idx, 1);
-      if (handlers.length === 0) detach();
-    };
+    if (!files || files.length === 0) return;
+    onFiles(Array.from(files));
   }
 
   return {
     get dragOver() {
       return dragOver;
     },
-    register,
+    onDragEnter,
+    onDragOver,
+    onDragLeave,
+    onDrop,
   };
-}
-
-export function setDragDropContext(): DragDropContext {
-  const ctx = createDragDropContext();
-  setContext(CONTEXT_KEY, ctx);
-  return ctx;
-}
-
-export function getDragDropContext(): DragDropContext {
-  const ctx = getContext<DragDropContext | undefined>(CONTEXT_KEY);
-  if (!ctx) {
-    throw new Error(
-      "DragDropContext not found. Call setDragDropContext() in the root layout.",
-    );
-  }
-  return ctx;
 }

--- a/packages/ui/src/lib/drag-drop.test.ts
+++ b/packages/ui/src/lib/drag-drop.test.ts
@@ -98,9 +98,12 @@ describe("createDragDropState — dragOver lifecycle", () => {
     state.onDragLeave(asDragEvent(mockEvent({ files: [] })));
     state.onDragLeave(asDragEvent(mockEvent({ files: [] })));
     state.onDragEnter(asDragEvent(mockEvent({ files: [] })));
-    // After one matched enter we should still see dragOver true —
-    // proves the counter clamped at 0, not -2.
-    expect(state.dragOver).toBe(true);
+    state.onDragLeave(asDragEvent(mockEvent({ files: [] })));
+    // With the Math.max(0, …) clamp the counter rides 0 → 0 → 1 → 0, so
+    // the final leave clears dragOver. Without it the counter goes
+    // negative and the matched enter never brings it back to 0 — dragOver
+    // would stay stuck true.
+    expect(state.dragOver).toBe(false);
   });
 });
 
@@ -117,6 +120,15 @@ describe("createDragDropState — browser-required side effects", () => {
     const e = mockEvent({ files: [] });
     state.onDragOver(asDragEvent(e));
     expect(e.defaultPrevented).toBe(true);
+  });
+
+  it("ignores dragover for non-file drags", () => {
+    const state = createDragDropState(vi.fn());
+    const e = mockEvent({ nonFile: true });
+    state.onDragOver(asDragEvent(e));
+    // Non-file drags (text/url) must not be preventDefault'd, or the
+    // browser's own drag preview gets hijacked.
+    expect(e.defaultPrevented).toBe(false);
   });
 
   it("sets dropEffect = copy on dragenter and dragover", () => {

--- a/packages/ui/src/lib/drag-drop.test.ts
+++ b/packages/ui/src/lib/drag-drop.test.ts
@@ -1,0 +1,161 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { describe, expect, it, vi } from "vitest";
+import { createDragDropState } from "./drag-drop.svelte.ts";
+
+interface MockDataTransfer {
+  types: readonly string[];
+  files: ArrayLike<File> & Iterable<File>;
+  dropEffect: string;
+}
+
+interface MockEvent {
+  dataTransfer: MockDataTransfer | null;
+  defaultPrevented: boolean;
+  preventDefault(): void;
+}
+
+function mockEvent(opts: { files?: File[]; nonFile?: boolean } = {}): MockEvent {
+  const files = opts.files ?? [];
+  const types = opts.nonFile ? ["text/plain"] : opts.files !== undefined ? ["Files"] : [];
+  const fileList: ArrayLike<File> & Iterable<File> = {
+    length: files.length,
+    ...Object.fromEntries(files.map((f, i) => [i, f])),
+    [Symbol.iterator]: function* () {
+      yield* files;
+    },
+  } as ArrayLike<File> & Iterable<File>;
+  let defaultPrevented = false;
+  return {
+    dataTransfer: {
+      types,
+      files: fileList,
+      dropEffect: "none",
+    },
+    get defaultPrevented() {
+      return defaultPrevented;
+    },
+    preventDefault() {
+      defaultPrevented = true;
+    },
+  };
+}
+
+function file(name = "x.txt"): File {
+  return new File(["x"], name, { type: "text/plain" });
+}
+
+// Test helper — pretend MockEvent is DragEvent for the state machine's
+// signature. The state machine only touches dataTransfer + preventDefault,
+// so the duck-type is sufficient and we avoid happy-dom DragEvent quirks.
+const asDragEvent = (e: MockEvent) => e as unknown as DragEvent;
+
+describe("createDragDropState — drag filtering", () => {
+  it("ignores drags whose dataTransfer carries no Files type", () => {
+    const onFiles = vi.fn();
+    const state = createDragDropState(onFiles);
+    const e = mockEvent({ nonFile: true });
+    state.onDragEnter(asDragEvent(e));
+    expect(state.dragOver).toBe(false);
+    expect(e.defaultPrevented).toBe(false);
+    state.onDrop(asDragEvent(e));
+    expect(onFiles).not.toHaveBeenCalled();
+  });
+});
+
+describe("createDragDropState — dragOver lifecycle", () => {
+  it("flips dragOver true on enter, clears on leave", () => {
+    const state = createDragDropState(vi.fn());
+    state.onDragEnter(asDragEvent(mockEvent({ files: [] })));
+    expect(state.dragOver).toBe(true);
+    state.onDragLeave(asDragEvent(mockEvent({ files: [] })));
+    expect(state.dragOver).toBe(false);
+  });
+
+  it("nested enter/leave: counter keeps dragOver true until matched", () => {
+    const state = createDragDropState(vi.fn());
+    state.onDragEnter(asDragEvent(mockEvent({ files: [] })));
+    state.onDragEnter(asDragEvent(mockEvent({ files: [] })));
+    expect(state.dragOver).toBe(true);
+    state.onDragLeave(asDragEvent(mockEvent({ files: [] })));
+    // Still nested — only one leave matches one of the two enters.
+    expect(state.dragOver).toBe(true);
+    state.onDragLeave(asDragEvent(mockEvent({ files: [] })));
+    expect(state.dragOver).toBe(false);
+  });
+
+  it("drop clears dragOver even without prior leave", () => {
+    const state = createDragDropState(vi.fn());
+    state.onDragEnter(asDragEvent(mockEvent({ files: [] })));
+    expect(state.dragOver).toBe(true);
+    state.onDrop(asDragEvent(mockEvent({ files: [file()] })));
+    expect(state.dragOver).toBe(false);
+  });
+
+  it("dragLeave does not underflow past zero", () => {
+    const state = createDragDropState(vi.fn());
+    state.onDragLeave(asDragEvent(mockEvent({ files: [] })));
+    state.onDragLeave(asDragEvent(mockEvent({ files: [] })));
+    state.onDragEnter(asDragEvent(mockEvent({ files: [] })));
+    // After one matched enter we should still see dragOver true —
+    // proves the counter clamped at 0, not -2.
+    expect(state.dragOver).toBe(true);
+  });
+});
+
+describe("createDragDropState — browser-required side effects", () => {
+  it("preventDefault on dragenter (required to register as drop target)", () => {
+    const state = createDragDropState(vi.fn());
+    const e = mockEvent({ files: [] });
+    state.onDragEnter(asDragEvent(e));
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it("preventDefault on dragover (required for drop to fire)", () => {
+    const state = createDragDropState(vi.fn());
+    const e = mockEvent({ files: [] });
+    state.onDragOver(asDragEvent(e));
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it("sets dropEffect = copy on dragenter and dragover", () => {
+    const state = createDragDropState(vi.fn());
+    const enter = mockEvent({ files: [] });
+    state.onDragEnter(asDragEvent(enter));
+    expect(enter.dataTransfer?.dropEffect).toBe("copy");
+
+    const over = mockEvent({ files: [] });
+    state.onDragOver(asDragEvent(over));
+    expect(over.dataTransfer?.dropEffect).toBe("copy");
+  });
+});
+
+describe("createDragDropState — onFiles dispatch", () => {
+  it("invokes onFiles with the dropped files as an array", () => {
+    const onFiles = vi.fn();
+    const state = createDragDropState(onFiles);
+    const f1 = file("a.txt");
+    const f2 = file("b.txt");
+    state.onDrop(asDragEvent(mockEvent({ files: [f1, f2] })));
+    expect(onFiles).toHaveBeenCalledOnce();
+    const passed = onFiles.mock.calls[0]?.[0] as File[];
+    expect(passed).toHaveLength(2);
+    expect(passed[0]?.name).toBe("a.txt");
+    expect(passed[1]?.name).toBe("b.txt");
+  });
+
+  it("does not call onFiles for an empty file list", () => {
+    const onFiles = vi.fn();
+    const state = createDragDropState(onFiles);
+    state.onDrop(asDragEvent(mockEvent({ files: [] })));
+    expect(onFiles).not.toHaveBeenCalled();
+  });
+
+  it("calls preventDefault on drop", () => {
+    const state = createDragDropState(vi.fn());
+    const e = mockEvent({ files: [file()] });
+    state.onDrop(asDragEvent(e));
+    expect(e.defaultPrevented).toBe(true);
+  });
+});

--- a/packages/ui/src/lib/hotkeys.svelte.ts
+++ b/packages/ui/src/lib/hotkeys.svelte.ts
@@ -74,7 +74,14 @@ export function createHotkeyRegistry(): HotkeyRegistry {
       if (!matches(b, e)) continue;
       if (b.when && !b.when(e)) continue;
       if (b.preventDefault !== false) e.preventDefault();
-      b.handler(e);
+      // A throwing handler must not propagate out of the window listener:
+      // the event is already consumed (preventDefault ran), and an
+      // uncaught throw would break dispatch for every later keystroke.
+      try {
+        b.handler(e);
+      } catch (err) {
+        console.error("hotkey handler threw", err);
+      }
       return;
     }
   }

--- a/packages/ui/src/lib/hotkeys.svelte.ts
+++ b/packages/ui/src/lib/hotkeys.svelte.ts
@@ -1,0 +1,155 @@
+/**
+ * Global keyboard shortcut registry.
+ *
+ * Single window-level keydown listener that dispatches to registered
+ * bindings in stack order (last-registered wins). Lazy: the window
+ * listener only attaches while at least one binding is registered, and
+ * detaches when the last one is disposed.
+ *
+ * When two bindings share a combo, the dispatcher walks the stack from
+ * top to bottom and fires the first match whose `when()` is truthy.
+ * Earlier registrations never run for a combo a later registration also
+ * claims — except when the later one's `when()` returns false, in which
+ * case dispatch falls through to the next match.
+ *
+ * @module
+ */
+
+import { getContext, setContext } from "svelte";
+
+const CONTEXT_KEY = Symbol("hotkey-registry");
+
+export interface HotkeyBinding {
+  /** KeyboardEvent.key value. Single-character keys match case-insensitively. */
+  key: string;
+  /** Cmd on Mac, Ctrl elsewhere. Mutually exclusive with `meta`/`ctrl`. */
+  cmdOrCtrl?: boolean;
+  /** Strictly Ctrl. Mac users get Ctrl, not Cmd. */
+  ctrl?: boolean;
+  /** Strictly Cmd (Meta). */
+  meta?: boolean;
+  /** Default false — Shift must NOT be pressed. */
+  shift?: boolean;
+  /** Default false — Alt must NOT be pressed. */
+  alt?: boolean;
+  /**
+   * Reactive gate. Bindings whose `when` returns false are skipped; the
+   * dispatcher continues walking down the stack to the next match.
+   */
+  when?: (e: KeyboardEvent) => boolean;
+  /** Default true. */
+  preventDefault?: boolean;
+  handler: (e: KeyboardEvent) => void;
+}
+
+export interface HotkeyRegistry {
+  /**
+   * Register a binding. Returns a disposer; call it (or return it from a
+   * `$effect`) to remove the binding. The window listener detaches when
+   * no bindings remain.
+   */
+  register(binding: HotkeyBinding): () => void;
+}
+
+export function createHotkeyRegistry(): HotkeyRegistry {
+  const bindings: HotkeyBinding[] = [];
+  let listener: ((e: KeyboardEvent) => void) | null = null;
+
+  function ensureListener() {
+    if (listener || typeof window === "undefined") return;
+    listener = handle;
+    window.addEventListener("keydown", listener);
+  }
+
+  function detachListener() {
+    if (!listener || typeof window === "undefined") return;
+    window.removeEventListener("keydown", listener);
+    listener = null;
+  }
+
+  function handle(e: KeyboardEvent) {
+    for (let i = bindings.length - 1; i >= 0; i--) {
+      const b = bindings[i];
+      if (!b) continue;
+      if (!matches(b, e)) continue;
+      if (b.when && !b.when(e)) continue;
+      if (b.preventDefault !== false) e.preventDefault();
+      b.handler(e);
+      return;
+    }
+  }
+
+  function register(binding: HotkeyBinding): () => void {
+    bindings.push(binding);
+    ensureListener();
+    return () => {
+      const idx = bindings.lastIndexOf(binding);
+      if (idx >= 0) bindings.splice(idx, 1);
+      if (bindings.length === 0) detachListener();
+    };
+  }
+
+  return { register };
+}
+
+function matches(b: HotkeyBinding, e: KeyboardEvent): boolean {
+  if (!matchesKey(b.key, e.key)) return false;
+
+  const wantShift = b.shift === true;
+  const wantAlt = b.alt === true;
+  if (e.shiftKey !== wantShift) return false;
+  if (e.altKey !== wantAlt) return false;
+
+  if (b.cmdOrCtrl) {
+    // Either modifier (or both) satisfies cmdOrCtrl. Matches the common
+    // `e.metaKey || e.ctrlKey` idiom used throughout the codebase.
+    if (!(e.metaKey || e.ctrlKey)) return false;
+  } else {
+    const wantMeta = b.meta === true;
+    const wantCtrl = b.ctrl === true;
+    if (e.metaKey !== wantMeta) return false;
+    if (e.ctrlKey !== wantCtrl) return false;
+  }
+  return true;
+}
+
+function matchesKey(bindingKey: string, eventKey: string): boolean {
+  // Single-character keys match case-insensitively: a Shift+D binding
+  // declares `key: "d"`, but the browser delivers `e.key === "D"` because
+  // Shift is held. Lowercasing both sides papers over that.
+  if (bindingKey.length === 1) {
+    return bindingKey.toLowerCase() === eventKey.toLowerCase();
+  }
+  return bindingKey === eventKey;
+}
+
+/**
+ * Common `when` predicate: skip the binding when the user is typing in a
+ * text field (input, textarea, select, contentEditable). Useful for
+ * single-letter shortcuts that would otherwise eat keystrokes the user
+ * is trying to put into a form.
+ */
+export function notInTextField(e: KeyboardEvent): boolean {
+  const t = e.target;
+  if (t instanceof HTMLInputElement) return false;
+  if (t instanceof HTMLTextAreaElement) return false;
+  if (t instanceof HTMLSelectElement) return false;
+  if (t instanceof HTMLElement && t.isContentEditable) return false;
+  return true;
+}
+
+export function setHotkeyRegistry(): HotkeyRegistry {
+  const registry = createHotkeyRegistry();
+  setContext(CONTEXT_KEY, registry);
+  return registry;
+}
+
+export function getHotkeyRegistry(): HotkeyRegistry {
+  const ctx = getContext<HotkeyRegistry | undefined>(CONTEXT_KEY);
+  if (!ctx) {
+    throw new Error(
+      "HotkeyRegistry not found. Call setHotkeyRegistry() in the root layout.",
+    );
+  }
+  return ctx;
+}

--- a/packages/ui/src/lib/hotkeys.test.ts
+++ b/packages/ui/src/lib/hotkeys.test.ts
@@ -1,0 +1,209 @@
+/**
+ * @vitest-environment happy-dom
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHotkeyRegistry, notInTextField } from "./hotkeys.svelte.ts";
+
+const disposers: Array<() => void> = [];
+
+afterEach(() => {
+  while (disposers.length > 0) {
+    const d = disposers.pop();
+    d?.();
+  }
+});
+
+function track<T extends () => void>(dispose: T): T {
+  disposers.push(dispose);
+  return dispose;
+}
+
+function dispatch(opts: Partial<KeyboardEventInit> & { key: string }): KeyboardEvent {
+  const e = new KeyboardEvent("keydown", { cancelable: true, ...opts });
+  window.dispatchEvent(e);
+  return e;
+}
+
+describe("HotkeyRegistry — stack ordering", () => {
+  it("last-registered binding wins for the same combo", () => {
+    const reg = createHotkeyRegistry();
+    const a = vi.fn();
+    const b = vi.fn();
+    track(reg.register({ key: "k", cmdOrCtrl: true, handler: a }));
+    track(reg.register({ key: "k", cmdOrCtrl: true, handler: b }));
+    dispatch({ key: "k", metaKey: true });
+    expect(b).toHaveBeenCalledOnce();
+    expect(a).not.toHaveBeenCalled();
+  });
+
+  it("falls through to earlier binding when later's when() returns false", () => {
+    const reg = createHotkeyRegistry();
+    const a = vi.fn();
+    const b = vi.fn();
+    track(reg.register({ key: "k", cmdOrCtrl: true, handler: a }));
+    track(
+      reg.register({ key: "k", cmdOrCtrl: true, when: () => false, handler: b }),
+    );
+    dispatch({ key: "k", metaKey: true });
+    expect(a).toHaveBeenCalledOnce();
+    expect(b).not.toHaveBeenCalled();
+  });
+});
+
+describe("HotkeyRegistry — modifier matching", () => {
+  it("cmdOrCtrl matches Cmd alone", () => {
+    const reg = createHotkeyRegistry();
+    const h = vi.fn();
+    track(reg.register({ key: "k", cmdOrCtrl: true, handler: h }));
+    dispatch({ key: "k", metaKey: true });
+    expect(h).toHaveBeenCalledOnce();
+  });
+
+  it("cmdOrCtrl matches Ctrl alone", () => {
+    const reg = createHotkeyRegistry();
+    const h = vi.fn();
+    track(reg.register({ key: "k", cmdOrCtrl: true, handler: h }));
+    dispatch({ key: "k", ctrlKey: true });
+    expect(h).toHaveBeenCalledOnce();
+  });
+
+  it("strict ctrl rejects pure Cmd", () => {
+    const reg = createHotkeyRegistry();
+    const h = vi.fn();
+    track(reg.register({ key: "f", ctrl: true, handler: h }));
+    dispatch({ key: "f", metaKey: true });
+    expect(h).not.toHaveBeenCalled();
+  });
+
+  it("strict meta rejects pure Ctrl", () => {
+    const reg = createHotkeyRegistry();
+    const h = vi.fn();
+    track(reg.register({ key: "f", meta: true, handler: h }));
+    dispatch({ key: "f", ctrlKey: true });
+    expect(h).not.toHaveBeenCalled();
+  });
+
+  it("rejects when Shift is held but the binding didn't request it", () => {
+    const reg = createHotkeyRegistry();
+    const h = vi.fn();
+    track(reg.register({ key: "r", handler: h }));
+    dispatch({ key: "r", shiftKey: true });
+    expect(h).not.toHaveBeenCalled();
+  });
+
+  it("requires Shift when the binding requests it", () => {
+    const reg = createHotkeyRegistry();
+    const h = vi.fn();
+    track(reg.register({ key: "d", cmdOrCtrl: true, shift: true, handler: h }));
+    dispatch({ key: "d", metaKey: true, shiftKey: true });
+    expect(h).toHaveBeenCalledOnce();
+  });
+
+  it("rejects when Alt is held but the binding didn't request it", () => {
+    const reg = createHotkeyRegistry();
+    const h = vi.fn();
+    track(reg.register({ key: "k", cmdOrCtrl: true, handler: h }));
+    dispatch({ key: "k", metaKey: true, altKey: true });
+    expect(h).not.toHaveBeenCalled();
+  });
+});
+
+describe("HotkeyRegistry — key matching", () => {
+  it("single-char keys match case-insensitively (Shift+key delivers uppercase)", () => {
+    const reg = createHotkeyRegistry();
+    const h = vi.fn();
+    track(reg.register({ key: "d", cmdOrCtrl: true, shift: true, handler: h }));
+    dispatch({ key: "D", metaKey: true, shiftKey: true });
+    expect(h).toHaveBeenCalledOnce();
+  });
+
+  it("multi-char key names are case-sensitive", () => {
+    const reg = createHotkeyRegistry();
+    const h = vi.fn();
+    track(reg.register({ key: "Escape", handler: h }));
+    dispatch({ key: "escape" });
+    expect(h).not.toHaveBeenCalled();
+  });
+});
+
+describe("HotkeyRegistry — preventDefault", () => {
+  it("calls preventDefault by default", () => {
+    const reg = createHotkeyRegistry();
+    track(reg.register({ key: "k", cmdOrCtrl: true, handler: () => {} }));
+    const e = dispatch({ key: "k", metaKey: true });
+    expect(e.defaultPrevented).toBe(true);
+  });
+
+  it("respects preventDefault: false", () => {
+    const reg = createHotkeyRegistry();
+    track(
+      reg.register({
+        key: "k",
+        cmdOrCtrl: true,
+        preventDefault: false,
+        handler: () => {},
+      }),
+    );
+    const e = dispatch({ key: "k", metaKey: true });
+    expect(e.defaultPrevented).toBe(false);
+  });
+});
+
+describe("HotkeyRegistry — lifecycle", () => {
+  it("disposer removes the binding", () => {
+    const reg = createHotkeyRegistry();
+    const h = vi.fn();
+    const dispose = reg.register({ key: "k", cmdOrCtrl: true, handler: h });
+    dispose();
+    dispatch({ key: "k", metaKey: true });
+    expect(h).not.toHaveBeenCalled();
+  });
+
+  it("attaches window listener lazily on first register and detaches after last dispose", () => {
+    const addSpy = vi.spyOn(window, "addEventListener");
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    const reg = createHotkeyRegistry();
+    expect(addSpy).not.toHaveBeenCalledWith("keydown", expect.any(Function));
+    const dispose = reg.register({ key: "k", cmdOrCtrl: true, handler: () => {} });
+    expect(addSpy).toHaveBeenCalledWith("keydown", expect.any(Function));
+    dispose();
+    expect(removeSpy).toHaveBeenCalledWith("keydown", expect.any(Function));
+    addSpy.mockRestore();
+    removeSpy.mockRestore();
+  });
+});
+
+describe("notInTextField", () => {
+  function eventFor(el: Element): KeyboardEvent {
+    const e = new KeyboardEvent("keydown", { key: "/" });
+    // KeyboardEvent.target is read-only without a dispatch; override for the test.
+    Object.defineProperty(e, "target", { value: el, configurable: true });
+    return e;
+  }
+
+  it("returns false for <input>", () => {
+    expect(notInTextField(eventFor(document.createElement("input")))).toBe(false);
+  });
+
+  it("returns false for <textarea>", () => {
+    expect(notInTextField(eventFor(document.createElement("textarea")))).toBe(
+      false,
+    );
+  });
+
+  it("returns false for <select>", () => {
+    expect(notInTextField(eventFor(document.createElement("select")))).toBe(false);
+  });
+
+  it("returns false for contenteditable elements", () => {
+    const div = document.createElement("div");
+    div.setAttribute("contenteditable", "true");
+    expect(notInTextField(eventFor(div))).toBe(false);
+  });
+
+  it("returns true for ordinary elements (div, button, body)", () => {
+    expect(notInTextField(eventFor(document.createElement("div")))).toBe(true);
+    expect(notInTextField(eventFor(document.createElement("button")))).toBe(true);
+    expect(notInTextField(eventFor(document.body))).toBe(true);
+  });
+});

--- a/packages/ui/src/lib/hotkeys.test.ts
+++ b/packages/ui/src/lib/hotkeys.test.ts
@@ -48,6 +48,39 @@ describe("HotkeyRegistry — stack ordering", () => {
     expect(a).toHaveBeenCalledOnce();
     expect(b).not.toHaveBeenCalled();
   });
+
+  it("walks past multiple disabled bindings to the first enabled match", () => {
+    const reg = createHotkeyRegistry();
+    const a = vi.fn();
+    const b = vi.fn();
+    const c = vi.fn();
+    track(reg.register({ key: "k", cmdOrCtrl: true, handler: a }));
+    track(reg.register({ key: "k", cmdOrCtrl: true, when: () => false, handler: b }));
+    track(reg.register({ key: "k", cmdOrCtrl: true, when: () => false, handler: c }));
+    dispatch({ key: "k", metaKey: true });
+    expect(a).toHaveBeenCalledOnce();
+    expect(b).not.toHaveBeenCalled();
+    expect(c).not.toHaveBeenCalled();
+  });
+
+  it("a throwing handler is consumed and does not break later dispatch", () => {
+    const reg = createHotkeyRegistry();
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const a = vi.fn(() => {
+      throw new Error("boom");
+    });
+    const b = vi.fn();
+    track(reg.register({ key: "k", cmdOrCtrl: true, handler: b }));
+    track(reg.register({ key: "k", cmdOrCtrl: true, handler: a }));
+    dispatch({ key: "k", metaKey: true });
+    // Top-of-stack handler threw and consumed the event — b never runs.
+    expect(a).toHaveBeenCalledOnce();
+    expect(b).not.toHaveBeenCalled();
+    // A subsequent event still dispatches.
+    dispatch({ key: "k", metaKey: true });
+    expect(a).toHaveBeenCalledTimes(2);
+    errSpy.mockRestore();
+  });
 });
 
 describe("HotkeyRegistry — modifier matching", () => {
@@ -168,6 +201,11 @@ describe("HotkeyRegistry — lifecycle", () => {
     expect(addSpy).toHaveBeenCalledWith("keydown", expect.any(Function));
     dispose();
     expect(removeSpy).toHaveBeenCalledWith("keydown", expect.any(Function));
+    // Re-registering after the listener detached must re-attach it — a
+    // detach that forgets to null `listener` would silently no-op here.
+    addSpy.mockClear();
+    track(reg.register({ key: "j", cmdOrCtrl: true, handler: () => {} }));
+    expect(addSpy).toHaveBeenCalledWith("keydown", expect.any(Function));
     addSpy.mockRestore();
     removeSpy.mockRestore();
   });

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -2,12 +2,9 @@ export { default as Badge } from "./badge.svelte";
 export { default as Button } from "./button.svelte";
 export { Collapsible } from "./collapsible/index.js";
 export { Dialog } from "./dialog/index.js";
-export {
-  createDragDropContext,
-  getDragDropContext,
-  setDragDropContext,
-} from "./drag-drop.svelte.js";
-export type { DragDropContext, DragDropHandler } from "./drag-drop.svelte.js";
+export { createDragDropState } from "./drag-drop.svelte.js";
+export type { DragDropState } from "./drag-drop.svelte.js";
+export { default as DragDropZone } from "./drag-drop-zone.svelte";
 export { DropdownMenu } from "./dropdown-menu/index.js";
 export { default as FormattedData } from "./formatted-data.svelte";
 export {

--- a/packages/ui/src/lib/index.ts
+++ b/packages/ui/src/lib/index.ts
@@ -2,8 +2,21 @@ export { default as Badge } from "./badge.svelte";
 export { default as Button } from "./button.svelte";
 export { Collapsible } from "./collapsible/index.js";
 export { Dialog } from "./dialog/index.js";
+export {
+  createDragDropContext,
+  getDragDropContext,
+  setDragDropContext,
+} from "./drag-drop.svelte.js";
+export type { DragDropContext, DragDropHandler } from "./drag-drop.svelte.js";
 export { DropdownMenu } from "./dropdown-menu/index.js";
 export { default as FormattedData } from "./formatted-data.svelte";
+export {
+  createHotkeyRegistry,
+  getHotkeyRegistry,
+  notInTextField,
+  setHotkeyRegistry,
+} from "./hotkeys.svelte.js";
+export type { HotkeyBinding, HotkeyRegistry } from "./hotkeys.svelte.js";
 export { IconLarge, IconSmall, Icons } from "./icons/index.js";
 export { default as JsonHighlight } from "./json-highlight.svelte";
 export { default as MarkdownRendered } from "./markdown/markdown-rendered.svelte";

--- a/tools/agent-playground/src/lib/components/agents/agent-catalog.svelte
+++ b/tools/agent-playground/src/lib/components/agents/agent-catalog.svelte
@@ -16,6 +16,7 @@
 -->
 
 <script lang="ts">
+  import { getHotkeyRegistry } from "@atlas/ui";
   import { goto } from "$app/navigation";
   import type { AgentMetadata } from "$lib/queries";
   import CatalogRow from "./catalog-row.svelte";
@@ -85,59 +86,68 @@
     }
   }
 
-  function handleKeydown(e: KeyboardEvent) {
-    // Cmd+I: focus search
-    if ((e.metaKey || e.ctrlKey) && e.key === "i") {
-      e.preventDefault();
+  // Catalog keyboard shortcuts. Arrow + Enter bindings deliberately
+  // run at window scope so the user can navigate the list from
+  // anywhere on the page; the search input's own onkeydown handles
+  // ArrowDown specifically (jumps from search into the list) and runs
+  // before this since element-scoped listeners precede window ones.
+  const hotkeys = getHotkeyRegistry();
+
+  $effect(() => hotkeys.register({
+    key: "i", cmdOrCtrl: true,
+    handler: () => {
       searchInput?.focus();
       searchInput?.select();
-      return;
-    }
+    },
+  }));
 
-    // Escape: clear search and reset focus
-    if (e.key === "Escape") {
-      e.preventDefault();
+  $effect(() => hotkeys.register({
+    key: "Escape",
+    handler: () => {
       searchQuery = "";
       focusedIndex = -1;
       searchInput?.blur();
-      return;
-    }
+    },
+  }));
 
-    // Arrow keys and Enter only apply when not typing in search
-    // (unless search is focused, arrows should still navigate)
-    if (e.key === "ArrowDown") {
-      e.preventDefault();
-      if (filteredAgents.length === 0) return;
-      focusRow(focusedIndex + 1);
-      return;
-    }
+  $effect(() => hotkeys.register({
+    key: "ArrowDown",
+    when: () => filteredAgents.length > 0,
+    handler: () => focusRow(focusedIndex + 1),
+  }));
 
-    if (e.key === "ArrowUp") {
-      e.preventDefault();
-      if (filteredAgents.length === 0) return;
+  $effect(() => hotkeys.register({
+    key: "ArrowUp",
+    when: () => filteredAgents.length > 0,
+    handler: () => {
       if (focusedIndex <= 0) {
         focusedIndex = -1;
         searchInput?.focus();
         return;
       }
       focusRow(focusedIndex - 1);
-      return;
-    }
+    },
+  }));
 
-    // Enter: toggle spec sheet on focused agent
-    // Cmd+Enter: navigate to workbench
-    if (e.key === "Enter" && focusedIndex >= 0 && focusedIndex < filteredAgents.length) {
-      e.preventDefault();
+  // Plain Enter toggles the focused agent's spec sheet.
+  $effect(() => hotkeys.register({
+    key: "Enter",
+    when: () => focusedIndex >= 0 && focusedIndex < filteredAgents.length,
+    handler: () => {
       const agent = filteredAgents[focusedIndex];
-      if (!agent) return;
-      if (e.metaKey || e.ctrlKey) {
-        navigate(agent.id);
-      } else {
-        toggleExpanded(agent.id);
-      }
-      return;
-    }
-  }
+      if (agent) toggleExpanded(agent.id);
+    },
+  }));
+
+  // Cmd/Ctrl+Enter opens the focused agent in the workbench.
+  $effect(() => hotkeys.register({
+    key: "Enter", cmdOrCtrl: true,
+    when: () => focusedIndex >= 0 && focusedIndex < filteredAgents.length,
+    handler: () => {
+      const agent = filteredAgents[focusedIndex];
+      if (agent) navigate(agent.id);
+    },
+  }));
 
   function handleSearchKeydown(e: KeyboardEvent) {
     if (e.key === "ArrowDown") {
@@ -170,8 +180,6 @@
     return `${bundledCount} bundled + ${userCount} user agents`;
   });
 </script>
-
-<svelte:window onkeydown={handleKeydown} />
 
 <div class="catalog">
   <header class="catalog-header">

--- a/tools/agent-playground/src/lib/components/chat/user-chat.svelte
+++ b/tools/agent-playground/src/lib/components/chat/user-chat.svelte
@@ -2,7 +2,7 @@
   import { untrack } from "svelte";
   import { Chat as ChatImpl } from "@ai-sdk/svelte";
   import type { AtlasUIMessage } from "@atlas/agent-sdk";
-  import { toast } from "@atlas/ui";
+  import { getDragDropContext, getHotkeyRegistry, toast } from "@atlas/ui";
   import { createQuery, useQueryClient } from "@tanstack/svelte-query";
   import { page } from "$app/state";
   import { browser } from "$app/environment";
@@ -50,30 +50,33 @@
   let inspectorOpen = $state(false);
   let fullscreen = $state(false);
 
-  function handleGlobalKeydown(e: KeyboardEvent) {
-    // Cmd+Shift+D (Debug) — Cmd+Shift+I is intercepted by Chrome DevTools
-    if ((e.metaKey || e.ctrlKey) && e.shiftKey && e.key === "d") {
-      e.preventDefault();
-      inspectorOpen = !inspectorOpen;
-      return;
-    }
-    // Ctrl+F toggles fullscreen — deliberately Ctrl, never ⌘, so Mac's
-    // ⌘+F find-in-page is untouched. Tradeoff: on Windows/Linux Ctrl+F
-    // *is* browser find, so it's shadowed inside the chat surface. This
-    // is a local dev tool and the in-app shortcut is the priority here;
-    // revisit if that becomes a real friction point.
-    if (e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey && e.key === "f") {
-      e.preventDefault();
-      fullscreen = !fullscreen;
-      return;
-    }
-    if (e.key === "Escape" && fullscreen) {
-      fullscreen = false;
-    }
-  }
+  const hotkeys = getHotkeyRegistry();
+  const dragDrop = getDragDropContext();
+
+  // Cmd/Ctrl+Shift+D toggles the debug inspector — Cmd+Shift+I is taken
+  // by Chrome DevTools.
+  $effect(() => hotkeys.register({
+    key: "d", cmdOrCtrl: true, shift: true,
+    handler: () => (inspectorOpen = !inspectorOpen),
+  }));
+
+  // Ctrl+F toggles fullscreen — deliberately Ctrl, never ⌘, so Mac's
+  // ⌘+F find-in-page is untouched. On Windows/Linux Ctrl+F *is* browser
+  // find, so it's shadowed inside the chat surface; this is a local dev
+  // tool and the in-app shortcut wins.
+  $effect(() => hotkeys.register({
+    key: "f", ctrl: true,
+    handler: () => (fullscreen = !fullscreen),
+  }));
+
+  $effect(() => hotkeys.register({
+    key: "Escape",
+    when: () => fullscreen,
+    handler: () => (fullscreen = false),
+  }));
+
   let systemPromptContext: { timestamp: string; systemMessages: string[] } | null = $state(null);
 
-  let chatDragOver = $state(false);
   /**
    * Attachments for the *next* outgoing message. Bound into `ChatInput`
    * via `bind:attachments` so the file picker and the chat-surface drop
@@ -114,40 +117,11 @@
     }
   }
 
-  function handleChatDrop(e: DragEvent) {
-    e.preventDefault();
-    chatDragOver = false;
-    if (e.dataTransfer?.files) {
-      void addDroppedFiles(e.dataTransfer.files);
-    }
-  }
+  $effect(() => dragDrop.register({
+    onFiles: (files) => void addDroppedFiles(files),
+  }));
 
-  // Safari requires preventDefault on BOTH dragenter and dragover to register
-  // the element as a valid drop target; without dragenter prevention it falls
-  // back to its default file-open behavior on drop.
-  function handleChatDragEnter(e: DragEvent) {
-    e.preventDefault();
-    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
-    chatDragOver = true;
-  }
-
-  function handleChatDragOver(e: DragEvent) {
-    e.preventDefault();
-    if (e.dataTransfer) e.dataTransfer.dropEffect = "copy";
-    chatDragOver = true;
-  }
-
-  function handleChatDragLeave(e: DragEvent) {
-    // Only dismiss if leaving the container (not entering a child)
-    if (
-      e.currentTarget instanceof HTMLElement &&
-      !e.currentTarget.contains(e.relatedTarget as Node)
-    ) {
-      chatDragOver = false;
-    }
-  }
-
-  async function addDroppedFiles(files: FileList) {
+  async function addDroppedFiles(files: readonly File[]) {
     const rejected: File[] = [];
     const duplicates: File[] = [];
     for (const file of files) {
@@ -1393,19 +1367,8 @@
   });
 </script>
 
-<svelte:window onkeydown={handleGlobalKeydown} />
-
-<div
-  class="user-chat"
-  class:chat-drag-over={chatDragOver}
-  class:fullscreen
-  ondrop={handleChatDrop}
-  ondragenter={handleChatDragEnter}
-  ondragover={handleChatDragOver}
-  ondragleave={handleChatDragLeave}
-  role="presentation"
->
-  {#if chatDragOver}
+<div class="user-chat" class:fullscreen>
+  {#if dragDrop.dragOver}
     <div class="drop-overlay">
       <span>Drop file here</span>
     </div>
@@ -1556,6 +1519,10 @@
     flex-direction: column;
     min-block-size: 0;
     overflow: hidden;
+    /* Containing block for the absolutely-positioned drop overlay below.
+       `.user-chat.fullscreen` overrides with position: fixed, which wins
+       on specificity. */
+    position: relative;
   }
 
   .rehydrating-indicator {
@@ -1680,10 +1647,6 @@
   }
 
   /* ─── Drag-drop overlay ────────────────────────────────────────────── */
-
-  .user-chat.chat-drag-over {
-    position: relative;
-  }
 
   .drop-overlay {
     align-items: center;

--- a/tools/agent-playground/src/lib/components/chat/user-chat.svelte
+++ b/tools/agent-playground/src/lib/components/chat/user-chat.svelte
@@ -2,7 +2,7 @@
   import { untrack } from "svelte";
   import { Chat as ChatImpl } from "@ai-sdk/svelte";
   import type { AtlasUIMessage } from "@atlas/agent-sdk";
-  import { getDragDropContext, getHotkeyRegistry, toast } from "@atlas/ui";
+  import { DragDropZone, getHotkeyRegistry, toast } from "@atlas/ui";
   import { createQuery, useQueryClient } from "@tanstack/svelte-query";
   import { page } from "$app/state";
   import { browser } from "$app/environment";
@@ -51,7 +51,6 @@
   let fullscreen = $state(false);
 
   const hotkeys = getHotkeyRegistry();
-  const dragDrop = getDragDropContext();
 
   // Cmd/Ctrl+Shift+D toggles the debug inspector — Cmd+Shift+I is taken
   // by Chrome DevTools.
@@ -116,10 +115,6 @@
       }
     }
   }
-
-  $effect(() => dragDrop.register({
-    onFiles: (files) => void addDroppedFiles(files),
-  }));
 
   async function addDroppedFiles(files: readonly File[]) {
     const rejected: File[] = [];
@@ -1367,12 +1362,14 @@
   });
 </script>
 
-<div class="user-chat" class:fullscreen>
-  {#if dragDrop.dragOver}
-    <div class="drop-overlay">
-      <span>Drop file here</span>
-    </div>
-  {/if}
+<DragDropZone onFiles={(files) => void addDroppedFiles(files)}>
+  {#snippet children({ dragOver })}
+    <div class="user-chat" class:fullscreen>
+      {#if dragOver}
+        <div class="drop-overlay">
+          <span>Drop file here</span>
+        </div>
+      {/if}
 
 
   {#if chat && chat.messages.length > 0}
@@ -1511,6 +1508,8 @@
     />
   </div>
 </div>
+  {/snippet}
+</DragDropZone>
 
 <style>
   .user-chat {

--- a/tools/agent-playground/src/lib/components/settings/model-picker.svelte
+++ b/tools/agent-playground/src/lib/components/settings/model-picker.svelte
@@ -17,6 +17,7 @@
   callback with a `ModelChoice | null` payload.
 -->
 <script lang="ts">
+  import { getHotkeyRegistry } from "@atlas/ui";
   import ProviderMark from "./provider-mark.svelte";
 
   interface Model {
@@ -92,15 +93,13 @@
     searchInput?.focus();
   });
 
-  // ESC closes the picker. Attached globally so focus doesn't need to be
-  // on the picker itself — anywhere inside it works.
-  $effect(() => {
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  });
+  // Escape closes the picker. Stack-registered globally so focus
+  // doesn't have to be inside the picker — anywhere on the page works.
+  const hotkeys = getHotkeyRegistry();
+  $effect(() => hotkeys.register({
+    key: "Escape",
+    handler: () => onClose(),
+  }));
 
   const activeProviderEntry = $derived(
     activeProvider ? (catalog.find((e) => e.provider === activeProvider) ?? null) : null,

--- a/tools/agent-playground/src/routes/+layout.svelte
+++ b/tools/agent-playground/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { notInTextField, NotificationPortal, setDragDropContext, setHotkeyRegistry } from "@atlas/ui";
+  import { notInTextField, NotificationPortal, setHotkeyRegistry } from "@atlas/ui";
   import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
   import { onMount } from "svelte";
   import { browser } from "$app/environment";
@@ -23,7 +23,6 @@
   const { children } = $props();
 
   const hotkeys = setHotkeyRegistry();
-  setDragDropContext();
 
   // Routes that opt out of the playground app shell (sidebar, palette, etc.)
   // and render their children directly. Two consumers today:

--- a/tools/agent-playground/src/routes/+layout.svelte
+++ b/tools/agent-playground/src/routes/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { NotificationPortal } from "@atlas/ui";
+  import { notInTextField, NotificationPortal, setDragDropContext, setHotkeyRegistry } from "@atlas/ui";
   import { QueryClient, QueryClientProvider } from "@tanstack/svelte-query";
   import { onMount } from "svelte";
   import { browser } from "$app/environment";
@@ -21,6 +21,9 @@
   import { loadUpdateStatus } from "$lib/update-status.svelte";
 
   const { children } = $props();
+
+  const hotkeys = setHotkeyRegistry();
+  setDragDropContext();
 
   // Routes that opt out of the playground app shell (sidebar, palette, etc.)
   // and render their children directly. Two consumers today:
@@ -81,39 +84,40 @@
   let paletteOpen = $state(false);
   let paletteMode = $state<"chat" | "switcher">("chat");
 
-  /**
-   * Bare `/` opens chat mode. Cmd/Ctrl+/ opens switcher mode.
-   * Bare `/` is suppressed while typing in inputs/textareas/contenteditables;
-   * the modified form is allowed to fire from anywhere.
-   */
-  function handleGlobalKeydown(e: KeyboardEvent) {
-    const t = e.target as HTMLElement | null;
-    if (e.key.toLowerCase() === "k" && (e.metaKey || e.ctrlKey) && !e.altKey && !e.shiftKey) {
-      e.preventDefault();
+  // ⌘K / Ctrl+K opens the chat palette. Allowed everywhere — the
+  // command palette is a high-priority surface and we want it
+  // reachable from any focus state.
+  $effect(() => hotkeys.register({
+    key: "k", cmdOrCtrl: true,
+    handler: () => {
       paletteMode = "chat";
       paletteOpen = true;
-      return;
-    }
-    if (e.key === "/" && (e.metaKey || e.ctrlKey) && !e.altKey) {
-      // Cmd/Ctrl+/ is a default keymap inside code editors (e.g., CodeMirror toggle-comment).
-      if (t?.isContentEditable) return;
-      e.preventDefault();
+    },
+  }));
+
+  // ⌘/ / Ctrl+/ opens the workspace switcher palette. Suppressed only
+  // inside contentEditable surfaces — Cmd+/ is the default
+  // toggle-comment keymap in CodeMirror and we don't want to steal it.
+  $effect(() => hotkeys.register({
+    key: "/", cmdOrCtrl: true,
+    when: (e) => !(e.target instanceof HTMLElement && e.target.isContentEditable),
+    handler: () => {
       paletteMode = "switcher";
       paletteOpen = true;
-      return;
-    }
-    if (e.key !== "/" || e.metaKey || e.ctrlKey || e.altKey) return;
-    if (t) {
-      const tag = t.tagName;
-      if (tag === "INPUT" || tag === "TEXTAREA" || t.isContentEditable) return;
-    }
-    e.preventDefault();
-    paletteMode = "chat";
-    paletteOpen = true;
-  }
-</script>
+    },
+  }));
 
-<svelte:window onkeydown={handleGlobalKeydown} />
+  // Bare `/` opens the chat palette. Suppressed while typing in any
+  // text field — otherwise you couldn't type `/` into a message.
+  $effect(() => hotkeys.register({
+    key: "/",
+    when: notInTextField,
+    handler: () => {
+      paletteMode = "chat";
+      paletteOpen = true;
+    },
+  }));
+</script>
 
 <svelte:head>
   <title>Friday Studio</title>

--- a/tools/agent-playground/src/routes/inspector/+page.svelte
+++ b/tools/agent-playground/src/routes/inspector/+page.svelte
@@ -18,7 +18,7 @@
   import { deriveSignalDetails, type SignalDetail } from "@atlas/config/signal-details";
   import { deriveTopology } from "@atlas/config/topology";
   import type { AgentBlock } from "@atlas/core/session/session-events";
-  import { Dialog, DropdownMenu, IconSmall } from "@atlas/ui";
+  import { Dialog, DropdownMenu, getHotkeyRegistry, IconSmall, notInTextField } from "@atlas/ui";
   import { createQuery, useQueryClient } from "@tanstack/svelte-query";
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
@@ -352,24 +352,15 @@
     goto(url.toString(), { replaceState: true });
   }
 
-  function handleKeydown(e: KeyboardEvent) {
-    // Skip when focus is in an input/textarea/contenteditable
-    const target = e.target;
-    if (target instanceof HTMLInputElement) return;
-    if (target instanceof HTMLTextAreaElement) return;
-    if (target instanceof HTMLSelectElement) return;
-    if (target instanceof HTMLElement && target.isContentEditable) return;
-
-    // Escape: close inspection panel
-    if (e.key === "Escape" && selectedBlock) {
-      e.preventDefault();
-      selectStep(null);
-      return;
-    }
-  }
+  // Escape closes the inspection panel when one is open and the user
+  // isn't typing in a text field.
+  const hotkeys = getHotkeyRegistry();
+  $effect(() => hotkeys.register({
+    key: "Escape",
+    when: (e) => notInTextField(e) && selectedBlock !== null,
+    handler: () => selectStep(null),
+  }));
 </script>
-
-<svelte:window onkeydown={handleKeydown} />
 
 <div class="inspector">
   <!-- Zone 1: Toolbar (hidden when picker is showing) -->

--- a/tools/agent-playground/src/routes/memory/[workspaceId]/[memoryName]/+page.svelte
+++ b/tools/agent-playground/src/routes/memory/[workspaceId]/[memoryName]/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { getHotkeyRegistry, notInTextField } from "@atlas/ui";
   import { createQuery } from "@tanstack/svelte-query";
   import { page } from "$app/state";
   import MemoryEntryTable from "$lib/components/MemoryEntryTable.svelte";
@@ -55,21 +56,16 @@
   const isFetchingEntries = $derived(entriesQuery.isFetching);
   const entriesError = $derived(entriesQuery.error);
 
-  function handleKeydown(e: KeyboardEvent) {
-    const target = e.target;
-    if (target instanceof HTMLInputElement) return;
-    if (target instanceof HTMLTextAreaElement) return;
-    if (target instanceof HTMLSelectElement) return;
-    if (target instanceof HTMLElement && target.isContentEditable) return;
-
-    if (e.key === "r" || e.key === "R") {
-      e.preventDefault();
-      entriesQuery.refetch();
-    }
-  }
+  // `r` refetches narrative entries — suppressed when typing in a text
+  // field. The single-char matcher is case-insensitive so capslock
+  // still works; Shift+R is rejected (shift must NOT be pressed).
+  const hotkeys = getHotkeyRegistry();
+  $effect(() => hotkeys.register({
+    key: "r",
+    when: notInTextField,
+    handler: () => entriesQuery.refetch(),
+  }));
 </script>
-
-<svelte:window onkeydown={handleKeydown} />
 
 <div class="memory-detail">
   <header class="page-header">

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/+layout.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/+layout.svelte
@@ -3,7 +3,7 @@
   import { humanizeStepName } from "@atlas/config/pipeline-utils";
   import { deriveTopology } from "@atlas/config/topology";
   import { deriveWorkspaceAgents } from "@atlas/config/workspace-agents";
-  import { PageLayout } from "@atlas/ui";
+  import { getHotkeyRegistry, PageLayout } from "@atlas/ui";
   import { createQuery } from "@tanstack/svelte-query";
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
@@ -131,16 +131,14 @@
     goto(`/platform/${workspaceId}/skills?addSkill=true`);
   }
 
-  /** Escape key returns to idle sidebar. */
-  function handleKeydown(e: KeyboardEvent) {
-    if (e.key === "Escape" && workspaceId && (selectedNode || selectedWorkspaceAgent)) {
-      goto(`/platform/${workspaceId}`);
-    }
-  }
+  // Escape returns to the idle sidebar when a node/agent is selected.
+  const hotkeys = getHotkeyRegistry();
+  $effect(() => hotkeys.register({
+    key: "Escape",
+    when: () => Boolean(workspaceId && (selectedNode || selectedWorkspaceAgent)),
+    handler: () => goto(`/platform/${workspaceId}`),
+  }));
 </script>
-
-<!-- svelte-ignore a11y_no_static_element_interactions -->
-<svelte:window onkeydown={handleKeydown} />
 
 <PageLayout.Root>
   {@render children?.()}

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/chat/[[chatId]]/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/chat/[[chatId]]/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { Button, ListDetail } from "@atlas/ui";
+  import { Button, getHotkeyRegistry, ListDetail } from "@atlas/ui";
   import { goto } from "$app/navigation";
   import { browser } from "$app/environment";
   import { page } from "$app/state";
@@ -36,14 +36,13 @@
     }
   });
 
-  function handleGlobalKeydown(e: KeyboardEvent) {
-    // Ctrl+B — hide / reveal the chat list sidebar. Cmd+B is reserved
-    // for Mac browser's bookmarks bar so we don't intercept it.
-    if (e.ctrlKey && !e.metaKey && !e.shiftKey && !e.altKey && e.key === "b") {
-      e.preventDefault();
-      sidebarCollapsed = !sidebarCollapsed;
-    }
-  }
+  // Ctrl+B — hide / reveal the chat list sidebar. Deliberately Ctrl
+  // only, never ⌘, so Mac's ⌘+B (bookmarks bar) is untouched.
+  const hotkeys = getHotkeyRegistry();
+  $effect(() => hotkeys.register({
+    key: "b", ctrl: true,
+    handler: () => (sidebarCollapsed = !sidebarCollapsed),
+  }));
 
   function handleSelectChat(chatId: string) {
     if (chatId === data.chatId) return;
@@ -60,8 +59,6 @@
     goto(`/platform/${encodeURIComponent(workspaceId)}/chat`);
   }
 </script>
-
-<svelte:window onkeydown={handleGlobalKeydown} />
 
 {#key workspaceId}
   <ListDetail bind:sidebarCollapsed>

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/jobs/[jobName]/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/jobs/[jobName]/+page.svelte
@@ -15,7 +15,7 @@
 -->
 
 <script lang="ts">
-  import { markdownToHTMLSafe, toast } from "@atlas/ui";
+  import { getHotkeyRegistry, markdownToHTMLSafe, notInTextField, toast } from "@atlas/ui";
   import { createQuery, queryOptions, skipToken } from "@tanstack/svelte-query";
   import { page } from "$app/state";
   import WorkspaceBreadcrumb from "$lib/components/workspace/workspace-breadcrumb.svelte";
@@ -219,21 +219,21 @@
     }
   }
 
-  $effect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape" && selected) {
-        selected = null;
-        return;
-      }
-      if (e.key !== "/") return;
-      const tag = (document.activeElement as HTMLElement | null)?.tagName;
-      if (tag === "INPUT" || tag === "TEXTAREA") return;
-      e.preventDefault();
-      visibleSearchEl?.focus();
-    }
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  });
+  // Escape clears the selected skill detail; `/` focuses the visible-skills
+  // search input (suppressed in any text field so typing `/` works).
+  const hotkeys = getHotkeyRegistry();
+
+  $effect(() => hotkeys.register({
+    key: "Escape",
+    when: () => selected !== null,
+    handler: () => (selected = null),
+  }));
+
+  $effect(() => hotkeys.register({
+    key: "/",
+    when: notInTextField,
+    handler: () => visibleSearchEl?.focus(),
+  }));
 
   async function attach(skill: SkillRow) {
     if (!workspaceId || !jobName) return;


### PR DESCRIPTION
## Summary
- Adds `HotkeyRegistry` and `DragDropContext` to `@atlas/ui` — generic, lifecycle-gated, stack-based.
- Migrates the playground's chat hotkeys + chat drag-drop out of `user-chat.svelte` (~95 lines off the file).
- Migrates 11 more keydown handlers across 7 files to the shared registry; removes 6 `<svelte:window onkeydown>` listeners and 2 ad-hoc `window.addEventListener("keydown")` effects.

## Behavior

**`HotkeyRegistry`** — single window-level `keydown` listener. Stack-based dispatch (top of stack wins; falls through when `when()` returns false). Modifier matching: `cmdOrCtrl` (⌘ on Mac, Ctrl elsewhere), `ctrl` (strict, never ⌘), `meta` (strict ⌘). Single-character keys match case-insensitively so a Shift+D binding declared as `key: "d"` actually fires. Listener attaches lazily and detaches when the last binding is disposed.

**`DragDropContext`** — body-level `dragenter`/`over`/`leave`/`drop`. Lifecycle-gated: route components register in a `\$effect`, unmounting disposes — no path matching. Counter-based nesting (no overlay flicker on child dragenter/leave). Files-only (`dataTransfer.types` includes `"Files"`). Filtering, accept rules, and uploads stay at the call site.

## Side effect

The chat inspector hotkey (**⌘/Ctrl+Shift+D**) now works. The previous handler compared `e.key === "d"`, which fails when Shift produces \`"D"\` — the registry's matcher lowercases single-char keys.

## Test plan
- [ ] Chat: **Ctrl+F** toggles fullscreen; **⌘F** on Mac still opens browser find
- [ ] Chat: **⌘/Ctrl+Shift+D** toggles inspector
- [ ] Chat: **Esc** exits fullscreen only when in fullscreen
- [ ] Chat: drag a file over the chat → overlay appears, drop → upload starts
- [ ] Chat: drag/drop overlay doesn't flicker when dragging across child elements
- [ ] Navigate off chat route → drag/drop no longer responds
- [ ] Command palette: **⌘K** and **⌘/** work anywhere; bare **/** works outside text fields, suppressed inside inputs/textareas/contentEditable
- [ ] **⌘/** inside CodeMirror does NOT open palette (toggle-comment still works)
- [ ] Workspace: **Esc** returns to idle from agents/jobs/signals; does nothing on overview
- [ ] Chat route: **Ctrl+B** toggles chat-list sidebar; state persists across reload; **⌘B** on Mac still opens browser bookmarks bar
- [ ] Memory page: **r** refetches; suppressed when typing in any text field
- [ ] Inspector: **Esc** closes a selected block; does nothing otherwise
- [ ] Jobs detail: **Esc** clears selected skill; **/** focuses search (suppressed in text fields)
- [ ] Model picker: **Esc** closes the picker (intentionally fires even inside the search input)
- [ ] Stack ordering: with model picker open over inspector with a selected block — first Esc closes picker, second Esc closes block panel
- [ ] Regressions: Alt-held chat timestamps still expand to full date; chat tool-call menus still close on Esc; command-palette inputs still handle ⌘P / ⌘/ / ⌘K locally; agent-workbench textarea ⌘+Enter still submits