### PR TITLE
fix(bundle): exclude .venv/__pycache__/*.pyc from workspace export

### DIFF
--- a/packages/bundle/src/bundle.test.ts
+++ b/packages/bundle/src/bundle.test.ts
@@ -159,6 +159,53 @@ describe("exportBundle + importBundle round-trip", () => {
     }
   });
 
+  it("strips agent build artifacts (.venv/__pycache__/.pyc) from the zip and still round-trips", async () => {
+    // A real Studio agent dir: source files alongside a fat local virtualenv.
+    // The .venv is what bloats a workspace export past the import size cap.
+    await mkdir(join(workDir, "agents", "knowledge"), { recursive: true });
+    await writeFile(join(workDir, "agents", "knowledge", "agent.py"), "print('knowledge')\n");
+    await writeFile(
+      join(workDir, "agents", "knowledge", "metadata.json"),
+      JSON.stringify({ id: "knowledge", version: "1.0.0", description: "k" }),
+    );
+    await mkdir(join(workDir, "agents", "knowledge", ".venv", "lib", "site-packages"), {
+      recursive: true,
+    });
+    await writeFile(
+      join(workDir, "agents", "knowledge", ".venv", "lib", "site-packages", "cygrpc.so"),
+      "x".repeat(8192),
+    );
+    await mkdir(join(workDir, "agents", "knowledge", "__pycache__"), { recursive: true });
+    await writeFile(join(workDir, "agents", "knowledge", "__pycache__", "agent.cpython.pyc"), "b");
+    await writeFile(join(workDir, "agents", "knowledge", "agent.pyc"), "b");
+
+    const zipBytes = await exportBundle({
+      workspaceDir: workDir,
+      workspaceYml: await readFile(join(workDir, "workspace.yml"), "utf-8"),
+      mode: "definition",
+      workspace: { name: "demo", version: "1.0.0" },
+    });
+
+    // Nothing under .venv/, no __pycache__/, no *.pyc made it into the archive.
+    const JSZip = (await import("jszip")).default;
+    const zip = await JSZip.loadAsync(zipBytes);
+    const names = Object.keys(zip.files);
+    expect(names).toContain("agents/knowledge/agent.py");
+    expect(names).toContain("agents/knowledge/metadata.json");
+    expect(names.some((n) => n.includes("/.venv/"))).toBe(false);
+    expect(names.some((n) => n.includes("/__pycache__/"))).toBe(false);
+    expect(names.some((n) => n.endsWith(".pyc"))).toBe(false);
+
+    // Integrity holds: the lockfile hash (computed over the stripped set) matches
+    // the re-hash of the extracted, equally-stripped dir.
+    const result = await importBundle({ zipBytes, targetDir: importDir });
+    expect(result.primitives).toContainEqual({
+      kind: "agent",
+      name: "knowledge",
+      path: "agents/knowledge",
+    });
+  });
+
   it("rejects an externalAgents entry that collides with a workspace-local agent", async () => {
     await mkdir(join(workDir, "agents", "dupe"), { recursive: true });
     await writeFile(join(workDir, "agents", "dupe", "agent.py"), "local\n");

--- a/packages/bundle/src/bundle.ts
+++ b/packages/bundle/src/bundle.ts
@@ -1,7 +1,7 @@
 import { mkdir, readdir, readFile, rename, rm, stat, writeFile } from "node:fs/promises";
 import { dirname, join, relative, sep } from "node:path";
 import JSZip from "jszip";
-import { hashPrimitive } from "./hasher.ts";
+import { hashPrimitive, isBundleExcludedEntry } from "./hasher.ts";
 import { type Lockfile, readLockfile } from "./lockfile.ts";
 
 export interface ExportOptions {
@@ -58,6 +58,10 @@ async function listPrimitiveDirs(dir: string): Promise<string[]> {
 async function walkFilesRecursive(root: string, current: string, acc: string[]): Promise<void> {
   const entries = await readdir(current, { withFileTypes: true });
   for (const entry of entries) {
+    // Same exclusion set as the integrity hasher (hasher.ts). Both walks MUST
+    // skip identical entries: a file shipped in the zip but absent from the
+    // lockfile hash — or the reverse — fails importBundle's integrity check.
+    if (isBundleExcludedEntry(entry.name)) continue;
     const abs = join(current, entry.name);
     if (entry.isDirectory()) {
       await walkFilesRecursive(root, abs, acc);

--- a/packages/bundle/src/hasher.test.ts
+++ b/packages/bundle/src/hasher.test.ts
@@ -68,6 +68,27 @@ describe("hashPrimitive", () => {
     expect(result.files).toEqual(["keep.txt"]);
   });
 
+  it("excludes build artifacts (.venv, venv, __pycache__, node_modules, *.pyc)", async () => {
+    await writeFile(join(dir, "agent.py"), "print('hi')\n");
+    await writeFile(join(dir, "metadata.json"), "{}\n");
+    for (const cache of [".venv", "venv", "__pycache__", "node_modules"]) {
+      await mkdir(join(dir, cache, "deep"), { recursive: true });
+      await writeFile(join(dir, cache, "deep", "blob.so"), "binary\n");
+    }
+    await writeFile(join(dir, "module.pyc"), "bytecode");
+    const result = await hashPrimitive(dir);
+    expect(result.files).toEqual(["agent.py", "metadata.json"]);
+  });
+
+  it("hash is unaffected by adding/removing a .venv (export/import stay consistent)", async () => {
+    await writeFile(join(dir, "agent.py"), "print('hi')\n");
+    const before = await hashPrimitive(dir);
+    await mkdir(join(dir, ".venv", "lib"), { recursive: true });
+    await writeFile(join(dir, ".venv", "lib", "huge.so"), "x".repeat(4096));
+    const after = await hashPrimitive(dir);
+    expect(after.hash).toBe(before.hash);
+  });
+
   it("recurses into subdirectories with sorted relative paths", async () => {
     await mkdir(join(dir, "nested"));
     await writeFile(join(dir, "nested", "b.txt"), "B\n");

--- a/packages/bundle/src/hasher.ts
+++ b/packages/bundle/src/hasher.ts
@@ -12,7 +12,31 @@ export interface HashResult {
   files: string[];
 }
 
-const DEFAULT_EXCLUDES = [".DS_Store", ".git", ".atlas-ignore"];
+/**
+ * Entry names (a single path segment — file or directory) excluded from BOTH
+ * the bundle archive (`exportBundle`'s file walk) and the lockfile integrity
+ * hash. The two MUST agree: a path counted in the hash but missing from the
+ * zip — or the reverse — fails `importBundle`'s per-primitive integrity check.
+ * This is the single source of truth for "what never belongs in a bundle".
+ *
+ * Two reasons something lands here:
+ *   - hash noise: editor/VCS scratch whose presence must not perturb the
+ *     content hash (`.DS_Store`, `.git`, `.atlas-ignore`, `*.tmp`).
+ *   - build artifacts: large, platform-specific caches that the import side
+ *     regenerates anyway. A macOS agent `.venv` is ~250 MB of darwin
+ *     `.so`/`.dylib` a Linux runtime can neither run nor needs (it reinstalls
+ *     its own deps), and shipping it is what blows a workspace export past the
+ *     import size cap.
+ */
+const EXCLUDED_NAMES = new Set([
+  ".DS_Store",
+  ".git",
+  ".atlas-ignore",
+  ".venv",
+  "venv",
+  "__pycache__",
+  "node_modules",
+]);
 
 function hasBinaryContent(bytes: Buffer): boolean {
   const scanLen = Math.min(bytes.length, 1024);
@@ -33,16 +57,17 @@ function normalizeTextBytes(bytes: Buffer): Buffer {
   return Buffer.from(out);
 }
 
-function isExcluded(name: string): boolean {
-  if (DEFAULT_EXCLUDES.includes(name)) return true;
+export function isBundleExcludedEntry(name: string): boolean {
+  if (EXCLUDED_NAMES.has(name)) return true;
   if (name.endsWith(".tmp")) return true;
+  if (name.endsWith(".pyc")) return true;
   return false;
 }
 
 async function walk(root: string, current: string, acc: string[]): Promise<void> {
   const entries = await readdir(current, { withFileTypes: true });
   for (const entry of entries) {
-    if (isExcluded(entry.name)) continue;
+    if (isBundleExcludedEntry(entry.name)) continue;
     const abs = join(current, entry.name);
     if (entry.isDirectory()) {
       await walk(root, abs, acc);


### PR DESCRIPTION
😏 *Senryū*

> Packed the whole venv
> to mail one tiny workspace—
> the cap said "no zip"

## Summary

- Workspace export walked **every** file under `agents/` into the bundle zip, including each agent's local `.venv`. A two-agent workspace ballooned to **87 MB / 10,960 files** — mostly macOS-native `.so`/`.dylib` plus a 26 MB `ruff` binary that a Linux runtime can neither run nor needs (it reinstalls its own deps on import).
- That oversized bundle tripped Cloud's 25 MB import cap, which truncates the upload; the lost end-of-central-directory record then surfaces as the **misleading** `open zip: zip: not a valid zip file` — the file is fine, it was just chopped.
- Fix: generalize the hasher's exclusion into one exported predicate `isBundleExcludedEntry`, now covering `.venv`, `venv`, `__pycache__`, `node_modules`, `*.pyc` (alongside the existing `.DS_Store`/`.git`/`.atlas-ignore`/`*.tmp`), applied to **both** the export file walk (`bundle.ts`) and the integrity hash (`hasher.ts`).

### Why both walks

`importBundle` re-hashes each extracted primitive and compares it to `workspace.lock`. If a path is in the zip but not the lockfile hash — or vice versa — the per-primitive integrity check fails. So the exclusion set must be **identical** on the archive side and the hash side; the shared predicate enforces that. Stripping in only one place would make every Studio→Studio import throw `integrity check failed`.

Real impact on the bundle that prompted this: **87 MB → 359 KB** (10,960 → 75 files).

## Test Plan

- `npx vitest run packages/bundle/src/{hasher,bundle}.test.ts` → **121 passed**.
- New cases:
  - hasher excludes `.venv`/`venv`/`__pycache__`/`node_modules`/`*.pyc`; adding/removing a `.venv` does not change the hash.
  - `exportBundle` strips an agent's `.venv`/`__pycache__`/`.pyc` from the zip **and** the bundle still round-trips through `importBundle` (integrity passes).
- `deno check packages/bundle/src/{hasher,bundle}.ts packages/bundle/mod.ts` → clean.
- lint-staged (biome + `deno lint`) clean on commit.
