### PR TITLE
fix(playground): render run-detail results as markdown, not escaped JSON

### DIFF
--- a/tools/agent-playground/src/lib/components/session/index.ts
+++ b/tools/agent-playground/src/lib/components/session/index.ts
@@ -1,3 +1,4 @@
 export { default as AgentBlockCard } from "./agent-block-card.svelte";
 export { parseError } from "./parse-error.ts";
+export { default as SessionResults } from "./session-results.svelte";
 export { StepBlock } from "./step-block/index.ts";

--- a/tools/agent-playground/src/lib/components/session/session-results.svelte
+++ b/tools/agent-playground/src/lib/components/session/session-results.svelte
@@ -1,16 +1,25 @@
 <!--
   Renders the final per-agent results map that lands on the run-detail
   "Complete"/"Failed" roll-up. `query.data.results` is typed as
-  `Record<string, unknown>` because agents can emit any shape via
-  `complete()`, FSM `outputTo`, or the chat-tool's implicit `{ text }`
-  fall-through. This component does the runtime branching so markdown
-  prose, structured `{response, data}` payloads, `{text}` envelopes,
-  error envelopes, and raw JSON fallbacks all land in the right
-  renderer.
+  `Record<string, unknown>` but in practice the FSM session reducer
+  (`packages/core/src/session/session-reducer.ts:90`) only ever assigns
+  `block.output` — an *object* — keyed by `block.agentName`. Two shapes
+  carry markdown prose in real sessions, the rest fall back to a JSON
+  view:
 
-  Lifts the splitMarkdownByTables + MarkdownRendered + TableView
-  pattern from the fullscreen artifact markdown view
-  (`/artifacts/[id]/markdown/+page.svelte`).
+    - `{ response, data? }` — Agent SDK `complete({ response, data })`
+                              per `writing-workspace-jobs/SKILL.md:715`.
+    - `{ text }`            — workspace-chat / "unknown" agent
+                              fall-through (the dominant shape).
+
+  Bare strings and `{error}` envelopes are intentionally NOT handled
+  here: the reducer never produces a string output, and session-level
+  errors flow through `query.data.error` → the `sessionError` branch in
+  the parent page, not through this map.
+
+  Markdown rendering lifts the splitMarkdownByTables + MarkdownRendered
+  + TableView pattern from the fullscreen artifact view at
+  `/artifacts/[id]/markdown/+page.svelte`.
 -->
 
 <script lang="ts">
@@ -26,25 +35,9 @@
 
   const entries = $derived(Object.entries(results));
 
-  type ErrorResult = { error: string };
   type ProseSlice = { prose: string; data?: unknown };
 
