### PR TITLE
feat(llm): local OpenAI-compatible provider (LM Studio / Ollama / vLLM)

### DIFF
--- a/packages/llm/src/local.test.ts
+++ b/packages/llm/src/local.test.ts
@@ -1,0 +1,51 @@
+import process from "node:process";
+import { afterEach, describe, expect, it } from "vitest";
+import { createLocalWithOptions } from "./local.ts";
+
+/**
+ * Smoke test for the constructor — purely shape-level. The actual HTTP
+ * traffic isn't exercised here (no MockAgent / no real server); we rely on
+ * `@ai-sdk/openai` (a third-party SDK) to honor the `baseURL` we pass.
+ * Matches the repo precedent: `openrouter.ts` ships with zero tests.
+ */
+describe("createLocalWithOptions", () => {
+  const envBackup: Record<string, string | undefined> = {};
+  function withEnv(vars: Record<string, string | undefined>) {
+    for (const k of Object.keys(vars)) {
+      envBackup[k] = process.env[k];
+      if (vars[k] === undefined) delete process.env[k];
+      else process.env[k] = vars[k];
+    }
+  }
+  afterEach(() => {
+    for (const k of Object.keys(envBackup)) {
+      if (envBackup[k] === undefined) delete process.env[k];
+      else process.env[k] = envBackup[k];
+    }
+    for (const k of Object.keys(envBackup)) delete envBackup[k];
+  });
+
+  it("returns a provider when explicit options are passed", () => {
+    const provider = createLocalWithOptions({
+      baseURL: "http://localhost:1234/v1",
+      apiKey: "test",
+    });
+    // The provider is a callable function that also exposes `.chat()`.
+    expect(typeof provider.chat).toBe("function");
+    expect(typeof provider.languageModel).toBe("function");
+  });
+
+  it("reads baseURL and apiKey from env vars when options are omitted", () => {
+    withEnv({ LOCAL_BASE_URL: "http://localhost:11434/v1", LOCAL_API_KEY: "ollama" });
+    const provider = createLocalWithOptions();
+    expect(typeof provider.chat).toBe("function");
+  });
+
+  it("does not throw when LOCAL_BASE_URL is unset (falls back to LM Studio default)", () => {
+    withEnv({ LOCAL_BASE_URL: undefined, LOCAL_API_KEY: undefined });
+    // Construction must not throw — the registry instantiates this provider
+    // eagerly even for users who never use it. Credential gating elsewhere
+    // ensures it's only *invoked* when LOCAL_BASE_URL is set.
+    expect(() => createLocalWithOptions()).not.toThrow();
+  });
+});

--- a/packages/llm/src/local.ts
+++ b/packages/llm/src/local.ts
@@ -1,0 +1,46 @@
+import process from "node:process";
+import { createOpenAI, type OpenAIProvider, type OpenAIProviderSettings } from "@ai-sdk/openai";
+import { createProxyFetch, PROVIDER_ENV_VARS } from "./util.ts";
+
+/**
+ * Configuration options for creating a local OpenAI-compatible client.
+ *
+ * Targets self-hosted runtimes that speak OpenAI's Chat Completions API
+ * — LM Studio (`http://localhost:1234/v1`), Ollama
+ * (`http://localhost:11434/v1`), vLLM, llama.cpp's server, and anything
+ * else that mirrors the same shape.
+ */
+interface LocalOptions {
+  /** Base URL for the local server. Defaults to LOCAL_BASE_URL env var, then to LM Studio's default port. */
+  baseURL?: string;
+  /** API key. Most local servers ignore it; defaults to LOCAL_API_KEY env var, then to a dummy string. */
+  apiKey?: string;
+  /** HTTP proxy URL. Defaults to LOCAL_PROXY_URL env var. */
+  httpProxy?: string;
+}
+
+/**
+ * Creates a client for a local OpenAI-compatible LLM server.
+ *
+ * `LOCAL_BASE_URL` is what unlocks this provider — see
+ * `hasCredential` in `platform-models.ts` and `resolveCredential` in
+ * `model-catalog.ts`. The constructor itself falls back to LM Studio's
+ * default port so a stray invocation surfaces a connection error against
+ * a plausible address rather than something cryptic.
+ *
+ * `apiKey` defaults to the literal string `"local"` because most local
+ * servers ignore auth entirely, but `@ai-sdk/openai` requires a non-empty
+ * string and 401s if you pass `undefined`.
+ */
+export function createLocalWithOptions(opts: LocalOptions = {}): OpenAIProvider {
+  const httpProxy = opts.httpProxy || process.env.LOCAL_PROXY_URL;
+
+  const localOptions: OpenAIProviderSettings = {
+    apiKey: opts.apiKey || process.env[PROVIDER_ENV_VARS.local] || "local",
+    baseURL: opts.baseURL || process.env.LOCAL_BASE_URL || "http://localhost:1234/v1",
+  };
+  if (httpProxy) {
+    localOptions.fetch = createProxyFetch(httpProxy);
+  }
+  return createOpenAI(localOptions);
+}

