### PR TITLE
fix(fsm): surface no-op signals as SKIPPED, not silent COMPLETED

### DIFF
--- a/packages/fsm-engine/fsm-engine.ts
+++ b/packages/fsm-engine/fsm-engine.ts
@@ -411,6 +411,30 @@ export type AgentExecutor = (
   options?: AgentExecutorOptions,
 ) => Promise<AgentSDKExecutionResult>;
 
+/**
+ * Outcome of a top-level {@link FSMEngine.signal} call. Returned so callers
+ * (e.g. the workspace runtime) can distinguish a real run from a silent
+ * no-op — a signal that matched no `on:` handler at the current state used
+ * to resolve as `Promise<void>` and looked indistinguishable from a clean
+ * completion. Refs #322.
+ */
+export type SignalOutcome = {
+  /** True iff at least one transition committed during this signal() drain. */
+  transitionTaken: boolean;
+  /** FSM state after the drain. */
+  finalState: string;
+  /** Number of queued signals processed during this drain (cascades > 1). */
+  signalsProcessed: number;
+  /**
+   * When `transitionTaken` is false, why. `no-handler`: no `on[sig.type]`
+   * at the current state. `queued`: this call was re-entrant — the signal
+   * was appended to the in-flight queue and will be drained by the outer
+   * invocation; this outcome reflects only the re-entrant call, not the
+   * eventual processing.
+   */
+  reason?: "no-handler" | "queued";
+};
+
 export interface FSMEngineOptions {
   llmProvider?: LLMProvider;
   documentStore: DocumentStore;
@@ -697,12 +721,21 @@ export class FSMEngine {
        */
       delegationDepth?: number;
     },
-  ): Promise<void> {
+  ): Promise<SignalOutcome> {
     const signalWithContext: SignalWithContext = context ? { ...sig, _context: context } : sig;
     this._signalQueue.push(signalWithContext);
-    if (!this._processing) {
-      await this.processQueue();
+    // Re-entrant call (e.g. from `context.emit` inside an action). The
+    // outer invocation owns the drain and will return the real aggregate;
+    // this call just queues. Reflect that honestly.
+    if (this._processing) {
+      return {
+        transitionTaken: false,
+        finalState: this._currentState,
+        signalsProcessed: 0,
+        reason: "queued",
+      };
     }
+    return await this.processQueue();
   }
 
   /**
@@ -753,13 +786,15 @@ export class FSMEngine {
     }
   }
 
-  private async processQueue(): Promise<void> {
+  private async processQueue(): Promise<SignalOutcome> {
     this._processing = true;
     this._processedSignalsCount = 0;
     // Clear stale prepare config from previous signal batches so external
     // signals start fresh. Cascaded signals within this run will see
     // __lastPrepare set by earlier signals in the same batch.
     this._results.delete("__lastPrepare");
+    let anyTransitionTaken = false;
+    let signalsProcessed = 0;
     try {
       while (this._signalQueue.length > 0) {
         if (this._processedSignalsCount++ > FSMEngine.MAX_PROCESSED_SIGNALS) {
@@ -770,16 +805,26 @@ export class FSMEngine {
         }
         const sig = this._signalQueue.shift();
         if (sig) {
-          await this.processSingleSignal(sig);
+          const took = await this.processSingleSignal(sig);
+          signalsProcessed++;
+          if (took) anyTransitionTaken = true;
         }
       }
     } finally {
       this._processing = false;
     }
+    return anyTransitionTaken
+      ? { transitionTaken: true, finalState: this._currentState, signalsProcessed }
+      : {
+          transitionTaken: false,
+          finalState: this._currentState,
+          signalsProcessed,
+          reason: "no-handler",
+        };
   }
 
-  private async processSingleSignal(sig: SignalWithContext): Promise<void> {
-    await withOtelSpan(
+  private async processSingleSignal(sig: SignalWithContext): Promise<boolean> {
+    return await withOtelSpan(
       "fsm.signal",
       {
         "fsm.state": this._currentState,
@@ -790,10 +835,16 @@ export class FSMEngine {
     );
   }
 
+  /**
+   * Returns `true` iff a transition committed for this signal. `false`
+   * covers the silent no-op paths: no `on:` handler at the current state,
+   * a malformed/empty transitions list. Errors during the commit phase
+   * throw and propagate; they are not represented in this boolean.
+   */
   private async processSingleSignalInner(
     sig: SignalWithContext,
     otelSpan: OtelSpan | null,
-  ): Promise<void> {
+  ): Promise<boolean> {
     logger.debug("Processing signal", {
       signalType: sig.type,
       currentState: this._currentState,
@@ -808,13 +859,13 @@ export class FSMEngine {
         signalType: sig.type,
         currentState: this._currentState,
       });
-      return; // No transition for this signal
+      return false; // No transition for this signal
     }
 
     // Get transitions for this signal type
     const transitionsOrSingle = state.on[sig.type];
     if (!transitionsOrSingle) {
-      return; // No transition for this signal
+      return false; // No transition for this signal
     }
     const transitions = Array.isArray(transitionsOrSingle)
       ? transitionsOrSingle
@@ -822,7 +873,7 @@ export class FSMEngine {
 
     const selectedTransition: TransitionDefinition | null = transitions[0] ?? null;
 
-    if (!selectedTransition) return; // No valid transition found
+    if (!selectedTransition) return false; // No valid transition found
 
     // Skip chain-through: resolve the effective target by chaining through skipped states
     const skipStates = sig._context?.skipStates ?? [];
@@ -1013,6 +1064,8 @@ export class FSMEngine {
           },
         });
       }
