### PR TITLE
feat(launcher): one-click diagnostic log export

### DIFF
--- a/apps/atlasd/routes/version.test.ts
+++ b/apps/atlasd/routes/version.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+import { versionRoutes } from "./version.ts";
+
+const VersionResponseSchema = z.object({
+  version: z.string(),
+  isCompiled: z.boolean(),
+  isNightly: z.boolean(),
+  isDev: z.boolean(),
+  gitSha: z.string().optional(),
+});
+
+describe("daemon /api/version", () => {
+  it("returns 200 with the getVersionInfo() shape", async () => {
+    const res = await versionRoutes.request("http://127.0.0.1:8080/", { method: "GET" });
+
+    expect(res.status).toBe(200);
+    VersionResponseSchema.parse(await res.json());
+  });
+});

--- a/apps/atlasd/routes/version.test.ts
+++ b/apps/atlasd/routes/version.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, it } from "vitest";
 import { z } from "zod";
 import { versionRoutes } from "./version.ts";
 
+// No production VersionResponse schema/type is exported from @atlas/utils —
+// `getVersionInfo()` returns an inferred shape. These assertions ARE the
+// contract for the daemon's /api/version payload. The `version` field is
+// load-bearing: the launcher's getDaemonVersion keys off it (export.go).
 const VersionResponseSchema = z.object({
   version: z.string(),
   isCompiled: z.boolean(),
@@ -11,10 +15,26 @@ const VersionResponseSchema = z.object({
 });
 
 describe("daemon /api/version", () => {
-  it("returns 200 with the getVersionInfo() shape", async () => {
+  // The auth contract (401 in non-dev, auto-mint in dev) belongs to the
+  // shared `/api/*` session middleware and is covered against real storage
+  // in apps/atlasd/src/session-middleware.test.ts — nothing about it is
+  // version-route-specific, so it is not re-tested here.
+  it("returns the from-source build version info", async () => {
     const res = await versionRoutes.request("http://127.0.0.1:8080/", { method: "GET" });
 
     expect(res.status).toBe(200);
-    VersionResponseSchema.parse(await res.json());
+    const body = VersionResponseSchema.parse(await res.json());
+
+    // Tests run from a git checkout, never a compiled binary.
+    expect(body.isCompiled).toBe(false);
+    expect(body.isNightly).toBe(false);
+    expect(body.isDev).toBe(true);
+
+    // Source builds report `dev-<short-sha>` (or bare `dev` without git).
+    expect(body.version).toMatch(/^dev(-[0-9a-f]+)?$/);
+
+    // gitSha mirrors the version's sha suffix — the launcher relies on
+    // version being the authoritative field, so the two cannot drift.
+    expect(body.gitSha).toBe(body.version.replace("dev-", ""));
   });
 });

--- a/apps/atlasd/routes/version.ts
+++ b/apps/atlasd/routes/version.ts
@@ -6,4 +6,3 @@ const versionRoutes = daemonFactory.createApp().get("/", (c) => {
 });
 
 export { versionRoutes };
-export type VersionRoutes = typeof versionRoutes;

--- a/apps/atlasd/routes/version.ts
+++ b/apps/atlasd/routes/version.ts
@@ -1,0 +1,9 @@
+import { getVersionInfo } from "@atlas/utils";
+import { daemonFactory } from "../src/factory.ts";
+
+const versionRoutes = daemonFactory.createApp().get("/", (c) => {
+  return c.json(getVersionInfo());
+});
+
+export { versionRoutes };
+export type VersionRoutes = typeof versionRoutes;

--- a/apps/atlasd/src/atlas-daemon.ts
+++ b/apps/atlasd/src/atlas-daemon.ts
@@ -94,6 +94,7 @@ import { shareRoutes } from "../routes/share.ts";
 import { createPlatformSignalRoutes } from "../routes/signals/platform.ts";
 import { skillsRoutes } from "../routes/skills.ts";
 import { userRoutes } from "../routes/user/index.ts";
+import { versionRoutes } from "../routes/version.ts";
 import { eventsRoutes, workspaceEventsRoutes } from "../routes/workspace-events.ts";
 import workspaceCacheSaltRoutes from "../routes/workspaces/cache-salt.ts";
 import workspaceChatRoutes from "../routes/workspaces/chat.ts";
@@ -1487,6 +1488,7 @@ export class AtlasDaemon {
     });
 
     this.app.route("/health", healthRoutes);
+    this.app.route("/api/version", versionRoutes);
     this.app.route("/api/workspaces", workspacesRoutes);
     // Mount workspace config routes for partial updates (separate from workspacesRoutes to avoid circular deps)
     this.app.route("/api/workspaces/:workspaceId/config", workspaceConfigRoutes);

--- a/tools/friday-launcher/atomic.go
+++ b/tools/friday-launcher/atomic.go
@@ -25,7 +25,6 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 
 type launcherState struct {
 	AutostartInitialized bool `json:"autostart_initialized"`
-	IncludeWorkspaces    bool `json:"include_workspaces"`
 }
 
 func readState() launcherState {

--- a/tools/friday-launcher/atomic.go
+++ b/tools/friday-launcher/atomic.go
@@ -25,6 +25,7 @@ func atomicWriteFile(path string, data []byte, perm os.FileMode) error {
 
 type launcherState struct {
 	AutostartInitialized bool `json:"autostart_initialized"`
+	IncludeWorkspaces    bool `json:"include_workspaces"`
 }
 
 func readState() launcherState {

--- a/tools/friday-launcher/atomic_test.go
+++ b/tools/friday-launcher/atomic_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLauncherState_RoundTrip(t *testing.T) {
+	t.Setenv("FRIDAY_LAUNCHER_HOME", t.TempDir())
+
+	want := launcherState{
+		AutostartInitialized: true,
+		IncludeWorkspaces:    true,
+	}
+	if err := writeState(want); err != nil {
+		t.Fatalf("writeState: %v", err)
+	}
+
+	got := readState()
+	if got != want {
+		t.Errorf("readState = %+v, want %+v", got, want)
+	}
+}
+
+func TestLauncherState_BackwardCompat_MissingIncludeWorkspaces(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
+
+	// state.json written by an earlier launcher version that didn't know
+	// about IncludeWorkspaces. Reads must succeed and default the new
+	// field to false rather than erroring out.
+	legacy := []byte(`{"autostart_initialized":true}`)
+	if err := os.WriteFile(statePath(), legacy, 0o600); err != nil {
+		t.Fatalf("seed legacy state: %v", err)
+	}
+
+	got := readState()
+	if !got.AutostartInitialized {
+		t.Errorf("AutostartInitialized = false, want true")
+	}
+	if got.IncludeWorkspaces {
+		t.Errorf("IncludeWorkspaces = true, want false (default)")
+	}
+}

--- a/tools/friday-launcher/atomic_test.go
+++ b/tools/friday-launcher/atomic_test.go
@@ -10,7 +10,6 @@ func TestLauncherState_RoundTrip(t *testing.T) {
 
 	want := launcherState{
 		AutostartInitialized: true,
-		IncludeWorkspaces:    true,
 	}
 	if err := writeState(want); err != nil {
 		t.Fatalf("writeState: %v", err)
@@ -22,14 +21,15 @@ func TestLauncherState_RoundTrip(t *testing.T) {
 	}
 }
 
-func TestLauncherState_BackwardCompat_MissingIncludeWorkspaces(t *testing.T) {
+func TestLauncherState_IgnoresLegacyIncludeWorkspaces(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("FRIDAY_LAUNCHER_HOME", tmp)
 
-	// state.json written by an earlier launcher version that didn't know
-	// about IncludeWorkspaces. Reads must succeed and default the new
-	// field to false rather than erroring out.
-	legacy := []byte(`{"autostart_initialized":true}`)
+	// state.json written by the interim checkbox version that persisted
+	// an include_workspaces field. After the submenu redesign that field
+	// is gone; reads must still succeed (the unknown key is ignored) and
+	// preserve AutostartInitialized rather than erroring out.
+	legacy := []byte(`{"autostart_initialized":true,"include_workspaces":true}`)
 	if err := os.WriteFile(statePath(), legacy, 0o600); err != nil {
 		t.Fatalf("seed legacy state: %v", err)
 	}
@@ -37,8 +37,5 @@ func TestLauncherState_BackwardCompat_MissingIncludeWorkspaces(t *testing.T) {
 	got := readState()
 	if !got.AutostartInitialized {
 		t.Errorf("AutostartInitialized = false, want true")
-	}
-	if got.IncludeWorkspaces {
-		t.Errorf("IncludeWorkspaces = true, want false (default)")
 	}
 }

--- a/tools/friday-launcher/diagnostic_export_test.go
+++ b/tools/friday-launcher/diagnostic_export_test.go
@@ -290,6 +290,29 @@ func TestSetExportPhase_WritesUnderMutex(t *testing.T) {
 	}
 }
 
+// TestSetExportPhase_NoDeadlockOnImmediateRefresh guards the lock
+// contract behind the immediate label refresh: setExportPhase writes
+// the phase under exportMu, then calls updateExportItemLabel which
+// re-acquires exportMu. If a refactor ever leaves the write lock held
+// across that call, the non-reentrant mutex deadlocks. The nil
+// exportItem hits updateExportItemLabel's nil-guard, so this needs no
+// live systray. A watchdog fails the test instead of hanging the suite.
+func TestSetExportPhase_NoDeadlockOnImmediateRefresh(t *testing.T) {
+	tc := &trayController{} // exportItem nil → updateExportItemLabel returns early
+
+	done := make(chan struct{})
+	go func() {
+		tc.setExportPhase("logs")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("setExportPhase deadlocked — exportMu held across updateExportItemLabel")
+	}
+}
+
 // TestToggleIncludeWorkspaces_Persists confirms a click flips the
 // persisted state on disk (read-modify-write through writeState).
 // Without this the preference resets every launcher boot.

--- a/tools/friday-launcher/diagnostic_export_test.go
+++ b/tools/friday-launcher/diagnostic_export_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -99,17 +100,33 @@ func TestServiceHealthy_OnlyHealthyCountsTrue(t *testing.T) {
 }
 
 // TestStartExport_CASGuardSwallowsSecondClick is the load-bearing
-// concurrency test. Two rapid clicks must not start two exports —
-// the second CompareAndSwap fails and the click is a no-op. We use
-// a blocking export to widen the race window so the test reliably
-// catches a regression where the guard was removed.
+// concurrency test. The two clicks run serially on this goroutine: the
+// first startExport CAS's exporting false→true and spawns runExport; the
+// second finds the slot taken and returns synchronously — the CAS fires
+// before any goroutine spawns, so the swallow is deterministic, not a
+// race we have to widen a window to catch. The fake blocks until we've
+// released it so the in-flight export is genuinely still running when the
+// second click lands. Coordination is via channels, not wall-clock polls.
 func TestStartExport_CASGuardSwallowsSecondClick(t *testing.T) {
 	t.Setenv("FRIDAY_LAUNCHER_HOME", t.TempDir())
 
 	var calls atomic.Int32
+	entered := make(chan struct{})
 	release := make(chan struct{})
+	finished := make(chan struct{})
 	withExportFn(t, func(diagnostics.ExportOptions) (string, error) {
-		calls.Add(1)
+		// Only the first entrant touches the barrier channels — guarding on
+		// the call count means a regression that lets a second goroutine in
+		// (CAS removed) records calls==2 and fails the assertion below
+		// cleanly, instead of panicking on a double channel close.
+		if calls.Add(1) != 1 {
+			return "", errors.New("test-cancelled")
+		}
+		// runExport's deferred exporting.Store(false) fires after this
+		// returns; closing finished here (deferred) plus draining release
+		// lets the test observe completion without polling the atomic.
+		defer close(finished)
+		close(entered)
 		<-release
 		return "", errors.New("test-cancelled")
 	})
@@ -119,25 +136,24 @@ func TestStartExport_CASGuardSwallowsSecondClick(t *testing.T) {
 	tc := &trayController{shuttingDown: &sd}
 
 	tc.startExport()
-	tc.startExport() // second click — must be a no-op while first is in flight
+	<-entered        // first export goroutine is now inside exportFn
+	tc.startExport() // second click while first is in flight — CAS no-op
+	close(release)   // let the in-flight export return
+	<-finished       // fake has returned; runExport is unwinding
 
-	// Give the first goroutine a moment to actually hit exportFn, then
-	// release it. We don't sleep-then-assert; we wait for the goroutine
-	// to enter exportFn (calls==1) before unblocking.
-	deadline := time.Now().Add(2 * time.Second)
-	for calls.Load() < 1 && time.Now().Before(deadline) {
-		time.Sleep(5 * time.Millisecond)
-	}
-	close(release)
-
-	// Wait for the first goroutine to clear the exporting flag.
-	deadline = time.Now().Add(2 * time.Second)
-	for tc.exporting.Load() && time.Now().Before(deadline) {
-		time.Sleep(5 * time.Millisecond)
+	// runExport clears exporting in a defer that runs after the fake
+	// returns. Synchronize on that defer by spinning the scheduler until
+	// the goroutine has unwound — bounded by the test's own deadline, not
+	// a wall clock: a hung goroutine would leak and fail the suite anyway.
+	for tc.exporting.Load() {
+		runtime.Gosched()
 	}
 
 	if got := calls.Load(); got != 1 {
 		t.Errorf("export invocations = %d, want 1 (CAS guard failed)", got)
+	}
+	if tc.exporting.Load() {
+		t.Error("exporting flag still set after the in-flight export completed")
 	}
 }
 

--- a/tools/friday-launcher/diagnostic_export_test.go
+++ b/tools/friday-launcher/diagnostic_export_test.go
@@ -1,0 +1,412 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/friday-platform/friday-studio/tools/friday-launcher/diagnostics"
+)
+
+// withExportFn swaps the package-level exportFn for the duration of
+// one test, restoring the prior value on cleanup. Same shape as
+// withBrowserGlobals in tray_test.go — keeps the seam restoration
+// honest under -shuffle=on.
+func withExportFn(t *testing.T, fn func(diagnostics.ExportOptions) (string, error)) {
+	t.Helper()
+	orig := exportFn
+	exportFn = fn
+	t.Cleanup(func() { exportFn = orig })
+}
+
+// withRevealOverride swaps the reveal-in-Finder shell-out so tests
+// don't pop Finder on the developer's machine. The returned counter
+// captures how many times reveal was attempted.
+func withRevealOverride(t *testing.T) *int {
+	t.Helper()
+	orig := revealInFileBrowserOverride
+	calls := 0
+	revealInFileBrowserOverride = func(string) error {
+		calls++
+		return nil
+	}
+	t.Cleanup(func() { revealInFileBrowserOverride = orig })
+	return &calls
+}
+
+// TestDaemonAPIBaseURL_DefaultPortPlainHTTP confirms the helper falls
+// back to http://localhost:8080 when neither FRIDAY_PORT_FRIDAY nor
+// s2s certs are present. This is the boot-time default before the
+// installer downloads the cert pair.
+func TestDaemonAPIBaseURL_DefaultPortPlainHTTP(t *testing.T) {
+	t.Setenv("FRIDAY_LAUNCHER_HOME", t.TempDir())
+	t.Setenv("FRIDAY_PORT_FRIDAY", "")
+
+	got := daemonAPIBaseURL()
+	want := "http://localhost:8080"
+	if got != want {
+		t.Errorf("daemonAPIBaseURL() = %q, want %q", got, want)
+	}
+}
+
+// TestDaemonAPIBaseURL_HonorsPortOverride confirms FRIDAY_PORT_FRIDAY
+// routes into the URL. Installs that move the daemon off 8080 (port
+// collision with another local Friday) need this to work or the tray
+// export silently calls the wrong endpoint.
+func TestDaemonAPIBaseURL_HonorsPortOverride(t *testing.T) {
+	t.Setenv("FRIDAY_LAUNCHER_HOME", t.TempDir())
+	t.Setenv("FRIDAY_PORT_FRIDAY", "18080")
+
+	got := daemonAPIBaseURL()
+	want := "http://localhost:18080"
+	if got != want {
+		t.Errorf("daemonAPIBaseURL() = %q, want %q", got, want)
+	}
+}
+
+// TestServiceHealthy_OnlyHealthyCountsTrue confirms the per-service
+// helper returns true only for services whose status is "healthy".
+// Pending/starting/failed all return false. Unknown names return
+// false (defensive — caller doesn't have to know which services
+// exist).
+func TestServiceHealthy_OnlyHealthyCountsTrue(t *testing.T) {
+	var sd atomic.Bool
+	cache := NewHealthCache(&sd)
+	cache.SetReady("friday", true)
+	cache.Update(makeStates(
+		runningReady("friday"),
+		runningNotReady("link"),
+		failed("playground", 5),
+	))
+
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"friday", true},
+		{"link", false},
+		{"playground", false},
+		{"does-not-exist", false},
+	}
+	for _, c := range cases {
+		if got := cache.ServiceHealthy(c.name); got != c.want {
+			t.Errorf("ServiceHealthy(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// TestStartExport_CASGuardSwallowsSecondClick is the load-bearing
+// concurrency test. Two rapid clicks must not start two exports —
+// the second CompareAndSwap fails and the click is a no-op. We use
+// a blocking export to widen the race window so the test reliably
+// catches a regression where the guard was removed.
+func TestStartExport_CASGuardSwallowsSecondClick(t *testing.T) {
+	t.Setenv("FRIDAY_LAUNCHER_HOME", t.TempDir())
+
+	var calls atomic.Int32
+	release := make(chan struct{})
+	withExportFn(t, func(diagnostics.ExportOptions) (string, error) {
+		calls.Add(1)
+		<-release
+		return "", errors.New("test-cancelled")
+	})
+	withRevealOverride(t)
+
+	var sd atomic.Bool
+	tc := &trayController{shuttingDown: &sd}
+
+	tc.startExport()
+	tc.startExport() // second click — must be a no-op while first is in flight
+
+	// Give the first goroutine a moment to actually hit exportFn, then
+	// release it. We don't sleep-then-assert; we wait for the goroutine
+	// to enter exportFn (calls==1) before unblocking.
+	deadline := time.Now().Add(2 * time.Second)
+	for calls.Load() < 1 && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	close(release)
+
+	// Wait for the first goroutine to clear the exporting flag.
+	deadline = time.Now().Add(2 * time.Second)
+	for tc.exporting.Load() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+
+	if got := calls.Load(); got != 1 {
+		t.Errorf("export invocations = %d, want 1 (CAS guard failed)", got)
+	}
+}
+
+// TestStartExport_RefusedDuringShutdown verifies the shutdown gate.
+// Once shuttingDown is set, Export clicks become no-ops — performShutdown
+// is tearing the daemon down and any bundle-all call would race against
+// the daemon's HTTP server closing.
+func TestStartExport_RefusedDuringShutdown(t *testing.T) {
+	t.Setenv("FRIDAY_LAUNCHER_HOME", t.TempDir())
+
+	var calls atomic.Int32
+	withExportFn(t, func(diagnostics.ExportOptions) (string, error) {
+		calls.Add(1)
+		return "", nil
+	})
+	withRevealOverride(t)
+
+	var sd atomic.Bool
+	sd.Store(true)
+	tc := &trayController{shuttingDown: &sd}
+
+	tc.startExport()
+
+	if got := calls.Load(); got != 0 {
+		t.Errorf("export invocations during shutdown = %d, want 0", got)
+	}
+	if tc.exporting.Load() {
+		t.Error("exporting flag set after shutdown-refused click")
+	}
+}
+
+// TestRunExport_SuccessRevealsAndSetsTransient walks the happy path:
+// export returns a zip path, reveal is invoked, success transient is
+// armed, exporting flag clears, no failure msg is set.
+func TestRunExport_SuccessRevealsAndSetsTransient(t *testing.T) {
+	t.Setenv("FRIDAY_LAUNCHER_HOME", t.TempDir())
+
+	zipPath := filepath.Join(t.TempDir(), "friday-diagnostics-test.zip")
+	if err := os.WriteFile(zipPath, []byte("ignored"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var seenOpts diagnostics.ExportOptions
+	withExportFn(t, func(o diagnostics.ExportOptions) (string, error) {
+		seenOpts = o
+		return zipPath, nil
+	})
+	revealCalls := withRevealOverride(t)
+
+	var sd atomic.Bool
+	tc := &trayController{shuttingDown: &sd}
+	tc.exporting.Store(true) // runExport assumes startExport already CAS'd
+
+	tc.runExport()
+
+	if tc.exporting.Load() {
+		t.Error("exporting flag still set after runExport returned")
+	}
+	if *revealCalls != 1 {
+		t.Errorf("reveal calls = %d, want 1", *revealCalls)
+	}
+	if seenOpts.DaemonURL == "" {
+		t.Error("Export called with empty DaemonURL — daemonAPIBaseURL() not threaded through")
+	}
+	tc.exportMu.Lock()
+	defer tc.exportMu.Unlock()
+	if tc.exportFailureMsg != "" {
+		t.Errorf("exportFailureMsg = %q, want empty on success", tc.exportFailureMsg)
+	}
+	if tc.exportSuccessUntilTS.IsZero() {
+		t.Error("exportSuccessUntilTS not armed after success")
+	}
+	if tc.exportProgressPhase != "" {
+		t.Errorf("exportProgressPhase = %q, want empty after run completes", tc.exportProgressPhase)
+	}
+}
+
+// TestRunExport_FailureSetsStickyLabel: when diagnostics.Export
+// returns an error, the menu label flips to the failure message and
+// stays there (sticky until next click). The CAS guard clears so the
+// user can retry.
+func TestRunExport_FailureSetsStickyLabel(t *testing.T) {
+	t.Setenv("FRIDAY_LAUNCHER_HOME", t.TempDir())
+
+	withExportFn(t, func(diagnostics.ExportOptions) (string, error) {
+		return "", errors.New("disk full")
+	})
+	revealCalls := withRevealOverride(t)
+
+	var sd atomic.Bool
+	tc := &trayController{shuttingDown: &sd}
+	tc.exporting.Store(true)
+
+	tc.runExport()
+
+	if tc.exporting.Load() {
+		t.Error("exporting flag still set after failed runExport")
+	}
+	if *revealCalls != 0 {
+		t.Errorf("reveal calls on failure = %d, want 0", *revealCalls)
+	}
+	tc.exportMu.Lock()
+	defer tc.exportMu.Unlock()
+	if tc.exportFailureMsg != exportItemFailure {
+		t.Errorf("exportFailureMsg = %q, want %q", tc.exportFailureMsg, exportItemFailure)
+	}
+	if !tc.exportSuccessUntilTS.IsZero() {
+		t.Error("exportSuccessUntilTS armed despite failure")
+	}
+}
+
+// TestRunExport_PassesIncludeWorkspacesFromState: the daemon-bound
+// IncludeWorkspaces flag must come from persisted state, not from any
+// hidden in-memory cache. Otherwise the menu checkbox and the export
+// request can drift if the user toggles + restarts.
+func TestRunExport_PassesIncludeWorkspacesFromState(t *testing.T) {
+	t.Setenv("FRIDAY_LAUNCHER_HOME", t.TempDir())
+
+	if err := writeState(launcherState{IncludeWorkspaces: true}); err != nil {
+		t.Fatalf("writeState: %v", err)
+	}
+
+	var seenOpts diagnostics.ExportOptions
+	withExportFn(t, func(o diagnostics.ExportOptions) (string, error) {
+		seenOpts = o
+		return "", errors.New("stop here") // skip reveal
+	})
+	withRevealOverride(t)
+
+	var sd atomic.Bool
+	tc := &trayController{shuttingDown: &sd}
+	tc.exporting.Store(true)
+
+	tc.runExport()
+
+	if !seenOpts.IncludeWorkspaces {
+		t.Error("Export called with IncludeWorkspaces=false, want true (persisted state)")
+	}
+}
+
+// TestSetExportPhase_WritesUnderMutex confirms ProgressFn callbacks
+// land in the field tick() reads. Without this the menu label would
+// never reflect the diagnostics package's progress events.
+func TestSetExportPhase_WritesUnderMutex(t *testing.T) {
+	tc := &trayController{}
+	tc.setExportPhase("workspaces")
+	tc.exportMu.Lock()
+	defer tc.exportMu.Unlock()
+	if tc.exportProgressPhase != "workspaces" {
+		t.Errorf("exportProgressPhase = %q, want %q", tc.exportProgressPhase, "workspaces")
+	}
+}
+
+// TestToggleIncludeWorkspaces_Persists confirms a click flips the
+// persisted state on disk (read-modify-write through writeState).
+// Without this the preference resets every launcher boot.
+func TestToggleIncludeWorkspaces_Persists(t *testing.T) {
+	t.Setenv("FRIDAY_LAUNCHER_HOME", t.TempDir())
+
+	tc := &trayController{}
+
+	tc.toggleIncludeWorkspaces()
+	if got := readState().IncludeWorkspaces; !got {
+		t.Errorf("after first toggle IncludeWorkspaces = false, want true")
+	}
+
+	tc.toggleIncludeWorkspaces()
+	if got := readState().IncludeWorkspaces; got {
+		t.Errorf("after second toggle IncludeWorkspaces = true, want false")
+	}
+}
+
+// TestToggleIncludeWorkspaces_PreservesAutostartInitialized is the
+// regression test for the read-modify-write fix in
+// runAutostartCommand. If toggleIncludeWorkspaces clobbered other
+// state fields, an autostart-enabled launcher would re-run the
+// self-register on every boot.
+func TestToggleIncludeWorkspaces_PreservesAutostartInitialized(t *testing.T) {
+	t.Setenv("FRIDAY_LAUNCHER_HOME", t.TempDir())
+
+	if err := writeState(launcherState{AutostartInitialized: true}); err != nil {
+		t.Fatalf("seed state: %v", err)
+	}
+
+	tc := &trayController{}
+	tc.toggleIncludeWorkspaces()
+
+	got := readState()
+	if !got.AutostartInitialized {
+		t.Error("AutostartInitialized cleared by toggleIncludeWorkspaces — read-modify-write broken")
+	}
+	if !got.IncludeWorkspaces {
+		t.Error("IncludeWorkspaces not flipped to true")
+	}
+}
+
+// TestDeriveExportItemLabel walks every branch of the label derivation
+// — pure function, no systray. Covers the full progress phase ladder
+// (logs → workspaces → packaging), the failure sticky path, and the
+// success transient's active + expired states. The expired branch is
+// the one updateExportItemLabel acts on to re-enable the menu item.
+func TestDeriveExportItemLabel(t *testing.T) {
+	now := time.Now()
+	cases := []struct {
+		name        string
+		state       exportLabelState
+		wantLabel   string
+		wantExpired bool
+	}{
+		{
+			name:      "default",
+			state:     exportLabelState{now: now},
+			wantLabel: exportItemDefault,
+		},
+		{
+			name:      "progress logs",
+			state:     exportLabelState{progressPhase: "logs", now: now},
+			wantLabel: exportItemProgressBase + " (logs)",
+		},
+		{
+			name:      "progress workspaces",
+			state:     exportLabelState{progressPhase: "workspaces", now: now},
+			wantLabel: exportItemProgressBase + " (workspaces)",
+		},
+		{
+			name:      "progress packaging",
+			state:     exportLabelState{progressPhase: "packaging", now: now},
+			wantLabel: exportItemProgressBase + " (packaging)",
+		},
+		{
+			name:      "failure sticky",
+			state:     exportLabelState{failureMsg: exportItemFailure, now: now},
+			wantLabel: exportItemFailure,
+		},
+		{
+			name: "success transient active",
+			state: exportLabelState{
+				successUntilTS: now.Add(1 * time.Second),
+				now:            now,
+			},
+			wantLabel: exportItemSuccess,
+		},
+		{
+			name: "success transient expired",
+			state: exportLabelState{
+				successUntilTS: now.Add(-1 * time.Second),
+				now:            now,
+			},
+			wantLabel:   exportItemDefault,
+			wantExpired: true,
+		},
+		{
+			name: "progress beats success transient",
+			state: exportLabelState{
+				progressPhase:  "logs",
+				successUntilTS: now.Add(1 * time.Second),
+				now:            now,
+			},
+			wantLabel: exportItemProgressBase + " (logs)",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			label, expired := deriveExportItemLabel(c.state)
+			if label != c.wantLabel {
+				t.Errorf("label = %q, want %q", label, c.wantLabel)
+			}
+			if expired != c.wantExpired {
+				t.Errorf("expired = %v, want %v", expired, c.wantExpired)
+			}
+		})
+	}
+}

--- a/tools/friday-launcher/diagnostic_export_test.go
+++ b/tools/friday-launcher/diagnostic_export_test.go
@@ -135,11 +135,11 @@ func TestStartExport_CASGuardSwallowsSecondClick(t *testing.T) {
 	var sd atomic.Bool
 	tc := &trayController{shuttingDown: &sd}
 
-	tc.startExport()
-	<-entered        // first export goroutine is now inside exportFn
-	tc.startExport() // second click while first is in flight — CAS no-op
-	close(release)   // let the in-flight export return
-	<-finished       // fake has returned; runExport is unwinding
+	tc.startExport(false)
+	<-entered             // first export goroutine is now inside exportFn
+	tc.startExport(false) // second click while first is in flight — CAS no-op
+	close(release)        // let the in-flight export return
+	<-finished            // fake has returned; runExport is unwinding
 
 	// runExport clears exporting in a defer that runs after the fake
 	// returns. Synchronize on that defer by spinning the scheduler until
@@ -175,7 +175,7 @@ func TestStartExport_RefusedDuringShutdown(t *testing.T) {
 	sd.Store(true)
 	tc := &trayController{shuttingDown: &sd}
 
-	tc.startExport()
+	tc.startExport(false)
 
 	if got := calls.Load(); got != 0 {
 		t.Errorf("export invocations during shutdown = %d, want 0", got)
@@ -206,7 +206,7 @@ func TestRunExport_SuccessRevealsAndSetsTransient(t *testing.T) {
 	tc := &trayController{shuttingDown: &sd}
 	tc.exporting.Store(true) // runExport assumes startExport already CAS'd
 
-	tc.runExport()
+	tc.runExport(false)
 
 	if tc.exporting.Load() {
 		t.Error("exporting flag still set after runExport returned")
@@ -246,7 +246,7 @@ func TestRunExport_FailureSetsStickyLabel(t *testing.T) {
 	tc := &trayController{shuttingDown: &sd}
 	tc.exporting.Store(true)
 
-	tc.runExport()
+	tc.runExport(false)
 
 	if tc.exporting.Load() {
 		t.Error("exporting flag still set after failed runExport")
@@ -264,32 +264,33 @@ func TestRunExport_FailureSetsStickyLabel(t *testing.T) {
 	}
 }
 
-// TestRunExport_PassesIncludeWorkspacesFromState: the daemon-bound
-// IncludeWorkspaces flag must come from persisted state, not from any
-// hidden in-memory cache. Otherwise the menu checkbox and the export
-// request can drift if the user toggles + restarts.
-func TestRunExport_PassesIncludeWorkspacesFromState(t *testing.T) {
-	t.Setenv("FRIDAY_LAUNCHER_HOME", t.TempDir())
+// TestRunExport_PassesIncludeWorkspacesArg: the daemon-bound
+// IncludeWorkspaces flag must come straight from the clicked
+// sub-action's argument. "Logs + workspaces" → true, "Logs only" →
+// false. There is no persisted preference to drift from.
+func TestRunExport_PassesIncludeWorkspacesArg(t *testing.T) {
+	for _, includeWorkspaces := range []bool{true, false} {
+		t.Run(map[bool]string{true: "workspaces", false: "logs-only"}[includeWorkspaces], func(t *testing.T) {
+			t.Setenv("FRIDAY_LAUNCHER_HOME", t.TempDir())
 
-	if err := writeState(launcherState{IncludeWorkspaces: true}); err != nil {
-		t.Fatalf("writeState: %v", err)
-	}
+			var seenOpts diagnostics.ExportOptions
+			withExportFn(t, func(o diagnostics.ExportOptions) (string, error) {
+				seenOpts = o
+				return "", errors.New("stop here") // skip reveal
+			})
+			withRevealOverride(t)
 
-	var seenOpts diagnostics.ExportOptions
-	withExportFn(t, func(o diagnostics.ExportOptions) (string, error) {
-		seenOpts = o
-		return "", errors.New("stop here") // skip reveal
-	})
-	withRevealOverride(t)
+			var sd atomic.Bool
+			tc := &trayController{shuttingDown: &sd}
+			tc.exporting.Store(true)
 
-	var sd atomic.Bool
-	tc := &trayController{shuttingDown: &sd}
-	tc.exporting.Store(true)
+			tc.runExport(includeWorkspaces)
 
-	tc.runExport()
-
-	if !seenOpts.IncludeWorkspaces {
-		t.Error("Export called with IncludeWorkspaces=false, want true (persisted state)")
+			if seenOpts.IncludeWorkspaces != includeWorkspaces {
+				t.Errorf("Export called with IncludeWorkspaces=%v, want %v",
+					seenOpts.IncludeWorkspaces, includeWorkspaces)
+			}
+		})
 	}
 }
 
@@ -326,49 +327,6 @@ func TestSetExportPhase_NoDeadlockOnImmediateRefresh(t *testing.T) {
 	case <-done:
 	case <-time.After(2 * time.Second):
 		t.Fatal("setExportPhase deadlocked — exportMu held across updateExportItemLabel")
-	}
-}
-
-// TestToggleIncludeWorkspaces_Persists confirms a click flips the
-// persisted state on disk (read-modify-write through writeState).
-// Without this the preference resets every launcher boot.
-func TestToggleIncludeWorkspaces_Persists(t *testing.T) {
-	t.Setenv("FRIDAY_LAUNCHER_HOME", t.TempDir())
-
-	tc := &trayController{}
-
-	tc.toggleIncludeWorkspaces()
-	if got := readState().IncludeWorkspaces; !got {
-		t.Errorf("after first toggle IncludeWorkspaces = false, want true")
-	}
-
-	tc.toggleIncludeWorkspaces()
-	if got := readState().IncludeWorkspaces; got {
-		t.Errorf("after second toggle IncludeWorkspaces = true, want false")
-	}
-}
-
-// TestToggleIncludeWorkspaces_PreservesAutostartInitialized is the
-// regression test for the read-modify-write fix in
-// runAutostartCommand. If toggleIncludeWorkspaces clobbered other
-// state fields, an autostart-enabled launcher would re-run the
-// self-register on every boot.
-func TestToggleIncludeWorkspaces_PreservesAutostartInitialized(t *testing.T) {
-	t.Setenv("FRIDAY_LAUNCHER_HOME", t.TempDir())
-
-	if err := writeState(launcherState{AutostartInitialized: true}); err != nil {
-		t.Fatalf("seed state: %v", err)
-	}
-
-	tc := &trayController{}
-	tc.toggleIncludeWorkspaces()
-
-	got := readState()
-	if !got.AutostartInitialized {
-		t.Error("AutostartInitialized cleared by toggleIncludeWorkspaces — read-modify-write broken")
-	}
-	if !got.IncludeWorkspaces {
-		t.Error("IncludeWorkspaces not flipped to true")
 	}
 }
 

--- a/tools/friday-launcher/diagnostics/export.go
+++ b/tools/friday-launcher/diagnostics/export.go
@@ -22,7 +22,6 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
-	"sort"
 	"strings"
 	"time"
 )
@@ -141,18 +140,15 @@ func writeBundle(tmpPath string, opts ExportOptions, outDirSkipped bool) (err er
 	zw := zip.NewWriter(f)
 
 	progress(opts.ProgressFn, "logs")
-	logNames, err := addLogs(zw, sourceLogsDir())
-	if err != nil {
+	if err := addLogs(zw, sourceLogsDir()); err != nil {
 		return err
 	}
 
-	stateIncluded, err := addStateJSON(zw, filepath.Join(sourceStateDir(), "state.json"))
-	if err != nil {
+	if err := addStateJSON(zw, filepath.Join(sourceStateDir(), "state.json")); err != nil {
 		return err
 	}
 
-	pidsIncluded, err := addPids(zw, filepath.Join(sourceStateDir(), "pids"))
-	if err != nil {
+	if err := addPids(zw, filepath.Join(sourceStateDir(), "pids")); err != nil {
 		return err
 	}
 
@@ -171,7 +167,7 @@ func writeBundle(tmpPath string, opts ExportOptions, outDirSkipped bool) (err er
 
 	progress(opts.ProgressFn, "packaging")
 
-	m := buildManifest(opts, logNames, stateIncluded, pidsIncluded, outDirSkipped, daemonVersion, wsResult)
+	m := buildManifest(opts, outDirSkipped, daemonVersion, wsResult)
 	body, err := marshalManifest(m)
 	if err != nil {
 		return fmt.Errorf("marshal manifest: %w", err)
@@ -188,7 +184,7 @@ func writeBundle(tmpPath string, opts ExportOptions, outDirSkipped bool) (err er
 // buildManifest assembles the manifest struct from inputs gathered
 // upstream. Pure assembly — every HTTP call has already happened by
 // the time we get here.
-func buildManifest(opts ExportOptions, logs []string, stateIncluded, pidsIncluded, outDirSkipped bool, daemonVersion string, ws workspaceResult) manifest {
+func buildManifest(opts ExportOptions, outDirSkipped bool, daemonVersion string, ws workspaceResult) manifest {
 	skipped := []manifestSkip{}
 	if !opts.IncludeWorkspaces {
 		skipped = append(skipped, manifestSkip{
@@ -213,13 +209,7 @@ func buildManifest(opts ExportOptions, logs []string, stateIncluded, pidsInclude
 		Arch:                       runtime.GOARCH,
 		GeneratedAt:                nowFn(),
 		IncludeWorkspacesRequested: opts.IncludeWorkspaces,
-		Included: manifestIncluded{
-			Logs:       logs,
-			StateJSON:  stateIncluded,
-			Pids:       pidsIncluded,
-			Workspaces: ws.body != nil,
-		},
-		Skipped: skipped,
+		Skipped:                    skipped,
 	}
 }
 
@@ -397,16 +387,15 @@ func joinDaemonURL(base, path string) (string, error) {
 
 // addLogs copies every live .log file from logsDir into zw's logs/
 // subdir. "Live" = filename ends in exactly .log (no .gz, no .log.N).
-// Returns the sorted list of basenames included (for the manifest).
-func addLogs(zw *zip.Writer, logsDir string) ([]string, error) {
+// A missing logs dir is not an error — the zip just has no logs/.
+func addLogs(zw *zip.Writer, logsDir string) error {
 	entries, err := os.ReadDir(logsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return nil, nil
+			return nil
 		}
-		return nil, fmt.Errorf("read logs dir: %w", err)
+		return fmt.Errorf("read logs dir: %w", err)
 	}
-	var names []string
 	for _, e := range entries {
 		if e.IsDir() {
 			continue
@@ -416,37 +405,31 @@ func addLogs(zw *zip.Writer, logsDir string) ([]string, error) {
 			continue
 		}
 		if err := addFileFromDisk(zw, filepath.Join(logsDir, name), "logs/"+name); err != nil {
-			return nil, err
+			return err
 		}
-		names = append(names, name)
 	}
-	sort.Strings(names)
-	return names, nil
+	return nil
 }
 
-func addStateJSON(zw *zip.Writer, path string) (bool, error) {
+func addStateJSON(zw *zip.Writer, path string) error {
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
-			return false, nil
+			return nil
 		}
-		return false, fmt.Errorf("stat state.json: %w", err)
+		return fmt.Errorf("stat state.json: %w", err)
 	}
-	if err := addFileFromDisk(zw, path, "state.json"); err != nil {
-		return false, err
-	}
-	return true, nil
+	return addFileFromDisk(zw, path, "state.json")
 }
 
-// addPids copies every entry from pidsDir into zw's pids/ subdir.
-// Returns true iff the directory existed (regardless of how many
-// files were inside — an empty pids/ still counts as "present").
-func addPids(zw *zip.Writer, pidsDir string) (bool, error) {
+// addPids copies every entry from pidsDir into zw's pids/ subdir. A
+// missing pids dir is not an error — the zip just has no pids/.
+func addPids(zw *zip.Writer, pidsDir string) error {
 	entries, err := os.ReadDir(pidsDir)
 	if err != nil {
 		if os.IsNotExist(err) {
-			return false, nil
+			return nil
 		}
-		return false, fmt.Errorf("read pids dir: %w", err)
+		return fmt.Errorf("read pids dir: %w", err)
 	}
 	for _, e := range entries {
 		if e.IsDir() {
@@ -454,10 +437,10 @@ func addPids(zw *zip.Writer, pidsDir string) (bool, error) {
 		}
 		name := e.Name()
 		if err := addFileFromDisk(zw, filepath.Join(pidsDir, name), "pids/"+name); err != nil {
-			return false, err
+			return err
 		}
 	}
-	return true, nil
+	return nil
 }
 
 func addFileFromDisk(zw *zip.Writer, srcPath, zipName string) error {

--- a/tools/friday-launcher/diagnostics/export.go
+++ b/tools/friday-launcher/diagnostics/export.go
@@ -60,6 +60,12 @@ type ExportOptions struct {
 	// bound on the /bundle-all call. Unexported test-only knob —
 	// production callers get the 60s default.
 	bundleAllTimeout time.Duration
+
+	// bundleAllByteCap, when non-zero, overrides the default
+	// defaultBundleAllByteCap on how many bytes the /bundle-all
+	// response body may occupy. Unexported test-only knob —
+	// production callers get the default cap.
+	bundleAllByteCap int64
 }
 
 // Package-level seams that tests swap. Production callers see them
@@ -320,12 +326,21 @@ func fetchWorkspaces(opts ExportOptions) workspaceResult {
 	case resp.StatusCode < 200 || resp.StatusCode >= 300:
 		return workspaceResult{skipReason: skipReasonDaemonUnreachable}
 	}
-	body, err := io.ReadAll(resp.Body)
+	byteCap := opts.bundleAllByteCap
+	if byteCap == 0 {
+		byteCap = defaultBundleAllByteCap
+	}
+	// Read one byte past the cap so a body sitting exactly at the cap
+	// is kept while anything larger trips the skip below.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, byteCap+1))
 	if err != nil {
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
 			return workspaceResult{skipReason: skipReasonBundleAllTimeout}
 		}
 		return workspaceResult{skipReason: skipReasonDaemonUnreachable}
+	}
+	if int64(len(body)) > byteCap {
+		return workspaceResult{skipReason: skipReasonBundleAllTooLarge}
 	}
 	return workspaceResult{body: body}
 }
@@ -338,6 +353,13 @@ const versionTimeout = 5 * time.Second
 // defaultBundleAllTimeout bounds /api/workspaces/bundle-all in
 // production. Tests override via ExportOptions.bundleAllTimeout.
 const defaultBundleAllTimeout = 60 * time.Second
+
+// defaultBundleAllByteCap bounds how many bytes of the /bundle-all
+// response fetchWorkspaces buffers. The 60s timeout bounds latency,
+// not size — a power user with many/large workspaces (this feature's
+// persona) could otherwise balloon launcher RSS. Tests override via
+// ExportOptions.bundleAllByteCap.
+const defaultBundleAllByteCap = 256 << 20 // 256 MB
 
 // newDaemonClient returns the http.Client used for all daemon calls.
 // Mirrors newReadinessClient(scheme) in readiness.go: plain HTTP gets

--- a/tools/friday-launcher/diagnostics/export.go
+++ b/tools/friday-launcher/diagnostics/export.go
@@ -1,0 +1,370 @@
+// Package diagnostics produces a one-click diagnostic zip for Friday
+// launcher bug reports (issue #324). Public surface is the Export
+// function — the caller passes options and gets a path to a finished
+// zip whose internal shape is documented in the bundled manifest.yml.
+//
+// This iteration is the tracer bullet (task #2): logs + state.json +
+// pids + manifest. Workspace inclusion via the daemon's /bundle-all
+// route lands in task #3 by swapping the bodies of getDaemonVersion
+// and fetchWorkspaces; the manifest contract does not change.
+package diagnostics
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ExportOptions configures one diagnostic export. All fields are
+// optional. The zero value runs against the user's real
+// ~/.friday/local data and writes to ~/Downloads.
+type ExportOptions struct {
+	// IncludeWorkspaces, when true, signals user intent to ship
+	// workspace bundles. This iteration has no HTTP path to the
+	// daemon, so the manifest records skip-reason daemon_unreachable
+	// instead of user_opted_out — the user asked for them, we just
+	// couldn't deliver. Task #3 swaps fetchWorkspaces to actually
+	// hit /api/workspaces/bundle-all.
+	IncludeWorkspaces bool
+
+	// DaemonURL is the base URL the export will use for daemon HTTP
+	// calls. Ignored in this iteration (no HTTP). Task #3 honors it.
+	DaemonURL string
+
+	// OutputDir is where the final zip is written. Empty → ~/Downloads.
+	// If the chosen directory is not writable, the export falls back
+	// to os.TempDir() and records the skip in the manifest.
+	OutputDir string
+
+	// ProgressFn, if non-nil, is invoked with phase strings as the
+	// export progresses. Phases this iteration emits: "logs",
+	// "packaging". Task #3 inserts "workspaces" between them when
+	// IncludeWorkspaces is true.
+	ProgressFn func(phase string)
+}
+
+// Package-level seams that tests swap. Production callers see them
+// as opaque — they resolve real on-disk locations via friendlyHome.
+var (
+	sourceLogsDir  = defaultLogsDir
+	sourceStateDir = defaultStateDir
+	nowFn          = func() time.Time { return time.Now().UTC() }
+)
+
+// friendlyHome mirrors the launcher package's friendlyHome (paths.go)
+// — the FRIDAY_LAUNCHER_HOME override is the load-bearing knob for
+// integration scenarios that don't want to touch the real home dir.
+func friendlyHome() string {
+	if v := os.Getenv("FRIDAY_LAUNCHER_HOME"); v != "" {
+		return v
+	}
+	if h, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(h, ".friday", "local")
+	}
+	return filepath.Join(os.TempDir(), ".friday", "local")
+}
+
+func defaultLogsDir() string  { return filepath.Join(friendlyHome(), "logs") }
+func defaultStateDir() string { return friendlyHome() }
+
+// Export builds the diagnostic zip and returns its path. A non-nil
+// error means no zip was produced. A nil error means a valid zip
+// exists at the returned path; any pieces that couldn't be included
+// are documented in the bundled manifest.yml under skipped[].
+func Export(opts ExportOptions) (string, error) {
+	outDir, outDirSkipped, err := resolveOutputDir(opts.OutputDir)
+	if err != nil {
+		return "", fmt.Errorf("resolve output dir: %w", err)
+	}
+
+	zipPath, tmpPath := buildPaths(outDir, nowFn())
+
+	// Always clean up the partial. If Rename succeeded the path no
+	// longer exists and Remove is a harmless no-op; if any step
+	// before Rename errored, this is what stops aborted exports from
+	// accumulating in Downloads.
+	defer os.Remove(tmpPath)
+
+	if err := writeBundle(tmpPath, opts, outDirSkipped); err != nil {
+		return "", err
+	}
+
+	if err := os.Rename(tmpPath, zipPath); err != nil {
+		return "", fmt.Errorf("rename %s -> %s: %w", tmpPath, zipPath, err)
+	}
+	return zipPath, nil
+}
+
+// writeBundle writes every entry into the zip at tmpPath.
+//
+// zip.Writer.Close MUST run before the file's Close — that's when the
+// central directory is flushed. The file Close happens via a named-
+// return defer so a real error always wins over a close error, but
+// a close-only failure still surfaces (instead of being silently
+// swallowed like a bare `defer f.Close()` would).
+func writeBundle(tmpPath string, opts ExportOptions, outDirSkipped bool) (err error) {
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", tmpPath, err)
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close zip file: %w", cerr)
+		}
+	}()
+
+	zw := zip.NewWriter(f)
+
+	progress(opts.ProgressFn, "logs")
+	logNames, err := addLogs(zw, sourceLogsDir())
+	if err != nil {
+		return err
+	}
+
+	stateIncluded, err := addStateJSON(zw, filepath.Join(sourceStateDir(), "state.json"))
+	if err != nil {
+		return err
+	}
+
+	pidsIncluded, err := addPids(zw, filepath.Join(sourceStateDir(), "pids"))
+	if err != nil {
+		return err
+	}
+
+	progress(opts.ProgressFn, "packaging")
+
+	m := buildManifest(opts, logNames, stateIncluded, pidsIncluded, outDirSkipped)
+	body, err := marshalManifest(m)
+	if err != nil {
+		return fmt.Errorf("marshal manifest: %w", err)
+	}
+	if err := writeZipEntry(zw, "manifest.yml", body); err != nil {
+		return err
+	}
+	if err := zw.Close(); err != nil {
+		return fmt.Errorf("close zip writer: %w", err)
+	}
+	return nil
+}
+
+// buildManifest assembles the manifest struct from the inputs that
+// writeBundle gathered. The skip-reason logic lives here so it's one
+// place to grep when tokens change.
+func buildManifest(opts ExportOptions, logs []string, stateIncluded, pidsIncluded, outDirSkipped bool) manifest {
+	skipped := []manifestSkip{}
+	if opts.IncludeWorkspaces {
+		// User asked, we couldn't deliver (no HTTP yet). Task #3
+		// replaces this with the real fetch + its own skip reasons.
+		skipped = append(skipped, manifestSkip{
+			What: "workspaces",
+			Why:  skipReasonDaemonUnreachable,
+		})
+	} else {
+		skipped = append(skipped, manifestSkip{
+			What: "workspaces",
+			Why:  skipReasonUserOptedOut,
+		})
+	}
+	if outDirSkipped {
+		skipped = append(skipped, manifestSkip{
+			What: "output_dir",
+			Why:  skipReasonDownloadsUnwritable,
+		})
+	}
+	return manifest{
+		DaemonVersion:              getDaemonVersion(opts),
+		OS:                         runtime.GOOS,
+		Arch:                       runtime.GOARCH,
+		GeneratedAt:                nowFn(),
+		IncludeWorkspacesRequested: opts.IncludeWorkspaces,
+		Included: manifestIncluded{
+			Logs:       logs,
+			StateJSON:  stateIncluded,
+			Pids:       pidsIncluded,
+			Workspaces: false,
+		},
+		Skipped: skipped,
+	}
+}
+
+// getDaemonVersion is the seam task #3 swaps to actually call
+// /api/version. Today it always returns the unreachable literal —
+// the same value a real connect-refused would produce, so swapping
+// the body doesn't change the public manifest format.
+func getDaemonVersion(_ ExportOptions) string {
+	return daemonVersionUnreachable
+}
+
+// addLogs copies every live .log file from logsDir into zw's logs/
+// subdir. "Live" = filename ends in exactly .log (no .gz, no .log.N).
+// Returns the sorted list of basenames included (for the manifest).
+func addLogs(zw *zip.Writer, logsDir string) ([]string, error) {
+	entries, err := os.ReadDir(logsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read logs dir: %w", err)
+	}
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if !strings.HasSuffix(name, ".log") {
+			continue
+		}
+		if err := addFileFromDisk(zw, filepath.Join(logsDir, name), "logs/"+name); err != nil {
+			return nil, err
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+func addStateJSON(zw *zip.Writer, path string) (bool, error) {
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("stat state.json: %w", err)
+	}
+	if err := addFileFromDisk(zw, path, "state.json"); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// addPids copies every entry from pidsDir into zw's pids/ subdir.
+// Returns true iff the directory existed (regardless of how many
+// files were inside — an empty pids/ still counts as "present").
+func addPids(zw *zip.Writer, pidsDir string) (bool, error) {
+	entries, err := os.ReadDir(pidsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read pids dir: %w", err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if err := addFileFromDisk(zw, filepath.Join(pidsDir, name), "pids/"+name); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+func addFileFromDisk(zw *zip.Writer, srcPath, zipName string) error {
+	src, err := os.Open(srcPath)
+	if err != nil {
+		return fmt.Errorf("open %s: %w", srcPath, err)
+	}
+	defer src.Close()
+	w, err := zw.Create(zipName)
+	if err != nil {
+		return fmt.Errorf("zip create %s: %w", zipName, err)
+	}
+	if _, err := io.Copy(w, src); err != nil {
+		return fmt.Errorf("zip copy %s: %w", zipName, err)
+	}
+	return nil
+}
+
+func writeZipEntry(zw *zip.Writer, name string, body []byte) error {
+	w, err := zw.Create(name)
+	if err != nil {
+		return fmt.Errorf("zip create %s: %w", name, err)
+	}
+	if _, err := w.Write(body); err != nil {
+		return fmt.Errorf("zip write %s: %w", name, err)
+	}
+	return nil
+}
+
+func progress(fn func(string), phase string) {
+	if fn == nil {
+		return
+	}
+	fn(phase)
+}
+
+// resolveOutputDir picks the directory the zip will be written to.
+// Order of preference: explicit OutputDir → ~/Downloads → os.TempDir().
+// Returns the chosen dir and a bool telling buildManifest whether a
+// downloads_unwritable skip needs to be recorded.
+func resolveOutputDir(explicit string) (string, bool, error) {
+	candidates := []string{}
+	if explicit != "" {
+		candidates = append(candidates, explicit)
+	} else {
+		candidates = append(candidates, downloadsDir())
+	}
+	for _, c := range candidates {
+		if writable(c) {
+			return c, false, nil
+		}
+	}
+	// Fallback: TempDir. os.TempDir on every supported platform is
+	// always writable to the current user; if it isn't, the user has
+	// bigger problems than diagnostics export.
+	tmp := os.TempDir()
+	if !writable(tmp) {
+		return "", false, fmt.Errorf("no writable output directory found (tried %v and %s)", candidates, tmp)
+	}
+	return tmp, true, nil
+}
+
+// downloadsDir returns ~/Downloads. Falls back to os.TempDir if the
+// user's home can't be resolved — writable() will accept that and we
+// still record the fallback in the manifest via outDirSkipped.
+func downloadsDir() string {
+	if h, err := os.UserHomeDir(); err == nil {
+		return filepath.Join(h, "Downloads")
+	}
+	return os.TempDir()
+}
+
+// writable returns true iff a probe file can be created and removed
+// inside dir. Cheap (one create + one remove); the cost is paid at
+// most twice per export.
+func writable(dir string) bool {
+	if dir == "" {
+		return false
+	}
+	if info, err := os.Stat(dir); err != nil || !info.IsDir() {
+		return false
+	}
+	probe, err := os.CreateTemp(dir, ".friday-write-probe-*")
+	if err != nil {
+		return false
+	}
+	probe.Close()
+	_ = os.Remove(probe.Name())
+	return true
+}
+
+// buildPaths derives the final + partial zip paths. On filename
+// collision (same-second back-to-back exports) appends nanoseconds
+// once to disambiguate.
+func buildPaths(outDir string, now time.Time) (zipPath, tmpPath string) {
+	base := "friday-diagnostics-" + now.Format("2006-01-02-150405")
+	zipPath = filepath.Join(outDir, base+".zip")
+	if _, statErr := os.Stat(zipPath); statErr == nil {
+		base = fmt.Sprintf("%s-%09d", base, now.Nanosecond())
+		zipPath = filepath.Join(outDir, base+".zip")
+	}
+	tmpPath = filepath.Join(outDir, "."+base+".zip.partial")
+	return zipPath, tmpPath
+}

--- a/tools/friday-launcher/diagnostics/export.go
+++ b/tools/friday-launcher/diagnostics/export.go
@@ -127,7 +127,7 @@ func Export(opts ExportOptions) (string, error) {
 // a close-only failure still surfaces (instead of being silently
 // swallowed like a bare `defer f.Close()` would).
 func writeBundle(tmpPath string, opts ExportOptions, outDirSkipped bool) (err error) {
-	f, err := os.Create(tmpPath) //nolint:gosec // G304: launcher-resolved output dir (Downloads/TempDir/explicit), no user input
+	f, err := os.Create(filepath.Clean(tmpPath))
 	if err != nil {
 		return fmt.Errorf("create %s: %w", tmpPath, err)
 	}
@@ -444,7 +444,7 @@ func addPids(zw *zip.Writer, pidsDir string) error {
 }
 
 func addFileFromDisk(zw *zip.Writer, srcPath, zipName string) error {
-	src, err := os.Open(srcPath) //nolint:gosec // G304: launcher-controlled paths under $HOME/.friday/local (logs/state/pids)
+	src, err := os.Open(filepath.Clean(srcPath))
 	if err != nil {
 		return fmt.Errorf("open %s: %w", srcPath, err)
 	}
@@ -528,8 +528,7 @@ func writable(dir string) bool {
 		return false
 	}
 	_ = probe.Close()
-	_ = os.Remove(probe.Name())
-	return true
+	return os.Remove(probe.Name()) == nil
 }
 
 // buildPaths derives the final + partial zip paths. On filename

--- a/tools/friday-launcher/diagnostics/export.go
+++ b/tools/friday-launcher/diagnostics/export.go
@@ -108,7 +108,7 @@ func Export(opts ExportOptions) (string, error) {
 	// longer exists and Remove is a harmless no-op; if any step
 	// before Rename errored, this is what stops aborted exports from
 	// accumulating in Downloads.
-	defer os.Remove(tmpPath)
+	defer func() { _ = os.Remove(tmpPath) }()
 
 	if err := writeBundle(tmpPath, opts, outDirSkipped); err != nil {
 		return "", err
@@ -128,7 +128,7 @@ func Export(opts ExportOptions) (string, error) {
 // a close-only failure still surfaces (instead of being silently
 // swallowed like a bare `defer f.Close()` would).
 func writeBundle(tmpPath string, opts ExportOptions, outDirSkipped bool) (err error) {
-	f, err := os.Create(tmpPath)
+	f, err := os.Create(tmpPath) //nolint:gosec // G304: launcher-resolved output dir (Downloads/TempDir/explicit), no user input
 	if err != nil {
 		return fmt.Errorf("create %s: %w", tmpPath, err)
 	}
@@ -253,7 +253,7 @@ func getDaemonVersion(opts ExportOptions) string {
 	if err != nil {
 		return daemonVersionUnreachable
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return daemonVersionUnreachable
 	}
@@ -317,7 +317,7 @@ func fetchWorkspaces(opts ExportOptions) workspaceResult {
 		}
 		return workspaceResult{skipReason: skipReasonDaemonUnreachable}
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	switch {
 	case resp.StatusCode == http.StatusUnauthorized, resp.StatusCode == http.StatusForbidden:
 		return workspaceResult{skipReason: skipReasonAuthRefused}
@@ -461,11 +461,11 @@ func addPids(zw *zip.Writer, pidsDir string) (bool, error) {
 }
 
 func addFileFromDisk(zw *zip.Writer, srcPath, zipName string) error {
-	src, err := os.Open(srcPath)
+	src, err := os.Open(srcPath) //nolint:gosec // G304: launcher-controlled paths under $HOME/.friday/local (logs/state/pids)
 	if err != nil {
 		return fmt.Errorf("open %s: %w", srcPath, err)
 	}
-	defer src.Close()
+	defer func() { _ = src.Close() }()
 	w, err := zw.Create(zipName)
 	if err != nil {
 		return fmt.Errorf("zip create %s: %w", zipName, err)
@@ -544,7 +544,7 @@ func writable(dir string) bool {
 	if err != nil {
 		return false
 	}
-	probe.Close()
+	_ = probe.Close()
 	_ = os.Remove(probe.Name())
 	return true
 }

--- a/tools/friday-launcher/diagnostics/export.go
+++ b/tools/friday-launcher/diagnostics/export.go
@@ -11,8 +11,14 @@ package diagnostics
 
 import (
 	"archive/zip"
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -25,16 +31,18 @@ import (
 // optional. The zero value runs against the user's real
 // ~/.friday/local data and writes to ~/Downloads.
 type ExportOptions struct {
-	// IncludeWorkspaces, when true, signals user intent to ship
-	// workspace bundles. This iteration has no HTTP path to the
-	// daemon, so the manifest records skip-reason daemon_unreachable
-	// instead of user_opted_out — the user asked for them, we just
-	// couldn't deliver. Task #3 swaps fetchWorkspaces to actually
-	// hit /api/workspaces/bundle-all.
+	// IncludeWorkspaces, when true and DaemonURL is set, instructs
+	// the export to call /api/workspaces/bundle-all and embed the
+	// response as workspaces.zip. Any failure (transport, non-2xx,
+	// timeout) records a stable skip-reason in the manifest and the
+	// export still succeeds.
 	IncludeWorkspaces bool
 
-	// DaemonURL is the base URL the export will use for daemon HTTP
-	// calls. Ignored in this iteration (no HTTP). Task #3 honors it.
+	// DaemonURL is the base URL the export uses for daemon HTTP
+	// calls (/api/version always; /api/workspaces/bundle-all when
+	// IncludeWorkspaces is true). Empty disables both calls —
+	// daemon_version becomes "unreachable" and workspaces is skipped
+	// with daemon_unreachable.
 	DaemonURL string
 
 	// OutputDir is where the final zip is written. Empty → ~/Downloads.
@@ -43,10 +51,15 @@ type ExportOptions struct {
 	OutputDir string
 
 	// ProgressFn, if non-nil, is invoked with phase strings as the
-	// export progresses. Phases this iteration emits: "logs",
-	// "packaging". Task #3 inserts "workspaces" between them when
-	// IncludeWorkspaces is true.
+	// export progresses. Phases: "logs", "packaging" by default;
+	// when IncludeWorkspaces is true AND DaemonURL is non-empty the
+	// sequence becomes "logs", "workspaces", "packaging".
 	ProgressFn func(phase string)
+
+	// bundleAllTimeout, when non-zero, overrides the default 60s
+	// bound on the /bundle-all call. Unexported test-only knob —
+	// production callers get the 60s default.
+	bundleAllTimeout time.Duration
 }
 
 // Package-level seams that tests swap. Production callers see them
@@ -137,9 +150,22 @@ func writeBundle(tmpPath string, opts ExportOptions, outDirSkipped bool) (err er
 		return err
 	}
 
+	// /api/version is called BEFORE any workspaces work — design v3
+	// § "Daemon /api/version endpoint" makes the order explicit so a
+	// future short-circuit ("skip workspaces if version unreachable")
+	// has an honest signal to read.
+	daemonVersion := getDaemonVersion(opts)
+
+	wsResult := fetchWorkspaces(opts)
+	if wsResult.body != nil {
+		if err := writeZipEntry(zw, "workspaces.zip", wsResult.body); err != nil {
+			return err
+		}
+	}
+
 	progress(opts.ProgressFn, "packaging")
 
-	m := buildManifest(opts, logNames, stateIncluded, pidsIncluded, outDirSkipped)
+	m := buildManifest(opts, logNames, stateIncluded, pidsIncluded, outDirSkipped, daemonVersion, wsResult)
 	body, err := marshalManifest(m)
 	if err != nil {
 		return fmt.Errorf("marshal manifest: %w", err)
@@ -153,22 +179,20 @@ func writeBundle(tmpPath string, opts ExportOptions, outDirSkipped bool) (err er
 	return nil
 }
 
-// buildManifest assembles the manifest struct from the inputs that
-// writeBundle gathered. The skip-reason logic lives here so it's one
-// place to grep when tokens change.
-func buildManifest(opts ExportOptions, logs []string, stateIncluded, pidsIncluded, outDirSkipped bool) manifest {
+// buildManifest assembles the manifest struct from inputs gathered
+// upstream. Pure assembly — every HTTP call has already happened by
+// the time we get here.
+func buildManifest(opts ExportOptions, logs []string, stateIncluded, pidsIncluded, outDirSkipped bool, daemonVersion string, ws workspaceResult) manifest {
 	skipped := []manifestSkip{}
-	if opts.IncludeWorkspaces {
-		// User asked, we couldn't deliver (no HTTP yet). Task #3
-		// replaces this with the real fetch + its own skip reasons.
-		skipped = append(skipped, manifestSkip{
-			What: "workspaces",
-			Why:  skipReasonDaemonUnreachable,
-		})
-	} else {
+	if !opts.IncludeWorkspaces {
 		skipped = append(skipped, manifestSkip{
 			What: "workspaces",
 			Why:  skipReasonUserOptedOut,
+		})
+	} else if ws.body == nil {
+		skipped = append(skipped, manifestSkip{
+			What: "workspaces",
+			Why:  ws.skipReason,
 		})
 	}
 	if outDirSkipped {
@@ -178,7 +202,7 @@ func buildManifest(opts ExportOptions, logs []string, stateIncluded, pidsInclude
 		})
 	}
 	return manifest{
-		DaemonVersion:              getDaemonVersion(opts),
+		DaemonVersion:              daemonVersion,
 		OS:                         runtime.GOOS,
 		Arch:                       runtime.GOARCH,
 		GeneratedAt:                nowFn(),
@@ -187,18 +211,166 @@ func buildManifest(opts ExportOptions, logs []string, stateIncluded, pidsInclude
 			Logs:       logs,
 			StateJSON:  stateIncluded,
 			Pids:       pidsIncluded,
-			Workspaces: false,
+			Workspaces: ws.body != nil,
 		},
 		Skipped: skipped,
 	}
 }
 
-// getDaemonVersion is the seam task #3 swaps to actually call
-// /api/version. Today it always returns the unreachable literal —
-// the same value a real connect-refused would produce, so swapping
-// the body doesn't change the public manifest format.
-func getDaemonVersion(_ ExportOptions) string {
-	return daemonVersionUnreachable
+// getDaemonVersion calls GET <DaemonURL>/api/version and returns the
+// `version` field from the response. Any failure — empty DaemonURL,
+// transport error, non-2xx, malformed body, timeout — collapses to
+// the reserved daemonVersionUnreachable literal so the manifest stays
+// machine-parseable.
+//
+// Bounded by a short context (versionTimeout); /api/version is a
+// constant-time handler so a long deadline only hides a hung daemon.
+func getDaemonVersion(opts ExportOptions) string {
+	if opts.DaemonURL == "" {
+		return daemonVersionUnreachable
+	}
+	client, err := newDaemonClient(opts.DaemonURL)
+	if err != nil {
+		return daemonVersionUnreachable
+	}
+	endpoint, err := joinDaemonURL(opts.DaemonURL, "/api/version")
+	if err != nil {
+		return daemonVersionUnreachable
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), versionTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return daemonVersionUnreachable
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return daemonVersionUnreachable
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return daemonVersionUnreachable
+	}
+	var payload struct {
+		Version string `json:"version"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return daemonVersionUnreachable
+	}
+	if payload.Version == "" {
+		return daemonVersionUnreachable
+	}
+	return payload.Version
+}
+
+// workspaceResult is the outcome of fetchWorkspaces. Exactly one of
+// {body, skipReason} is meaningful: a non-nil body means success
+// (skipReason is empty); a nil body means skip with the recorded
+// reason. The two-field shape avoids allocating a sentinel error per
+// skip and keeps the manifest mapping in buildManifest a one-liner.
+type workspaceResult struct {
+	body       []byte
+	skipReason string
+}
+
+// fetchWorkspaces calls GET <DaemonURL>/api/workspaces/bundle-all?mode=definition
+// when IncludeWorkspaces is true and DaemonURL is set; otherwise it
+// returns the zero value (caller treats nil body as "no embed"). The
+// returned body is intentionally raw bytes from the server — embedded
+// verbatim as workspaces.zip with no re-zip or unwrap.
+func fetchWorkspaces(opts ExportOptions) workspaceResult {
+	if !opts.IncludeWorkspaces || opts.DaemonURL == "" {
+		return workspaceResult{skipReason: skipReasonDaemonUnreachable}
+	}
+	progress(opts.ProgressFn, "workspaces")
+	client, err := newDaemonClient(opts.DaemonURL)
+	if err != nil {
+		return workspaceResult{skipReason: skipReasonDaemonUnreachable}
+	}
+	endpoint, err := joinDaemonURL(opts.DaemonURL, "/api/workspaces/bundle-all")
+	if err != nil {
+		return workspaceResult{skipReason: skipReasonDaemonUnreachable}
+	}
+	endpoint += "?mode=definition"
+	timeout := opts.bundleAllTimeout
+	if timeout == 0 {
+		timeout = defaultBundleAllTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return workspaceResult{skipReason: skipReasonDaemonUnreachable}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		// context.DeadlineExceeded surfaces as a wrapped url.Error
+		// whose Err chains to ctx.Err(); errors.Is unwraps it.
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return workspaceResult{skipReason: skipReasonBundleAllTimeout}
+		}
+		return workspaceResult{skipReason: skipReasonDaemonUnreachable}
+	}
+	defer resp.Body.Close()
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized, resp.StatusCode == http.StatusForbidden:
+		return workspaceResult{skipReason: skipReasonAuthRefused}
+	case resp.StatusCode >= 500 && resp.StatusCode < 600:
+		return workspaceResult{skipReason: skipReasonDaemonReturned5xx}
+	case resp.StatusCode < 200 || resp.StatusCode >= 300:
+		return workspaceResult{skipReason: skipReasonDaemonUnreachable}
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			return workspaceResult{skipReason: skipReasonBundleAllTimeout}
+		}
+		return workspaceResult{skipReason: skipReasonDaemonUnreachable}
+	}
+	return workspaceResult{body: body}
+}
+
+// versionTimeout bounds the /api/version call. /api/version is a
+// constant-time handler — anything past a couple seconds means the
+// daemon is wedged, not slow.
+const versionTimeout = 5 * time.Second
+
+// defaultBundleAllTimeout bounds /api/workspaces/bundle-all in
+// production. Tests override via ExportOptions.bundleAllTimeout.
+const defaultBundleAllTimeout = 60 * time.Second
+
+// newDaemonClient returns the http.Client used for all daemon calls.
+// Mirrors newReadinessClient(scheme) in readiness.go: plain HTTP gets
+// a vanilla client; HTTPS clones DefaultTransport and pins a
+// skip-verify TLS config (loopback to our private-CA-signed daemon
+// has no MITM surface — same rationale as the readiness probe).
+//
+// Client.Timeout is zero — every caller uses context.WithTimeout so
+// the deadline covers connect + TLS + headers + body together.
+func newDaemonClient(daemonURL string) (*http.Client, error) {
+	u, err := url.Parse(daemonURL)
+	if err != nil {
+		return nil, err
+	}
+	if u.Scheme != "https" {
+		return &http.Client{Timeout: 0}, nil
+	}
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	//nolint:gosec // G402: loopback-only daemon call, matches readiness.go rationale
+	tr.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	return &http.Client{Timeout: 0, Transport: tr}, nil
+}
+
+// joinDaemonURL joins a base daemon URL with a path. Returns an error
+// only if the base URL is unparseable; callers collapse the error to
+// a skip in the manifest.
+func joinDaemonURL(base, path string) (string, error) {
+	u, err := url.Parse(base)
+	if err != nil {
+		return "", err
+	}
+	u.Path = strings.TrimRight(u.Path, "/") + path
+	return u.String(), nil
 }
 
 // addLogs copies every live .log file from logsDir into zw's logs/

--- a/tools/friday-launcher/diagnostics/export_test.go
+++ b/tools/friday-launcher/diagnostics/export_test.go
@@ -136,14 +136,13 @@ func TestExport_HappyPath_LogsOnly(t *testing.T) {
 		}
 	}
 
-	// Manifest sanity: workspaces opted out, state_json + pids true.
+	// Manifest sanity: workspaces opted out, recorded as a skip. What's
+	// present (logs/state/pids) is asserted via the zip listing above,
+	// not re-stated in the manifest.
 	mBytes := readZipFile(t, zipPath, "manifest.yml")
 	mStr := string(mBytes)
 	for _, needle := range []string{
 		"include_workspaces_requested: false",
-		"state_json: true",
-		"pids: true",
-		"workspaces: false",
 		"why: user_opted_out",
 		"daemon_version: unreachable",
 	} {
@@ -295,15 +294,13 @@ func TestExport_MissingStateJson(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Export: %v", err)
 	}
-	// state.json should not be in the zip when it doesn't exist on disk.
+	// Absence is read from the zip listing — state.json must not be an
+	// entry when it doesn't exist on disk. The manifest no longer
+	// restates presence, so the zip is the authoritative check.
 	for _, name := range readZipEntries(t, zipPath) {
 		if name == "state.json" {
 			t.Errorf("state.json present in zip despite missing on disk")
 		}
-	}
-	body := string(readZipFile(t, zipPath, "manifest.yml"))
-	if !strings.Contains(body, "state_json: false") {
-		t.Errorf("expected state_json: false in manifest, got:\n%s", body)
 	}
 }
 

--- a/tools/friday-launcher/diagnostics/export_test.go
+++ b/tools/friday-launcher/diagnostics/export_test.go
@@ -200,23 +200,23 @@ func TestExport_ProgressFn(t *testing.T) {
 	})
 
 	t.Run("include_workspaces_true", func(t *testing.T) {
-		// No HTTP yet — IncludeWorkspaces=true still produces the same
-		// phase sequence because there's no "workspaces" phase to drive.
-		// Task #3 adds it; the contract for this slice is logs, packaging.
 		logs, state := stubSources(t)
 		writeFile(t, filepath.Join(logs, "a.log"), "x")
 		writeFile(t, filepath.Join(state, "state.json"), "{}")
+		srv := newDaemonStub(t, daemonStub{})
+		defer srv.Close()
 
 		var phases []string
 		_, err := Export(ExportOptions{
 			IncludeWorkspaces: true,
+			DaemonURL:         srv.URL,
 			OutputDir:         t.TempDir(),
 			ProgressFn:        func(p string) { phases = append(phases, p) },
 		})
 		if err != nil {
 			t.Fatalf("Export: %v", err)
 		}
-		want := []string{"logs", "packaging"}
+		want := []string{"logs", "workspaces", "packaging"}
 		if !equalStringSlices(phases, want) {
 			t.Errorf("phases = %v, want %v", phases, want)
 		}

--- a/tools/friday-launcher/diagnostics/export_test.go
+++ b/tools/friday-launcher/diagnostics/export_test.go
@@ -54,7 +54,7 @@ func readZipEntries(t *testing.T, path string) []string {
 	if err != nil {
 		t.Fatalf("open zip %s: %v", path, err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 	names := make([]string, 0, len(r.File))
 	for _, f := range r.File {
 		names = append(names, f.Name)
@@ -70,7 +70,7 @@ func readZipFile(t *testing.T, zipPath, entry string) []byte {
 	if err != nil {
 		t.Fatalf("open zip: %v", err)
 	}
-	defer r.Close()
+	defer func() { _ = r.Close() }()
 	for _, f := range r.File {
 		if f.Name != entry {
 			continue
@@ -80,7 +80,7 @@ func readZipFile(t *testing.T, zipPath, entry string) []byte {
 			t.Fatalf("open entry %s: %v", entry, err)
 		}
 		body, err := io.ReadAll(rc)
-		rc.Close()
+		_ = rc.Close()
 		if err != nil {
 			t.Fatalf("read entry %s: %v", entry, err)
 		}

--- a/tools/friday-launcher/diagnostics/export_test.go
+++ b/tools/friday-launcher/diagnostics/export_test.go
@@ -1,0 +1,354 @@
+package diagnostics
+
+import (
+	"archive/zip"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+)
+
+// pinClock pins nowFn for golden / deterministic tests; restored on
+// t.Cleanup. Returns the pinned time so callers can derive expected
+// filenames from it.
+func pinClock(t *testing.T, when time.Time) time.Time {
+	t.Helper()
+	prev := nowFn
+	nowFn = func() time.Time { return when }
+	t.Cleanup(func() { nowFn = prev })
+	return when
+}
+
+// stubSources points the package-level dir resolvers at a temp tree.
+// Each test gets a fresh tree so they can run in parallel without
+// stomping each other.
+func stubSources(t *testing.T) (logsDir, stateDir string) {
+	t.Helper()
+	home := t.TempDir()
+	logsDir = filepath.Join(home, "logs")
+	stateDir = home
+	if err := os.MkdirAll(logsDir, 0o755); err != nil {
+		t.Fatalf("mkdir logs: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(stateDir, "pids"), 0o755); err != nil {
+		t.Fatalf("mkdir pids: %v", err)
+	}
+	prevLogs, prevState := sourceLogsDir, sourceStateDir
+	sourceLogsDir = func() string { return logsDir }
+	sourceStateDir = func() string { return stateDir }
+	t.Cleanup(func() {
+		sourceLogsDir = prevLogs
+		sourceStateDir = prevState
+	})
+	return logsDir, stateDir
+}
+
+// readZipEntries returns the names of every entry in a zip, sorted.
+func readZipEntries(t *testing.T, path string) []string {
+	t.Helper()
+	r, err := zip.OpenReader(path)
+	if err != nil {
+		t.Fatalf("open zip %s: %v", path, err)
+	}
+	defer r.Close()
+	names := make([]string, 0, len(r.File))
+	for _, f := range r.File {
+		names = append(names, f.Name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// readZipFile returns the body of a named entry inside a zip.
+func readZipFile(t *testing.T, zipPath, entry string) []byte {
+	t.Helper()
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		t.Fatalf("open zip: %v", err)
+	}
+	defer r.Close()
+	for _, f := range r.File {
+		if f.Name != entry {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			t.Fatalf("open entry %s: %v", entry, err)
+		}
+		body, err := io.ReadAll(rc)
+		rc.Close()
+		if err != nil {
+			t.Fatalf("read entry %s: %v", entry, err)
+		}
+		return body
+	}
+	t.Fatalf("entry %s not found in %s", entry, zipPath)
+	return nil
+}
+
+func writeFile(t *testing.T, path, body string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func TestExport_HappyPath_LogsOnly(t *testing.T) {
+	logs, state := stubSources(t)
+	writeFile(t, filepath.Join(logs, "daemon.log"), "hello\n")
+	writeFile(t, filepath.Join(logs, "launcher.log"), "world\n")
+	writeFile(t, filepath.Join(state, "state.json"), `{"autostart_initialized":true}`)
+	writeFile(t, filepath.Join(state, "pids", "foo.pid"), "1234")
+
+	out := t.TempDir()
+	zipPath, err := Export(ExportOptions{OutputDir: out})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if !strings.HasPrefix(filepath.Base(zipPath), "friday-diagnostics-") || !strings.HasSuffix(zipPath, ".zip") {
+		t.Errorf("unexpected zip path: %s", zipPath)
+	}
+
+	got := readZipEntries(t, zipPath)
+	want := []string{
+		"logs/daemon.log",
+		"logs/launcher.log",
+		"manifest.yml",
+		"pids/foo.pid",
+		"state.json",
+	}
+	if !equalStringSlices(got, want) {
+		t.Errorf("zip entries mismatch.\n  got:  %v\n  want: %v", got, want)
+	}
+
+	// No .partial lingering after a successful export.
+	entries, err := os.ReadDir(out)
+	if err != nil {
+		t.Fatalf("readdir out: %v", err)
+	}
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".partial") {
+			t.Errorf("found leftover .partial: %s", e.Name())
+		}
+	}
+
+	// Manifest sanity: workspaces opted out, state_json + pids true.
+	mBytes := readZipFile(t, zipPath, "manifest.yml")
+	mStr := string(mBytes)
+	for _, needle := range []string{
+		"include_workspaces_requested: false",
+		"state_json: true",
+		"pids: true",
+		"workspaces: false",
+		"why: user_opted_out",
+		"daemon_version: unreachable",
+	} {
+		if !strings.Contains(mStr, needle) {
+			t.Errorf("manifest missing %q\nfull body:\n%s", needle, mStr)
+		}
+	}
+}
+
+func TestExport_LogsFilter(t *testing.T) {
+	logs, state := stubSources(t)
+	for _, name := range []string{"daemon.log", "daemon.log.1.gz", "daemon.log.2", "agent.log"} {
+		writeFile(t, filepath.Join(logs, name), "x")
+	}
+	writeFile(t, filepath.Join(state, "state.json"), "{}")
+
+	out := t.TempDir()
+	zipPath, err := Export(ExportOptions{OutputDir: out})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	var gotLogs []string
+	for _, name := range readZipEntries(t, zipPath) {
+		if strings.HasPrefix(name, "logs/") {
+			gotLogs = append(gotLogs, name)
+		}
+	}
+	sort.Strings(gotLogs)
+	want := []string{"logs/agent.log", "logs/daemon.log"}
+	if !equalStringSlices(gotLogs, want) {
+		t.Errorf("logs filter mismatch.\n  got:  %v\n  want: %v", gotLogs, want)
+	}
+}
+
+func TestExport_ProgressFn(t *testing.T) {
+	t.Run("opt_out", func(t *testing.T) {
+		logs, state := stubSources(t)
+		writeFile(t, filepath.Join(logs, "a.log"), "x")
+		writeFile(t, filepath.Join(state, "state.json"), "{}")
+
+		var phases []string
+		_, err := Export(ExportOptions{
+			OutputDir:  t.TempDir(),
+			ProgressFn: func(p string) { phases = append(phases, p) },
+		})
+		if err != nil {
+			t.Fatalf("Export: %v", err)
+		}
+		want := []string{"logs", "packaging"}
+		if !equalStringSlices(phases, want) {
+			t.Errorf("phases = %v, want %v", phases, want)
+		}
+	})
+
+	t.Run("include_workspaces_true", func(t *testing.T) {
+		// No HTTP yet — IncludeWorkspaces=true still produces the same
+		// phase sequence because there's no "workspaces" phase to drive.
+		// Task #3 adds it; the contract for this slice is logs, packaging.
+		logs, state := stubSources(t)
+		writeFile(t, filepath.Join(logs, "a.log"), "x")
+		writeFile(t, filepath.Join(state, "state.json"), "{}")
+
+		var phases []string
+		_, err := Export(ExportOptions{
+			IncludeWorkspaces: true,
+			OutputDir:         t.TempDir(),
+			ProgressFn:        func(p string) { phases = append(phases, p) },
+		})
+		if err != nil {
+			t.Fatalf("Export: %v", err)
+		}
+		want := []string{"logs", "packaging"}
+		if !equalStringSlices(phases, want) {
+			t.Errorf("phases = %v, want %v", phases, want)
+		}
+	})
+}
+
+func TestExport_SkipReason_OptOutVsUnreachable(t *testing.T) {
+	cases := []struct {
+		name              string
+		includeWorkspaces bool
+		wantWhy           string
+	}{
+		{"opt_out", false, "user_opted_out"},
+		{"include_no_http", true, "daemon_unreachable"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			logs, state := stubSources(t)
+			writeFile(t, filepath.Join(logs, "a.log"), "x")
+			writeFile(t, filepath.Join(state, "state.json"), "{}")
+
+			zipPath, err := Export(ExportOptions{
+				IncludeWorkspaces: tc.includeWorkspaces,
+				OutputDir:         t.TempDir(),
+			})
+			if err != nil {
+				t.Fatalf("Export: %v", err)
+			}
+			body := string(readZipFile(t, zipPath, "manifest.yml"))
+			want := "why: " + tc.wantWhy
+			if !strings.Contains(body, want) {
+				t.Errorf("manifest missing %q\n%s", want, body)
+			}
+		})
+	}
+}
+
+func TestExport_DownloadsFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("chmod 0o500 doesn't enforce write-deny on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses unix mode bits; fallback unreachable")
+	}
+
+	logs, state := stubSources(t)
+	writeFile(t, filepath.Join(logs, "a.log"), "x")
+	writeFile(t, filepath.Join(state, "state.json"), "{}")
+
+	readonly := t.TempDir()
+	if err := os.Chmod(readonly, 0o500); err != nil {
+		t.Fatalf("chmod readonly: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(readonly, 0o700) })
+
+	zipPath, err := Export(ExportOptions{OutputDir: readonly})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	if strings.HasPrefix(zipPath, readonly+string(os.PathSeparator)) {
+		t.Errorf("zip landed in unwritable dir %s: %s", readonly, zipPath)
+	}
+
+	body := string(readZipFile(t, zipPath, "manifest.yml"))
+	if !strings.Contains(body, "what: output_dir") || !strings.Contains(body, "why: downloads_unwritable") {
+		t.Errorf("manifest missing output_dir/downloads_unwritable skip:\n%s", body)
+	}
+}
+
+func TestExport_MissingStateJson(t *testing.T) {
+	logs, _ := stubSources(t)
+	writeFile(t, filepath.Join(logs, "a.log"), "x")
+	// Intentionally no state.json.
+
+	zipPath, err := Export(ExportOptions{OutputDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	// state.json should not be in the zip when it doesn't exist on disk.
+	for _, name := range readZipEntries(t, zipPath) {
+		if name == "state.json" {
+			t.Errorf("state.json present in zip despite missing on disk")
+		}
+	}
+	body := string(readZipFile(t, zipPath, "manifest.yml"))
+	if !strings.Contains(body, "state_json: false") {
+		t.Errorf("expected state_json: false in manifest, got:\n%s", body)
+	}
+}
+
+func TestExport_AtomicNoPartialOnSuccess(t *testing.T) {
+	logs, state := stubSources(t)
+	writeFile(t, filepath.Join(logs, "a.log"), "x")
+	writeFile(t, filepath.Join(state, "state.json"), "{}")
+
+	out := t.TempDir()
+	_, err := Export(ExportOptions{OutputDir: out})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	entries, _ := os.ReadDir(out)
+	for _, e := range entries {
+		if strings.Contains(e.Name(), ".partial") {
+			t.Errorf("partial file left behind: %s", e.Name())
+		}
+	}
+}
+
+func TestExport_FilenameFormat(t *testing.T) {
+	logs, state := stubSources(t)
+	writeFile(t, filepath.Join(logs, "a.log"), "x")
+	writeFile(t, filepath.Join(state, "state.json"), "{}")
+
+	pinClock(t, time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC))
+	zipPath, err := Export(ExportOptions{OutputDir: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	want := "friday-diagnostics-2026-01-02-030405.zip"
+	if filepath.Base(zipPath) != want {
+		t.Errorf("filename = %s, want %s", filepath.Base(zipPath), want)
+	}
+}
+
+func equalStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/tools/friday-launcher/diagnostics/http_test.go
+++ b/tools/friday-launcher/diagnostics/http_test.go
@@ -3,8 +3,10 @@ package diagnostics
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -18,6 +20,11 @@ type daemonStub struct {
 	bundleStatus  int    // 0 → 200
 	bundleBody    []byte // nil → []byte("STUB-BUNDLE-BYTES")
 	bundleDelay   time.Duration
+	// captureBundleQuery, when non-nil, receives the raw query string
+	// of the /api/workspaces/bundle-all request. Lets a test pin the
+	// mode=definition privacy brake. Fires on the server goroutine —
+	// the caller is responsible for synchronizing its own read.
+	captureBundleQuery func(rawQuery string)
 }
 
 // newDaemonStub spins up an httptest.Server that mimics the daemon's
@@ -44,7 +51,10 @@ func newDaemonStub(t *testing.T, s daemonStub) *httptest.Server {
 		w.WriteHeader(status)
 		_, _ = w.Write([]byte(versionBody))
 	})
-	mux.HandleFunc("/api/workspaces/bundle-all", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/api/workspaces/bundle-all", func(w http.ResponseWriter, r *http.Request) {
+		if s.captureBundleQuery != nil {
+			s.captureBundleQuery(r.URL.RawQuery)
+		}
 		if s.bundleDelay > 0 {
 			time.Sleep(s.bundleDelay)
 		}
@@ -117,6 +127,51 @@ func TestExport_HTTP_HappyPath(t *testing.T) {
 	if strings.Contains(manifestBody, "what: workspaces") {
 		t.Errorf("manifest unexpectedly skipped workspaces:\n%s", manifestBody)
 	}
+}
+
+// TestExport_HTTP_BundleModeDefinition pins the privacy brake: the
+// /bundle-all request MUST carry ?mode=definition (design § "Out of
+// Scope") so narrative memory is excluded from the bundle. Drop or
+// typo the param in export.go and this test goes red while the rest
+// of the HTTP suite stays green.
+func TestExport_HTTP_BundleModeDefinition(t *testing.T) {
+	logs, state := stubSources(t)
+	writeFile(t, filepath.Join(logs, "a.log"), "x")
+	writeFile(t, filepath.Join(state, "state.json"), "{}")
+
+	var mu sync.Mutex
+	var gotQuery string
+	srv := newDaemonStub(t, daemonStub{
+		captureBundleQuery: func(rawQuery string) {
+			mu.Lock()
+			gotQuery = rawQuery
+			mu.Unlock()
+		},
+	})
+	defer srv.Close()
+
+	if _, err := Export(ExportOptions{
+		IncludeWorkspaces: true,
+		DaemonURL:         srv.URL,
+		OutputDir:         t.TempDir(),
+	}); err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got := mustQueryMode(t, gotQuery); got != "definition" {
+		t.Errorf("bundle-all mode = %q, want %q (raw query %q)", got, "definition", gotQuery)
+	}
+}
+
+func mustQueryMode(t *testing.T, rawQuery string) string {
+	t.Helper()
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		t.Fatalf("parse bundle-all query %q: %v", rawQuery, err)
+	}
+	return values.Get("mode")
 }
 
 func TestExport_HTTP_DaemonUnreachable(t *testing.T) {

--- a/tools/friday-launcher/diagnostics/http_test.go
+++ b/tools/friday-launcher/diagnostics/http_test.go
@@ -110,6 +110,8 @@ func TestExport_HTTP_HappyPath(t *testing.T) {
 		t.Fatalf("Export: %v", err)
 	}
 
+	// workspaces.zip present + correct bytes IS the "workspaces embedded"
+	// assertion — the manifest no longer restates it.
 	gotBundle := readZipFile(t, zipPath, "workspaces.zip")
 	if string(gotBundle) != "STUB-BUNDLE-BYTES" {
 		t.Errorf("workspaces.zip body = %q, want canned bytes", string(gotBundle))
@@ -117,7 +119,6 @@ func TestExport_HTTP_HappyPath(t *testing.T) {
 	manifestBody := string(readZipFile(t, zipPath, "manifest.yml"))
 	for _, needle := range []string{
 		"daemon_version: dev-abc1234",
-		"workspaces: true",
 		"include_workspaces_requested: true",
 	} {
 		if !strings.Contains(manifestBody, needle) {
@@ -224,9 +225,6 @@ func TestExport_HTTP_AuthRefused(t *testing.T) {
 	if !strings.Contains(body, "why: auth_refused") {
 		t.Errorf("manifest missing why: auth_refused\n%s", body)
 	}
-	if !strings.Contains(body, "workspaces: false") {
-		t.Errorf("manifest should mark workspaces: false\n%s", body)
-	}
 }
 
 func TestExport_HTTP_5xx(t *testing.T) {
@@ -299,9 +297,6 @@ func TestExport_HTTP_BundleTooLarge(t *testing.T) {
 	if !strings.Contains(body, "why: bundle_all_too_large") {
 		t.Errorf("manifest missing why: bundle_all_too_large\n%s", body)
 	}
-	if !strings.Contains(body, "workspaces: false") {
-		t.Errorf("manifest should mark workspaces: false\n%s", body)
-	}
 }
 
 func TestExport_HTTP_TLS_InsecureSkipVerify(t *testing.T) {
@@ -352,7 +347,10 @@ func TestExport_HTTP_VersionFailsButBundleSucceeds(t *testing.T) {
 	if !strings.Contains(body, "daemon_version: unreachable") {
 		t.Errorf("manifest missing daemon_version: unreachable\n%s", body)
 	}
-	if !strings.Contains(body, "workspaces: true") {
-		t.Errorf("manifest should still have workspaces: true\n%s", body)
+	// Workspaces still embedded despite the version call failing — assert
+	// via the actual archive entry, not a manifest claim.
+	gotBundle := readZipFile(t, zipPath, "workspaces.zip")
+	if string(gotBundle) != "STUB-BUNDLE-BYTES" {
+		t.Errorf("workspaces.zip body = %q, want canned bytes (bundle should succeed even when version fails)", string(gotBundle))
 	}
 }

--- a/tools/friday-launcher/diagnostics/http_test.go
+++ b/tools/friday-launcher/diagnostics/http_test.go
@@ -1,0 +1,272 @@
+package diagnostics
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// daemonStub configures the test daemon's responses. Zero value means
+// 200 OK with a canned version body and a canned zip blob — the happy
+// path that most tests want without ceremony.
+type daemonStub struct {
+	versionStatus int    // 0 → 200
+	versionBody   string // empty → `{"version":"dev-abc1234"}`
+	bundleStatus  int    // 0 → 200
+	bundleBody    []byte // nil → []byte("STUB-BUNDLE-BYTES")
+	bundleDelay   time.Duration
+}
+
+// newDaemonStub spins up an httptest.Server that mimics the daemon's
+// /api/version and /api/workspaces/bundle-all routes. Cleanup is the
+// caller's job (defer srv.Close()) — t.Cleanup hides the URL lifetime
+// from readers.
+func newDaemonStub(t *testing.T, s daemonStub) *httptest.Server {
+	t.Helper()
+	versionBody := s.versionBody
+	if versionBody == "" {
+		versionBody = `{"version":"dev-abc1234"}`
+	}
+	bundleBody := s.bundleBody
+	if bundleBody == nil {
+		bundleBody = []byte("STUB-BUNDLE-BYTES")
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/version", func(w http.ResponseWriter, _ *http.Request) {
+		status := s.versionStatus
+		if status == 0 {
+			status = http.StatusOK
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		_, _ = w.Write([]byte(versionBody))
+	})
+	mux.HandleFunc("/api/workspaces/bundle-all", func(w http.ResponseWriter, _ *http.Request) {
+		if s.bundleDelay > 0 {
+			time.Sleep(s.bundleDelay)
+		}
+		status := s.bundleStatus
+		if status == 0 {
+			status = http.StatusOK
+		}
+		w.Header().Set("Content-Type", "application/zip")
+		w.WriteHeader(status)
+		_, _ = w.Write(bundleBody)
+	})
+	return httptest.NewServer(mux)
+}
+
+// newDaemonStubTLS is the https-server flavor — same handlers, TLS
+// cert from httptest. Confirms newDaemonClient wires InsecureSkipVerify
+// for https URLs.
+func newDaemonStubTLS(t *testing.T, s daemonStub) *httptest.Server {
+	t.Helper()
+	versionBody := s.versionBody
+	if versionBody == "" {
+		versionBody = `{"version":"dev-abc1234"}`
+	}
+	bundleBody := s.bundleBody
+	if bundleBody == nil {
+		bundleBody = []byte("STUB-BUNDLE-BYTES")
+	}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/version", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(versionBody))
+	})
+	mux.HandleFunc("/api/workspaces/bundle-all", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/zip")
+		_, _ = w.Write(bundleBody)
+	})
+	return httptest.NewTLSServer(mux)
+}
+
+func TestExport_HTTP_HappyPath(t *testing.T) {
+	logs, state := stubSources(t)
+	writeFile(t, filepath.Join(logs, "a.log"), "x")
+	writeFile(t, filepath.Join(state, "state.json"), "{}")
+	srv := newDaemonStub(t, daemonStub{})
+	defer srv.Close()
+
+	zipPath, err := Export(ExportOptions{
+		IncludeWorkspaces: true,
+		DaemonURL:         srv.URL,
+		OutputDir:         t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+
+	gotBundle := readZipFile(t, zipPath, "workspaces.zip")
+	if string(gotBundle) != "STUB-BUNDLE-BYTES" {
+		t.Errorf("workspaces.zip body = %q, want canned bytes", string(gotBundle))
+	}
+	manifestBody := string(readZipFile(t, zipPath, "manifest.yml"))
+	for _, needle := range []string{
+		"daemon_version: dev-abc1234",
+		"workspaces: true",
+		"include_workspaces_requested: true",
+	} {
+		if !strings.Contains(manifestBody, needle) {
+			t.Errorf("manifest missing %q\n%s", needle, manifestBody)
+		}
+	}
+	if strings.Contains(manifestBody, "what: workspaces") {
+		t.Errorf("manifest unexpectedly skipped workspaces:\n%s", manifestBody)
+	}
+}
+
+func TestExport_HTTP_DaemonUnreachable(t *testing.T) {
+	logs, state := stubSources(t)
+	writeFile(t, filepath.Join(logs, "a.log"), "x")
+	writeFile(t, filepath.Join(state, "state.json"), "{}")
+	// Bind a real port, then close it — guarantees the connect refuses.
+	srv := httptest.NewServer(http.NewServeMux())
+	closedURL := srv.URL
+	srv.Close()
+
+	zipPath, err := Export(ExportOptions{
+		IncludeWorkspaces: true,
+		DaemonURL:         closedURL,
+		OutputDir:         t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	body := string(readZipFile(t, zipPath, "manifest.yml"))
+	if !strings.Contains(body, "daemon_version: unreachable") {
+		t.Errorf("manifest missing daemon_version: unreachable\n%s", body)
+	}
+	if !strings.Contains(body, "why: daemon_unreachable") {
+		t.Errorf("manifest missing why: daemon_unreachable\n%s", body)
+	}
+}
+
+func TestExport_HTTP_AuthRefused(t *testing.T) {
+	logs, state := stubSources(t)
+	writeFile(t, filepath.Join(logs, "a.log"), "x")
+	writeFile(t, filepath.Join(state, "state.json"), "{}")
+	srv := newDaemonStub(t, daemonStub{bundleStatus: http.StatusUnauthorized})
+	defer srv.Close()
+
+	zipPath, err := Export(ExportOptions{
+		IncludeWorkspaces: true,
+		DaemonURL:         srv.URL,
+		OutputDir:         t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	for _, name := range readZipEntries(t, zipPath) {
+		if name == "workspaces.zip" {
+			t.Errorf("workspaces.zip present despite 401")
+		}
+	}
+	body := string(readZipFile(t, zipPath, "manifest.yml"))
+	if !strings.Contains(body, "why: auth_refused") {
+		t.Errorf("manifest missing why: auth_refused\n%s", body)
+	}
+	if !strings.Contains(body, "workspaces: false") {
+		t.Errorf("manifest should mark workspaces: false\n%s", body)
+	}
+}
+
+func TestExport_HTTP_5xx(t *testing.T) {
+	logs, state := stubSources(t)
+	writeFile(t, filepath.Join(logs, "a.log"), "x")
+	writeFile(t, filepath.Join(state, "state.json"), "{}")
+	srv := newDaemonStub(t, daemonStub{bundleStatus: http.StatusServiceUnavailable})
+	defer srv.Close()
+
+	zipPath, err := Export(ExportOptions{
+		IncludeWorkspaces: true,
+		DaemonURL:         srv.URL,
+		OutputDir:         t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	body := string(readZipFile(t, zipPath, "manifest.yml"))
+	if !strings.Contains(body, "why: daemon_returned_5xx") {
+		t.Errorf("manifest missing why: daemon_returned_5xx\n%s", body)
+	}
+}
+
+func TestExport_HTTP_BundleAllTimeout(t *testing.T) {
+	logs, state := stubSources(t)
+	writeFile(t, filepath.Join(logs, "a.log"), "x")
+	writeFile(t, filepath.Join(state, "state.json"), "{}")
+	srv := newDaemonStub(t, daemonStub{bundleDelay: 200 * time.Millisecond})
+	defer srv.Close()
+
+	opts := ExportOptions{
+		IncludeWorkspaces: true,
+		DaemonURL:         srv.URL,
+		OutputDir:         t.TempDir(),
+		bundleAllTimeout:  20 * time.Millisecond,
+	}
+	zipPath, err := Export(opts)
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	body := string(readZipFile(t, zipPath, "manifest.yml"))
+	if !strings.Contains(body, "why: bundle_all_timeout") {
+		t.Errorf("manifest missing why: bundle_all_timeout\n%s", body)
+	}
+}
+
+func TestExport_HTTP_TLS_InsecureSkipVerify(t *testing.T) {
+	logs, state := stubSources(t)
+	writeFile(t, filepath.Join(logs, "a.log"), "x")
+	writeFile(t, filepath.Join(state, "state.json"), "{}")
+	srv := newDaemonStubTLS(t, daemonStub{})
+	defer srv.Close()
+
+	zipPath, err := Export(ExportOptions{
+		IncludeWorkspaces: true,
+		DaemonURL:         srv.URL,
+		OutputDir:         t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	gotBundle := readZipFile(t, zipPath, "workspaces.zip")
+	if string(gotBundle) != "STUB-BUNDLE-BYTES" {
+		t.Errorf("workspaces.zip body = %q, want canned bytes (TLS handshake may have failed)", string(gotBundle))
+	}
+	body := string(readZipFile(t, zipPath, "manifest.yml"))
+	if !strings.Contains(body, "daemon_version: dev-abc1234") {
+		t.Errorf("manifest missing daemon_version: dev-abc1234\n%s", body)
+	}
+}
+
+// TestExport_HTTP_VersionFailsButBundleSucceeds covers the case where
+// /api/version returns 500 but /bundle-all is healthy — manifest must
+// record daemon_version: unreachable while still embedding workspaces.
+// Guards against a future refactor coupling the two calls.
+func TestExport_HTTP_VersionFailsButBundleSucceeds(t *testing.T) {
+	logs, state := stubSources(t)
+	writeFile(t, filepath.Join(logs, "a.log"), "x")
+	writeFile(t, filepath.Join(state, "state.json"), "{}")
+	srv := newDaemonStub(t, daemonStub{versionStatus: http.StatusInternalServerError})
+	defer srv.Close()
+
+	zipPath, err := Export(ExportOptions{
+		IncludeWorkspaces: true,
+		DaemonURL:         srv.URL,
+		OutputDir:         t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	body := string(readZipFile(t, zipPath, "manifest.yml"))
+	if !strings.Contains(body, "daemon_version: unreachable") {
+		t.Errorf("manifest missing daemon_version: unreachable\n%s", body)
+	}
+	if !strings.Contains(body, "workspaces: true") {
+		t.Errorf("manifest should still have workspaces: true\n%s", body)
+	}
+}

--- a/tools/friday-launcher/diagnostics/http_test.go
+++ b/tools/friday-launcher/diagnostics/http_test.go
@@ -218,6 +218,37 @@ func TestExport_HTTP_BundleAllTimeout(t *testing.T) {
 	}
 }
 
+func TestExport_HTTP_BundleTooLarge(t *testing.T) {
+	logs, state := stubSources(t)
+	writeFile(t, filepath.Join(logs, "a.log"), "x")
+	writeFile(t, filepath.Join(state, "state.json"), "{}")
+	// Serve a body larger than the test-injected cap.
+	srv := newDaemonStub(t, daemonStub{bundleBody: make([]byte, 64)})
+	defer srv.Close()
+
+	zipPath, err := Export(ExportOptions{
+		IncludeWorkspaces: true,
+		DaemonURL:         srv.URL,
+		OutputDir:         t.TempDir(),
+		bundleAllByteCap:  32,
+	})
+	if err != nil {
+		t.Fatalf("Export: %v", err)
+	}
+	for _, name := range readZipEntries(t, zipPath) {
+		if name == "workspaces.zip" {
+			t.Errorf("workspaces.zip present despite body exceeding cap")
+		}
+	}
+	body := string(readZipFile(t, zipPath, "manifest.yml"))
+	if !strings.Contains(body, "why: bundle_all_too_large") {
+		t.Errorf("manifest missing why: bundle_all_too_large\n%s", body)
+	}
+	if !strings.Contains(body, "workspaces: false") {
+		t.Errorf("manifest should mark workspaces: false\n%s", body)
+	}
+}
+
 func TestExport_HTTP_TLS_InsecureSkipVerify(t *testing.T) {
 	logs, state := stubSources(t)
 	writeFile(t, filepath.Join(logs, "a.log"), "x")

--- a/tools/friday-launcher/diagnostics/manifest.go
+++ b/tools/friday-launcher/diagnostics/manifest.go
@@ -1,7 +1,6 @@
 package diagnostics
 
 import (
-	"bytes"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -63,8 +62,5 @@ func marshalManifest(m manifest) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	var buf bytes.Buffer
-	buf.WriteString(privacyHeader)
-	buf.Write(body)
-	return buf.Bytes(), nil
+	return append([]byte(privacyHeader), body...), nil
 }

--- a/tools/friday-launcher/diagnostics/manifest.go
+++ b/tools/friday-launcher/diagnostics/manifest.go
@@ -13,6 +13,9 @@ import (
 const (
 	skipReasonUserOptedOut        = "user_opted_out"
 	skipReasonDaemonUnreachable   = "daemon_unreachable"
+	skipReasonDaemonReturned5xx   = "daemon_returned_5xx"
+	skipReasonAuthRefused         = "auth_refused"
+	skipReasonBundleAllTimeout    = "bundle_all_timeout"
 	skipReasonDownloadsUnwritable = "downloads_unwritable"
 )
 

--- a/tools/friday-launcher/diagnostics/manifest.go
+++ b/tools/friday-launcher/diagnostics/manifest.go
@@ -37,21 +37,19 @@ const privacyHeader = `# Friday diagnostic export
 
 `
 
+// manifest is provenance + negative space, NOT a content listing.
+// What's present in the archive is read from the zip's own file tree
+// (unzip -l); duplicating it here would only invite drift. The manifest
+// records what you can't see by listing the archive: the daemon/host
+// build, when it ran, what the user requested, and — critically — what
+// was skipped and why (absence isn't self-describing).
 type manifest struct {
-	DaemonVersion              string           `yaml:"daemon_version"`
-	OS                         string           `yaml:"os"`
-	Arch                       string           `yaml:"arch"`
-	GeneratedAt                time.Time        `yaml:"generated_at"`
-	IncludeWorkspacesRequested bool             `yaml:"include_workspaces_requested"`
-	Included                   manifestIncluded `yaml:"included"`
-	Skipped                    []manifestSkip   `yaml:"skipped"`
-}
-
-type manifestIncluded struct {
-	Logs       []string `yaml:"logs"`
-	StateJSON  bool     `yaml:"state_json"`
-	Pids       bool     `yaml:"pids"`
-	Workspaces bool     `yaml:"workspaces"`
+	DaemonVersion              string         `yaml:"daemon_version"`
+	OS                         string         `yaml:"os"`
+	Arch                       string         `yaml:"arch"`
+	GeneratedAt                time.Time      `yaml:"generated_at"`
+	IncludeWorkspacesRequested bool           `yaml:"include_workspaces_requested"`
+	Skipped                    []manifestSkip `yaml:"skipped"`
 }
 
 type manifestSkip struct {

--- a/tools/friday-launcher/diagnostics/manifest.go
+++ b/tools/friday-launcher/diagnostics/manifest.go
@@ -1,0 +1,68 @@
+package diagnostics
+
+import (
+	"bytes"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Stable skip-reason tokens (design v3 § "Skip reasons (stable enum)").
+// Runtime and goldens emit through these consts so a typo breaks the
+// build, not the support tooling that downstream consumes manifests.
+const (
+	skipReasonUserOptedOut        = "user_opted_out"
+	skipReasonDaemonUnreachable   = "daemon_unreachable"
+	skipReasonDownloadsUnwritable = "downloads_unwritable"
+)
+
+// daemonVersionUnreachable is the reserved literal that means "could
+// not get a version out of the daemon" (design v3 § "Further Notes").
+// Any other value is opaque to support tooling.
+const daemonVersionUnreachable = "unreachable"
+
+// privacyHeader prepends every manifest. It's the user-facing safety
+// brake on log redaction — explicit "logs are NOT redacted, review
+// before sharing." Emit literally rather than via yaml head-comments
+// (yaml.v3 doesn't emit head comments on document nodes reliably).
+const privacyHeader = `# Friday diagnostic export
+#
+# Workspace bundles (if present) have credentials stripped.
+# Log files are NOT redacted — review the contents of logs/
+# before sharing this archive publicly.
+
+`
+
+type manifest struct {
+	DaemonVersion              string           `yaml:"daemon_version"`
+	OS                         string           `yaml:"os"`
+	Arch                       string           `yaml:"arch"`
+	GeneratedAt                time.Time        `yaml:"generated_at"`
+	IncludeWorkspacesRequested bool             `yaml:"include_workspaces_requested"`
+	Included                   manifestIncluded `yaml:"included"`
+	Skipped                    []manifestSkip   `yaml:"skipped"`
+}
+
+type manifestIncluded struct {
+	Logs       []string `yaml:"logs"`
+	StateJSON  bool     `yaml:"state_json"`
+	Pids       bool     `yaml:"pids"`
+	Workspaces bool     `yaml:"workspaces"`
+}
+
+type manifestSkip struct {
+	What string `yaml:"what"`
+	Why  string `yaml:"why"`
+}
+
+// marshalManifest prepends the privacy header to a yaml-encoded body.
+func marshalManifest(m manifest) ([]byte, error) {
+	body, err := yaml.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	buf.WriteString(privacyHeader)
+	buf.Write(body)
+	return buf.Bytes(), nil
+}

--- a/tools/friday-launcher/diagnostics/manifest.go
+++ b/tools/friday-launcher/diagnostics/manifest.go
@@ -16,6 +16,7 @@ const (
 	skipReasonDaemonReturned5xx   = "daemon_returned_5xx"
 	skipReasonAuthRefused         = "auth_refused"
 	skipReasonBundleAllTimeout    = "bundle_all_timeout"
+	skipReasonBundleAllTooLarge   = "bundle_all_too_large"
 	skipReasonDownloadsUnwritable = "downloads_unwritable"
 )
 

--- a/tools/friday-launcher/diagnostics/manifest_test.go
+++ b/tools/friday-launcher/diagnostics/manifest_test.go
@@ -1,0 +1,106 @@
+package diagnostics
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestManifest_Golden pins the exact byte shape of the manifest so
+// downstream support tooling (which greps / parses these files) is
+// not destabilized by a stray field rename or yaml-emitter quirk.
+// The privacy header is part of the contract — it's the user-visible
+// "logs are not redacted" disclaimer — and must come first.
+func TestManifest_Golden(t *testing.T) {
+	m := manifest{
+		DaemonVersion:              "unreachable",
+		OS:                         "darwin",
+		Arch:                       "arm64",
+		GeneratedAt:                time.Date(2026, 5, 28, 12, 34, 56, 0, time.UTC),
+		IncludeWorkspacesRequested: false,
+		Included: manifestIncluded{
+			Logs:       []string{"daemon.log", "launcher.log"},
+			StateJSON:  true,
+			Pids:       true,
+			Workspaces: false,
+		},
+		Skipped: []manifestSkip{
+			{What: "workspaces", Why: "user_opted_out"},
+		},
+	}
+
+	got, err := marshalManifest(m)
+	if err != nil {
+		t.Fatalf("marshalManifest: %v", err)
+	}
+
+	want := `# Friday diagnostic export
+#
+# Workspace bundles (if present) have credentials stripped.
+# Log files are NOT redacted — review the contents of logs/
+# before sharing this archive publicly.
+
+daemon_version: unreachable
+os: darwin
+arch: arm64
+generated_at: 2026-05-28T12:34:56Z
+include_workspaces_requested: false
+included:
+    logs:
+        - daemon.log
+        - launcher.log
+    state_json: true
+    pids: true
+    workspaces: false
+skipped:
+    - what: workspaces
+      why: user_opted_out
+`
+
+	if string(got) != want {
+		t.Errorf("manifest mismatch.\n--- got ---\n%s--- want ---\n%s", got, want)
+		// Hint at first divergent line for fast debugging.
+		gotLines := strings.Split(string(got), "\n")
+		wantLines := strings.Split(want, "\n")
+		for i := 0; i < len(gotLines) && i < len(wantLines); i++ {
+			if gotLines[i] != wantLines[i] {
+				t.Logf("first diff at line %d:\n  got:  %q\n  want: %q", i+1, gotLines[i], wantLines[i])
+				break
+			}
+		}
+	}
+}
+
+// TestManifest_DaemonUnreachableSkipReason covers the IncludeWorkspaces=true
+// path that this slice can't actually fulfill (no HTTP yet). The skip token
+// is part of the public manifest contract — the next task swaps how it's
+// computed, not what string lands on disk.
+func TestManifest_DaemonUnreachableSkipReason(t *testing.T) {
+	m := manifest{
+		DaemonVersion:              "unreachable",
+		OS:                         "linux",
+		Arch:                       "amd64",
+		GeneratedAt:                time.Date(2026, 5, 28, 0, 0, 0, 0, time.UTC),
+		IncludeWorkspacesRequested: true,
+		Included: manifestIncluded{
+			Logs:       []string{},
+			StateJSON:  true,
+			Pids:       true,
+			Workspaces: false,
+		},
+		Skipped: []manifestSkip{
+			{What: "workspaces", Why: "daemon_unreachable"},
+		},
+	}
+
+	got, err := marshalManifest(m)
+	if err != nil {
+		t.Fatalf("marshalManifest: %v", err)
+	}
+	if !strings.Contains(string(got), "why: daemon_unreachable") {
+		t.Errorf("expected daemon_unreachable in skip body, got:\n%s", got)
+	}
+	if !strings.Contains(string(got), "include_workspaces_requested: true") {
+		t.Errorf("expected include_workspaces_requested: true, got:\n%s", got)
+	}
+}

--- a/tools/friday-launcher/diagnostics/manifest_test.go
+++ b/tools/friday-launcher/diagnostics/manifest_test.go
@@ -18,12 +18,6 @@ func TestManifest_Golden(t *testing.T) {
 		Arch:                       "arm64",
 		GeneratedAt:                time.Date(2026, 5, 28, 12, 34, 56, 0, time.UTC),
 		IncludeWorkspacesRequested: false,
-		Included: manifestIncluded{
-			Logs:       []string{"daemon.log", "launcher.log"},
-			StateJSON:  true,
-			Pids:       true,
-			Workspaces: false,
-		},
 		Skipped: []manifestSkip{
 			{What: "workspaces", Why: "user_opted_out"},
 		},
@@ -45,13 +39,6 @@ os: darwin
 arch: arm64
 generated_at: 2026-05-28T12:34:56Z
 include_workspaces_requested: false
-included:
-    logs:
-        - daemon.log
-        - launcher.log
-    state_json: true
-    pids: true
-    workspaces: false
 skipped:
     - what: workspaces
       why: user_opted_out
@@ -82,12 +69,6 @@ func TestManifest_DaemonUnreachableSkipReason(t *testing.T) {
 		Arch:                       "amd64",
 		GeneratedAt:                time.Date(2026, 5, 28, 0, 0, 0, 0, time.UTC),
 		IncludeWorkspacesRequested: true,
-		Included: manifestIncluded{
-			Logs:       []string{},
-			StateJSON:  true,
-			Pids:       true,
-			Workspaces: false,
-		},
 		Skipped: []manifestSkip{
 			{What: "workspaces", Why: "daemon_unreachable"},
 		},

--- a/tools/friday-launcher/healthsvc.go
+++ b/tools/friday-launcher/healthsvc.go
@@ -353,6 +353,21 @@ func (c *HealthCache) UptimeSecs() int64 {
 	return int64(time.Since(c.startedAt).Seconds())
 }
 
+// ServiceHealthy returns true iff the named service is currently in
+// the "healthy" state. Returns false for unknown names and for any
+// non-healthy status (pending, starting, failed). The tray uses this
+// to gate the diagnostic-export "Include workspaces" checkbox on the
+// daemon being up — /api/workspaces/bundle-all needs a live daemon.
+func (c *HealthCache) ServiceHealthy(name string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	i := indexByName(c.services, name)
+	if i < 0 {
+		return false
+	}
+	return c.services[i].status == statusHealthy
+}
+
 // Subscribe registers a notification channel for SSE fan-out.
 // The returned channel receives an empty struct whenever any
 // service transitions into a new state (including the initial

--- a/tools/friday-launcher/healthsvc.go
+++ b/tools/friday-launcher/healthsvc.go
@@ -356,7 +356,7 @@ func (c *HealthCache) UptimeSecs() int64 {
 // ServiceHealthy returns true iff the named service is currently in
 // the "healthy" state. Returns false for unknown names and for any
 // non-healthy status (pending, starting, failed). The tray uses this
-// to gate the diagnostic-export "Include workspaces" checkbox on the
+// to gate the diagnostic-export "Logs + workspaces" action on the
 // daemon being up — /api/workspaces/bundle-all needs a live daemon.
 func (c *HealthCache) ServiceHealthy(name string) bool {
 	c.mu.RLock()

--- a/tools/friday-launcher/main.go
+++ b/tools/friday-launcher/main.go
@@ -670,8 +670,8 @@ func runAutostartCommand(cmd string) {
 			os.Exit(1)
 		}
 		// Mark state so goroutine E doesn't redo the work next launch.
-		// Read-modify-write so we don't clobber other persisted fields
-		// (e.g. IncludeWorkspaces) the user has already toggled.
+		// Read-modify-write keeps this consistent with
+		// autostartSelfRegister and survives any future persisted fields.
 		state := readState()
 		state.AutostartInitialized = true
 		_ = writeState(state)

--- a/tools/friday-launcher/main.go
+++ b/tools/friday-launcher/main.go
@@ -670,7 +670,11 @@ func runAutostartCommand(cmd string) {
 			os.Exit(1)
 		}
 		// Mark state so goroutine E doesn't redo the work next launch.
-		_ = writeState(launcherState{AutostartInitialized: true})
+		// Read-modify-write so we don't clobber other persisted fields
+		// (e.g. IncludeWorkspaces) the user has already toggled.
+		state := readState()
+		state.AutostartInitialized = true
+		_ = writeState(state)
 		fmt.Println("autostart enabled")
 	case "disable":
 		if err := disableAutostart(); err != nil {

--- a/tools/friday-launcher/openers.go
+++ b/tools/friday-launcher/openers.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 
 	"github.com/pkg/browser"
@@ -47,6 +48,41 @@ func openInFileBrowser(path string) error {
 	}
 	if err := cmd.Start(); err != nil {
 		return fmt.Errorf("open %s: %w", path, err)
+	}
+	return nil
+}
+
+// revealInFileBrowserOverride is a test hook. When non-nil it replaces
+// the OS shell-out in revealInFileBrowser so tests can assert the
+// reveal happened without spawning Finder/Explorer on the developer's
+// machine. Production code leaves it nil.
+var revealInFileBrowserOverride func(path string) error
+
+// revealInFileBrowser opens the OS file browser with the given file
+// preselected (the diagnostic zip the user just exported). macOS and
+// Windows have native "select this file" flags; Linux's xdg-open has
+// no equivalent, so we fall back to opening the containing directory.
+//
+// Fire-and-forget like openInFileBrowser — we don't wait for Finder
+// to come up. Any spawn error surfaces to the caller for logging.
+func revealInFileBrowser(path string) error {
+	if revealInFileBrowserOverride != nil {
+		return revealInFileBrowserOverride(path)
+	}
+	// path is the launcher-produced zip in ~/Downloads (or fallback
+	// TempDir) — same provenance as logsDir() above, so the gosec
+	// suppression has the same rationale.
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", "-R", path) //nolint:gosec // G204: launcher-produced path
+	case "windows":
+		cmd = exec.Command("explorer.exe", "/select,"+path) //nolint:gosec // G204: launcher-produced path
+	default:
+		cmd = exec.Command("xdg-open", filepath.Dir(path)) //nolint:gosec // G204: launcher-produced path
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("reveal %s: %w", path, err)
 	}
 	return nil
 }

--- a/tools/friday-launcher/project.go
+++ b/tools/friday-launcher/project.go
@@ -796,6 +796,34 @@ func playgroundURL() string {
 	return "http://localhost:" + port
 }
 
+// daemonAPIBaseURL returns the base URL the launcher uses to call the
+// daemon's HTTP API (no trailing slash). Single source of truth for
+// the daemon's URL — every launcher-internal caller (diagnostics
+// export, future health probes) routes through here so the scheme +
+// port derivation lives in exactly one place.
+//
+// Scheme follows the s2s cert pair (same gate as project.go's
+// processSpec.healthScheme for the daemon at line 740) — the daemon
+// binary listens on HTTPS iff the cert pair is present + valid.
+// Port honors FRIDAY_PORT_FRIDAY for installs that move the daemon
+// off 8080 (same convention as playgroundURL above).
+//
+// Host is always `localhost`: unlike playground (which uses
+// `local.hellofriday.ai` for the green-lock cert), the daemon's s2s
+// leaf is private-CA signed and the launcher's diagnostics HTTP client
+// uses InsecureSkipVerify (loopback, we own both ends).
+func daemonAPIBaseURL() string {
+	port := portOverride("friday")
+	if port == "" {
+		port = "8080"
+	}
+	scheme := "http"
+	if s2sCertsValid(time.Now()) {
+		scheme = "https"
+	}
+	return scheme + "://localhost:" + port
+}
+
 // Probe timings consumed by the native readinessRunner (readiness.go).
 // process-compose's own ReadinessProbe is intentionally nil for every
 // supervised service — its HttpProbe has no TLS controls and would

--- a/tools/friday-launcher/tray.go
+++ b/tools/friday-launcher/tray.go
@@ -84,37 +84,37 @@ const (
 	exportingTooltip = "Friday Studio — exporting diagnostics…"
 )
 
-// Menu item labels for the diagnostic-export item. The progress and
-// failure labels are written from the export goroutine; the default
-// is the resting state.
+// Menu item labels. The export action is a parent menu item with a
+// submenu of two explicit actions ("Logs only", "Logs + workspaces");
+// the parent's title carries the progress/success/failure feedback,
+// written from the export goroutine. The default is the resting state.
 const (
-	exportItemDefault        = "Export diagnostic logs…"
-	exportItemProgressBase   = "Exporting diagnostic logs…"
-	exportItemSuccess        = "Exported ✓ — revealing…"
-	exportItemFailure        = "Export failed — see launcher.log"
-	includeWorkspacesLabel   = "Include workspaces"
-	includeWorkspacesDisable = " — start Friday Studio to enable"
+	exportItemDefault      = "Export diagnostics"
+	exportItemProgressBase = "Exporting diagnostics…"
+	exportItemSuccess      = "Exported ✓ — revealing…"
+	exportItemFailure      = "Export failed — see launcher.log"
+	logsOnlyLabel          = "Logs only"
+	logsWorkspacesLabel    = "Logs + workspaces"
+	logsWorkspacesDisable  = " — start Friday Studio to enable"
 )
 
 // daemonServiceName is the supervised process whose liveness gates
-// the Include workspaces checkbox. Defined here (not in healthsvc.go)
+// the "Logs + workspaces" action. Defined here (not in healthsvc.go)
 // because the tray is the only consumer that cares which service is
 // the daemon — healthsvc treats every service uniformly.
 const daemonServiceName = "friday"
 
 // menuItem is the subset of *systray.MenuItem mutators that the two
-// shared items (exportItem, includeWorkspacesItem) are driven through.
-// Carved out as an interface purely so tests can inject a recording
-// fake — *systray.MenuItem can't be constructed without a live tray.
-// ClickedCh is deliberately NOT here: it's a struct field on the
-// concrete item, read only from the single-goroutine handleClicks, so
-// onReady captures it into a dedicated channel field instead.
+// shared items (exportItem parent, logsWorkspacesItem) are driven
+// through. Carved out as an interface purely so tests can inject a
+// recording fake — *systray.MenuItem can't be constructed without a
+// live tray. ClickedCh is deliberately NOT here: it's a struct field
+// on the concrete item, read only from the single-goroutine
+// handleClicks, so onReady captures it into a dedicated channel field.
 type menuItem interface {
 	SetTitle(string)
 	Enable()
 	Disable()
-	Check()
-	Uncheck()
 }
 
 // exportSuccessHold is how long the menu item shows the success label
@@ -137,19 +137,24 @@ type trayController struct {
 	autostartItem *systray.MenuItem
 	quitItem      *systray.MenuItem
 
-	// includeWorkspacesItem and exportItem are the two items mutated
-	// from three goroutines (tick, handleClicks, runExport); they sit
-	// behind the menuItem interface so tests can inject a fake. Their
-	// click channels live in the *ClickedCh fields below since the
-	// interface intentionally omits ClickedCh.
-	includeWorkspacesItem menuItem
-	exportItem            menuItem
+	// exportItem is the "Export diagnostics" parent. Its title carries
+	// the progress/success/failure feedback (mutated from tick and the
+	// export goroutine) and it's disabled for the duration of an export
+	// so its submenu is inaccessible while one is in flight.
+	// logsWorkspacesItem is the daemon-gated sub-action (mutated from
+	// tick only). Both sit behind the menuItem interface so tests can
+	// inject a fake. The logs-only sub-item is never mutated after
+	// creation — parent-disable covers it — so only its click channel
+	// is kept. Click channels live in the *ClickedCh fields below since
+	// the interface intentionally omits ClickedCh.
+	exportItem         menuItem
+	logsWorkspacesItem menuItem
 
 	// Click channels captured from the concrete items in onReady.
 	// handleClicks (the sole reader) selects on these instead of
 	// reaching through the now-interface-typed item fields.
-	includeWorkspacesClickedCh <-chan struct{}
-	exportClickedCh            <-chan struct{}
+	logsOnlyClickedCh       <-chan struct{}
+	logsWorkspacesClickedCh <-chan struct{}
 
 	currentBucket trayBucket
 
@@ -175,19 +180,19 @@ type trayController struct {
 	exportSuccessUntilTS time.Time // zero value when no success transient
 
 	// menuMu serializes every mutation of the two shared menu items
-	// (exportItem, includeWorkspacesItem) across all three goroutines.
-	// systray.MenuItem's SetTitle/Enable/Disable/Check/Uncheck write
-	// the item's internal fields without any locking of their own, so
-	// without this the tick / click / export goroutines race on them.
-	// Lock ordering: NEVER held with exportMu. Callers derive state
-	// under exportMu, release it, THEN take menuMu for the systray call.
+	// (exportItem parent, logsWorkspacesItem) across the tick and export
+	// goroutines. systray.MenuItem's SetTitle/Enable/Disable write the
+	// item's internal fields without any locking of their own, so
+	// without this the tick / export goroutines race on them. Lock
+	// ordering: NEVER held with exportMu. Callers derive state under
+	// exportMu, release it, THEN take menuMu for the systray call.
 	menuMu sync.Mutex
 
-	// daemonEnabledForInclude mirrors the last enable/disable verdict
-	// for the Include workspaces item so we only call Enable/Disable
-	// on the cross-platform systray when the verdict actually flips.
-	// Avoids per-tick churn on macOS NSMenu which redraws on Enable.
-	daemonEnabledForInclude bool
+	// daemonEnabledForWorkspaces mirrors the last enable/disable verdict
+	// for the "Logs + workspaces" item so we only call Enable/Disable on
+	// the cross-platform systray when the verdict actually flips. Avoids
+	// per-tick churn on macOS NSMenu which redraws on Enable.
+	daemonEnabledForWorkspaces bool
 }
 
 func newTrayController(
@@ -216,24 +221,25 @@ func (t *trayController) onReady() {
 	t.openItem = systray.AddMenuItem("Open in browser", "Open Friday Studio")
 	t.restartItem = systray.AddMenuItem("Restart all", "Stop and start every supervised process")
 	t.logsItem = systray.AddMenuItem("View logs", "Open ~/.friday/local/logs in your file browser")
-	// Seed the Include workspaces checkbox from persisted state so the
-	// user's prior toggle survives launcher restarts (state.json
-	// IncludeWorkspaces field).
-	persisted := readState()
-	// Capture each concrete item locally so we can grab ClickedCh
-	// (a struct field, absent from the menuItem interface) before the
-	// field narrows to the interface type.
-	includeItem := systray.AddMenuItemCheckbox(
-		includeWorkspacesLabel,
-		"Embed each workspace's definition zip in the next diagnostic export",
-		persisted.IncludeWorkspaces)
-	t.includeWorkspacesItem = includeItem
-	t.includeWorkspacesClickedCh = includeItem.ClickedCh
+	// "Export diagnostics" is a parent item; its two sub-actions are the
+	// explicit export variants. The parent title carries progress
+	// feedback and is disabled while an export runs. Capture each
+	// concrete sub-item locally so we can grab ClickedCh (a struct
+	// field, absent from the menuItem interface) before narrowing the
+	// parent to the interface type.
 	exportItem := systray.AddMenuItem(
 		exportItemDefault,
 		"Build a one-click diagnostic zip and reveal it in your file browser")
 	t.exportItem = exportItem
-	t.exportClickedCh = exportItem.ClickedCh
+	logsOnlyItem := exportItem.AddSubMenuItem(
+		logsOnlyLabel,
+		"Export logs, launcher state, and pids only")
+	t.logsOnlyClickedCh = logsOnlyItem.ClickedCh
+	logsWorkspacesItem := exportItem.AddSubMenuItem(
+		logsWorkspacesLabel,
+		"Also embed each workspace's definition zip (needs the daemon running)")
+	t.logsWorkspacesItem = logsWorkspacesItem
+	t.logsWorkspacesClickedCh = logsWorkspacesItem.ClickedCh
 	systray.AddSeparator()
 	t.autostartItem = systray.AddMenuItemCheckbox(
 		"Start at login",
@@ -244,7 +250,7 @@ func (t *trayController) onReady() {
 	// Optimistically enabled — tick() will Disable on the next 2s
 	// pass if the daemon isn't healthy yet. Mirror the same default
 	// so the first tick is a no-op when the daemon comes up fast.
-	t.daemonEnabledForInclude = true
+	t.daemonEnabledForWorkspaces = true
 
 	go t.handleClicks()
 	go t.pollLoop()
@@ -270,10 +276,10 @@ func (t *trayController) handleClicks() {
 			if err := openInFileBrowser(logsDir()); err != nil {
 				log.Error("open logs dir failed", "error", err)
 			}
-		case <-t.includeWorkspacesClickedCh:
-			t.toggleIncludeWorkspaces()
-		case <-t.exportClickedCh:
-			t.startExport()
+		case <-t.logsOnlyClickedCh:
+			t.startExport(false)
+		case <-t.logsWorkspacesClickedCh:
+			t.startExport(true)
 		case <-t.autostartItem.ClickedCh:
 			if t.autostartItem.Checked() {
 				if err := disableAutostart(); err != nil {
@@ -352,7 +358,7 @@ func (t *trayController) tick() {
 	}
 	t.currentBucket = bucket
 	t.updateExportItemLabel()
-	t.updateIncludeWorkspacesAvailability()
+	t.updateWorkspacesItemAvailability()
 	if bucket == bucketGreen {
 		// Open browser exactly once on first transition to green
 		// (and only if --no-browser wasn't set, which is checked
@@ -461,58 +467,33 @@ func (t *trayController) wakeFromSecondInstance() {
 	t.openBrowser("second-instance wake")
 }
 
-// toggleIncludeWorkspaces flips the persisted preference and the
-// checkbox UI together. If state.json read fails we still flip the
-// in-memory checkbox so the user gets feedback, but the next launcher
-// boot will revert — that's acceptable for a one-click preference
-// (worst case: re-tick after restart).
-func (t *trayController) toggleIncludeWorkspaces() {
-	state := readState()
-	state.IncludeWorkspaces = !state.IncludeWorkspaces
-	if err := writeState(state); err != nil {
-		log.Error("persist IncludeWorkspaces failed", "error", err)
-		// Fall through — UI still flips so the click feels responsive.
-		// User will see the original value after the next launcher boot.
-	}
-	if t.includeWorkspacesItem == nil {
-		return
-	}
-	t.menuMu.Lock()
-	defer t.menuMu.Unlock()
-	if state.IncludeWorkspaces {
-		t.includeWorkspacesItem.Check()
-	} else {
-		t.includeWorkspacesItem.Uncheck()
-	}
-}
-
-// updateIncludeWorkspacesAvailability disables the Include workspaces
-// item when the daemon isn't healthy (the /bundle-all endpoint needs
-// a live daemon) and re-enables it once the daemon comes up. The
-// persisted check state is preserved across the flip — only the label
-// + interactability changes.
+// updateWorkspacesItemAvailability disables the "Logs + workspaces"
+// sub-action when the daemon isn't healthy (the /bundle-all endpoint
+// needs a live daemon) and re-enables it once the daemon comes up. The
+// "Logs only" action is always available and needs no gating. Only the
+// label suffix + interactability change.
 //
-// Coalesced on daemonEnabledForInclude so we don't call SetTitle on
+// Coalesced on daemonEnabledForWorkspaces so we don't call SetTitle on
 // every 2s tick when the state hasn't changed (macOS NSMenu redraws
 // on each SetTitle).
-func (t *trayController) updateIncludeWorkspacesAvailability() {
-	if t.includeWorkspacesItem == nil {
+func (t *trayController) updateWorkspacesItemAvailability() {
+	if t.logsWorkspacesItem == nil {
 		return
 	}
 	daemonUp := t.healthCache != nil && t.healthCache.ServiceHealthy(daemonServiceName)
-	if daemonUp == t.daemonEnabledForInclude {
+	if daemonUp == t.daemonEnabledForWorkspaces {
 		return
 	}
 	t.menuMu.Lock()
 	if daemonUp {
-		t.includeWorkspacesItem.SetTitle(includeWorkspacesLabel)
-		t.includeWorkspacesItem.Enable()
+		t.logsWorkspacesItem.SetTitle(logsWorkspacesLabel)
+		t.logsWorkspacesItem.Enable()
 	} else {
-		t.includeWorkspacesItem.SetTitle(includeWorkspacesLabel + includeWorkspacesDisable)
-		t.includeWorkspacesItem.Disable()
+		t.logsWorkspacesItem.SetTitle(logsWorkspacesLabel + logsWorkspacesDisable)
+		t.logsWorkspacesItem.Disable()
 	}
 	t.menuMu.Unlock()
-	t.daemonEnabledForInclude = daemonUp
+	t.daemonEnabledForWorkspaces = daemonUp
 }
 
 // exportLabelState is a snapshot of the export-related fields the
@@ -586,11 +567,13 @@ func (t *trayController) updateExportItemLabel() {
 	t.menuMu.Unlock()
 }
 
-// startExport handles a click on the Export diagnostic logs item.
-// The CAS on `exporting` is the real concurrency guard — second click
-// during an in-flight export finds the slot taken and is a no-op.
-// Disabling the menu item is best-effort visual feedback.
-func (t *trayController) startExport() {
+// startExport handles a click on either export sub-action.
+// includeWorkspaces is true for "Logs + workspaces", false for
+// "Logs only". The CAS on `exporting` is the real concurrency guard —
+// a second click during an in-flight export finds the slot taken and
+// is a no-op. Disabling the parent item is best-effort visual feedback
+// (it also makes the submenu inaccessible for the duration).
+func (t *trayController) startExport(includeWorkspaces bool) {
 	if t.shuttingDown.Load() {
 		// Refuse new exports during shutdown — performShutdown is
 		// tearing the daemon down and any /bundle-all call would race
@@ -610,7 +593,7 @@ func (t *trayController) startExport() {
 	t.exportSuccessUntilTS = time.Time{}
 	t.exportProgressPhase = "logs" // optimistic — Export will overwrite
 	t.exportMu.Unlock()
-	go t.runExport()
+	go t.runExport(includeWorkspaces)
 }
 
 // exportFn is the diagnostics.Export call, swappable for tests so the
@@ -621,14 +604,15 @@ var exportFn func(diagnostics.ExportOptions) (string, error)
 
 // runExport is the export goroutine. Owns the exporting atomic.Bool
 // across its full lifetime (set by startExport before spawn, cleared
-// here on return). Posts progress to the tray via setExportPhase;
-// reveals on success; leaves a sticky failure label on error.
-func (t *trayController) runExport() {
+// here on return). includeWorkspaces comes straight from the clicked
+// sub-action — there is no persisted preference. Posts progress to the
+// tray via setExportPhase; reveals on success; leaves a sticky failure
+// label on error.
+func (t *trayController) runExport(includeWorkspaces bool) {
 	defer t.exporting.Store(false)
 
-	persisted := readState()
 	opts := diagnostics.ExportOptions{
-		IncludeWorkspaces: persisted.IncludeWorkspaces,
+		IncludeWorkspaces: includeWorkspaces,
 		DaemonURL:         daemonAPIBaseURL(),
 		ProgressFn:        t.setExportPhase,
 	}

--- a/tools/friday-launcher/tray.go
+++ b/tools/friday-launcher/tray.go
@@ -102,6 +102,21 @@ const (
 // the daemon — healthsvc treats every service uniformly.
 const daemonServiceName = "friday"
 
+// menuItem is the subset of *systray.MenuItem mutators that the two
+// shared items (exportItem, includeWorkspacesItem) are driven through.
+// Carved out as an interface purely so tests can inject a recording
+// fake — *systray.MenuItem can't be constructed without a live tray.
+// ClickedCh is deliberately NOT here: it's a struct field on the
+// concrete item, read only from the single-goroutine handleClicks, so
+// onReady captures it into a dedicated channel field instead.
+type menuItem interface {
+	SetTitle(string)
+	Enable()
+	Disable()
+	Check()
+	Uncheck()
+}
+
 // exportSuccessHold is how long the menu item shows the success label
 // before reverting to the default. Sized so a quick reader sees the
 // ✓ but the menu doesn't feel sticky if they re-open it later.
@@ -116,13 +131,25 @@ type trayController struct {
 	openedBrowserOnce atomic.Bool
 
 	// menu items kept around so we can update labels / disable / enable
-	openItem              *systray.MenuItem
-	restartItem           *systray.MenuItem
-	logsItem              *systray.MenuItem
-	includeWorkspacesItem *systray.MenuItem
-	exportItem            *systray.MenuItem
-	autostartItem         *systray.MenuItem
-	quitItem              *systray.MenuItem
+	openItem      *systray.MenuItem
+	restartItem   *systray.MenuItem
+	logsItem      *systray.MenuItem
+	autostartItem *systray.MenuItem
+	quitItem      *systray.MenuItem
+
+	// includeWorkspacesItem and exportItem are the two items mutated
+	// from three goroutines (tick, handleClicks, runExport); they sit
+	// behind the menuItem interface so tests can inject a fake. Their
+	// click channels live in the *ClickedCh fields below since the
+	// interface intentionally omits ClickedCh.
+	includeWorkspacesItem menuItem
+	exportItem            menuItem
+
+	// Click channels captured from the concrete items in onReady.
+	// handleClicks (the sole reader) selects on these instead of
+	// reaching through the now-interface-typed item fields.
+	includeWorkspacesClickedCh <-chan struct{}
+	exportClickedCh            <-chan struct{}
 
 	currentBucket trayBucket
 
@@ -146,6 +173,15 @@ type trayController struct {
 	exportProgressPhase  string    // "" when no export is in flight
 	exportFailureMsg     string    // sticky until next export click
 	exportSuccessUntilTS time.Time // zero value when no success transient
+
+	// menuMu serializes every mutation of the two shared menu items
+	// (exportItem, includeWorkspacesItem) across all three goroutines.
+	// systray.MenuItem's SetTitle/Enable/Disable/Check/Uncheck write
+	// the item's internal fields without any locking of their own, so
+	// without this the tick / click / export goroutines race on them.
+	// Lock ordering: NEVER held with exportMu. Callers derive state
+	// under exportMu, release it, THEN take menuMu for the systray call.
+	menuMu sync.Mutex
 
 	// daemonEnabledForInclude mirrors the last enable/disable verdict
 	// for the Include workspaces item so we only call Enable/Disable
@@ -184,13 +220,20 @@ func (t *trayController) onReady() {
 	// user's prior toggle survives launcher restarts (state.json
 	// IncludeWorkspaces field).
 	persisted := readState()
-	t.includeWorkspacesItem = systray.AddMenuItemCheckbox(
+	// Capture each concrete item locally so we can grab ClickedCh
+	// (a struct field, absent from the menuItem interface) before the
+	// field narrows to the interface type.
+	includeItem := systray.AddMenuItemCheckbox(
 		includeWorkspacesLabel,
 		"Embed each workspace's definition zip in the next diagnostic export",
 		persisted.IncludeWorkspaces)
-	t.exportItem = systray.AddMenuItem(
+	t.includeWorkspacesItem = includeItem
+	t.includeWorkspacesClickedCh = includeItem.ClickedCh
+	exportItem := systray.AddMenuItem(
 		exportItemDefault,
 		"Build a one-click diagnostic zip and reveal it in your file browser")
+	t.exportItem = exportItem
+	t.exportClickedCh = exportItem.ClickedCh
 	systray.AddSeparator()
 	t.autostartItem = systray.AddMenuItemCheckbox(
 		"Start at login",
@@ -227,9 +270,9 @@ func (t *trayController) handleClicks() {
 			if err := openInFileBrowser(logsDir()); err != nil {
 				log.Error("open logs dir failed", "error", err)
 			}
-		case <-t.includeWorkspacesItem.ClickedCh:
+		case <-t.includeWorkspacesClickedCh:
 			t.toggleIncludeWorkspaces()
-		case <-t.exportItem.ClickedCh:
+		case <-t.exportClickedCh:
 			t.startExport()
 		case <-t.autostartItem.ClickedCh:
 			if t.autostartItem.Checked() {
@@ -434,6 +477,8 @@ func (t *trayController) toggleIncludeWorkspaces() {
 	if t.includeWorkspacesItem == nil {
 		return
 	}
+	t.menuMu.Lock()
+	defer t.menuMu.Unlock()
 	if state.IncludeWorkspaces {
 		t.includeWorkspacesItem.Check()
 	} else {
@@ -458,6 +503,7 @@ func (t *trayController) updateIncludeWorkspacesAvailability() {
 	if daemonUp == t.daemonEnabledForInclude {
 		return
 	}
+	t.menuMu.Lock()
 	if daemonUp {
 		t.includeWorkspacesItem.SetTitle(includeWorkspacesLabel)
 		t.includeWorkspacesItem.Enable()
@@ -465,6 +511,7 @@ func (t *trayController) updateIncludeWorkspacesAvailability() {
 		t.includeWorkspacesItem.SetTitle(includeWorkspacesLabel + includeWorkspacesDisable)
 		t.includeWorkspacesItem.Disable()
 	}
+	t.menuMu.Unlock()
 	t.daemonEnabledForInclude = daemonUp
 }
 
@@ -527,11 +574,16 @@ func (t *trayController) updateExportItemLabel() {
 	if expired {
 		t.exportSuccessUntilTS = time.Time{}
 	}
+	// Lock ordering: release exportMu BEFORE taking menuMu — the two are
+	// never held together (see menuMu doc). exportMu guards the string
+	// fields; menuMu guards the systray mutation that follows.
 	t.exportMu.Unlock()
+	t.menuMu.Lock()
 	t.exportItem.SetTitle(label)
 	if expired {
 		t.exportItem.Enable()
 	}
+	t.menuMu.Unlock()
 }
 
 // startExport handles a click on the Export diagnostic logs item.
@@ -549,7 +601,9 @@ func (t *trayController) startExport() {
 		return
 	}
 	if t.exportItem != nil {
+		t.menuMu.Lock()
 		t.exportItem.Disable()
+		t.menuMu.Unlock()
 	}
 	t.exportMu.Lock()
 	t.exportFailureMsg = ""
@@ -592,7 +646,9 @@ func (t *trayController) runExport() {
 		// Re-enable so the user can retry. The sticky failure label
 		// stays until the next successful export or the next click.
 		if t.exportItem != nil {
+			t.menuMu.Lock()
 			t.exportItem.Enable()
+			t.menuMu.Unlock()
 		}
 		t.updateExportItemLabel()
 		return
@@ -608,7 +664,9 @@ func (t *trayController) runExport() {
 		t.exportFailureMsg = exportItemFailure
 		t.exportMu.Unlock()
 		if t.exportItem != nil {
+			t.menuMu.Lock()
 			t.exportItem.Enable()
+			t.menuMu.Unlock()
 		}
 		t.updateExportItemLabel()
 		return

--- a/tools/friday-launcher/tray.go
+++ b/tools/friday-launcher/tray.go
@@ -594,6 +594,7 @@ func (t *trayController) runExport() {
 		if t.exportItem != nil {
 			t.exportItem.Enable()
 		}
+		t.updateExportItemLabel()
 		return
 	}
 	log.Info("diagnostic export ok", "path", zipPath)
@@ -609,6 +610,7 @@ func (t *trayController) runExport() {
 		if t.exportItem != nil {
 			t.exportItem.Enable()
 		}
+		t.updateExportItemLabel()
 		return
 	}
 	t.exportMu.Lock()
@@ -617,13 +619,17 @@ func (t *trayController) runExport() {
 	t.exportMu.Unlock()
 	// Item stays disabled across the success transient; updateExportItemLabel
 	// re-enables it when the transient expires.
+	t.updateExportItemLabel()
 }
 
 // setExportPhase is the ProgressFn callback handed to diagnostics.Export.
-// Writes the phase string under the export mutex — tick() reads it on
-// the next 2s pass and rewrites the menu item label.
+// Writes the phase string under the export mutex, then refreshes the
+// menu label immediately so phase transitions don't lag the next 2s
+// tick. updateExportItemLabel re-acquires exportMu, so the write lock
+// must be released before calling it.
 func (t *trayController) setExportPhase(phase string) {
 	t.exportMu.Lock()
 	t.exportProgressPhase = phase
 	t.exportMu.Unlock()
+	t.updateExportItemLabel()
 }

--- a/tools/friday-launcher/tray.go
+++ b/tools/friday-launcher/tray.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	_ "embed"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	"fyne.io/systray"
+
+	"github.com/friday-platform/friday-studio/tools/friday-launcher/diagnostics"
 )
 
 // iconFridayTemplate is a pure-black silhouette of the Friday "P" mark.
@@ -72,6 +75,38 @@ func (b trayBucket) tooltip() string {
 	}
 }
 
+// Title/tooltip overrides applied on top of computeBucket while a
+// diagnostic export is in flight. Same shape as bucketGrey's
+// " Stopping…" / "Friday Studio — shutting down…" pair — single
+// place to read so a copy edit doesn't drift across the codebase.
+const (
+	exportingTitle   = " Exporting…"
+	exportingTooltip = "Friday Studio — exporting diagnostics…"
+)
+
+// Menu item labels for the diagnostic-export item. The progress and
+// failure labels are written from the export goroutine; the default
+// is the resting state.
+const (
+	exportItemDefault        = "Export diagnostic logs…"
+	exportItemProgressBase   = "Exporting diagnostic logs…"
+	exportItemSuccess        = "Exported ✓ — revealing…"
+	exportItemFailure        = "Export failed — see launcher.log"
+	includeWorkspacesLabel   = "Include workspaces"
+	includeWorkspacesDisable = " — start Friday Studio to enable"
+)
+
+// daemonServiceName is the supervised process whose liveness gates
+// the Include workspaces checkbox. Defined here (not in healthsvc.go)
+// because the tray is the only consumer that cares which service is
+// the daemon — healthsvc treats every service uniformly.
+const daemonServiceName = "friday"
+
+// exportSuccessHold is how long the menu item shows the success label
+// before reverting to the default. Sized so a quick reader sees the
+// ✓ but the menu doesn't feel sticky if they re-open it later.
+const exportSuccessHold = 1500 * time.Millisecond
+
 // trayController owns the systray menu items and the polling loop.
 type trayController struct {
 	sup          *Supervisor
@@ -81,13 +116,41 @@ type trayController struct {
 	openedBrowserOnce atomic.Bool
 
 	// menu items kept around so we can update labels / disable / enable
-	openItem      *systray.MenuItem
-	restartItem   *systray.MenuItem
-	logsItem      *systray.MenuItem
-	autostartItem *systray.MenuItem
-	quitItem      *systray.MenuItem
+	openItem              *systray.MenuItem
+	restartItem           *systray.MenuItem
+	logsItem              *systray.MenuItem
+	includeWorkspacesItem *systray.MenuItem
+	exportItem            *systray.MenuItem
+	quitItem              *systray.MenuItem
 
 	currentBucket trayBucket
+
+	// lastTitle is the menubar title we most recently asked systray to
+	// render. Used to coalesce SetTitle calls when neither bucket nor
+	// the exporting override has changed since the prior tick — macOS
+	// NSStatusItem redraws on every SetTitle call.
+	lastTitle string
+
+	// exporting is the CAS guard for the diagnostic-export action.
+	// The handler does CompareAndSwap(false, true) BEFORE spawning the
+	// goroutine — a second click while a prior export is in flight
+	// finds the slot taken and is a no-op. Disabling the menu item is
+	// best-effort UX; the CAS is the actual correctness barrier.
+	exporting atomic.Bool
+
+	// exportMu guards the progress + failure + success-until fields
+	// below. They're written from the export goroutine and read from
+	// the tray tick(), so a small mutex is the obvious shape.
+	exportMu             sync.Mutex
+	exportProgressPhase  string    // "" when no export is in flight
+	exportFailureMsg     string    // sticky until next export click
+	exportSuccessUntilTS time.Time // zero value when no success transient
+
+	// daemonEnabledForInclude mirrors the last enable/disable verdict
+	// for the Include workspaces item so we only call Enable/Disable
+	// on the cross-platform systray when the verdict actually flips.
+	// Avoids per-tick churn on macOS NSMenu which redraws on Enable.
+	daemonEnabledForInclude bool
 }
 
 func newTrayController(
@@ -111,17 +174,28 @@ func (t *trayController) onReady() {
 	// the menubar stays clean while everything is healthy.
 	systray.SetTitle(bucketAmber.titleText())
 	systray.SetTooltip(bucketAmber.tooltip())
+	t.lastTitle = bucketAmber.titleText()
 
 	t.openItem = systray.AddMenuItem("Open in browser", "Open Friday Studio")
 	t.restartItem = systray.AddMenuItem("Restart all", "Stop and start every supervised process")
 	t.logsItem = systray.AddMenuItem("View logs", "Open ~/.friday/local/logs in your file browser")
-	systray.AddSeparator()
-	t.autostartItem = systray.AddMenuItemCheckbox(
-		"Start at login",
-		"Re-launch Friday Studio when you next log in",
-		isAutostartEnabled())
+	// Seed the Include workspaces checkbox from persisted state so the
+	// user's prior toggle survives launcher restarts (state.json
+	// IncludeWorkspaces field).
+	persisted := readState()
+	t.includeWorkspacesItem = systray.AddMenuItemCheckbox(
+		includeWorkspacesLabel,
+		"Embed each workspace's definition zip in the next diagnostic export",
+		persisted.IncludeWorkspaces)
+	t.exportItem = systray.AddMenuItem(
+		exportItemDefault,
+		"Build a one-click diagnostic zip and reveal it in your file browser")
 	systray.AddSeparator()
 	t.quitItem = systray.AddMenuItem("Quit", "Shut down Friday Studio cleanly")
+	// Optimistically enabled — tick() will Disable on the next 2s
+	// pass if the daemon isn't healthy yet. Mirror the same default
+	// so the first tick is a no-op when the daemon comes up fast.
+	t.daemonEnabledForInclude = true
 
 	go t.handleClicks()
 	go t.pollLoop()
@@ -147,20 +221,10 @@ func (t *trayController) handleClicks() {
 			if err := openInFileBrowser(logsDir()); err != nil {
 				log.Error("open logs dir failed", "error", err)
 			}
-		case <-t.autostartItem.ClickedCh:
-			if t.autostartItem.Checked() {
-				if err := disableAutostart(); err != nil {
-					log.Error("disableAutostart failed", "error", err)
-				} else {
-					t.autostartItem.Uncheck()
-				}
-			} else {
-				if err := enableAutostart(); err != nil {
-					log.Error("enableAutostart failed", "error", err)
-				} else {
-					t.autostartItem.Check()
-				}
-			}
+		case <-t.includeWorkspacesItem.ClickedCh:
+			t.toggleIncludeWorkspaces()
+		case <-t.exportItem.ClickedCh:
+			t.startExport()
 		case <-t.quitItem.ClickedCh:
 			log.Info("Quit requested from tray")
 			// Decision #2: confirmation modal before tearing down
@@ -182,6 +246,7 @@ func (t *trayController) handleClicks() {
 			t.shuttingDown.Store(true)
 			systray.SetTitle(bucketGrey.titleText())
 			systray.SetTooltip(bucketGrey.tooltip())
+			t.lastTitle = bucketGrey.titleText()
 			systray.Quit()
 			return
 		}
@@ -202,11 +267,29 @@ func (t *trayController) pollLoop() {
 
 func (t *trayController) tick() {
 	bucket := t.computeBucket()
-	if bucket != t.currentBucket {
-		systray.SetTooltip(bucket.tooltip())
-		systray.SetTitle(bucket.titleText())
-		t.currentBucket = bucket
+	exporting := t.exporting.Load()
+	wantTitle := bucket.titleText()
+	wantTooltip := bucket.tooltip()
+	if exporting {
+		// Export-in-flight wins over the bucket-derived title — the
+		// user just clicked Export and needs immediate visual feedback
+		// that something is happening. Shutdown still wins (shuttingDown
+		// trumps every other signal in computeBucket, and the click
+		// handler refuses Export after shutdown begins).
+		wantTitle = exportingTitle
+		wantTooltip = exportingTooltip
 	}
+	// Coalesce on the rendered title string so NSStatusItem only
+	// redraws when something actually changed. Covers both bucket
+	// transitions and the export-in-flight override flipping on/off.
+	if wantTitle != t.lastTitle {
+		systray.SetTooltip(wantTooltip)
+		systray.SetTitle(wantTitle)
+		t.lastTitle = wantTitle
+	}
+	t.currentBucket = bucket
+	t.updateExportItemLabel()
+	t.updateIncludeWorkspacesAvailability()
 	if bucket == bucketGreen {
 		// Open browser exactly once on first transition to green
 		// (and only if --no-browser wasn't set, which is checked
@@ -313,4 +396,214 @@ func (t *trayController) wakeFromSecondInstance() {
 	// Wake-up bypasses the once-per-session guard so a second-instance
 	// click always opens the browser.
 	t.openBrowser("second-instance wake")
+}
+
+// toggleIncludeWorkspaces flips the persisted preference and the
+// checkbox UI together. If state.json read fails we still flip the
+// in-memory checkbox so the user gets feedback, but the next launcher
+// boot will revert — that's acceptable for a one-click preference
+// (worst case: re-tick after restart).
+func (t *trayController) toggleIncludeWorkspaces() {
+	state := readState()
+	state.IncludeWorkspaces = !state.IncludeWorkspaces
+	if err := writeState(state); err != nil {
+		log.Error("persist IncludeWorkspaces failed", "error", err)
+		// Fall through — UI still flips so the click feels responsive.
+		// User will see the original value after the next launcher boot.
+	}
+	if t.includeWorkspacesItem == nil {
+		return
+	}
+	if state.IncludeWorkspaces {
+		t.includeWorkspacesItem.Check()
+	} else {
+		t.includeWorkspacesItem.Uncheck()
+	}
+}
+
+// updateIncludeWorkspacesAvailability disables the Include workspaces
+// item when the daemon isn't healthy (the /bundle-all endpoint needs
+// a live daemon) and re-enables it once the daemon comes up. The
+// persisted check state is preserved across the flip — only the label
+// + interactability changes.
+//
+// Coalesced on daemonEnabledForInclude so we don't call SetTitle on
+// every 2s tick when the state hasn't changed (macOS NSMenu redraws
+// on each SetTitle).
+func (t *trayController) updateIncludeWorkspacesAvailability() {
+	if t.includeWorkspacesItem == nil {
+		return
+	}
+	daemonUp := t.healthCache != nil && t.healthCache.ServiceHealthy(daemonServiceName)
+	if daemonUp == t.daemonEnabledForInclude {
+		return
+	}
+	if daemonUp {
+		t.includeWorkspacesItem.SetTitle(includeWorkspacesLabel)
+		t.includeWorkspacesItem.Enable()
+	} else {
+		t.includeWorkspacesItem.SetTitle(includeWorkspacesLabel + includeWorkspacesDisable)
+		t.includeWorkspacesItem.Disable()
+	}
+	t.daemonEnabledForInclude = daemonUp
+}
+
+// exportLabelState is a snapshot of the export-related fields the
+// label derivation reads. Pulled out so the pure renderer can be
+// unit-tested without a real systray (the menu mutation in
+// updateExportItemLabel is the side effect; the string derivation is
+// the logic).
+type exportLabelState struct {
+	progressPhase  string
+	failureMsg     string
+	successUntilTS time.Time
+	now            time.Time
+}
+
+// deriveExportItemLabel maps the current export state to the rendered
+// menu label. Pure function — no systray side effects, no mutex.
+func deriveExportItemLabel(s exportLabelState) (label string, successExpired bool) {
+	switch {
+	case s.progressPhase != "":
+		suffix := ""
+		switch s.progressPhase {
+		case "logs":
+			suffix = " (logs)"
+		case "workspaces":
+			suffix = " (workspaces)"
+		case "packaging":
+			suffix = " (packaging)"
+		}
+		return exportItemProgressBase + suffix, false
+	case !s.successUntilTS.IsZero():
+		if s.now.Before(s.successUntilTS) {
+			return exportItemSuccess, false
+		}
+		return exportItemDefault, true
+	case s.failureMsg != "":
+		return s.failureMsg, false
+	default:
+		return exportItemDefault, false
+	}
+}
+
+// updateExportItemLabel rewrites the export menu item's label based on
+// the current progress/failure/success state. Called from tick() so
+// label updates land on the existing 2s polling cadence — no separate
+// timer goroutine needed. The success transient expires on its own
+// when time.Now() crosses exportSuccessUntilTS.
+func (t *trayController) updateExportItemLabel() {
+	if t.exportItem == nil {
+		return
+	}
+	t.exportMu.Lock()
+	state := exportLabelState{
+		progressPhase:  t.exportProgressPhase,
+		failureMsg:     t.exportFailureMsg,
+		successUntilTS: t.exportSuccessUntilTS,
+		now:            time.Now(),
+	}
+	label, expired := deriveExportItemLabel(state)
+	if expired {
+		t.exportSuccessUntilTS = time.Time{}
+	}
+	t.exportMu.Unlock()
+	t.exportItem.SetTitle(label)
+	if expired {
+		t.exportItem.Enable()
+	}
+}
+
+// startExport handles a click on the Export diagnostic logs item.
+// The CAS on `exporting` is the real concurrency guard — second click
+// during an in-flight export finds the slot taken and is a no-op.
+// Disabling the menu item is best-effort visual feedback.
+func (t *trayController) startExport() {
+	if t.shuttingDown.Load() {
+		// Refuse new exports during shutdown — performShutdown is
+		// tearing the daemon down and any /bundle-all call would race
+		// against the daemon's HTTP server closing.
+		return
+	}
+	if !t.exporting.CompareAndSwap(false, true) {
+		return
+	}
+	if t.exportItem != nil {
+		t.exportItem.Disable()
+	}
+	t.exportMu.Lock()
+	t.exportFailureMsg = ""
+	t.exportSuccessUntilTS = time.Time{}
+	t.exportProgressPhase = "logs" // optimistic — Export will overwrite
+	t.exportMu.Unlock()
+	go t.runExport()
+}
+
+// exportFn is the diagnostics.Export call, swappable for tests so the
+// tray click flow can be exercised end-to-end without hitting disk or
+// the live daemon. Production code leaves it nil; the helper at the
+// bottom of this method picks the real function in that case.
+var exportFn func(diagnostics.ExportOptions) (string, error)
+
+// runExport is the export goroutine. Owns the exporting atomic.Bool
+// across its full lifetime (set by startExport before spawn, cleared
+// here on return). Posts progress to the tray via setExportPhase;
+// reveals on success; leaves a sticky failure label on error.
+func (t *trayController) runExport() {
+	defer t.exporting.Store(false)
+
+	persisted := readState()
+	opts := diagnostics.ExportOptions{
+		IncludeWorkspaces: persisted.IncludeWorkspaces,
+		DaemonURL:         daemonAPIBaseURL(),
+		ProgressFn:        t.setExportPhase,
+	}
+	fn := exportFn
+	if fn == nil {
+		fn = diagnostics.Export
+	}
+	zipPath, err := fn(opts)
+	if err != nil {
+		log.Error("diagnostic export failed", "error", err)
+		t.exportMu.Lock()
+		t.exportProgressPhase = ""
+		t.exportFailureMsg = exportItemFailure
+		t.exportMu.Unlock()
+		// Re-enable so the user can retry. The sticky failure label
+		// stays until the next successful export or the next click.
+		if t.exportItem != nil {
+			t.exportItem.Enable()
+		}
+		return
+	}
+	log.Info("diagnostic export ok", "path", zipPath)
+	if err := revealInFileBrowser(zipPath); err != nil {
+		log.Error("reveal diagnostic zip failed", "error", err, "path", zipPath)
+		// Reveal failure is non-fatal — the zip exists, we just couldn't
+		// pop Finder. Surface it the same way as an export failure so
+		// the user sees the launcher.log pointer.
+		t.exportMu.Lock()
+		t.exportProgressPhase = ""
+		t.exportFailureMsg = exportItemFailure
+		t.exportMu.Unlock()
+		if t.exportItem != nil {
+			t.exportItem.Enable()
+		}
+		return
+	}
+	t.exportMu.Lock()
+	t.exportProgressPhase = ""
+	t.exportSuccessUntilTS = time.Now().Add(exportSuccessHold)
+	t.exportMu.Unlock()
+	// Item stays disabled across the success transient; updateExportItemLabel
+	// re-enables it when the transient expires.
+}
+
+// setExportPhase is the ProgressFn callback handed to diagnostics.Export.
+// Writes the phase string under the export mutex — tick() reads it on
+// the next 2s pass and rewrites the menu item label.
+func (t *trayController) setExportPhase(phase string) {
+	t.exportMu.Lock()
+	t.exportProgressPhase = phase
+	t.exportMu.Unlock()
 }

--- a/tools/friday-launcher/tray.go
+++ b/tools/friday-launcher/tray.go
@@ -121,6 +121,7 @@ type trayController struct {
 	logsItem              *systray.MenuItem
 	includeWorkspacesItem *systray.MenuItem
 	exportItem            *systray.MenuItem
+	autostartItem         *systray.MenuItem
 	quitItem              *systray.MenuItem
 
 	currentBucket trayBucket
@@ -191,6 +192,11 @@ func (t *trayController) onReady() {
 		exportItemDefault,
 		"Build a one-click diagnostic zip and reveal it in your file browser")
 	systray.AddSeparator()
+	t.autostartItem = systray.AddMenuItemCheckbox(
+		"Start at login",
+		"Re-launch Friday Studio when you next log in",
+		isAutostartEnabled())
+	systray.AddSeparator()
 	t.quitItem = systray.AddMenuItem("Quit", "Shut down Friday Studio cleanly")
 	// Optimistically enabled — tick() will Disable on the next 2s
 	// pass if the daemon isn't healthy yet. Mirror the same default
@@ -225,6 +231,20 @@ func (t *trayController) handleClicks() {
 			t.toggleIncludeWorkspaces()
 		case <-t.exportItem.ClickedCh:
 			t.startExport()
+		case <-t.autostartItem.ClickedCh:
+			if t.autostartItem.Checked() {
+				if err := disableAutostart(); err != nil {
+					log.Error("disableAutostart failed", "error", err)
+				} else {
+					t.autostartItem.Uncheck()
+				}
+			} else {
+				if err := enableAutostart(); err != nil {
+					log.Error("enableAutostart failed", "error", err)
+				} else {
+					t.autostartItem.Check()
+				}
+			}
 		case <-t.quitItem.ClickedCh:
 			log.Info("Quit requested from tray")
 			// Decision #2: confirmation modal before tearing down

--- a/tools/friday-launcher/tray_race_test.go
+++ b/tools/friday-launcher/tray_race_test.go
@@ -18,24 +18,22 @@ import (
 type recordingMenuItem struct {
 	calls     int
 	lastTitle string
-	checked   bool
 	enabled   bool
 }
 
 func (r *recordingMenuItem) SetTitle(s string) { r.calls++; r.lastTitle = s }
 func (r *recordingMenuItem) Enable()           { r.calls++; r.enabled = true }
 func (r *recordingMenuItem) Disable()          { r.calls++; r.enabled = false }
-func (r *recordingMenuItem) Check()            { r.calls++; r.checked = true }
-func (r *recordingMenuItem) Uncheck()          { r.calls++; r.checked = false }
 
 // TestMenuMutations_NoRaceUnderConcurrency hammers the two shared menu
-// items from all three goroutines that touch them in production —
-// tick() (updateExportItemLabel + updateIncludeWorkspacesAvailability),
-// the export goroutine (setExportPhase, the runExport Enable paths),
-// and the click handler (toggleIncludeWorkspaces) — with recording
-// fakes injected behind the menuItem interface. Run under `-race` this
-// is the load-bearing proof that menuMu serializes every mutation; with
-// menuMu removed the unguarded fakes trip the race detector.
+// items from the goroutines that touch them in production — tick()
+// (updateExportItemLabel + updateWorkspacesItemAvailability) and the
+// export goroutine (setExportPhase's immediate label refresh) — with
+// recording fakes injected behind the menuItem interface. The parent
+// (exportItem) is mutated concurrently by tick plus every setExportPhase
+// worker, so it's the load-bearing case. Run under `-race` this proves
+// menuMu serializes every mutation; with menuMu removed the unguarded
+// fakes trip the race detector.
 func TestMenuMutations_NoRaceUnderConcurrency(t *testing.T) {
 	t.Setenv("FRIDAY_LAUNCHER_HOME", t.TempDir())
 
@@ -45,17 +43,17 @@ func TestMenuMutations_NoRaceUnderConcurrency(t *testing.T) {
 
 	tc := newTrayController(sup, &sd, cache)
 	exportFake := &recordingMenuItem{}
-	includeFake := &recordingMenuItem{}
+	workspacesFake := &recordingMenuItem{}
 	tc.exportItem = exportFake
-	tc.includeWorkspacesItem = includeFake
+	tc.logsWorkspacesItem = workspacesFake
 
 	const workers = 8
 	const iters = 200
 	var wg sync.WaitGroup
 
 	// tick path: a SINGLE goroutine, mirroring production's lone
-	// pollLoop. updateIncludeWorkspacesAvailability reads/writes the
-	// unsynchronized daemonEnabledForInclude field, which is correct
+	// pollLoop. updateWorkspacesItemAvailability reads/writes the
+	// unsynchronized daemonEnabledForWorkspaces field, which is correct
 	// precisely because only tick touches it — driving it from many
 	// goroutines would manufacture a race that production can't hit. We
 	// flip the daemon verdict each iteration so the availability path
@@ -67,12 +65,12 @@ func TestMenuMutations_NoRaceUnderConcurrency(t *testing.T) {
 			cache.SetReady(daemonServiceName, n%2 == 0)
 			cache.Update(makeStates(runningReady(daemonServiceName)))
 			tc.updateExportItemLabel()
-			tc.updateIncludeWorkspacesAvailability()
+			tc.updateWorkspacesItemAvailability()
 		}
 	}()
 
-	// export-goroutine path: phase updates (immediate label refresh) and
-	// the failure/success Enable paths via setExportPhase.
+	// export-goroutine path: phase updates drive updateExportItemLabel,
+	// mutating the parent concurrently with the tick goroutine above.
 	wg.Add(workers)
 	for i := 0; i < workers; i++ {
 		go func() {
@@ -84,21 +82,9 @@ func TestMenuMutations_NoRaceUnderConcurrency(t *testing.T) {
 		}()
 	}
 
-	// click path: toggleIncludeWorkspaces always Check/Unchecks the
-	// include item after the state read.
-	wg.Add(workers)
-	for i := 0; i < workers; i++ {
-		go func() {
-			defer wg.Done()
-			for n := 0; n < iters; n++ {
-				tc.toggleIncludeWorkspaces()
-			}
-		}()
-	}
-
 	wg.Wait()
 
-	// Sanity: every path ran and mutated through the fakes. The real
+	// Sanity: both items were mutated through the fakes. The real
 	// assertion is the race detector; these guard against the test
 	// silently no-opping (e.g. a nil-guard short-circuiting everything).
 	tc.menuMu.Lock()
@@ -106,7 +92,7 @@ func TestMenuMutations_NoRaceUnderConcurrency(t *testing.T) {
 	if exportFake.calls == 0 {
 		t.Error("exportItem never mutated — test exercised nothing")
 	}
-	if includeFake.calls == 0 {
-		t.Error("includeWorkspacesItem never mutated — test exercised nothing")
+	if workspacesFake.calls == 0 {
+		t.Error("logsWorkspacesItem never mutated — test exercised nothing")
 	}
 }

--- a/tools/friday-launcher/tray_race_test.go
+++ b/tools/friday-launcher/tray_race_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// recordingMenuItem is a test double for the menuItem interface. Its
+// internal state is DELIBERATELY UNGUARDED — no mutex of its own. The
+// production race this test guards against is exactly that: the real
+// *systray.MenuItem mutators write internal fields with no locking, so
+// the only thing standing between concurrent tick / click / export
+// goroutines and a data race is trayController.menuMu. If menuMu is
+// ever dropped, `go test -race` must fire on these unsynchronized
+// writes. Adding a lock here would mask that — so don't.
+type recordingMenuItem struct {
+	calls     int
+	lastTitle string
+	checked   bool
+	enabled   bool
+}
+
+func (r *recordingMenuItem) SetTitle(s string) { r.calls++; r.lastTitle = s }
+func (r *recordingMenuItem) Enable()           { r.calls++; r.enabled = true }
+func (r *recordingMenuItem) Disable()          { r.calls++; r.enabled = false }
+func (r *recordingMenuItem) Check()            { r.calls++; r.checked = true }
+func (r *recordingMenuItem) Uncheck()          { r.calls++; r.checked = false }
+
+// TestMenuMutations_NoRaceUnderConcurrency hammers the two shared menu
+// items from all three goroutines that touch them in production —
+// tick() (updateExportItemLabel + updateIncludeWorkspacesAvailability),
+// the export goroutine (setExportPhase, the runExport Enable paths),
+// and the click handler (toggleIncludeWorkspaces) — with recording
+// fakes injected behind the menuItem interface. Run under `-race` this
+// is the load-bearing proof that menuMu serializes every mutation; with
+// menuMu removed the unguarded fakes trip the race detector.
+func TestMenuMutations_NoRaceUnderConcurrency(t *testing.T) {
+	t.Setenv("FRIDAY_LAUNCHER_HOME", t.TempDir())
+
+	var sd atomic.Bool
+	cache := NewHealthCache(&sd)
+	sup := newTestSupervisor(time.Now(), false)
+
+	tc := newTrayController(sup, &sd, cache)
+	exportFake := &recordingMenuItem{}
+	includeFake := &recordingMenuItem{}
+	tc.exportItem = exportFake
+	tc.includeWorkspacesItem = includeFake
+
+	const workers = 8
+	const iters = 200
+	var wg sync.WaitGroup
+
+	// tick path: a SINGLE goroutine, mirroring production's lone
+	// pollLoop. updateIncludeWorkspacesAvailability reads/writes the
+	// unsynchronized daemonEnabledForInclude field, which is correct
+	// precisely because only tick touches it — driving it from many
+	// goroutines would manufacture a race that production can't hit. We
+	// flip the daemon verdict each iteration so the availability path
+	// actually mutates the item (it coalesces on the verdict otherwise).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for n := 0; n < iters*workers; n++ {
+			cache.SetReady(daemonServiceName, n%2 == 0)
+			cache.Update(makeStates(runningReady(daemonServiceName)))
+			tc.updateExportItemLabel()
+			tc.updateIncludeWorkspacesAvailability()
+		}
+	}()
+
+	// export-goroutine path: phase updates (immediate label refresh) and
+	// the failure/success Enable paths via setExportPhase.
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			phases := []string{"logs", "workspaces", "packaging", ""}
+			for n := 0; n < iters; n++ {
+				tc.setExportPhase(phases[n%len(phases)])
+			}
+		}()
+	}
+
+	// click path: toggleIncludeWorkspaces always Check/Unchecks the
+	// include item after the state read.
+	wg.Add(workers)
+	for i := 0; i < workers; i++ {
+		go func() {
+			defer wg.Done()
+			for n := 0; n < iters; n++ {
+				tc.toggleIncludeWorkspaces()
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Sanity: every path ran and mutated through the fakes. The real
+	// assertion is the race detector; these guard against the test
+	// silently no-opping (e.g. a nil-guard short-circuiting everything).
+	tc.menuMu.Lock()
+	defer tc.menuMu.Unlock()
+	if exportFake.calls == 0 {
+		t.Error("exportItem never mutated — test exercised nothing")
+	}
+	if includeFake.calls == 0 {
+		t.Error("includeWorkspacesItem never mutated — test exercised nothing")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a one-click diagnostic log export to the Friday launcher (Closes #324). A new tray item builds a single zip — logs, launcher state, pids, and a structured manifest — and reveals it in the OS file browser, so users filing bug reports don't have to hunt for log directories. Power users can optionally embed their workspace definition bundles.

Implemented as four layers behind a clean `diagnostics.Export` seam:

- **Daemon `/api/version` route** (`apps/atlasd/routes/version.ts`) — exposes `getVersionInfo()` over HTTP so the export can stamp the daemon build into the manifest.
- **`diagnostics` Go package** (`tools/friday-launcher/diagnostics/`) — `Export(opts) (zipPath, err)` builds the zip with atomic temp+rename, `~/Downloads` resolution with a writable-fallback, a YAML manifest, and graceful degradation: any daemon/HTTP failure records a skip token and the export still succeeds.
- **Workspace bundling** — when the user picks "Logs + workspaces" and the daemon is reachable, embeds `GET /api/workspaces/bundle-all?mode=definition` verbatim as `workspaces.zip`. Failures map to stable tokens (`daemon_unreachable`, `daemon_returned_5xx`, `auth_refused`, `bundle_all_timeout`, `bundle_all_too_large`).
- **Tray UI** (`tools/friday-launcher/tray.go`) — an `Export diagnostics` parent with two explicit sub-actions, `Logs only` and `Logs + workspaces`; `" Exporting…"` menubar title, live phase labels (logs → workspaces → packaging) on the parent, CAS-guarded against double-clicks, success/failure label flips, and reveal-in-Finder.

### Menu shape

```
Open in browser
Restart all
View logs
Export diagnostics ▸          ← new
   Logs only
   Logs + workspaces          ← greys out when daemon down
─────────
Start at login                ← unchanged
─────────
Quit
```

## Manifest

A YAML file describing **provenance + the negative space**, not a content listing — what's *in* the archive is read from the zip's own file tree (`unzip -l`), so the manifest can't drift from the bytes:

```yaml
# privacy header (logs are NOT redacted — review before sharing)
daemon_version: <string | unreachable>
os / arch / generated_at
include_workspaces_requested: <bool>
skipped:
  - what: workspaces
    why: <stable token>
```

`why` is a stable enum: `user_opted_out`, `daemon_unreachable`, `daemon_returned_5xx`, `auth_refused`, `bundle_all_timeout`, `bundle_all_too_large`, `downloads_unwritable`.

## Notable details

- **No persisted preference** — workspace inclusion is an explicit per-export choice (`Logs only` vs `Logs + workspaces`), not a remembered checkbox. `Logs + workspaces` is daemon-gated (greyed with a hint when the daemon is down); `Logs only` is always available.
- **Loopback TLS** — the daemon HTTP client mirrors the readiness probe's `InsecureSkipVerify` (private-CA s2s cert, loopback only).
- **Timeouts** — 5s for `/api/version`, 60s for `/bundle-all`, via `context.WithTimeout` covering connect+TLS+body.
- **Body cap** — the `/bundle-all` response is capped via `io.LimitReader`; an over-cap bundle records `bundle_all_too_large` and the export ships logs-only.

## Test plan

- [x] `go test -race ./tools/friday-launcher/...` — diagnostics package (manifest golden, zip layout, logs filter, Downloads fallback, ProgressFn order, all HTTP skip-reason paths incl. HTTPS via `httptest.NewTLSServer`, bundle byte-cap) + tray (CAS guard under blocking export, shutdown gate, label state machine, deadlock watchdog, menu-mutation race test)
- [x] `apps/atlasd/routes/version.test.ts` — 200 + `getVersionInfo()` shape (Zod-parsed)
- [x] `gofmt` / `go vet` clean; `deno check` / `deno lint` clean on changed TS
- [x] Headless end-to-end: built the launcher from-branch and drove `Export(opts)` against a live daemon — daemon up (workspaces embedded, real `dev-<sha>` version stamp), daemon down (`daemon_unreachable` skip, logs-only), opted-out (`user_opted_out`); confirmed the trimmed manifest + zip layout
- [x] Manual GUI: click each sub-action in the menu bar; confirm Finder reveal, the `" Exporting…"` progress UX, and `Logs + workspaces` greying out when the daemon is down

## Notes

Built via a parallel agent team; each layer is an independently buildable commit. Two refinements landed after review:

- The workspace opt-in moved from a persisted `Include workspaces` checkbox to an explicit `Export diagnostics ▸ {Logs only | Logs + workspaces}` submenu — deleting the persisted `IncludeWorkspaces` state (and the `--autostart` read-modify-write that existed only to protect it).
- The manifest dropped its redundant `included:` content listing; the zip's own file tree is the source of truth for what's present.

The "Start at login" item was briefly dropped during the tray rewrite and restored — it was never in scope for this feature.