--- a/packages/llm/src/model-catalog.test.ts
+++ b/packages/llm/src/model-catalog.test.ts
@@ -81,6 +81,7 @@ beforeEach(() => {
     GEMINI_API_KEY: undefined,
     GROQ_API_KEY: undefined,
     LITELLM_API_KEY: undefined,
+    LOCAL_BASE_URL: undefined,
   });
 });
 
@@ -145,12 +146,16 @@ describe("model-catalog — credential resolution", () => {
     });
   });
 
-  it("unlocks every provider when LITELLM_API_KEY is set (proxy mode)", async () => {
+  it("unlocks every proxyable provider when LITELLM_API_KEY is set (proxy mode)", async () => {
     stubEnv({ LITELLM_API_KEY: "sk-litellm" });
     vi.stubGlobal("fetch", mockJsonFetch({ [GATEWAY_URL]: { models: [] } }));
 
     const catalog = await getCatalog();
     for (const entry of catalog.entries) {
+      // `local` is the deliberate exception — a remote LiteLLM proxy
+      // can't satisfy a localhost endpoint. Covered separately in the
+      // "local provider" describe block.
+      if (entry.provider === "local") continue;
       expect(entry.credentialConfigured).toBe(true);
       // When LiteLLM covers everything there's nothing actionable to add.
       expect(entry.credentialEnvVar).toBeNull();
@@ -214,6 +219,114 @@ describe("model-catalog — groq direct fetch", () => {
     expect(groq.credentialConfigured).toBe(true); // key IS set, fetch just failed
     // Other providers still resolved normally.
     expect(find(catalog, "anthropic").error).toBeUndefined();
+  });
+});
+
+describe("model-catalog — local provider", () => {
+  // LM Studio, Ollama, vLLM, and llama.cpp all return this exact OpenAI-
+  // standard `/v1/models` shape. Use a representative sample of each.
+  function localListResponse(ids: string[]): Record<string, unknown> {
+    return { data: ids.map((id) => ({ id, object: "model" })) };
+  }
+
+  it("fetches models from a local server when LOCAL_BASE_URL is set", async () => {
+    stubEnv({ LOCAL_BASE_URL: "http://localhost:1234/v1" });
+    const lmStudio = localListResponse([
+      "llama-3.2-3b-instruct",
+      "qwen2.5-coder-7b-instruct",
+    ]);
+    vi.stubGlobal(
+      "fetch",
+      mockJsonFetch({
+        [GATEWAY_URL]: { models: [] },
+        "http://localhost:1234/v1/models": lmStudio,
+      }),
+    );
+
+    const catalog = await getCatalog();
+    const entry = find(catalog, "local");
+    expect(entry.credentialConfigured).toBe(true);
+    expect(entry.credentialEnvVar).toBe("LOCAL_BASE_URL");
+    expect(entry.models.map((m) => m.id)).toEqual([
+      "llama-3.2-3b-instruct",
+      "qwen2.5-coder-7b-instruct",
+    ]);
+    expect(entry.error).toBeUndefined();
+  });
+
+  it("normalizes a trailing slash on LOCAL_BASE_URL when building the /models URL", async () => {
+    stubEnv({ LOCAL_BASE_URL: "http://localhost:11434/v1/" });
+    vi.stubGlobal(
+      "fetch",
+      mockJsonFetch({
+        [GATEWAY_URL]: { models: [] },
+        // Note: no double slash before /models.
+        "http://localhost:11434/v1/models": localListResponse(["llama3.1:8b"]),
+      }),
+    );
+
+    const catalog = await getCatalog();
+    const entry = find(catalog, "local");
+    expect(entry.models.map((m) => m.id)).toEqual(["llama3.1:8b"]);
+  });
+
+  it("reports credentialConfigured=false and no error when LOCAL_BASE_URL is unset", async () => {
+    vi.stubGlobal("fetch", mockJsonFetch({ [GATEWAY_URL]: { models: [] } }));
+
+    const catalog = await getCatalog();
+    const entry = find(catalog, "local");
+    expect(entry.credentialConfigured).toBe(false);
+    expect(entry.credentialEnvVar).toBe("LOCAL_BASE_URL");
+    expect(entry.models).toEqual([]);
+    // No env var, no fetch attempt — so no error to surface either.
+    expect(entry.error).toBeUndefined();
+  });
+
+  it("surfaces a per-provider error when the local fetch fails (server not running)", async () => {
+    stubEnv({ LOCAL_BASE_URL: "http://localhost:1234/v1" });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((url: string) => {
+        if (url === GATEWAY_URL) {
+          return Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ models: [] }),
+          } as unknown as Response);
+        }
+        if (url === "http://localhost:1234/v1/models") {
+          // Real connection-refused throws — fetch rejects rather than 404s.
+          return Promise.reject(new Error("fetch failed: ECONNREFUSED"));
+        }
+        return Promise.resolve({
+          ok: false,
+          status: 404,
+          json: () => Promise.resolve({}),
+        } as unknown as Response);
+      }),
+    );
+
+    const catalog = await getCatalog();
+    const entry = find(catalog, "local");
+    expect(entry.models).toEqual([]);
+    expect(entry.error).toMatch(/ECONNREFUSED/);
+    // Env var IS set, the fetch just failed — UI shows "server not running",
+    // not "configure your credentials."
+    expect(entry.credentialConfigured).toBe(true);
+    // Other providers stay unaffected.
+    expect(find(catalog, "anthropic").error).toBeUndefined();
+  });
+
+  it("local is NOT auto-credentialed by LITELLM_API_KEY (localhost is not proxyable)", async () => {
+    stubEnv({ LITELLM_API_KEY: "sk-litellm", LOCAL_BASE_URL: undefined });
+    vi.stubGlobal("fetch", mockJsonFetch({ [GATEWAY_URL]: { models: [] } }));
+
+    const catalog = await getCatalog();
+    const entry = find(catalog, "local");
+    expect(entry.credentialConfigured).toBe(false);
+    // And the envVar hint stays actionable instead of being null'd out
+    // like the other providers under LiteLLM proxy mode.
+    expect(entry.credentialEnvVar).toBe("LOCAL_BASE_URL");
   });
 });
 

