### PR TITLE
fix(workspace-chat): guard title-generator so smallLLM failures don't paint fatal banner

### DIFF
--- a/packages/system/agents/workspace-chat/workspace-chat.agent.ts
+++ b/packages/system/agents/workspace-chat/workspace-chat.agent.ts
@@ -720,16 +720,27 @@ export const workspaceChatAgent = createAgent<string, WorkspaceChatResult>({
           throw new Error("Stream ID is missing");
         }
 
-        // Generate title on turns 2 and 4
+        // Generate title on turns 2 and 4. Guarded because the AI SDK
+        // doesn't wrap user onFinish callbacks (callOnFinish vs
+        // callOnStepFinish in handle-ui-message-stream-finish), so an
+        // uncaught throw here fails the whole stream and paints a
+        // fatal banner over an otherwise-successful turn.
         if (messages.length === 2 || messages.length === 4) {
-          const title = await generateChatTitle(platformModels, messages, logger);
-          const titleResult = await parseResult(
-            client
-              .workspaceChat(workspaceId)
-              [":chatId"].title.$patch({ param: { chatId: session.streamId }, json: { title } }),
-          );
-          if (!titleResult.ok) {
-            logger.error("Failed to update chat title", { streamId: session.streamId, title });
+          try {
+            const title = await generateChatTitle(platformModels, messages, logger);
+            const titleResult = await parseResult(
+              client
+                .workspaceChat(workspaceId)
+                [":chatId"].title.$patch({ param: { chatId: session.streamId }, json: { title } }),
+            );
+            if (!titleResult.ok) {
+              logger.error("Failed to update chat title", { streamId: session.streamId, title });
+            }
+          } catch (error) {
+            logger.warn("Title generation failed, leaving title as-is", {
+              streamId: session.streamId,
+              error,
+            });
           }
         }
 

--- a/packages/system/agents/workspace-chat/workspace-chat.handler.test.ts
+++ b/packages/system/agents/workspace-chat/workspace-chat.handler.test.ts
@@ -525,6 +525,24 @@ describe("workspace-chat handler", () => {
     expect(mockSmallLLM).not.toHaveBeenCalled();
   });
 
+  it("swallows smallLLM failures during title generation (no fatal banner)", async () => {
+    // Regression for #418: an uncaught throw inside generateChatTitle
+    // escaped onFinish (AI SDK doesn't wrap user onFinish callbacks),
+    // failing the whole stream and painting a fatal banner on top of
+    // an otherwise-successful turn.
+    const existingMessages = [makeMessage("user", "Hello")];
+    setupDefaultMocks(existingMessages);
+    mockSmallLLM.mockRejectedValueOnce(new Error("labels model unreachable"));
+
+    const handler = getHandler();
+    const ctx = makeContext();
+    const result = await handler("", ctx);
+
+    expect(mockSmallLLM).toHaveBeenCalledOnce();
+    // The turn completes successfully even though title generation threw.
+    expect(result).toHaveProperty("ok", true);
+  });
+
   // -----------------------------------------------------------------------
   // System prompt context capture
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `generateChatTitle()` runs inside `createUIMessageStream`'s `onFinish`. The AI SDK doesn't wrap user `onFinish` callbacks (`callOnFinish` runs them bare, unlike `callOnStepFinish`), so an uncaught throw escapes via `flush()` and fails the whole stream — the user sees a fatal red banner on top of an otherwise-successful turn whenever the labels model misbehaves (invalid model id, unreachable provider, missing API key, transient 5xx).
- Wraps the title-generation block and logs-and-continues, mirroring the `generateProgress` guard at `packages/bundled-agents/src/claude-code/agent.ts:517-522`.

Closes #418

## Test plan

- [x] `deno task test packages/system/agents/workspace-chat` — 34 files / 431 tests pass.
- [x] `deno check packages/system/agents/workspace-chat/workspace-chat.agent.ts` — clean.
- [x] `deno lint` — clean.
- [x] Manual: send a chat turn with an invalid `smallLLM` model id; main response renders fine, no fatal banner, warning logged.