### PR TITLE
fix(chat): composer textarea fills its row (real fix for Yena's report) + IME guard

### DIFF
--- a/tools/agent-playground/src/lib/components/chat/chat-input.svelte
+++ b/tools/agent-playground/src/lib/components/chat/chat-input.svelte
@@ -355,7 +355,17 @@
     }
   }
 
-  function handleInput() {
+  function handleInput(event?: Event) {
+    // Skip the burst of intermediate `input` events an IME fires against a
+    // half-composed buffer: `value` is the in-progress composition and
+    // diffing it would feed applyEditDelta a mid-composition string,
+    // corrupting tracked offsets. `isComposing` is true throughout the
+    // composition and false on the commit event, so the settled text still
+    // gets reconciled. Reading it off the event (vs. a sticky flag) leaves
+    // no state to get wedged if `compositionend` never fires — e.g. the
+    // user hits Enter or blurs mid-composition. The `oncompositionend`
+    // flush below covers browsers that don't emit a trailing commit event.
+    if (event instanceof InputEvent && event.isComposing) return;
     // Reconcile span offsets against the user's edit before any
     // downstream work that depends on them.
     mentionSpans = applyEditDelta(mentionSpans, prevValue, value);
@@ -534,6 +544,7 @@
         bind:value
         onkeydown={handleKeydown}
         oninput={handleInput}
+        oncompositionend={() => handleInput()}
         onclick={handleSelectionChange}
         onkeyup={handleSelectionChange}
         onblur={closeMentionPopover}

--- a/tools/agent-playground/src/lib/components/chat/chat-input.svelte
+++ b/tools/agent-playground/src/lib/components/chat/chat-input.svelte
@@ -645,8 +645,14 @@
   }
 
   /* Anchor for the mention popover — the popover positions itself
-     against this wrap so it sits just above the textarea. */
+     against this wrap so it sits just above the textarea. `display: flex`
+     is load-bearing: the textarea relies on `flex: 1` to fill the row, but
+     this wrap (added in #417) sits between it and the flex `.input-row`. As
+     a plain block the inline-block textarea collapsed to its ~20-col
+     intrinsic width (~146px), so only the placeholder area was clickable
+     and the rest of the row didn't focus the input. */
   .textarea-wrap {
+    display: flex;
     flex: 1;
     position: relative;
   }

--- a/tools/agent-playground/src/routes/platform/[workspaceId]/+page.svelte
+++ b/tools/agent-playground/src/routes/platform/[workspaceId]/+page.svelte
@@ -334,7 +334,14 @@
     mentionQuery = null;
   }
 
-  function handleComposerInput() {
+  function handleComposerInput(event?: Event) {
+    // Skip the intermediate `input` events an IME fires against a
+    // half-composed buffer; `isComposing` is false on the commit event so
+    // the settled text is still reconciled. No sticky flag means nothing to
+    // get wedged if `compositionend` is missed (Enter / blur mid-compose);
+    // the `oncompositionend` flush covers browsers without a trailing event.
+    // Mirrors chat-input.svelte.
+    if (event instanceof InputEvent && event.isComposing) return;
     mentionSpans = applyEditDelta(mentionSpans, prevStartMessage, startMessage);
     prevStartMessage = startMessage;
     refreshMentionQuery();
@@ -633,6 +640,7 @@
               bind:this={composerInputEl}
               onkeydown={handleStartKeydown}
               oninput={handleComposerInput}
+              oncompositionend={() => handleComposerInput()}
               onclick={handleComposerSelectionChange}
               onkeyup={handleComposerSelectionChange}
               onblur={closeMentionPopover}


### PR DESCRIPTION
## What

Fixes the chat composer bug Yena reported as "text duplicating." **The real cause was a layout/focus regression, not anything input-related** — see below. Contains two commits:

1. **`fix(chat): composer textarea fills its row`** — the actual fix.
2. `fix(playground): skip @-mention bookkeeping during IME composition` — a latent-bug hardening I wrote first while misdiagnosing this as an IME issue. Kept (review-Clean, genuinely correct for CJK @-mention typing) but it does **not** fix the report.

## Root cause (commit 1)

The textarea relies on `flex: 1` to fill the input row. PR #417 wrapped it in `.textarea-wrap` (the mention-popover anchor), which is `display: block`. With no flex parent, `flex: 1` is inert, so the inline-block textarea collapsed to its ~20-column intrinsic width (**~146px**). Consequences:

- Only the leftmost ~146px (the placeholder) focused the textarea; **clicking anywhere else in the row hit the inert wrapper `div` and did nothing.**
- The box looked misaligned (placeholder sat above the icon row).
- Users fighting the dead focus zone clicked-and-retyped, so the same phrase **accumulated** — which read as "duplication." Clean single typing never reproduced it, which is exactly why it looked like a phantom input bug.

## Fix

Make `.textarea-wrap` a flex container so the textarea's existing `flex: 1` stretches it to fill the row. One line + an explainer comment.

## Verified live (localhost:5200)

| | before | after |
|---|---|---|
| textarea width | 146px | 738px (fills row) |
| click middle of box → focus | ✗ (hit inert div) | ✓ focuses textarea |
| type `Hello Yena lol Hello Yena lol` | re-type loop → "duplication" | exact value, no dup |

## Note on the IME commit

Honest disclosure: I initially chased this as an IME composition issue (commit 2) — it was reviewed Clean but is unrelated to the report. It's harmless hardening (mention-span bookkeeping no longer runs against a half-composed buffer). Squash-merging is fine; if you'd rather drop it, I can strip it to leave only the layout fix.