--- a/packages/llm/src/model-catalog.test.ts
+++ b/packages/llm/src/model-catalog.test.ts
@@ -231,16 +231,10 @@ describe("model-catalog — local provider", () => {
 
   it("fetches models from a local server when LOCAL_BASE_URL is set", async () => {
     stubEnv({ LOCAL_BASE_URL: "http://localhost:1234/v1" });
-    const lmStudio = localListResponse([
-      "llama-3.2-3b-instruct",
-      "qwen2.5-coder-7b-instruct",
-    ]);
+    const lmStudio = localListResponse(["llama-3.2-3b-instruct", "qwen2.5-coder-7b-instruct"]);
     vi.stubGlobal(
       "fetch",
-      mockJsonFetch({
-        [GATEWAY_URL]: { models: [] },
-        "http://localhost:1234/v1/models": lmStudio,
-      }),
+      mockJsonFetch({ [GATEWAY_URL]: { models: [] }, "http://localhost:1234/v1/models": lmStudio }),
     );
 
     const catalog = await getCatalog();

--- a/packages/llm/src/model-catalog.ts
+++ b/packages/llm/src/model-catalog.ts
@@ -44,6 +44,7 @@ const CATALOG_PROVIDERS: readonly CatalogProvider[] = [
   "openai",
   "google",
   "groq",
+  "local",
   "openrouter",
 ] as const;
 
@@ -105,6 +106,9 @@ const GROQ_URL = "https://api.groq.com/openai/v1/models";
 // Server-side filter to tool-capable chat models — OpenRouter publishes 500+
 // model slugs and the unfiltered list dwarfs every other provider's picker.
 const OPENROUTER_URL = "https://openrouter.ai/api/v1/models?supported_parameters=tools";
+// Local OpenAI-compatible servers (LM Studio, Ollama, vLLM, llama.cpp)
+// expose loaded models at the standard OpenAI `/models` path.
+const LOCAL_MODELS_PATH = "/models";
 
 const FETCH_TIMEOUT_MS = 3_000;
 /** One hour — models don't change intra-session. Prewarm covers first paint. */
@@ -115,6 +119,10 @@ const ENV_VAR_BY_CATALOG_PROVIDER: Record<CatalogProvider, string> = {
   openai: PROVIDER_ENV_VARS.openai,
   google: PROVIDER_ENV_VARS.google,
   groq: PROVIDER_ENV_VARS.groq,
+  // The env var the user has to set to unlock local — diverges from
+  // PROVIDER_ENV_VARS.local (`LOCAL_API_KEY`) because for local servers
+  // the *credential* is the URL, not a key.
+  local: "LOCAL_BASE_URL",
   openrouter: PROVIDER_ENV_VARS.openrouter,
 };
 
@@ -144,6 +152,14 @@ export const PROVIDER_META: Record<CatalogProvider, ProviderMeta> = {
     keyPrefix: "sk-or-v1-",
     helpUrl: "openrouter.ai/keys",
   },
+  local: {
+    name: "Local",
+    letter: "L",
+    // No prefix — the credential is a URL, not an API key. The picker's
+    // locked banner needs to render a base-URL input for this provider.
+    keyPrefix: null,
+    helpUrl: "lmstudio.ai",
+  },
 };
 
 // ─── Schemas ───────────────────────────────────────────────────────────────
@@ -162,6 +178,11 @@ const groqResponseSchema = z.object({ data: z.array(z.object({ id: z.string() })
 const openrouterModelSchema = z.object({ id: z.string(), name: z.string() });
 const openrouterResponseSchema = z.object({ data: z.array(openrouterModelSchema) });
 type OpenRouterModel = z.infer<typeof openrouterModelSchema>;
+
+// LM Studio / Ollama / vLLM / llama.cpp all return the OpenAI-standard
+// `{ data: [{ id }] }` shape from `/v1/models`. We only need the id.
+const localModelSchema = z.object({ id: z.string() });
+const localResponseSchema = z.object({ data: z.array(localModelSchema) });
 
 // ─── Fetchers ──────────────────────────────────────────────────────────────
 
@@ -203,6 +224,25 @@ async function fetchOpenRouter(): Promise<OpenRouterModel[]> {
   return parsed.data;
 }
 
+/**
+ * Discover models loaded into the user's local OpenAI-compatible server
+ * by hitting `${LOCAL_BASE_URL}/models`. The caller has already verified
+ * the env var is set (see `fetchCatalog`) so a connection refusal here
+ * is a real failure — surface it so the picker can tell the user their
+ * server isn't running.
+ */
+async function fetchLocal(baseURL: string): Promise<string[]> {
+  // Trim any trailing slash so `${baseURL}${LOCAL_MODELS_PATH}` is well-formed.
+  const url = `${baseURL.replace(/\/$/, "")}${LOCAL_MODELS_PATH}`;
+  const res = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+  if (!res.ok) {
+    await discardBody(res);
+    throw new Error(`local server at ${baseURL} returned HTTP ${res.status}`);
+  }
+  const parsed = localResponseSchema.parse(await res.json());
+  return parsed.data.map((m) => m.id);
+}
+
 // ─── Filters / normalization ───────────────────────────────────────────────
 
 /**
@@ -227,6 +267,8 @@ function groupGatewayModels(models: GatewayModel[]): Record<CatalogProvider, Mod
     openai: [],
     google: [],
     groq: [],
+    // Local is fetched directly from the user's OpenAI-compatible server.
+    local: [],
     // OpenRouter is fetched directly from openrouter.ai, not the gateway.
     openrouter: [],
   };
@@ -341,11 +383,16 @@ function isOpenAiChatCapable(id: string): boolean {
  * `LITELLM_API_KEY` unlocks everything via the LiteLLM proxy (see
  * `packages/llm/src/registry.ts`), which is why we report `null` for
  * `credentialEnvVar` in that mode — there's nothing actionable to add.
+ * `local` is the exception: its credential is a base URL pointing at the
+ * user's own server, which a remote proxy can't substitute for.
  */
 function resolveCredential(provider: CatalogProvider): {
   configured: boolean;
   envVar: string | null;
 } {
+  if (provider === "local") {
+    return { configured: Boolean(process.env.LOCAL_BASE_URL), envVar: "LOCAL_BASE_URL" };
+  }
   if (process.env.LITELLM_API_KEY) return { configured: true, envVar: null };
   const envVar = ENV_VAR_BY_CATALOG_PROVIDER[provider];
   return { configured: Boolean(process.env[envVar]), envVar };
@@ -357,13 +404,17 @@ function resolveCredential(provider: CatalogProvider): {
  */
 async function fetchCatalog(): Promise<Catalog> {
   const groqKey = process.env.GROQ_API_KEY;
+  const localBaseUrl = process.env.LOCAL_BASE_URL;
 
-  // Fire gateway, openrouter, and (optionally) groq in parallel. allSettled
-  // so one provider timing out doesn't take the whole catalog with it.
-  const [gatewayResult, groqResult, openrouterResult] = await Promise.allSettled([
+  // Fire gateway, openrouter, and (optionally) groq + local in parallel.
+  // allSettled so one provider timing out doesn't take the whole catalog
+  // with it. The `local` fetch only fires when the user has opted in via
+  // `LOCAL_BASE_URL` — otherwise the entry stays empty with no error.
+  const [gatewayResult, groqResult, openrouterResult, localResult] = await Promise.allSettled([
     fetchGateway(),
     groqKey ? fetchGroq(groqKey) : Promise.reject(new Error("no GROQ_API_KEY")),
     fetchOpenRouter(),
+    localBaseUrl ? fetchLocal(localBaseUrl) : Promise.reject(new Error("no LOCAL_BASE_URL")),
   ]);
 
   const gatewayBuckets =
@@ -399,6 +450,19 @@ async function fetchCatalog(): Promise<Catalog> {
         )
       : null;
 
+  const localModels =
+    localResult.status === "fulfilled"
+      ? localResult.value.map((id) => ({ id, displayName: id }))
+      : null;
+  // Only surface a local error when LOCAL_BASE_URL is set; absence of the
+  // env var is a separate UI state (`credentialConfigured: false`).
+  const localError =
+    localBaseUrl && localResult.status === "rejected"
+      ? String(
+          localResult.reason instanceof Error ? localResult.reason.message : localResult.reason,
+        )
+      : null;
+
   const entries: CatalogEntry[] = CATALOG_PROVIDERS.map((provider) => {
     const cred = resolveCredential(provider);
     let models: ModelInfo[] = [];
@@ -417,6 +481,14 @@ async function fetchCatalog(): Promise<Catalog> {
       } else if (openrouterError) {
         error = openrouterError;
       }
+    } else if (provider === "local") {
+      if (localModels) {
+        models = localModels;
+      } else if (localError) {
+        error = localError;
+      }
+      // else: no LOCAL_BASE_URL set — empty models, no error, UI shows
+      // the `envVar` hint to point the user at LOCAL_BASE_URL.
     } else if (gatewayBuckets) {
       models = gatewayBuckets[provider];
     } else if (gatewayError) {

--- a/packages/llm/src/platform-models.ts
+++ b/packages/llm/src/platform-models.ts
@@ -83,9 +83,12 @@ function parseModelId(id: string): { provider: string; model: string } | null {
 /**
  * Check whether credentials for `provider` are available.
  * `LITELLM_API_KEY` universally satisfies any provider (matches smallLLM's
- * historical behavior and supports proxy-everything LiteLLM setups).
+ * historical behavior and supports proxy-everything LiteLLM setups) —
+ * except `local`, where the credential is a base URL pointing at the
+ * user's own server and a remote LiteLLM proxy can't substitute.
  */
 function hasCredential(provider: string): boolean {
+  if (provider === "local") return !!process.env.LOCAL_BASE_URL;
   if (process.env.LITELLM_API_KEY) return true;
   if (ALWAYS_CREDENTIALED.has(provider)) return true;
   if (!isRegistryProvider(provider)) return false;
@@ -126,7 +129,11 @@ export class PlatformModelsConfigError extends Error {
         lines.push(`  known providers: ${REGISTRY_PROVIDERS.join(", ")}`);
       } else if (err.kind === "missing_credential") {
         const parsed = parseModelId(err.value);
-        if (parsed && isRegistryProvider(parsed.provider) && hasEnvVar(parsed.provider)) {
+        if (parsed?.provider === "local") {
+          lines.push(
+            `  required env var: LOCAL_BASE_URL (e.g., http://localhost:1234/v1 for LM Studio)`,
+          );
+        } else if (parsed && isRegistryProvider(parsed.provider) && hasEnvVar(parsed.provider)) {
           const envVar = PROVIDER_ENV_VARS[parsed.provider];
           lines.push(`  required env var: ${envVar} (or LITELLM_API_KEY for proxied access)`);
         }

--- a/packages/llm/src/registry-id.ts
+++ b/packages/llm/src/registry-id.ts
@@ -9,6 +9,7 @@ export const REGISTRY_PROVIDERS = [
   "claude-code",
   "google",
   "groq",
+  "local",
   "openai",
   "openrouter",
 ] as const;
@@ -25,6 +26,7 @@ export type RegistryModelId =
   | `claude-code:${string}`
   | `google:${string}`
   | `groq:${string}`
+  | `local:${string}`
   | `openai:${string}`
   | `openrouter:${string}`;
 
@@ -46,6 +48,8 @@ export function buildRegistryModelId(provider: RegistryProvider, model: string):
       return `google:${model}`;
     case "groq":
       return `groq:${model}`;
+    case "local":
+      return `local:${model}`;
     case "openai":
       return `openai:${model}`;
     case "openrouter":

--- a/packages/llm/src/registry.ts
+++ b/packages/llm/src/registry.ts
@@ -8,6 +8,7 @@ import { createClaudeCode } from "ai-sdk-provider-claude-code";
 import { createAnthropicWithOptions } from "./anthropic.ts";
 import { createGoogleWithOptions } from "./google.ts";
 import { createGroqWithOptions } from "./groq.ts";
+import { createLocalWithOptions } from "./local.ts";
 import { createOpenAIWithOptions } from "./openai.ts";
 import { createOpenRouterWithOptions } from "./openrouter.ts";
 
@@ -104,6 +105,9 @@ function createRegistry() {
       "claude-code": createClaudeCodeProvider(),
       google: googleViaLitellm,
       groq: groqViaLitellm,
+      // Local servers (LM Studio / Ollama / vLLM) always connect direct —
+      // routing localhost through a remote LiteLLM proxy is the wrong shape.
+      local: createChatCompletionsProvider(createLocalWithOptions()),
       openai: litellmChatProvider,
       openrouter: createChatCompletionsProvider(createOpenRouterWithOptions()),
     });
@@ -115,6 +119,8 @@ function createRegistry() {
     "claude-code": createClaudeCodeProvider(),
     google: createGoogleWithOptions(),
     groq: createGroqWithOptions(),
+    // Force Chat Completions API — LM Studio / Ollama don't speak Responses API.
+    local: createChatCompletionsProvider(createLocalWithOptions()),
     openai: createOpenAIWithOptions(),
     openrouter: createChatCompletionsProvider(createOpenRouterWithOptions()),
   });

--- a/packages/llm/src/util.ts
+++ b/packages/llm/src/util.ts
@@ -33,11 +33,19 @@ export const PROVIDER_ENV_VARS: Record<ValidProvider, string> = {
   anthropic: "ANTHROPIC_API_KEY",
   google: "GEMINI_API_KEY",
   groq: "GROQ_API_KEY",
+  local: "LOCAL_API_KEY",
   openai: "OPENAI_API_KEY",
   openrouter: "OPENROUTER_API_KEY",
 } as const;
 
-const ValidProviderSchema = z.enum(["anthropic", "google", "groq", "openai", "openrouter"]);
+const ValidProviderSchema = z.enum([
+  "anthropic",
+  "google",
+  "groq",
+  "local",
+  "openai",
+  "openrouter",
+]);
 export type ValidProvider = z.infer<typeof ValidProviderSchema>;
 
 /**

--- a/tools/agent-playground/src/lib/components/settings/model-picker.svelte
+++ b/tools/agent-playground/src/lib/components/settings/model-picker.svelte
@@ -227,6 +227,13 @@
     </div>
 
     {#if locked && activeProviderEntry}
+      <!--
+        The `local` provider takes a base URL (LM Studio / Ollama / vLLM
+        endpoint), not an API key — so the input is plain text and the
+        copy points at a server URL rather than a credential string. All
+        other providers fall through to the password-input flow.
+      -->
+      {@const isLocal = activeProviderEntry.provider === "local"}
       <div class="locked-banner">
         <div class="locked-banner-head">
           <ProviderMark
@@ -238,20 +245,33 @@
           </div>
         </div>
         <div class="locked-banner-desc">
-          {activeProviderEntry.meta.name}'s models are locked until we have an API key.
-          Paste your key below — we'll save it to the daemon's .env file as
-          <code>{activeProviderEntry.credentialEnvVar}</code> and unlock
-          {activeProviderEntry.meta.name} immediately.
-          {#if activeProviderEntry.meta.helpUrl}
-            Get a key from <code>{activeProviderEntry.meta.helpUrl}</code>.
+          {#if isLocal}
+            Local models are locked until we know where your OpenAI-compatible
+            server is running. Paste its base URL below — we'll save it to the
+            daemon's .env file as <code>LOCAL_BASE_URL</code> and unlock Local
+            immediately.
+            {#if activeProviderEntry.meta.helpUrl}
+              Download a runtime from <code>{activeProviderEntry.meta.helpUrl}</code>
+              (also works with Ollama on <code>http://localhost:11434/v1</code>).
+            {/if}
+          {:else}
+            {activeProviderEntry.meta.name}'s models are locked until we have an API key.
+            Paste your key below — we'll save it to the daemon's .env file as
+            <code>{activeProviderEntry.credentialEnvVar}</code> and unlock
+            {activeProviderEntry.meta.name} immediately.
+            {#if activeProviderEntry.meta.helpUrl}
+              Get a key from <code>{activeProviderEntry.meta.helpUrl}</code>.
+            {/if}
           {/if}
         </div>
         <div class="key-input-row">
           <input
-            type="password"
-            placeholder={activeProviderEntry.meta.keyPrefix
-              ? `${activeProviderEntry.meta.keyPrefix}…`
-              : "API key"}
+            type={isLocal ? "text" : "password"}
+            placeholder={isLocal
+              ? "http://localhost:1234/v1"
+              : activeProviderEntry.meta.keyPrefix
+                ? `${activeProviderEntry.meta.keyPrefix}…`
+                : "API key"}
             value={keyInputs[activeProviderEntry.provider] ?? ""}
             oninput={(e) => {
               const v = (e.currentTarget as HTMLInputElement).value;


### PR DESCRIPTION
## Summary

Adds a `local` provider to `@atlas/llm` for self-hosted OpenAI-compatible servers — LM Studio, Ollama, vLLM, llama.cpp. Same pattern as OpenRouter (`@ai-sdk/openai` with a custom baseURL), but gated on a base URL rather than an API key because for localhost servers the URL **is** the credential.

- **Backend (`packages/llm`)** — new `local.ts` provider, registered in both direct and LiteLLM-mode registries (LiteLLM passthrough is intentionally skipped — localhost can't route through a hosted proxy). `hasCredential("local")` checks `LOCAL_BASE_URL`. Catalog fetcher hits `${LOCAL_BASE_URL}/models` for live model discovery against whatever LM Studio currently has loaded. Trailing slashes are normalized.
- **UI (`tools/agent-playground`)** — model-picker locked banner branches on `provider === "local"` to render a text URL input (not a password input) with a `http://localhost:1234/v1` placeholder and LM Studio / Ollama help copy. Backend `saveApiKey(envVar, value)` is generic and unchanged.
- **Tests** — catalog fetcher tests cover LM Studio happy path, trailing-slash normalization, unset env var, server-down error surfacing, and the "LITELLM_API_KEY does not unlock local" semantic. Plus a construction smoke test for `createLocalWithOptions`. 116/116 tests passing in `packages/llm`. Workspace typecheck and Svelte typecheck both clean.

## How it works

Set `LOCAL_BASE_URL` (via the daemon `.env` file or through the Settings → Models picker's "Save & unlock" banner) and Friday will:

1. Show a `Local` provider pill in the model picker, credentialed.
2. Hit `${baseURL}/models` to discover whatever model LM Studio / Ollama currently has loaded — no hardcoded model list.
3. Route any `local:<model-id>` selection through `@ai-sdk/openai` pointed at the local server, using the Chat Completions API (LM Studio/Ollama don't speak the Responses API).

`LOCAL_API_KEY` is optional and defaults to the literal string `"local"` — most local servers ignore auth entirely, but `@ai-sdk/openai` requires a non-empty key string.

## Test plan

Manually verified end-to-end against a real LM Studio instance (`google/gemma-4-e4b` loaded on port 1234):

- [x] **Case 1 — Locked Local pill renders in catalog.** `GET /api/config/models/catalog` shows `local` with `credentialConfigured: false`, `credentialEnvVar: "LOCAL_BASE_URL"`, empty models, no error.
- [x] **Case 2 — Banner shows text URL input (not password).** Picker → locked banner renders `type="text"` input with `placeholder="http://localhost:1234/v1"`, copy reads "Local models are locked until we know where your OpenAI-compatible server is running", help mentions LM Studio + Ollama.
- [x] **Case 3 — Paste URL → save → catalog refreshes.** "Save & unlock" flow flipped the Local pill to "connected", catalog discovered `google/gemma-4-e4b` (chat) and `text-embedding-nomic-embed-text-v1.5` (embedding). `LOCAL_BASE_URL` persisted to daemon `.env`.
- [x] **Case 4 — Trailing slash normalized.** Saving `http://localhost:1234/v1/` (trailing slash) discovers the same models — no double-slash artifacts in the outbound `/models` request.
- [x] **Case 5 — Chain picker writes `local:` to friday.yml.** Selecting `google/gemma-4-e4b` for the planner role and clicking "Save models" wrote `planner: 'local:google/gemma-4-e4b'` to `friday.yml`. The slash in the model id round-trips through `parseModelId` correctly (split at first colon only).
- [x] **Case 7 — End-to-end chat round-trip.** Direct registry call (`registry.languageModel("local:google/gemma-4-e4b")` → `generateText`) round-tripped through `@ai-sdk/openai` → LM Studio in ~5s. Response: _"I am Gemma 4, an open weights Large Language Model developed by Google DeepMind."_ Token usage parsed correctly (25 input / 232 output / 210 reasoning).
- [x] **Case 8 — Bad URL surfaces actionable error.** Setting `LOCAL_BASE_URL=http://localhost:9999/v1` (nothing running) surfaced `error: "tcp connect error: Connection refused (os error 61)"` in the catalog entry, `modelCount: 0`, `credentialConfigured: true` (env IS set, fetch just failed).

### Not validated in this pass

- **Case 6 (per-chat model pill)** — N/A. Plan referenced UI from an unmerged PR; not in current `main`.
- **Case 9 (server-down during session) + Case 10 (model swap)** — deferred. Same underlying mechanism as case 8 (catalog re-fetch surfaces error).

### Pre-existing finding (not a regression, worth a follow-up)

`GET /api/config/models` shows `resolved` stuck on the default chain after live edits to `friday.yml` — `createPlatformModels` captures `userConfig` at daemon-boot time, so changes need a daemon restart to take effect. Affects any `models:` change, not just local. Filing separately.

## Notes / non-goals

- **Multi-endpoint not supported.** One local server at a time; if we ever want `local-1` / `local-2` we'd want to redesign around workspace variables, not add more env vars.
- **No model catalog hardcoding.** Discovery is dynamic — whatever LM Studio has loaded is what shows up. Means a model that's not currently loaded won't appear in the picker until the user loads it and refreshes the catalog.
- **Catalog cache TTL is 1h.** Mutating `LOCAL_BASE_URL` via the env editor calls `invalidateCatalog()` so refreshes are immediate after the env-PUT path. Manual model swaps in LM Studio require a forced refresh (no-op env-PUT or daemon restart).