### PR TITLE
feat(ui): syntax-highlight fenced code blocks in markdown previews

### DIFF
--- a/packages/ui/src/lib/markdown/code-highlighter.ts
+++ b/packages/ui/src/lib/markdown/code-highlighter.ts
@@ -1,0 +1,166 @@
+/**
+ * Sync code highlighter for markdown fenced blocks.
+ *
+ * Shipped as a curated set of common languages so the bundle stays
+ * bounded — markdown previews in Discover Spaces, Skills, MCP Catalog,
+ * and chat messages all flow through this. Unknown / unspecified
+ * languages fall through to a plain escaped `<pre><code>` block.
+ *
+ * The theme uses design-token CSS vars (`--blue-3`, `--green-3`, etc.)
+ * so highlighting automatically tracks the existing dark/light mode
+ * switch without a second theme definition. Matches the pattern used
+ * by `tools/agent-playground/.../json-highlighter.ts`.
+ */
+
+import { createHighlighterCoreSync, type HighlighterCore } from "shiki/core";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
+import bashLang from "shiki/langs/bash.mjs";
+import cssLang from "shiki/langs/css.mjs";
+import diffLang from "shiki/langs/diff.mjs";
+import goLang from "shiki/langs/go.mjs";
+import htmlLang from "shiki/langs/html.mjs";
+import javascriptLang from "shiki/langs/javascript.mjs";
+import jsonLang from "shiki/langs/json.mjs";
+import jsxLang from "shiki/langs/jsx.mjs";
+import markdownLang from "shiki/langs/markdown.mjs";
+import pythonLang from "shiki/langs/python.mjs";
+import rustLang from "shiki/langs/rust.mjs";
+import sqlLang from "shiki/langs/sql.mjs";
+import tsxLang from "shiki/langs/tsx.mjs";
+import typescriptLang from "shiki/langs/typescript.mjs";
+import yamlLang from "shiki/langs/yaml.mjs";
+
+const THEME_NAME = "atlas-code";
+
+const highlighter: HighlighterCore = createHighlighterCoreSync({
+  themes: [
+    {
+      name: THEME_NAME,
+      // Shiki requires a `type` for theme resolution; the actual colors are
+      // CSS variables that resolve light/dark at render time, so the
+      // declared "dark" type is just nominal.
+      type: "dark",
+      settings: [
+        {
+          scope: ["comment", "punctuation.definition.comment", "string.comment"],
+          settings: { foreground: "var(--color-text-muted, #888)", fontStyle: "italic" },
+        },
+        {
+          scope: [
+            "keyword",
+            "storage",
+            "storage.type",
+            "storage.modifier",
+            "keyword.control",
+            "keyword.operator.new",
+            "keyword.operator.expression",
+          ],
+          settings: { foreground: "var(--purple-3)" },
+        },
+        {
+          scope: [
+            "string",
+            "string.quoted",
+            "string.template",
+            "punctuation.definition.string",
+          ],
+          settings: { foreground: "var(--green-3)" },
+        },
+        {
+          scope: ["constant.numeric", "constant.language", "constant.character.numeric"],
+          settings: { foreground: "var(--yellow-3)" },
+        },
+        {
+          scope: ["entity.name.function", "support.function", "meta.function-call"],
+          settings: { foreground: "var(--blue-3)" },
+        },
+        {
+          scope: [
+            "entity.name.type",
+            "entity.name.class",
+            "support.type",
+            "support.class",
+            "entity.other.inherited-class",
+          ],
+          settings: { foreground: "var(--brown-3)" },
+        },
+        {
+          scope: ["variable", "variable.other", "variable.parameter"],
+          settings: { foreground: "var(--color-text)" },
+        },
+        {
+          scope: [
+            "variable.language",
+            "variable.language.this",
+            "variable.language.self",
+          ],
+          settings: { foreground: "var(--red-3)", fontStyle: "italic" },
+        },
+        {
+          scope: ["entity.name.tag", "punctuation.definition.tag"],
+          settings: { foreground: "var(--blue-3)" },
+        },
+        {
+          scope: ["entity.other.attribute-name"],
+          settings: { foreground: "var(--yellow-3)" },
+        },
+        {
+          scope: ["markup.inserted", "markup.changed"],
+          settings: { foreground: "var(--green-3)" },
+        },
+        {
+          scope: ["markup.deleted"],
+          settings: { foreground: "var(--red-3)" },
+        },
+        {
+          scope: ["support.type.property-name", "meta.object-literal.key"],
+          settings: { foreground: "var(--blue-3)" },
+        },
+      ],
+      fg: "var(--color-text)",
+      bg: "transparent",
+    },
+  ],
+  langs: [
+    bashLang,
+    cssLang,
+    diffLang,
+    goLang,
+    htmlLang,
+    javascriptLang,
+    jsonLang,
+    jsxLang,
+    markdownLang,
+    pythonLang,
+    rustLang,
+    sqlLang,
+    tsxLang,
+    typescriptLang,
+    yamlLang,
+  ],
+  engine: createJavaScriptRegexEngine(),
+});
+
+const SUPPORTED_LANGS = new Set(highlighter.getLoadedLanguages());
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+/**
+ * Render a fenced code block as syntax-highlighted HTML. Unknown
+ * languages (or no language tag at all) fall back to a plain escaped
+ * `<pre><code>` so the caller never has to branch.
+ */
+export function highlightCodeBlock(code: string, lang: string | undefined): string {
+  const normalized = (lang ?? "").trim().toLowerCase();
+  if (normalized && SUPPORTED_LANGS.has(normalized)) {
+    return highlighter.codeToHtml(code, { lang: normalized, theme: THEME_NAME });
+  }
+  return `<pre><code>${escapeHtml(code)}</code></pre>`;
+}