+
+      return true;
     } catch (error) {
       // Classify the error to determine severity
       const errorCause = createErrorCause(error);
@@ -2605,7 +2658,9 @@ export class FSMEngine {
           this._results.set(key, data);
         }
       },
-      emit: (s: Signal) => this.signal(s),
+      emit: async (s: Signal) => {
+        await this.signal(s);
+      },
       updateDoc: this.makeUpdateDocFn(),
       createDoc: this.makeCreateDocFn(),
       deleteDoc: this.makeDeleteDocFn(),

--- a/packages/fsm-engine/mod.ts
+++ b/packages/fsm-engine/mod.ts
@@ -19,6 +19,7 @@ export type {
   AgentExecutor,
   AgentExecutorOptions,
   FSMEngineOptions,
+  SignalOutcome,
 } from "./fsm-engine.ts";
 export { FSMEngine, interpolatePromptPlaceholders } from "./fsm-engine.ts";
 // LLM integration

--- a/packages/workspace/src/__tests__/runtime-no-op-signal-status.test.ts
+++ b/packages/workspace/src/__tests__/runtime-no-op-signal-status.test.ts
@@ -1,31 +1,13 @@
 /**
- * Failing-test guard for the silent-no-op signal bug.
+ * Regression guard for the silent-no-op signal bug (#322).
  *
- * Repro: a workspace job declares an FSM whose initial state is also a
- * `type: final` state with no `on:` transitions. When the matching
- * signal is fired, `FSMEngine.processSingleSignalInner` (fsm-engine.ts
- * ~line 782) finds no `state.on[sig.type]`, logs DEBUG "No transition
- * defined for signal", and returns void. The runtime caller
- * (`runtime.ts` ~line 2083) sees no error from `engine.signal(...)`,
- * sets `session.status = COMPLETED`, and emits "Signal processed
- * successfully". Downstream chat-tool wrapper (`packages/system/agents/
- * workspace-chat/tools/job-tools.ts:404`) then returns
- * `{ success: true, status: "completed", artifactIds: [], summary: <empty
- * sentinel> }` — and the chat agent reports "Done — successfully" for a
+ * Contract: when the engine drains the signal queue without committing
+ * any transition (e.g. an FSM whose current state has no `on:` handler
+ * for the incoming signal), the session must surface as `SKIPPED`, not
+ * `COMPLETED`. The downstream chain converts `SKIPPED` to a `job-error`
+ * SSE event, which the chat-tool wrapper returns as `success: false`.
+ * Without that, the chat agent reports "Done — successfully" for a
  * session that did literally nothing.
- *
- * Discovered during a chat-driven QA round when a no-op fixture FSM
- * caused the chat agent to report a clean success on a job that did
- * literally nothing. Root-cause investigation pinpointed the engine's
- * silent return as the contract gap.
- *
- * Desired contract (this test asserts the fix): when the engine takes
- * zero transitions on a signal, the session must surface as `SKIPPED`,
- * not `COMPLETED`. This is the signal the chat-tool wrapper needs to
- * stop returning `success: true` for empty no-op runs.
- *
- * Currently failing — keeps failing until the runtime / engine plumbing
- * is taught to flag "transition not taken" as a non-completion.
  */
 
 import { rm } from "node:fs/promises";
@@ -83,14 +65,7 @@ afterEach(async () => {
   await rm(testDir, { recursive: true, force: true });
 });
 
