### PR TITLE
deps(cargo): bump tar from 0.4.45 to 0.4.46

### DIFF
--- a/apps/studio-installer/src-tauri/Cargo.lock
+++ b/apps/studio-installer/src-tauri/Cargo.lock
@@ -4272,9 +4272,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",


### PR DESCRIPTION
Resolves Dependabot alert [#39](https://github.com/friday-platform/friday-studio/security/dependabot/39) — **GHSA-3pv8-6f4r-ffg2**, tar-rs PAX header desynchronization (medium, CWE-20 / CWE-843).

### What
Bumps the Rust `tar` crate from **0.4.45 → 0.4.46** in `apps/studio-installer/src-tauri/Cargo.lock`.

### Why
In `tar` `<= 0.4.45`, a PAX (`x`) extension header is applied to the *next* entry in the stream regardless of type, instead of to the file entry [POSIX pax](https://pubs.opengroup.org/onlinepubs/9799919799/utilities/pax.html) prescribes (e.g. `x → L → file` wrongly applies `x` to `L`). A crafted archive can exploit this to desync the stream so members extract differently under tar-rs than under other tar parsers — obscuring the presence of malicious files. Fixed upstream in [0.4.46](https://github.com/composefs/tar-rs/releases/tag/0.4.46) ([PR #454](https://github.com/composefs/tar-rs/pull/454)).

`studio-installer` parses externally-produced archives — it extracts the studio bundle (`.tar.zst`) at install time via the `tar` crate — so it is in scope for this advisory.

### Scope / safety
- Lockfile-only patch bump. `Cargo.toml` already requires `tar = "0.4"`, so no manifest change is needed.
- `tar` 0.4.46 keeps the same dependency set (`filetime`, `libc`, `xattr`); no transitive churn.
- Verified with `cargo metadata --locked` — the updated lockfile is accepted with no further changes, and cargo fetched/verified `tar v0.4.46` against its checksum.

Diff is exactly the `tar` version + checksum lines (2 insertions, 2 deletions).