### PR TITLE
fix(jetstream): de-flake connect.test.ts URL-file rendezvous tests

### DIFF
--- a/packages/jetstream/src/connect.test.ts
+++ b/packages/jetstream/src/connect.test.ts
@@ -21,17 +21,22 @@ import process from "node:process";
 import type { Logger } from "@atlas/logger";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { connectOrSpawn } from "./connect.ts";
-import { brokerUrlFilePath, pickPort, spawnNatsServer } from "./spawn.ts";
+import { brokerUrlFilePath, spawnNatsServer } from "./spawn.ts";
 
 /**
- * Pick a port the OS just told us is free, then immediately release it.
- * Tiny TOCTOU window where some other process could grab it, but for
- * "nothing should be listening here" assertions this is dramatically
- * more reliable than hardcoding 65530-ish (inside macOS's ephemeral
- * range, where a parallel test or background process can legitimately
- * be assigned the same port).
+ * OS-assigned free port via `listen(0)`. Drawn from the kernel's
+ * ephemeral range — NOT the 10-slot Friday-reserved range used by
+ * `pickPort` in spawn.ts. The reserved range is concurrently claimed
+ * by the CI workflow's pre-launched daemon, daemon-startup tests, and
+ * nats-manager tests; using it here led to a flake where a just-stopped
+ * broker's port was probed against a sibling worker's half-spawned
+ * nats-server (or its own half-torn listening socket).
+ *
+ * Tiny TOCTOU window between close and the caller's bind — fine for
+ * both "spawn a broker here" (spawnNatsServer surfaces the conflict)
+ * and "assert nothing is listening here" patterns.
  */
-function pickDeadPort(): Promise<number> {
+function pickFreePort(): Promise<number> {
   return new Promise((resolve, reject) => {
     const srv = createServer();
     srv.unref();
@@ -42,10 +47,41 @@ function pickDeadPort(): Promise<number> {
         const port = addr.port;
         srv.close(() => resolve(port));
       } else {
-        srv.close(() => reject(new Error("could not resolve dead port")));
+        srv.close(() => reject(new Error("could not resolve free port")));
       }
     });
   });
