### PR TITLE
fix(playground): disambiguate same-named workspaces in MCP Catalog usage list

### DIFF
--- a/tools/agent-playground/src/lib/components/mcp/mcp-workspace-usage.svelte
+++ b/tools/agent-playground/src/lib/components/mcp/mcp-workspace-usage.svelte
@@ -38,6 +38,17 @@
       return [{ workspaceId: ws.id, workspaceName: ws.displayName, enabledServer }];
     });
   });
+
+  // Workspace `name` is not unique, only `id` is. When two rows share a
+  // display name, render the id as a secondary line so the user can tell
+  // them apart. Stays silent when names are unique.
+  const duplicatedNames = $derived.by<Set<string>>(() => {
+    const counts = new Map<string, number>();
+    for (const row of enabledRows) {
+      counts.set(row.workspaceName, (counts.get(row.workspaceName) ?? 0) + 1);
+    }
+    return new Set([...counts].filter(([, n]) => n > 1).map(([name]) => name));
+  });
 </script>
 
 {#if enabledRows.length > 0}
@@ -47,6 +58,9 @@
         <a class="workspace-name" href="/platform/{row.workspaceId}/settings/mcp">
           {row.workspaceName}
         </a>
+        {#if duplicatedNames.has(row.workspaceName)}
+          <div class="workspace-id" title="Workspace ID">{row.workspaceId}</div>
+        {/if}
         {#if row.enabledServer.agentIds && row.enabledServer.agentIds.length > 0}
           <div class="references">
             <span class="ref-label">Agents:</span>
@@ -90,6 +104,12 @@
 
   .workspace-name:hover {
     text-decoration: underline;
+  }
+
+  .workspace-id {
+    color: var(--text-faded);
+    font-family: var(--font-family-monospace);
+    font-size: var(--font-size-1);
   }
 
   .references {


### PR DESCRIPTION
## Summary

- Workspace `name` is not unique, only `id` is. On `/mcp/<server-id>/connections`, the "Enabled in these workspaces" sub-block rendered identical rows for any two workspaces that shared a display name — users couldn't tell them apart.
- The `workspaceId` was already in scope on each row (bound into the `href`); it just wasn't visible text.
- Renders the id as a muted secondary line, but **only** when the row's display name collides with another row in the same list. Zero visual noise when names are unique.

Closes #419

## Test plan

- [x] `deno task -f @atlas/agent-playground sync && npx svelte-check` — 0 errors, no new warnings on the edited file.
- [x] Manual: import the same workspace twice (so two rows share a name), open MCP Catalog → a server with both workspaces enabled → confirm the two colliding rows show the id, single-name rows do not.