-// `it.fails(...)` flips the assertion: the test PASSES while the
-// inner assertion fails (i.e. while the bug is unfixed) and FAILS
-// the moment the inner assertion starts to pass — that's the signal
-// to remove this `.fails` annotation and make it a regular green
-// test. Keeps CI green without papering over the bug: a fix to
-// runtime.ts/engine.ts that makes silent no-ops surface as SKIPPED
-// will trip CI on this test, forcing the cleanup. See issue #322.
-it.fails("flags a signal that took no transition as SKIPPED, not COMPLETED (refs #322)", async () => {
+it("flags a signal that took no transition as SKIPPED, not COMPLETED (refs #322)", async () => {
   runtime = new WorkspaceRuntime({ id: "test-no-op" }, configWithFinalInitialFSM(), {
     workspacePath: testDir,
     lazy: true,
@@ -100,16 +75,6 @@ it.fails("flags a signal that took no transition as SKIPPED, not COMPLETED (refs
 
   const session = await runtime.triggerSignalWithSession("reindex", {});
 
-  // Contract: a session that performed zero work and took zero
-  // transitions must NOT report `completed`. The chat-tool wrapper
-  // turns `completed` into `success: true` and the conversational
-  // agent then hallucinates a successful run. The right signal here
-  // is `skipped` — same status the runtime already uses for "user
-  // configuration issue" cases.
-  //
-  // Currently fails: runtime.ts:2083 sets COMPLETED whenever
-  // engine.signal() didn't throw, regardless of whether any
-  // transition fired.
   expect(session.status).not.toBe(WorkspaceSessionStatus.COMPLETED);
   expect(session.status).toBe(WorkspaceSessionStatus.SKIPPED);
 });

--- a/packages/workspace/src/runtime.ts
+++ b/packages/workspace/src/runtime.ts
@@ -2155,7 +2155,7 @@ export class WorkspaceRuntime {
         );
 
         try {
-          await awaitWithAbort(enginePromise, effectiveAbortSignal);
+          const signalOutcome = await awaitWithAbort(enginePromise, effectiveAbortSignal);
 
           session.artifacts = this.extractArtifacts(engine.documents);
           // Phase 2.B — persist eligible FSM documents as real artifacts so a
@@ -2185,6 +2185,17 @@ export class WorkspaceRuntime {
           // AbortController we composed up top and override the status.
           if (effectiveAbortSignal.aborted) {
             session.status = WorkspaceSessionStatus.CANCELLED;
+          } else if (!signalOutcome.transitionTaken) {
+            // The engine drained the queue without committing a single
+            // transition — the signal matched no `on:` handler at the
+            // current state. Treat this as SKIPPED (same status the
+            // runtime already uses for user-config issues) so the
+            // downstream chain converts it to a `job-error` SSE event and
+            // the chat-tool wrapper returns `success: false`. Refs #322.
+            session.status = WorkspaceSessionStatus.SKIPPED;
+            session.error = new Error(
+              `Signal "${signal.id}" had no matching transition in state "${engine.state}"`,
+            );
           } else {
             session.status = WorkspaceSessionStatus.COMPLETED;
           }


### PR DESCRIPTION
## Summary

Closes #322.

When a workspace job's FSM had no `on:` handler for an incoming signal, `FSMEngine.signal()` returned `Promise<void>` and the runtime treated the absence of a throw as a successful run — session marked `COMPLETED`, chat agent reporting "Done — successfully" for a session that did literally nothing.

**Fix:** `signal()` now returns a `SignalOutcome` with a `transitionTaken` flag. The runtime branches on it and downgrades to `SKIPPED` (with `session.error` carrying signal name + state) when zero transitions committed. The downstream chain (`SessionFailedError` → `job-error` SSE → wrapper `success: false`) already handles `SKIPPED` correctly, so no wrapper changes were needed.

## Why this layer

Three options were on the table (the issue listed two; an architecture review surfaced more):

- **Engine returns outcome (chosen):** the engine is the only thing that authoritatively knows whether a transition fired. Forward-compatible for future `"guard-rejected"` etc. without another signature break.
- **Runtime snapshots `state`/`documents`:** contained to one file, but false-negatives on `notification`-only and `emit`-only self-loop transitions.
- **Wrapper-side heuristic:** symptom-level patch; every new consumer (CLI, MCP, webhook) would re-implement the same heuristic.

`engine.signal()` had exactly one production caller (`runtime.ts:2082`), so the API-shape change is structurally backward-compatible for every `await engine.signal(...)` that ignores the return value.

## Test plan

- [x] `runtime-no-op-signal-status.test.ts` — regression guard in tree, flipped from `it.fails` to a regular green test
- [x] 625 tests across `packages/fsm-engine` + `packages/workspace` green
- [x] `deno check` clean across all four modified files
- [x] End-to-end against the daemon: same repro (`POST /api/workspaces/.../signals/reindex` on a final-only FSM) that returned `{status:"completed",success:true}` before now returns `HTTP 500 "session skipped: Signal \"reindex\" had no matching transition in state \"done\""`, and the `SessionView` shows `status: "skipped"`