+}
+
+/** Local copy of spawn.ts's private `tryBind` — used by waitUntilBindable. */
+function tryBind(port: number, host: string = "127.0.0.1"): Promise<boolean> {
+  return new Promise((resolve) => {
+    const srv = createServer();
+    srv.unref();
+    srv.once("error", () => resolve(false));
+    srv.once("listening", () => srv.close(() => resolve(true)));
+    srv.listen(port, host);
+  });
+}
+
+/**
+ * Spin until `port` is re-bindable. After `dead.stop()` the kernel can
+ * leave the listening socket half-torn for a few ms; tcpProbe() against
+ * it falsely reports "alive" and connectOrSpawn takes the reuse branch,
+ * then the real NATS handshake fails with CONNECTION_REFUSED. Waiting
+ * for tryBind to succeed before the test continues closes that window.
+ */
+async function waitUntilBindable(
+  port: number,
+  host: string = "127.0.0.1",
+  timeoutMs: number = 2_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await tryBind(port, host)) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error(`port ${port} did not become bindable within ${timeoutMs}ms`);
 }
 
 const noopLogger: Logger = {
@@ -81,7 +117,11 @@ describe("connectOrSpawn — URL-file rendezvous (source: url-file)", () => {
     // as if a sibling daemon had done so. connectOrSpawn must reuse it
     // (no second spawn against the same store dir — that would file-lock
     // conflict).
-    const broker = await spawnNatsServer({ port: await pickPort(), storeDir, logger: noopLogger });
+    const broker = await spawnNatsServer({
+      port: await pickFreePort(),
+      storeDir,
+      logger: noopLogger,
+    });
     try {
       await writeFile(brokerUrlFilePath(home), broker.url, "utf-8");
 
@@ -107,9 +147,14 @@ describe("connectOrSpawn — URL-file rendezvous (source: url-file)", () => {
     // Spawn + stop a broker, then write its now-dead URL to the file.
     // connectOrSpawn must detect the stale URL (TCP probe fails) and
     // spawn a fresh broker. spawnFallback defaults to true.
-    const dead = await spawnNatsServer({ port: await pickPort(), storeDir, logger: noopLogger });
+    const port = await pickFreePort();
+    const dead = await spawnNatsServer({ port, storeDir, logger: noopLogger });
     const deadUrl = dead.url;
     await dead.stop();
+    // Confirm the kernel has fully released the listening socket before
+    // we hand the URL to connectOrSpawn — otherwise its tcpProbe can
+    // race the teardown and falsely conclude the broker is still alive.
+    await waitUntilBindable(port);
     await writeFile(brokerUrlFilePath(home), deadUrl, "utf-8");
 
     const handle = await connectOrSpawn({ home, storeDir, logger: noopLogger });
@@ -133,9 +178,11 @@ describe("connectOrSpawn — spawnFallback=false honors the no-spawn contract", 
     // would silently spawn even with spawnFallback=false because the
     // source-tracking refactor moved the spawnFallback check into one
     // source branch.
-    const dead = await spawnNatsServer({ port: await pickPort(), storeDir, logger: noopLogger });
+    const port = await pickFreePort();
+    const dead = await spawnNatsServer({ port, storeDir, logger: noopLogger });
     const deadUrl = dead.url;
     await dead.stop();
+    await waitUntilBindable(port);
     await writeFile(brokerUrlFilePath(home), deadUrl, "utf-8");
 
     await expect(
@@ -154,9 +201,9 @@ describe("connectOrSpawn — spawnFallback=false honors the no-spawn contract", 
 
   it("throws when explicit URL fails to connect and spawnFallback=false", async () => {
     // Direct connect fails; spawnFallback=false means no fallback. The
-    // port comes from pickDeadPort() so we know nothing else can have
+    // port comes from pickFreePort() so we know nothing else can have
     // been assigned to it by the kernel in parallel.
-    const deadPort = await pickDeadPort();
+    const deadPort = await pickFreePort();
     await expect(
       connectOrSpawn({
         url: `nats://127.0.0.1:${deadPort}`,
@@ -172,7 +219,7 @@ describe("connectOrSpawn — spawnFallback=false honors the no-spawn contract", 
     // FRIDAY_NATS_URL is the operator's explicit declaration of an
     // external broker. If it fails, spawning silently would shadow the
     // operator's intent — throw even with spawnFallback=true.
-    const deadPort = await pickDeadPort();
+    const deadPort = await pickFreePort();
     process.env.FRIDAY_NATS_URL = `nats://127.0.0.1:${deadPort}`;
     try {
       await expect(


### PR DESCRIPTION
## Summary

Stop `packages/jetstream/src/connect.test.ts` from racing on the Friday-reserved NATS port range. Three spawn-broker call sites now use OS-assigned ephemeral ports; the two "spawn → stop → write dead URL → connectOrSpawn" tests wait for the kernel to actually release the listening socket before treating it as dead.

## When this started appearing

The flake has been hitting `main` since the day after the test was introduced. Most occurrences were masked by re-runs or "fixed forward" by the next merge happening to pass.

Documented `main`-branch failures, all with the same `connectOrSpawn — URL-file rendezvous (source: url-file) > falls through to spawn when the URL file points at a dead broker` signature:

| Run | Date (UTC) | Commit | Landed after | Failure |
|---|---|---|---|---|
| [25812681891](https://github.com/friday-platform/friday-studio/actions/runs/25812681891) | 2026-05-13 | `adf4084` | PR #300 | `NatsError: CONNECTION_REFUSED` |
| [25833618117](https://github.com/friday-platform/friday-studio/actions/runs/25833618117) | 2026-05-14 | `f26591c` | PR #310 | `Test timed out in 5000ms` |
| [25845363572](https://github.com/friday-platform/friday-studio/actions/runs/25845363572) | 2026-05-14 | `a8d5b6a` | PR #292 | `NatsError: CONNECTION_REFUSED` |
| [25880698515](https://github.com/friday-platform/friday-studio/actions/runs/25880698515) | 2026-05-14 | `b93c614` | agent-runtime undici-timeout PR | `NatsError: CONNECTION_REFUSED` |
| [26406937379](https://github.com/friday-platform/friday-studio/actions/runs/26406937379) | 2026-05-25 | `d5b3d8e` | PR #421 | `NatsError: CONNECTION_REFUSED` (re-run went green) |

Five `main`-branch failures since 2026-05-13. Four were never re-run — they stayed red on `main` and were unblocked by the next merge happening to pass. Only today's was re-run-to-green.

PR branches have been bleeding too: spot-checked example [run 26409174367](https://github.com/friday-platform/friday-studio/actions/runs/26409174367) is `attempt:2` failure on PR #422 (today, 2026-05-25), meaning even the first re-run wasn't enough to clear it.

Prior touch points on this test file:
- **PR #296 (2026-05-12)** — introduced the test.
- **PR #315 (2026-05-14)** — bumped the test's timeout from 5s → 20s after the test had already failed on its own CI. That dropped the `Test timed out` failure mode but didn't address `CONNECTION_REFUSED`, which kept firing.

Locally the test passes 5/5 in isolation in ~1s. Repro requires the CI concurrency profile.

## Diagnosis

`pickPort()` in `packages/jetstream/src/spawn.ts:193` iterates `FRIDAY_NATS_PORT_BASE..+RANGE-1` → 10 ports (14222–14231). That same range is concurrently drawn from by:

- the CI workflow's pre-launched daemon (`.github/workflows/test.yml:58` → `apps/atlasd/src/nats-manager.ts:98`)
- `apps/atlasd/daemon-startup.test.ts`
- `apps/atlasd/src/nats-manager.test.ts`
- `apps/atlas-cli/src/commands/migrate-handler.test.ts`
- `packages/jetstream/src/connect.test.ts` itself

In the failing test:

1. Spawn nats-server on `pickPort()` → port X.
2. `dead.stop()` — SIGTERM, wait for exit.
3. Write `nats://127.0.0.1:X` to the rendezvous file.
4. Call `connectOrSpawn` → reads file → `tcpProbe(X)`.

Between (2) and (4), the kernel can leave the listening socket half-torn for a brief window. A `tcpProbe` SYN succeeds against that lingering socket → `connectOrSpawn` takes the **reuse** branch → real NATS handshake → `CONNECTION_REFUSED`. The symptom (`CONNECTION_REFUSED`, not a connect timeout) is the tell that we hit a half-closed socket — not a fresh-spawn race.

PR #315's 5s → 20s timeout bump was treating the timeout symptom in isolation; this PR addresses both failure modes by closing the port-contention + half-closed-socket window.

## Fix

Single file: `packages/jetstream/src/connect.test.ts`.

- **Switch test broker spawns to OS-assigned ephemeral ports.** Renamed the file's existing `pickDeadPort` → `pickFreePort`, broadened its docstring, and used it for the three sites that previously called `pickPort`. The OS ephemeral range (typically 49152+) is enormous compared to Friday's 10-slot reserved range, eliminating contention with concurrent vitest workers and the CI-pre-launched daemon.
- **Wait for the kernel to actually release the port.** New `waitUntilBindable(port)` polls `tryBind` every 25ms until the bind succeeds, with a 2s ceiling so a genuinely stuck port surfaces loudly rather than silently. Called after `dead.stop()` in both the `spawnFallback=true` and `spawnFallback=false` "dead URL" tests, before any code that relies on the port being unbindable.

No production code changes. The Friday-reserved range still exists for production daemons that want a predictable port — tests just don't need that property. Production port-picking semantics remain covered by `apps/atlasd/daemon-startup.test.ts` and `apps/atlasd/src/nats-manager.test.ts`.

## Test plan

- [x] `deno task test packages/jetstream/src/connect.test.ts` × 5 — 7/7 pass each run, ~1s.
- [x] `deno check packages/jetstream/src/connect.test.ts` — clean.
- [x] `deno lint packages/jetstream/src/connect.test.ts` — clean.
- [x] `deno run -A npm:@biomejs/biome check packages/jetstream/src/connect.test.ts` — clean.
- [x] CI green on this branch.
