### PR TITLE
fix(playground): force identity encoding on the daemon/tunnel proxy

### DIFF
--- a/tools/agent-playground/src/lib/server/proxy.test.ts
+++ b/tools/agent-playground/src/lib/server/proxy.test.ts
@@ -194,6 +194,25 @@ describe("buildProxyHandler", () => {
     expect(forwardedHeaders.get("x-forwarded-prefix")).toBe("/api/daemon");
   });
 
+  it("forces identity Accept-Encoding upstream so the daemon never picks brotli", async () => {
+    // Regression: this proxy passes a node_modules-undici Agent as the
+    // `dispatcher` to Node's built-in fetch (a different undici instance).
+    // Built-in fetch decodes brotli on its own, but that cross-instance
+    // dispatcher makes it skip decode AND strip `Content-Encoding`, so a `br`
+    // response reaches the proxy as raw brotli with no encoding header and the
+    // client's JSON.parse chokes. Forcing `identity` upstream sidesteps it.
+    // (Vanilla fetch decodes brotli — don't be fooled into reverting this.)
+    // Must `set`, not `delete`: undici re-adds a `br, gzip, deflate` default
+    // when the header is absent.
+    fetchMock.mockResolvedValueOnce(new Response("{}", { status: 200 }));
+    const handler = buildProxyHandler({ upstream: "https://daemon.local:8080", label: "daemon" });
+    await handler(
+      event({ path: "api/workspaces/x/chat", headers: { "accept-encoding": "br, gzip, deflate" } }),
+    );
+    const forwardedHeaders = fetchMock.mock.calls[0]?.[1]?.headers as Headers;
+    expect(forwardedHeaders.get("accept-encoding")).toBe("identity");
+  });
+
   it("forwards 3xx redirects to the client instead of following them upstream", async () => {
     // Regression: OAuth flows (e.g. Link → Google authorize) depend on the
     // browser navigating the popup to accounts.google.com itself. If the SSR

--- a/tools/agent-playground/src/lib/server/proxy.ts
+++ b/tools/agent-playground/src/lib/server/proxy.ts
@@ -161,6 +161,20 @@ export async function executeProxyFetch(
   const headers = new Headers(request.headers);
   headers.delete("host");
   headers.delete("content-length");
+  // Force identity encoding upstream so the daemon never compresses. The cause
+  // is subtle: we pass a node_modules `undici` Agent as `dispatcher` (for its
+  // 1-hour timeouts) to Node's *built-in* fetch — a different undici instance.
+  // Built-in fetch decodes brotli on its own, but that cross-instance
+  // dispatcher makes it skip the decode pipeline (`res.body` arrives as raw
+  // brotli) AND strip `Content-Encoding` — so neither the body nor the
+  // response-side strip (HOP_BY_HOP_HEADERS) reveals the compression, and we'd
+  // ship raw brotli with no encoding header. The browser can't decode it and
+  // the app's `JSON.parse` chokes ("Unexpected token …"). NB: plain fetch
+  // decodes brotli fine — don't "simplify" this away after testing vanilla
+  // fetch; the dispatcher is what breaks decode. `set("identity")`, not
+  // `delete`: undici re-adds a `br, gzip, deflate` default when the header is
+  // absent. Compression buys nothing on a localhost hop anyway.
+  headers.set("accept-encoding", "identity");
 
   // Tell the upstream where the browser actually lives. Required for
   // services like Link that synthesize external callback URLs from


### PR DESCRIPTION
## What

The playground's daemon/tunnel reverse proxy (`lib/server/proxy.ts`) corrupts brotli-compressed JSON from the daemon, so `/api/daemon/*` responses reach the browser as raw bytes. Surfaces as a red **"Unexpected token … is not valid JSON"** in the chat-list panel (and anywhere parsing daemon JSON) on `localhost:5200`.

## Root cause (the subtle part)

`executeProxyFetch` passes a **node_modules `undici` `Agent`** as the `dispatcher` (for its 1-hour `headersTimeout`/`bodyTimeout`, see PR #314) to Node's **built-in** `fetch` — which is a **different undici instance**. Built-in fetch decodes brotli on its own, **but that cross-instance dispatcher makes it skip the decode pipeline AND strip the `Content-Encoding` header.** So:

1. The browser sends `Accept-Encoding: br, gzip, deflate`; the proxy forwarded it untouched.
2. The daemon replied with brotli + `Content-Encoding: br`.
3. Because of the foreign dispatcher, `res.body` came through as **raw brotli** and `res.headers` had **no** `content-encoding` — so neither the body nor the response-side strip (`HOP_BY_HOP_HEADERS`) could tell it was compressed.
4. The proxy shipped raw brotli with no encoding header → the browser can't decode → `JSON.parse(<brotli>)` throws.

### ⚠️ Don't revert this after testing vanilla `fetch`

Plain `fetch` (no dispatcher) **does** decode brotli — so an isolated test will "prove" this line is a no-op. It isn't: the **custom dispatcher** is what breaks decode. A/B against the live daemon, same Node:

| fetch | `res.body` first bytes | `content-encoding` |
|---|---|---|
| vanilla (no dispatcher) | `7b 22 63 68 61 74` = `{"chat` (decoded) | `br` |
| **with our `Agent` dispatcher** | `8b ff 7f cc 48 d2` (**raw brotli**) | `null` |

## Fix

Force `accept-encoding: identity` on the upstream request so the daemon never compresses (compression buys nothing on a localhost SSR hop). Must be `set`, **not `delete`** — undici re-adds a default `br, gzip, deflate` whenever the header is absent, which would let brotli straight back in.

## Verification

- Live: the chat list and all `/api/daemon/*` JSON load clean on `localhost:5200` (was: parse error → now: chats render).
- Added a proxy unit test asserting the forwarded request carries `accept-encoding: identity` even when the client sends `br, gzip, deflate`. `proxy.test.ts` green (12/12).

## Notes

- Independent of the composer IME fix (#469) — different subsystem. Applies to both the SvelteKit dev proxy and the compiled-binary Hono proxy (shared `executeProxyFetch`).
- Deeper fix (out of scope): align the dispatcher with the built-in undici so brotli decode works and compression is kept. The `Agent` import exists specifically for the long timeouts (PR #314), so that's a bigger change — `identity` is the right minimal fix here.