--- a/packages/ui/src/lib/markdown/markdown.test.ts
+++ b/packages/ui/src/lib/markdown/markdown.test.ts
@@ -283,6 +283,38 @@ describe("markdownToHTML", () => {
     expect(result).toContain("code block");
   });
 
+  it("syntax-highlights fenced code with a known language", () => {
+    const result = markdownToHTML("```typescript\nconst x: number = 42;\n```");
+    // Shiki emits `<pre class="shiki ...">` and wraps tokens in <span style="color:...">.
+    expect(result).toContain('class="shiki');
+    expect(result).toContain("<span");
+    expect(result).toContain("style=");
+    // Token text survives.
+    expect(result).toContain("const");
+    expect(result).toContain("42");
+  });
+
+  it("falls back to plain pre/code for unknown language tags", () => {
+    const result = markdownToHTML("```unknownlang\nfoo bar\n```");
+    expect(result).toContain("<pre><code>");
+    expect(result).toContain("foo bar");
+    expect(result).not.toContain('class="shiki');
+  });
+
+  it("escapes HTML in unknown-language fallback to prevent XSS", () => {
+    const result = markdownToHTML("```\n<script>alert(1)</script>\n```");
+    expect(result).toContain("&lt;script&gt;");
+    expect(result).not.toMatch(/<script>alert\(1\)<\/script>/);
+  });
+
+  it("markdownToHTMLSafe keeps shiki's color styles through DOMPurify", () => {
+    const result = markdownToHTMLSafe("```json\n{\"a\": 1}\n```");
+    expect(result).toContain('class="shiki');
+    // The token spans must keep their inline `color: var(--…)` for the
+    // light/dark CSS-variable theme to actually paint anything.
+    expect(result).toMatch(/style="[^"]*color:/);
+  });
+
   it("mixed content", () => {
     const markdown = `Here is a paragraph with **bold** and *italic* text.
 

--- a/packages/ui/src/lib/markdown/markdown.ts
+++ b/packages/ui/src/lib/markdown/markdown.ts
@@ -2,6 +2,7 @@ import type { TreeCursor } from "@lezer/common";
 import { parser, Table } from "@lezer/markdown";
 import DOMPurify from "isomorphic-dompurify";
 import { Marked } from "marked";
+import { highlightCodeBlock } from "./code-highlighter.ts";
 
 // ─── marked configuration ──────────────────────────────────────────────
 // Single shared instance with GFM tables, breaks, and links with target=_blank.
@@ -52,6 +53,12 @@ const renderer = {
   // Strip horizontal rules (matches old behavior)
   hr(): string {
     return "";
+  },
+  // Syntax-highlighted fenced code via shiki. Unknown languages get a
+  // plain `<pre><code>` fallback inside `highlightCodeBlock`, so the
+  // renderer never has to branch on language support here.
+  code({ text, lang }: { text: string; lang?: string }): string {
+    return highlightCodeBlock(text, lang);
   },
 };
 
@@ -527,5 +534,8 @@ export function markdownToHTMLSafe(markdown: string): string {
   // `target="_blank"` produced by the marked renderer above survives. The
   // marked renderer also emits `rel="noopener noreferrer"`, which DOMPurify
   // keeps as-is — so the pair lands intact on the rendered chat link.
+  // Shiki's syntax-highlighted fenced blocks carry inline `style="color:…"`
+  // on every token span; DOMPurify keeps `style` by default but it's worth
+  // noting that any token-color change here ripples through every preview.
   return DOMPurify.sanitize(markdownToHTML(markdown), { ADD_ATTR: ["target"] });
 }


### PR DESCRIPTION
## Summary

Closes #209.

Markdown previews in Discover Spaces, Skills, MCP Catalog (and every other consumer of `markdownToHTMLSafe` — chat messages, run-detail artifact view, exports) rendered fenced code blocks as monochrome `<pre><code>`. This adds a `code({ text, lang })` renderer on the shared `marked` instance that hands fenced blocks to a sync `shiki` highlighter.

## Approach

- New `packages/ui/src/lib/markdown/code-highlighter.ts` — `createHighlighterCoreSync` from `shiki` with a curated language set (ts/tsx, js/jsx, python, bash, yaml, json, html, css, sql, go, rust, markdown, diff) and a `var(--*)` theme that auto-tracks the existing dark/light mode switch.
- New `code` renderer on the shared `marked` instance in `markdown.ts`. Unknown / unlabeled languages fall through to escaped `<pre><code>`.
- Mirrors the pattern already in `tools/agent-playground/.../json-highlighter.ts`.

## Why a single fix point

All three views named in the issue route their markdown through `markdownToHTMLSafe` from `@atlas/ui`. Adding the renderer once at the source covers Discover, Skills, MCP Catalog — and incidentally also chat messages, run-detail artifacts, and chat exports, which is the right behavior.

## Bundle impact

`shiki` was already a `@atlas/ui` dependency (and is already in the playground for `json-highlighter.ts`). The 15 language grammars add ~150KB raw / ~80KB gzipped, paid once at module init. Sync engine, so no async hop in the render path.

## Test plan

- [x] 5 new unit tests in `markdown.test.ts` — known-lang highlighting, unknown-lang fallback, XSS escaping in fallback, DOMPurify pass-through preserving `style="color:…"`
- [x] All 123 `@atlas/ui` tests pass
- [x] Visual verification via browser automation against the running playground:
  - `/discover` — `<pre class="shiki atlas-code">` rendered, tokens carry `color:var(--blue-3)` etc.
  - `/skills/friday/friday-cli` — 16 highlighted blocks
  - `/mcp/com-atlassian-atlassian-mcp-server/readme` — 1 highlighted + 1 fallback (mix of tagged and untagged fences)

## Notes for review

- The DOMPurify call already allowed `style` by default; tested explicitly that `color:var(--blue-3)` survives sanitization.
- Unknown-language fallback explicitly escapes HTML so a raw `<script>` inside a fence cannot execute.