-  function isErrorResult(v: unknown): v is ErrorResult {
-    return (
-      typeof v === "object" && v !== null && typeof (v as { error?: unknown }).error === "string"
-    );
-  }
-
-  // Pulls the prose payload out of a result entry, regardless of which
-  // emit path produced it:
-  //   - bare string                — agents that return a raw markdown blob
-  //   - { response, data? }        — Agent SDK `complete({ response, data })`
-  //   - { text }                   — FSM workspace-chat / "unknown" agent
-  //                                   fall-through (the dominant shape)
-  // Returns null for anything else so the template can route to the
-  // JSON fallback. Errors are caught earlier — don't call this on them.
   function asProse(v: unknown): ProseSlice | null {
-    if (typeof v === "string") return { prose: v };
     if (typeof v !== "object" || v === null) return null;
     const obj = v as { response?: unknown; text?: unknown; data?: unknown };
     if (typeof obj.response === "string") return { prose: obj.response, data: obj.data };
@@ -56,15 +49,13 @@
 {#if entries.length > 0}
   <div class="results">
     {#each entries as [agentName, value] (agentName)}
+      {@const prose = asProse(value)}
       <div class="result-block">
         {#if entries.length > 1}
           <h4 class="result-agent">{agentName}</h4>
         {/if}
-        {#if isErrorResult(value)}
-          <p class="error-label">{value.error}</p>
-        {:else}
-          {@const prose = asProse(value)}
-          {#if prose}
+        {#if prose}
+          <FormattedData copyText={prose.prose} maxLines={20}>
             {#each splitMarkdownByTables(prose.prose) as segment, i (i)}
               {#if segment.kind === "prose"}
                 <MarkdownRendered>
@@ -74,16 +65,16 @@
                 <TableView columns={segment.model.columns} rows={segment.model.rows} />
               {/if}
             {/each}
-            {#if prose.data !== undefined}
-              <FormattedData copyText={JSON.stringify(prose.data, null, 2)} maxLines={7}>
-                <JsonHighlight code={JSON.stringify(prose.data, null, 2)} />
-              </FormattedData>
-            {/if}
-          {:else}
-            <FormattedData copyText={JSON.stringify(value, null, 2)} maxLines={7}>
-              <JsonHighlight code={JSON.stringify(value, null, 2)} />
+          </FormattedData>
+          {#if prose.data !== undefined}
+            <FormattedData copyText={JSON.stringify(prose.data, null, 2)} maxLines={7}>
+              <JsonHighlight code={JSON.stringify(prose.data, null, 2)} />
             </FormattedData>
           {/if}
+        {:else}
+          <FormattedData copyText={JSON.stringify(value, null, 2)} maxLines={7}>
+            <JsonHighlight code={JSON.stringify(value, null, 2)} />
+          </FormattedData>
         {/if}
       </div>
     {/each}
@@ -95,6 +86,7 @@
     display: flex;
     flex-direction: column;
     gap: var(--size-4);
+    margin-block-start: var(--size-2);
   }
 
   .result-block {
@@ -111,11 +103,5 @@
     letter-spacing: 0.02em;
     margin: 0;
     text-transform: uppercase;
-  }
-
-  .error-label {
-    color: var(--color-red);
-    font-size: var(--font-size-3);
-    font-weight: var(--font-weight-5);
   }
 </style>

--- a/tools/agent-playground/src/lib/components/session/session-results.svelte
+++ b/tools/agent-playground/src/lib/components/session/session-results.svelte
@@ -2,9 +2,11 @@
   Renders the final per-agent results map that lands on the run-detail
   "Complete"/"Failed" roll-up. `query.data.results` is typed as
   `Record<string, unknown>` because agents can emit any shape via
-  `complete()` — this component does the runtime branching so markdown
-  prose, structured `{response, data}` payloads, error envelopes, and
-  raw JSON fallbacks all land in the right renderer.
+  `complete()`, FSM `outputTo`, or the chat-tool's implicit `{ text }`
+  fall-through. This component does the runtime branching so markdown
+  prose, structured `{response, data}` payloads, `{text}` envelopes,
+  error envelopes, and raw JSON fallbacks all land in the right
+  renderer.
 
   Lifts the splitMarkdownByTables + MarkdownRendered + TableView
   pattern from the fullscreen artifact markdown view
@@ -24,21 +26,30 @@
 
   const entries = $derived(Object.entries(results));
 
-  type StructuredResult = { response: string; data?: unknown };
   type ErrorResult = { error: string };
-
-  function isStructuredResult(v: unknown): v is StructuredResult {
-    return (
-      typeof v === "object" &&
-      v !== null &&
-      typeof (v as { response?: unknown }).response === "string"
-    );
-  }
+  type ProseSlice = { prose: string; data?: unknown };
 
   function isErrorResult(v: unknown): v is ErrorResult {
     return (
       typeof v === "object" && v !== null && typeof (v as { error?: unknown }).error === "string"
     );
+  }
+
+  // Pulls the prose payload out of a result entry, regardless of which
+  // emit path produced it:
+  //   - bare string                — agents that return a raw markdown blob
+  //   - { response, data? }        — Agent SDK `complete({ response, data })`
+  //   - { text }                   — FSM workspace-chat / "unknown" agent
+  //                                   fall-through (the dominant shape)
+  // Returns null for anything else so the template can route to the
+  // JSON fallback. Errors are caught earlier — don't call this on them.
+  function asProse(v: unknown): ProseSlice | null {
+    if (typeof v === "string") return { prose: v };
+    if (typeof v !== "object" || v === null) return null;
+    const obj = v as { response?: unknown; text?: unknown; data?: unknown };
+    if (typeof obj.response === "string") return { prose: obj.response, data: obj.data };
+    if (typeof obj.text === "string") return { prose: obj.text };
+    return null;
   }
 </script>
 
@@ -49,37 +60,30 @@
         {#if entries.length > 1}
           <h4 class="result-agent">{agentName}</h4>
         {/if}
-        {#if typeof value === "string"}
-          {#each splitMarkdownByTables(value) as segment, i (i)}
-            {#if segment.kind === "prose"}
-              <MarkdownRendered>
-                {@html markdownToHTMLSafe(segment.markdown)}
-              </MarkdownRendered>
-            {:else}
-              <TableView columns={segment.model.columns} rows={segment.model.rows} />
-            {/if}
-          {/each}
-        {:else if isStructuredResult(value)}
-          {#each splitMarkdownByTables(value.response) as segment, i (i)}
-            {#if segment.kind === "prose"}
-              <MarkdownRendered>
-                {@html markdownToHTMLSafe(segment.markdown)}
-              </MarkdownRendered>
-            {:else}
-              <TableView columns={segment.model.columns} rows={segment.model.rows} />
-            {/if}
-          {/each}
-          {#if value.data !== undefined}
-            <FormattedData copyText={JSON.stringify(value.data, null, 2)} maxLines={7}>
-              <JsonHighlight code={JSON.stringify(value.data, null, 2)} />
-            </FormattedData>
-          {/if}
-        {:else if isErrorResult(value)}
+        {#if isErrorResult(value)}
           <p class="error-label">{value.error}</p>
         {:else}
-          <FormattedData copyText={JSON.stringify(value, null, 2)} maxLines={7}>
-            <JsonHighlight code={JSON.stringify(value, null, 2)} />
-          </FormattedData>
+          {@const prose = asProse(value)}
+          {#if prose}
+            {#each splitMarkdownByTables(prose.prose) as segment, i (i)}
+              {#if segment.kind === "prose"}
+                <MarkdownRendered>
+                  {@html markdownToHTMLSafe(segment.markdown)}
+                </MarkdownRendered>
+              {:else}
+                <TableView columns={segment.model.columns} rows={segment.model.rows} />
+              {/if}
+            {/each}
+            {#if prose.data !== undefined}
+              <FormattedData copyText={JSON.stringify(prose.data, null, 2)} maxLines={7}>
+                <JsonHighlight code={JSON.stringify(prose.data, null, 2)} />
+              </FormattedData>
+            {/if}
+          {:else}
+            <FormattedData copyText={JSON.stringify(value, null, 2)} maxLines={7}>
+              <JsonHighlight code={JSON.stringify(value, null, 2)} />
+            </FormattedData>
+          {/if}
         {/if}
       </div>
     {/each}

--- a/tools/agent-playground/src/lib/components/session/session-results.svelte
+++ b/tools/agent-playground/src/lib/components/session/session-results.svelte
@@ -1,0 +1,117 @@
+<!--
+  Renders the final per-agent results map that lands on the run-detail
+  "Complete"/"Failed" roll-up. `query.data.results` is typed as
+  `Record<string, unknown>` because agents can emit any shape via
+  `complete()` — this component does the runtime branching so markdown
+  prose, structured `{response, data}` payloads, error envelopes, and
+  raw JSON fallbacks all land in the right renderer.
+
+  Lifts the splitMarkdownByTables + MarkdownRendered + TableView
+  pattern from the fullscreen artifact markdown view
+  (`/artifacts/[id]/markdown/+page.svelte`).
+-->
+
+<script lang="ts">
+  import { FormattedData, JsonHighlight, MarkdownRendered, markdownToHTMLSafe } from "@atlas/ui";
+  import { splitMarkdownByTables } from "$lib/components/chat/table-parsers.ts";
+  import TableView from "$lib/components/chat/table-view.svelte";
+
+  interface Props {
+    results: Record<string, unknown>;
+  }
+
+  const { results }: Props = $props();
+
+  const entries = $derived(Object.entries(results));
+
+  type StructuredResult = { response: string; data?: unknown };
+  type ErrorResult = { error: string };
+
+  function isStructuredResult(v: unknown): v is StructuredResult {
+    return (
+      typeof v === "object" &&
+      v !== null &&
+      typeof (v as { response?: unknown }).response === "string"
+    );
+  }
+
+  function isErrorResult(v: unknown): v is ErrorResult {
+    return (
+      typeof v === "object" && v !== null && typeof (v as { error?: unknown }).error === "string"
+    );
+  }
+</script>
+
+{#if entries.length > 0}
+  <div class="results">
+    {#each entries as [agentName, value] (agentName)}
+      <div class="result-block">
+        {#if entries.length > 1}
+          <h4 class="result-agent">{agentName}</h4>
+        {/if}
+        {#if typeof value === "string"}
+          {#each splitMarkdownByTables(value) as segment, i (i)}
+            {#if segment.kind === "prose"}
+              <MarkdownRendered>
+                {@html markdownToHTMLSafe(segment.markdown)}
+              </MarkdownRendered>
+            {:else}
+              <TableView columns={segment.model.columns} rows={segment.model.rows} />
+            {/if}
+          {/each}
+        {:else if isStructuredResult(value)}
+          {#each splitMarkdownByTables(value.response) as segment, i (i)}
+            {#if segment.kind === "prose"}
+              <MarkdownRendered>
+                {@html markdownToHTMLSafe(segment.markdown)}
+              </MarkdownRendered>
+            {:else}
+              <TableView columns={segment.model.columns} rows={segment.model.rows} />
+            {/if}
+          {/each}
+          {#if value.data !== undefined}
+            <FormattedData copyText={JSON.stringify(value.data, null, 2)} maxLines={7}>
+              <JsonHighlight code={JSON.stringify(value.data, null, 2)} />
+            </FormattedData>
+          {/if}
+        {:else if isErrorResult(value)}
+          <p class="error-label">{value.error}</p>
+        {:else}
+          <FormattedData copyText={JSON.stringify(value, null, 2)} maxLines={7}>
+            <JsonHighlight code={JSON.stringify(value, null, 2)} />
+          </FormattedData>
+        {/if}
+      </div>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .results {
+    display: flex;
+    flex-direction: column;
+    gap: var(--size-4);
+  }
+
+  .result-block {
+    display: flex;
+    flex-direction: column;
+    gap: var(--size-2);
+    min-inline-size: 0;
+  }
+
+  .result-agent {
+    color: color-mix(in srgb, var(--color-text), transparent 35%);
+    font-size: var(--font-size-1);
+    font-weight: var(--font-weight-6);
+    letter-spacing: 0.02em;
+    margin: 0;
+    text-transform: uppercase;
+  }
+
+  .error-label {
+    color: var(--color-red);
+    font-size: var(--font-size-3);
+    font-weight: var(--font-weight-5);
+  }
+</style>

--- a/tools/agent-playground/src/lib/components/session/session-results.test.ts
+++ b/tools/agent-playground/src/lib/components/session/session-results.test.ts
@@ -1,0 +1,135 @@
+/**
+ * SSR tests for `session-results.svelte` — the per-agent results renderer
+ * the run-detail page mounts under the final "Complete"/"Failed" roll-up.
+ *
+ * The page's upstream type for `results` is `Record<string, unknown>`
+ * because agents emit anything they want through `complete()`. The
+ * component does the runtime branching: string markdown, structured
+ * `{response, data}`, `{error}`, raw JSON fallback. These tests pin each
+ * branch on the first paint so a future "simplification" can't quietly
+ * route a markdown string back into a JSON dump.
+ *
+ * Render-only assertions via `svelte/server` — no DOM event simulation.
+ * `markdownToHTMLSafe` uses `isomorphic-dompurify` which transparently
+ * spins up jsdom in Node, so the rendered markdown HTML lands in the
+ * SSR body.
+ */
+
+import { render } from "svelte/server";
+import { describe, expect, it } from "vitest";
+import SessionResults from "./session-results.svelte";
+
+describe("session-results", () => {
+  it("renders nothing when the results map is empty", () => {
+    const { body } = render(SessionResults, { props: { results: {} } });
+    expect(body).not.toContain("result-block");
+    expect(body).not.toContain('class="results"');
+  });
+
+  it("string value renders as markdown prose, not escaped JSON", () => {
+    const markdown = "# Result\n\nThe agent **succeeded** at the task.";
+    const { body } = render(SessionResults, { props: { results: { agent_one: markdown } } });
+    expect(body).toContain("<h1");
+    expect(body).toContain("Result</h1>");
+    expect(body).toContain("<strong>succeeded</strong>");
+    // Never re-stringified through JsonHighlight.
+    expect(body).not.toContain("\\n\\n");
+    expect(body).not.toContain("# Result\\n");
+  });
+
+  it("string value with an embedded GFM table renders prose + TableView", () => {
+    const markdown =
+      "Some prose first.\n\n| col1 | col2 |\n| --- | --- |\n| a | b |\n\nMore prose after.";
+    const { body } = render(SessionResults, { props: { results: { agent_one: markdown } } });
+    // Both prose chunks land.
+    expect(body).toContain("Some prose first");
+    expect(body).toContain("More prose after");
+    // Table headers + cell values arrive via TableView, not as a markdown
+    // <table> from MarkdownRendered.
+    expect(body).toContain("col1");
+    expect(body).toContain("col2");
+    expect(body).toContain(">a<");
+    expect(body).toContain(">b<");
+  });
+
+  it("structured {response, data} renders response as markdown and data as JSON", () => {
+    const { body } = render(SessionResults, {
+      props: {
+        results: {
+          agent_one: {
+            response: "## Summary\n\nThe job is **done**.",
+            data: { rows_touched: 42, ok: true },
+          },
+        },
+      },
+    });
+    expect(body).toContain("<h2");
+    expect(body).toContain("Summary</h2>");
+    expect(body).toContain("<strong>done</strong>");
+    // The structured `data` payload still shows below as readable JSON.
+    expect(body).toContain("rows_touched");
+    expect(body).toContain("42");
+  });
+
+  it("structured value without `data` does not emit an empty JSON block", () => {
+    const { body } = render(SessionResults, {
+      props: { results: { agent_one: { response: "ok" } } },
+    });
+    expect(body).toContain("ok");
+    // The structured `data` JSON block only appears when the agent emits one.
+    expect(body).not.toContain("rows_touched");
+    expect(body).not.toMatch(/<code[^>]*>{}<\/code>/);
+  });
+
+  it("error envelope renders the error string with the error label class", () => {
+    const { body } = render(SessionResults, {
+      props: { results: { agent_one: { error: "blew up parsing yaml" } } },
+    });
+    expect(body).toContain("error-label");
+    expect(body).toContain("blew up parsing yaml");
+    // The error string is the whole render — no markdown pass and no JSON
+    // dump alongside.
+    expect(body).not.toContain("<h1");
+    expect(body).not.toMatch(/rows_touched/);
+  });
+
+  it("unrecognised shape falls back to a JSON view, not a markdown render", () => {
+    const { body } = render(SessionResults, {
+      props: { results: { agent_one: { weirdShape: [1, 2, 3] } } },
+    });
+    expect(body).toContain("weirdShape");
+    // The raw object should arrive as JSON-shaped text (key + array
+    // values), not as a parsed markdown render.
+    expect(body).toContain("1");
+    expect(body).toContain("2");
+    expect(body).toContain("3");
+    expect(body).not.toContain("error-label");
+  });
+
+  it("renders per-agent headers when there is more than one entry", () => {
+    const { body } = render(SessionResults, {
+      props: { results: { fetcher: "Fetched 12 docs.", summariser: "Summary is **here**." } },
+    });
+    expect(body).toContain("result-agent");
+    expect(body).toContain("fetcher");
+    expect(body).toContain("summariser");
+    expect(body).toContain("<strong>here</strong>");
+  });
+
+  it("does not render an agent-name header when there is only one entry", () => {
+    const { body } = render(SessionResults, {
+      props: { results: { only_agent: "just one result" } },
+    });
+    expect(body).toContain("just one result");
+    expect(body).not.toContain("result-agent");
+    expect(body).not.toContain(">only_agent<");
+  });
+
+  it("a null-valued entry falls back to the JSON view rather than crashing", () => {
+    const { body } = render(SessionResults, { props: { results: { agent_one: null } } });
+    // Lands in the JSON fallback path — typeof null === "object" but the
+    // structured/error guards reject it explicitly.
+    expect(body).toContain("null");
+    expect(body).not.toContain("error-label");
+  });
+});

--- a/tools/agent-playground/src/lib/components/session/session-results.test.ts
+++ b/tools/agent-playground/src/lib/components/session/session-results.test.ts
@@ -1,15 +1,15 @@
 /**
- * SSR tests for `session-results.svelte` — the per-agent results renderer
- * the run-detail page mounts under the final "Complete"/"Failed" roll-up.
+ * SSR tests for `session-results.svelte`.
  *
- * The page's upstream type for `results` is `Record<string, unknown>`
- * because agents emit anything they want through `complete()`, FSM
- * `outputTo`, or the chat-tool's implicit `{ text }` fall-through.
- * The component does the runtime branching: bare string, structured
- * `{response, data}`, `{text}` envelope, `{error}` envelope, raw JSON
- * fallback. These tests pin each branch on the first paint so a future
- * "simplification" can't quietly route a markdown payload back into a
- * JSON dump.
+ * Scope mirrors what the FSM session reducer at
+ * `packages/core/src/session/session-reducer.ts:90` actually produces:
+ *   - `{ response, data? }` from Agent SDK `complete({ response, data })`
+ *   - `{ text }`            from workspace-chat / "unknown" agent
+ *   - anything else         falls back to JsonHighlight
+ *
+ * Bare-string and `{error}` shapes are NOT exercised here — the reducer
+ * doesn't emit either into the `results` map (errors flow through
+ * `query.data.error` on the parent page, which is a separate branch).
  *
  * Render-only assertions via `svelte/server` — no DOM event simulation.
  * `markdownToHTMLSafe` uses `isomorphic-dompurify` which transparently
@@ -28,33 +28,31 @@ describe("session-results", () => {
     expect(body).not.toContain('class="results"');
   });
 
-  it("string value renders as markdown prose, not escaped JSON", () => {
-    const markdown = "# Result\n\nThe agent **succeeded** at the task.";
-    const { body } = render(SessionResults, { props: { results: { agent_one: markdown } } });
+  it("`{text}` envelope renders the markdown body — the dominant chat-tool shape", () => {
+    // This is what handle-chat / workspace-chat sessions emit. Real-world
+    // QA on a live daemon (melted_onion/b459e082) caught that the first
+    // cut of this component missed the `{text}` branch and dumped this
+    // shape back into JsonHighlight — the exact regression to lock here.
+    const { body } = render(SessionResults, {
+      props: {
+        results: {
+          unknown: {
+            text: "# Done\n\nThe assistant **finished** the task.\n\n- step one\n- step two",
+          },
+        },
+      },
+    });
     expect(body).toContain("<h1");
-    expect(body).toContain("Result</h1>");
-    expect(body).toContain("<strong>succeeded</strong>");
-    // Never re-stringified through JsonHighlight.
+    expect(body).toContain("Done</h1>");
+    expect(body).toContain("<strong>finished</strong>");
+    expect(body).toContain("step one");
+    expect(body).toContain("step two");
+    // Crucially: no escaped newlines, no JSON-shaped `"text": "..."`.
     expect(body).not.toContain("\\n\\n");
-    expect(body).not.toContain("# Result\\n");
+    expect(body).not.toMatch(/"text"\s*:/);
   });
 
-  it("string value with an embedded GFM table renders prose + TableView", () => {
-    const markdown =
-      "Some prose first.\n\n| col1 | col2 |\n| --- | --- |\n| a | b |\n\nMore prose after.";
-    const { body } = render(SessionResults, { props: { results: { agent_one: markdown } } });
-    // Both prose chunks land.
-    expect(body).toContain("Some prose first");
-    expect(body).toContain("More prose after");
-    // Table headers + cell values arrive via TableView, not as a markdown
-    // <table> from MarkdownRendered.
-    expect(body).toContain("col1");
-    expect(body).toContain("col2");
-    expect(body).toContain(">a<");
-    expect(body).toContain(">b<");
-  });
-
-  it("structured {response, data} renders response as markdown and data as JSON", () => {
+  it("`{response, data}` renders response as markdown and data as JSON", () => {
     const { body } = render(SessionResults, {
       props: {
         results: {
@@ -73,68 +71,54 @@ describe("session-results", () => {
     expect(body).toContain("42");
   });
 
-  it("structured value without `data` does not emit an empty JSON block", () => {
+  it("`{response}` without data does not emit an empty JSON block", () => {
     const { body } = render(SessionResults, {
       props: { results: { agent_one: { response: "ok" } } },
     });
     expect(body).toContain("ok");
-    // The structured `data` JSON block only appears when the agent emits one.
     expect(body).not.toContain("rows_touched");
     expect(body).not.toMatch(/<code[^>]*>{}<\/code>/);
   });
 
-  it("`{text}` envelope renders the markdown body — the dominant chat-tool shape", () => {
-    // This is what handle-chat / workspace-chat sessions actually emit
-    // ('agentName: unknown' under the hood). Real-world data caught
-    // during browser QA showed this was the missing branch.
+  it("markdown with an embedded GFM table renders prose + TableView", () => {
     const { body } = render(SessionResults, {
       props: {
         results: {
           unknown: {
-            text: "# Done\n\nThe assistant **finished** the task.\n\n- step one\n- step two",
+            text: "Some prose first.\n\n| col1 | col2 |\n| --- | --- |\n| a | b |\n\nMore prose after.",
           },
         },
       },
     });
-    expect(body).toContain("<h1");
-    expect(body).toContain("Done</h1>");
-    expect(body).toContain("<strong>finished</strong>");
-    // List items make it through too.
-    expect(body).toContain("step one");
-    expect(body).toContain("step two");
-    // Crucially: no escaped newlines, no JSON-shaped `"text": "..."`.
-    expect(body).not.toContain("\\n\\n");
-    expect(body).not.toMatch(/"text"\s*:/);
+    // Both prose chunks land.
+    expect(body).toContain("Some prose first");
+    expect(body).toContain("More prose after");
+    // Table headers + cell values arrive via TableView, not as a markdown
+    // <table> from MarkdownRendered.
+    expect(body).toContain("col1");
+    expect(body).toContain("col2");
+    expect(body).toContain(">a<");
+    expect(body).toContain(">b<");
   });
 
-  it("error envelope renders the error string with the error label class", () => {
-    const { body } = render(SessionResults, {
-      props: { results: { agent_one: { error: "blew up parsing yaml" } } },
-    });
-    expect(body).toContain("error-label");
-    expect(body).toContain("blew up parsing yaml");
-    // The error string is the whole render — no markdown pass and no JSON
-    // dump alongside.
-    expect(body).not.toContain("<h1");
-    expect(body).not.toMatch(/rows_touched/);
-  });
-
-  it("unrecognised shape falls back to a JSON view, not a markdown render", () => {
+  it("unrecognised object shape falls back to a JSON view", () => {
     const { body } = render(SessionResults, {
       props: { results: { agent_one: { weirdShape: [1, 2, 3] } } },
     });
     expect(body).toContain("weirdShape");
-    // The raw object should arrive as JSON-shaped text (key + array
-    // values), not as a parsed markdown render.
     expect(body).toContain("1");
     expect(body).toContain("2");
     expect(body).toContain("3");
-    expect(body).not.toContain("error-label");
   });
 
   it("renders per-agent headers when there is more than one entry", () => {
     const { body } = render(SessionResults, {
-      props: { results: { fetcher: "Fetched 12 docs.", summariser: "Summary is **here**." } },
+      props: {
+        results: {
+          fetcher: { text: "Fetched 12 docs." },
+          summariser: { response: "Summary is **here**." },
+        },
+      },
     });
     expect(body).toContain("result-agent");
     expect(body).toContain("fetcher");
@@ -144,7 +128,7 @@ describe("session-results", () => {
 
   it("does not render an agent-name header when there is only one entry", () => {
     const { body } = render(SessionResults, {
-      props: { results: { only_agent: "just one result" } },
+      props: { results: { only_agent: { text: "just one result" } } },
     });
     expect(body).toContain("just one result");
     expect(body).not.toContain("result-agent");
@@ -152,10 +136,11 @@ describe("session-results", () => {
   });
 
   it("a null-valued entry falls back to the JSON view rather than crashing", () => {
-    const { body } = render(SessionResults, { props: { results: { agent_one: null } } });
+    const { body } = render(SessionResults, {
+      props: { results: { agent_one: null } },
+    });
     // Lands in the JSON fallback path — typeof null === "object" but the
-    // structured/error guards reject it explicitly.
+    // prose extractor rejects null explicitly.
     expect(body).toContain("null");
-    expect(body).not.toContain("error-label");
   });
 });

--- a/tools/agent-playground/src/lib/components/session/session-results.test.ts
+++ b/tools/agent-playground/src/lib/components/session/session-results.test.ts
@@ -3,11 +3,13 @@
  * the run-detail page mounts under the final "Complete"/"Failed" roll-up.
  *
  * The page's upstream type for `results` is `Record<string, unknown>`
- * because agents emit anything they want through `complete()`. The
- * component does the runtime branching: string markdown, structured
- * `{response, data}`, `{error}`, raw JSON fallback. These tests pin each
- * branch on the first paint so a future "simplification" can't quietly
- * route a markdown string back into a JSON dump.
+ * because agents emit anything they want through `complete()`, FSM
+ * `outputTo`, or the chat-tool's implicit `{ text }` fall-through.
+ * The component does the runtime branching: bare string, structured
+ * `{response, data}`, `{text}` envelope, `{error}` envelope, raw JSON
+ * fallback. These tests pin each branch on the first paint so a future
+ * "simplification" can't quietly route a markdown payload back into a
+ * JSON dump.
  *
  * Render-only assertions via `svelte/server` — no DOM event simulation.
  * `markdownToHTMLSafe` uses `isomorphic-dompurify` which transparently
@@ -79,6 +81,30 @@ describe("session-results", () => {
     // The structured `data` JSON block only appears when the agent emits one.
     expect(body).not.toContain("rows_touched");
     expect(body).not.toMatch(/<code[^>]*>{}<\/code>/);
+  });
+
+  it("`{text}` envelope renders the markdown body — the dominant chat-tool shape", () => {
+    // This is what handle-chat / workspace-chat sessions actually emit
+    // ('agentName: unknown' under the hood). Real-world data caught
+    // during browser QA showed this was the missing branch.
+    const { body } = render(SessionResults, {
+      props: {
+        results: {
+          unknown: {
+            text: "# Done\n\nThe assistant **finished** the task.\n\n- step one\n- step two",
+          },
+        },
+      },
+    });
+    expect(body).toContain("<h1");
+    expect(body).toContain("Done</h1>");
+    expect(body).toContain("<strong>finished</strong>");
+    // List items make it through too.
+    expect(body).toContain("step one");
+    expect(body).toContain("step two");
+    // Crucially: no escaped newlines, no JSON-shaped `"text": "..."`.
+    expect(body).not.toContain("\\n\\n");
+    expect(body).not.toMatch(/"text"\s*:/);
   });
 
   it("error envelope renders the error string with the error label class", () => {

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/sessions/[sessionId]/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/sessions/[sessionId]/+page.svelte
@@ -5,22 +5,11 @@
     SessionView,
   } from "@atlas/core/session/session-events";
   import { initialSessionView, reduceSessionEvent } from "@atlas/core/session/session-reducer";
-  import {
-    Button,
-    FormattedData,
-    Icons,
-    IconSmall,
-    JsonHighlight,
-    MarkdownRendered,
-    markdownToHTMLSafe,
-    StatusBadge,
-  } from "@atlas/ui";
+  import { Button, FormattedData, Icons, IconSmall, StatusBadge } from "@atlas/ui";
   import { experimental_streamedQuery } from "@tanstack/query-core";
   import { createQuery } from "@tanstack/svelte-query";
   import { page } from "$app/state";
-  import { splitMarkdownByTables } from "$lib/components/chat/table-parsers.ts";
-  import TableView from "$lib/components/chat/table-view.svelte";
-  import { AgentBlockCard, parseError, StepBlock } from "$lib/components/session";
+  import { AgentBlockCard, parseError, SessionResults, StepBlock } from "$lib/components/session";
   import WorkspaceBreadcrumb from "$lib/components/workspace/workspace-breadcrumb.svelte";
   import { subscribeToSessionEvents } from "$lib/shared-worker/client.ts";
   import { formatDuration, formatSessionDate } from "$lib/utils/date";
@@ -64,21 +53,6 @@
   const sessionDate = $derived(
     query.data?.startedAt ? formatSessionDate(query.data.startedAt) : "",
   );
-
-  type StructuredResult = { response: string; data?: unknown };
-  type ErrorResult = { error: string };
-  function isStructuredResult(v: unknown): v is StructuredResult {
-    return (
-      typeof v === "object" &&
-      v !== null &&
-      typeof (v as { response?: unknown }).response === "string"
-    );
-  }
-  function isErrorResult(v: unknown): v is ErrorResult {
-    return (
-      typeof v === "object" && v !== null && typeof (v as { error?: unknown }).error === "string"
-    );
-  }
 
   /** Scroll to hash-targeted block once data has loaded. */
   let hasScrolled = $state(false);
@@ -193,48 +167,7 @@
                 </FormattedData>
               {/if}
             {:else if query.data.results && Object.keys(query.data.results).length > 0}
-              {@const entries = Object.entries(query.data.results)}
-              <div class="results">
-                {#each entries as [agentName, value] (agentName)}
-                  <div class="result-block">
-                    {#if entries.length > 1}
-                      <h4 class="result-agent">{agentName}</h4>
-                    {/if}
-                    {#if typeof value === "string"}
-                      {#each splitMarkdownByTables(value) as segment, i (i)}
-                        {#if segment.kind === "prose"}
-                          <MarkdownRendered>
-                            {@html markdownToHTMLSafe(segment.markdown)}
-                          </MarkdownRendered>
-                        {:else}
-                          <TableView columns={segment.model.columns} rows={segment.model.rows} />
-                        {/if}
-                      {/each}
-                    {:else if isStructuredResult(value)}
-                      {#each splitMarkdownByTables(value.response) as segment, i (i)}
-                        {#if segment.kind === "prose"}
-                          <MarkdownRendered>
-                            {@html markdownToHTMLSafe(segment.markdown)}
-                          </MarkdownRendered>
-                        {:else}
-                          <TableView columns={segment.model.columns} rows={segment.model.rows} />
-                        {/if}
-                      {/each}
-                      {#if value.data !== undefined}
-                        <FormattedData copyText={JSON.stringify(value.data, null, 2)} maxLines={7}>
-                          <JsonHighlight code={JSON.stringify(value.data, null, 2)} />
-                        </FormattedData>
-                      {/if}
-                    {:else if isErrorResult(value)}
-                      <p class="error-label">{value.error}</p>
-                    {:else}
-                      <FormattedData copyText={JSON.stringify(value, null, 2)} maxLines={7}>
-                        <JsonHighlight code={JSON.stringify(value, null, 2)} />
-                      </FormattedData>
-                    {/if}
-                  </div>
-                {/each}
-              </div>
+              <SessionResults results={query.data.results} />
             {/if}
           </StepBlock.Root>
         {/if}
@@ -391,28 +324,6 @@
     color: var(--color-red);
     font-size: var(--font-size-3);
     font-weight: var(--font-weight-5);
-  }
-
-  .results {
-    display: flex;
-    flex-direction: column;
-    gap: var(--size-4);
-  }
-
-  .result-block {
-    display: flex;
-    flex-direction: column;
-    gap: var(--size-2);
-    min-inline-size: 0;
-  }
-
-  .result-agent {
-    color: color-mix(in srgb, var(--color-text), transparent 35%);
-    font-size: var(--font-size-1);
-    font-weight: var(--font-weight-6);
-    letter-spacing: 0.02em;
-    margin: 0;
-    text-transform: uppercase;
   }
 
   .timeline {

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/sessions/[sessionId]/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/sessions/[sessionId]/+page.svelte
@@ -5,14 +5,25 @@
     SessionView,
   } from "@atlas/core/session/session-events";
   import { initialSessionView, reduceSessionEvent } from "@atlas/core/session/session-reducer";
-  import { Button, FormattedData, Icons, IconSmall, JsonHighlight, StatusBadge } from "@atlas/ui";
+  import {
+    Button,
+    FormattedData,
+    Icons,
+    IconSmall,
+    JsonHighlight,
+    MarkdownRendered,
+    markdownToHTMLSafe,
+    StatusBadge,
+  } from "@atlas/ui";
   import { experimental_streamedQuery } from "@tanstack/query-core";
   import { createQuery } from "@tanstack/svelte-query";
   import { page } from "$app/state";
+  import { splitMarkdownByTables } from "$lib/components/chat/table-parsers.ts";
+  import TableView from "$lib/components/chat/table-view.svelte";
   import { AgentBlockCard, parseError, StepBlock } from "$lib/components/session";
   import WorkspaceBreadcrumb from "$lib/components/workspace/workspace-breadcrumb.svelte";
-  import { formatDuration, formatSessionDate } from "$lib/utils/date";
   import { subscribeToSessionEvents } from "$lib/shared-worker/client.ts";
+  import { formatDuration, formatSessionDate } from "$lib/utils/date";
   import { tick } from "svelte";
 
   const sessionId = $derived(page.params.sessionId);
@@ -36,7 +47,11 @@
   const inspectorHref = $derived.by(() => {
     const jobName = query.data?.jobName;
     if (!jobName) return null;
-    const params = new URLSearchParams({ workspace: workspaceId, job: jobName, session: sessionId });
+    const params = new URLSearchParams({
+      workspace: workspaceId,
+      job: jobName,
+      session: sessionId,
+    });
     return `/inspector?${params}`;
   });
 
@@ -49,6 +64,21 @@
   const sessionDate = $derived(
     query.data?.startedAt ? formatSessionDate(query.data.startedAt) : "",
   );
+
+  type StructuredResult = { response: string; data?: unknown };
+  type ErrorResult = { error: string };
+  function isStructuredResult(v: unknown): v is StructuredResult {
+    return (
+      typeof v === "object" &&
+      v !== null &&
+      typeof (v as { response?: unknown }).response === "string"
+    );
+  }
+  function isErrorResult(v: unknown): v is ErrorResult {
+    return (
+      typeof v === "object" && v !== null && typeof (v as { error?: unknown }).error === "string"
+    );
+  }
 
   /** Scroll to hash-targeted block once data has loaded. */
   let hasScrolled = $state(false);
@@ -163,9 +193,48 @@
                 </FormattedData>
               {/if}
             {:else if query.data.results && Object.keys(query.data.results).length > 0}
-              <FormattedData copyText={JSON.stringify(query.data.results, null, 2)} maxLines={7}>
-                <JsonHighlight code={JSON.stringify(query.data.results, null, 2)} />
-              </FormattedData>
+              {@const entries = Object.entries(query.data.results)}
+              <div class="results">
+                {#each entries as [agentName, value] (agentName)}
+                  <div class="result-block">
+                    {#if entries.length > 1}
+                      <h4 class="result-agent">{agentName}</h4>
+                    {/if}
+                    {#if typeof value === "string"}
+                      {#each splitMarkdownByTables(value) as segment, i (i)}
+                        {#if segment.kind === "prose"}
+                          <MarkdownRendered>
+                            {@html markdownToHTMLSafe(segment.markdown)}
+                          </MarkdownRendered>
+                        {:else}
+                          <TableView columns={segment.model.columns} rows={segment.model.rows} />
+                        {/if}
+                      {/each}
+                    {:else if isStructuredResult(value)}
+                      {#each splitMarkdownByTables(value.response) as segment, i (i)}
+                        {#if segment.kind === "prose"}
+                          <MarkdownRendered>
+                            {@html markdownToHTMLSafe(segment.markdown)}
+                          </MarkdownRendered>
+                        {:else}
+                          <TableView columns={segment.model.columns} rows={segment.model.rows} />
+                        {/if}
+                      {/each}
+                      {#if value.data !== undefined}
+                        <FormattedData copyText={JSON.stringify(value.data, null, 2)} maxLines={7}>
+                          <JsonHighlight code={JSON.stringify(value.data, null, 2)} />
+                        </FormattedData>
+                      {/if}
+                    {:else if isErrorResult(value)}
+                      <p class="error-label">{value.error}</p>
+                    {:else}
+                      <FormattedData copyText={JSON.stringify(value, null, 2)} maxLines={7}>
+                        <JsonHighlight code={JSON.stringify(value, null, 2)} />
+                      </FormattedData>
+                    {/if}
+                  </div>
+                {/each}
+              </div>
             {/if}
           </StepBlock.Root>
         {/if}
@@ -322,6 +391,28 @@
     color: var(--color-red);
     font-size: var(--font-size-3);
     font-weight: var(--font-weight-5);
+  }
+
+  .results {
+    display: flex;
+    flex-direction: column;
+    gap: var(--size-4);
+  }
+
+  .result-block {
+    display: flex;
+    flex-direction: column;
+    gap: var(--size-2);
+    min-inline-size: 0;
+  }
+
+  .result-agent {
+    color: color-mix(in srgb, var(--color-text), transparent 35%);
+    font-size: var(--font-size-1);
+    font-weight: var(--font-weight-6);
+    letter-spacing: 0.02em;
+    margin: 0;
+    text-transform: uppercase;
   }
 
   .timeline {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -43,6 +43,10 @@ export default defineConfig({
     // default loader externalises node_modules and tries to import the
     // file as JS, which dies on the first `<`. Inlining lets the svelte
     // plugin compile it.
-    server: { deps: { inline: [/@tanstack\/svelte-query/] } },
+    server: {
+      deps: {
+        inline: [/@tanstack\/svelte-query/, /@tanstack\/svelte-table/, /@tanstack\/svelte-store/],
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary

- The final "Complete"/"Failed" roll-up on `/platform/<wsId>/sessions/<sessionId>` dumped `query.data.results` through `JsonHighlight` regardless of shape. LLM markdown landed as an escaped JSON string — users read the structural shape of the result instead of the result itself.
- Now branches per entry in the results map based on what the FSM session reducer at `packages/core/src/session/session-reducer.ts:90` actually emits:
  - `{ text: "..." }` (workspace-chat / `"unknown"` agent fall-through — the dominant real-world shape) → markdown via `splitMarkdownByTables` + `MarkdownRendered` / `TableView`
  - `{ response: "...", data?: ... }` (Agent SDK `complete({ response, data })`) → response as markdown, optional `data` as a `JsonHighlight` block below
  - anything else → the original `JsonHighlight` fallback
- Renderer is wrapped in `FormattedData` (the same chrome used by `Input`, tool call request/response panels, and the existing fallback) so it has a Copy button that copies the raw markdown source, a 20-line clamp + Expand, and consistent padding against the StepBlock header.
- Per-agent label is only shown when there's more than one entry, so single-result roll-ups stay clean.

Bare-string and `{ error }` branches that were in the first cut were dropped — the session reducer doesn't emit either into this map (errors flow through `query.data.error` to the parent page's `sessionError` branch, which is untouched).

Scope intentionally limited to the roll-up at lines 165-168 named in the issue. The per-block `AgentBlockCard` output renderer at `agent-block-card.svelte:213-214` has the same JSON-dump shape but is a separate surface — flagged for follow-up, not bundled.

Closes #420

## Test plan

- [ ] Daemon + playground: load a finished `handle-chat` run (`results.unknown = { text: "..." }`). Markdown headings / lists / inline code render as styled prose; Copy button is present top-right; no escaped `\n` in the output.
- [ ] Load a run whose result is `{ response, data }` (Agent SDK `complete()` with both fields). Response renders as markdown, `data` collapses into a separate JsonHighlight block below.
- [ ] Load a run whose result contains an embedded GFM table inside a `{ text }` or `{ response }` markdown payload. Table renders via `TableView` between markdown prose chunks.
- [ ] Load a run with multiple agents in the results map (FSM with multiple completing agents). Each gets a small uppercase agent-name header above its content.
- [ ] Load a run with an unrecognised object shape (neither `{response}` nor `{text}`). Falls back to the existing `JsonHighlight` view.
- [ ] Failed-session error rendering (`sessionError` branch in the parent page) is unchanged.

## QA notes

- Live verified on `melted_onion` sessions `b459e082` (`{text}`) and `846c24a3` (`{response}`).
- SSR tests in `session-results.test.ts` cover 9 cases: empty results, `{text}`, `{response, data}`, `{response}` alone, embedded GFM table, unrecognised shape, multi-agent, single-agent header suppression, null value.